### PR TITLE
refactor(tui): drop the provider prefix from the composer prompt

### DIFF
--- a/ui-tui/src/__tests__/prompt.test.ts
+++ b/ui-tui/src/__tests__/prompt.test.ts
@@ -4,28 +4,20 @@ import { composerPromptText } from '../lib/prompt.js'
 
 describe('composerPromptText', () => {
   it('returns shell prompt for ! commands', () => {
-    expect(composerPromptText('❯', 'coder', true)).toBe('$')
+    expect(composerPromptText('❯', true)).toBe('$')
   })
 
-  it('prefixes named profiles onto the normal prompt', () => {
-    expect(composerPromptText('❯', 'coder')).toBe('coder ❯')
-  })
-
-  it('does not prefix default or custom profiles', () => {
-    expect(composerPromptText('❯', 'default')).toBe('❯')
-    expect(composerPromptText('❯', 'custom')).toBe('❯')
+  it('is the bare brand glyph — no provider prefix (the stats line carries it)', () => {
     expect(composerPromptText('❯')).toBe('❯')
+    // Compound branding glyphs pass through unmodified.
+    expect(composerPromptText('Ψ >')).toBe('Ψ >')
   })
 
   it('uses a Termux-safe ASCII prompt marker in normal mode', () => {
-    expect(composerPromptText('❯', 'coder', false, true, 50)).toBe('>')
+    expect(composerPromptText('❯', false, true)).toBe('>')
   })
 
-  it('keeps profile prefix suppressed on narrow Termux widths', () => {
-    expect(composerPromptText('❯', 'upstr', false, true, 72)).toBe('>')
-  })
-
-  it('allows profile prefix on very wide Termux panes', () => {
-    expect(composerPromptText('❯', 'upstr', false, true, 120)).toBe('upstr >')
+  it('keeps shell mode ahead of Termux substitution', () => {
+    expect(composerPromptText('❯', true, true)).toBe('$')
   })
 })

--- a/ui-tui/src/__tests__/termuxComposerLayout.test.ts
+++ b/ui-tui/src/__tests__/termuxComposerLayout.test.ts
@@ -4,16 +4,9 @@ import { stableComposerColumns, transcriptBodyWidth } from '../lib/inputMetrics.
 import { composerPromptText } from '../lib/prompt.js'
 
 describe('Termux composer prompt + width guards', () => {
-  it('uses a single-cell ASCII prompt marker in Termux mode', () => {
-    expect(composerPromptText('❯', 'coder', false, true, 50)).toBe('>')
-  })
-
-  it('suppresses profile prefixes on narrow Termux panes', () => {
-    expect(composerPromptText('❯', 'upstr', false, true, 72)).toBe('>')
-  })
-
-  it('keeps profile context on very wide Termux panes', () => {
-    expect(composerPromptText('❯', 'upstr', false, true, 120)).toBe('upstr >')
+  it('uses a single-cell ASCII prompt marker in Termux mode at any width', () => {
+    // No provider prefix at any width — the stats line names the provider.
+    expect(composerPromptText('❯', false, true)).toBe('>')
   })
 
   it('reserves fewer columns for gutter on narrow Termux widths', () => {

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -191,13 +191,8 @@ const ComposerPane = memo(function ComposerPane({
   const isBlocked = useStore($isBlocked)
   const sh = composer.input.startsWith('!')
 
-  const promptText = composerPromptText(
-    ui.theme.brand.prompt,
-    ui.info?.profile_name,
-    sh,
-    TERMUX_TUI_MODE,
-    composer.cols
-  )
+  // Bare glyph — the provider already reads out on the stats line below.
+  const promptText = composerPromptText(ui.theme.brand.prompt, sh, TERMUX_TUI_MODE)
 
   const promptWidth = composerPromptWidth(promptText)
   const inputColumns = stableComposerColumns(composer.cols, promptWidth, TERMUX_TUI_MODE)

--- a/ui-tui/src/lib/prompt.ts
+++ b/ui-tui/src/lib/prompt.ts
@@ -1,36 +1,15 @@
 const TERMUX_SAFE_PROMPT = '>'
 
-export function composerPromptText(
-  prompt: string,
-  profileName?: null | string,
-  shellMode = false,
-  termuxMode = false,
-  totalCols?: number
-): string {
+// The composer marker is JUST the glyph — no provider/profile prefix. The
+// session-stats line under the composer already names the provider (and
+// model/cwd), so prefixing it here would say the same thing twice one row
+// apart. Shell mode keeps its `$`; Termux keeps a strictly single-cell ASCII
+// marker (decorative glyphs render with ambiguous width there and leave
+// stale arrow artifacts while typing).
+export function composerPromptText(prompt: string, shellMode = false, termuxMode = false): string {
   if (shellMode) {
     return '$'
   }
 
-  if (termuxMode) {
-    // Termux fonts/terminal backends can render decorative prompt glyphs with
-    // ambiguous width; keep the live composer marker strictly single-cell ASCII
-    // so we never leave stale arrow artifacts while typing.
-    const basePrompt = TERMUX_SAFE_PROMPT
-
-    // On very wide panes we can still include profile context. On narrow/mobile
-    // panes this burns precious columns and increases wrap/clipping risk.
-    const wideEnoughForProfile = typeof totalCols === 'number' ? totalCols >= 90 : false
-
-    if (wideEnoughForProfile && profileName && !['default', 'custom'].includes(profileName)) {
-      return `${profileName} ${basePrompt}`
-    }
-
-    return basePrompt
-  }
-
-  if (profileName && !['default', 'custom'].includes(profileName)) {
-    return `${profileName} ${prompt}`
-  }
-
-  return prompt
+  return termuxMode ? TERMUX_SAFE_PROMPT : prompt
 }


### PR DESCRIPTION
## What

The composer input marker read `deepseek ❯ `. Since #657 the session-stats line one row below already reads out `provider · model · cwd · turns · tokens · cost`, so the prefix said the same thing twice. The composer is now the bare brand glyph:

```
❯ Try "write a test for…"
deepseek · deepseek-v4-flash · ~/workspace/app · turns: 0 · tokens: 0 in / 0 out
```

- `composerPromptText` loses its `profileName`/`totalCols` params and all prefixing logic; bash-mode `$` and the Termux single-cell ASCII `>` are preserved (with a new test pinning shell-beats-termux precedence).
- The width-gated Termux profile prefix (≥90 cols) goes with it — narrow Termux panes previously showed the provider nowhere; now the always-on stats line shows it at every width (provider is the leftmost, never-shed segment).
- Transcript user rows and the composer width math already used the bare `t.brand.prompt`, so composer ↔ transcript gutter alignment actually improves when a provider is set. No other surface renders a prefixed marker (the intro banner names the provider deliberately).

## Verification

- prompt/termux test files rewritten for the new signature (8 tests, incl. compound-glyph pass-through `Ψ >`).
- tsc clean; eslint clean on changed files; full vitest suite = the same 9 pre-existing baseline failures, verified by test NAME against the parent commit.
- Live pyte run against the real DeepSeek backend: composer row `❯ Try "write a test for…"` with no provider prefix; stats line still `deepseek · deepseek-v4-flash · …`.
- Critic-reviewed: APPROVE (one optional fixture-naming cleanup deferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)