### PR TITLE
feat(mcp): make OAuth MCP servers reachable — the /mcp auth flow (C4)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -377,6 +377,9 @@ class _AgentSession:
         if subtype == "set_mcp_enabled":
             self._do_set_mcp_enabled(request_id, inner.get("server"), inner.get("enabled"))
             return
+        if subtype == "mcp_auth":
+            self._do_mcp_auth(request_id, inner.get("server"))
+            return
         if subtype == "external_includes":
             # External CLAUDE.md @-imports (ClaudeMdExternalIncludesDialog, §6).
             try:
@@ -933,29 +936,58 @@ class _AgentSession:
             # Re-render the MCP-instructions section for the new server set
             # (C2 — the port-idiomatic analog of TS's per-call UNCACHED
             # mcp_instructions section, given the memoized base prompt).
-            if self._base_system_prompt is not None and self.tool_context is not None:
-                try:
-                    from src.outputStyles import resolve_output_style
-                    from src.query.agent_loop_compat import build_effective_system_prompt
-
-                    tc = self.tool_context
-                    style_prompt = resolve_output_style(
-                        getattr(tc, "output_style_name", None),
-                        getattr(tc, "output_style_dir", None),
-                    ).prompt
-                    self._base_system_prompt = build_effective_system_prompt(
-                        style_prompt, tc, provider=self.provider,
-                        mcp_servers=self._mcp_server_infos(),
-                    )
-                    self.system_prompt = self._compose_with_plan(self._base_system_prompt)
-                except Exception:  # noqa: BLE001 — keep the toggle even if rebuild fails
-                    logger.debug(
-                        "[agent-server] prompt rebuild after set_mcp_enabled failed",
-                        exc_info=True,
-                    )
+            self._rebuild_base_prompt_for_mcp()
         self._reply(request_id, {
             "ok": True,
             "disabled": sorted(reg.disabled_servers) if reg is not None else [],
+        })
+
+    def _rebuild_base_prompt_for_mcp(self) -> None:
+        """Rebuild the memoized base prompt so a change to the live MCP server
+        set (toggle, or a /mcp-auth late connect) re-renders the REQUEST-scoped
+        mcp_instructions section (C2 uncached-section analog; C4 late-connect)."""
+        if self._base_system_prompt is None or self.tool_context is None:
+            return
+        try:
+            from src.outputStyles import resolve_output_style
+            from src.query.agent_loop_compat import build_effective_system_prompt
+
+            tc = self.tool_context
+            style_prompt = resolve_output_style(
+                getattr(tc, "output_style_name", None),
+                getattr(tc, "output_style_dir", None),
+            ).prompt
+            self._base_system_prompt = build_effective_system_prompt(
+                style_prompt, tc, provider=self.provider,
+                mcp_servers=self._mcp_server_infos(),
+            )
+            self.system_prompt = self._compose_with_plan(self._base_system_prompt)
+        except Exception:  # noqa: BLE001 — keep the change even if rebuild fails
+            logger.debug("[agent-server] MCP prompt rebuild failed", exc_info=True)
+
+    def _do_mcp_auth(self, request_id: object, server: object) -> None:
+        """/mcp auth <server> (C4): run the OAuth flow for a needs-auth MCP
+        server, then register its now-available tools + rebuild the prompt so
+        its instructions enter the system prompt (the C2 late-connect note)."""
+        name = str(server or "")
+        rt = getattr(self, "_mcp_runtime", None)
+        if rt is None or not name:
+            self._reply(request_id, {"ok": False, "error": "no MCP runtime or server name"})
+            return
+        result = rt.trigger_oauth(name)
+        if result.get("ok"):
+            reg = self.tool_registry
+            if reg is not None:
+                for mtool in result.get("tools", []):
+                    try:
+                        reg.register(mtool)
+                    except Exception:  # noqa: BLE001
+                        logger.debug("[agent-server] register MCP tool failed", exc_info=True)
+            self._rebuild_base_prompt_for_mcp()  # late-connect → surface instructions
+        self._reply(request_id, {
+            "ok": bool(result.get("ok")),
+            "error": result.get("error"),
+            "pending_auth": rt.pending_auth(),
         })
 
     def _do_set_thinking(self, request_id: object, action: object) -> None:
@@ -2612,6 +2644,18 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
                     "[agent-server] MCP: %d tool(s) from %d server(s)",
                     len(mcp_rt.tools), len(mcp_rt.servers),
                 )
+                # Surface OAuth servers awaiting auth (C4): a needs-auth server
+                # used to fail to connect silently. Tell the user how to act —
+                # /mcp auth <server> triggers the flow.
+                _pending = mcp_rt.pending_auth()
+                if _pending:
+                    _names = ", ".join(_pending)
+                    sess._emit(_system_message(
+                        sess.session_id,
+                        f"MCP server(s) need authentication: {_names}. "
+                        f"Run `/mcp auth <server>` to sign in.",
+                        level="info",
+                    ))
         except Exception:  # noqa: BLE001 — MCP must never break startup
             logger.debug("[agent-server] MCP bootstrap skipped", exc_info=True)
         profile_checkpoint("agent_server_mcp_done")

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -378,7 +378,7 @@ class _AgentSession:
             self._do_set_mcp_enabled(request_id, inner.get("server"), inner.get("enabled"))
             return
         if subtype == "mcp_auth":
-            self._do_mcp_auth(request_id, inner.get("server"))
+            await self._do_mcp_auth(request_id, inner.get("server"))
             return
         if subtype == "external_includes":
             # External CLAUDE.md @-imports (ClaudeMdExternalIncludesDialog, §6).
@@ -965,16 +965,27 @@ class _AgentSession:
         except Exception:  # noqa: BLE001 — keep the change even if rebuild fails
             logger.debug("[agent-server] MCP prompt rebuild failed", exc_info=True)
 
-    def _do_mcp_auth(self, request_id: object, server: object) -> None:
+    async def _do_mcp_auth(self, request_id: object, server: object) -> None:
         """/mcp auth <server> (C4): run the OAuth flow for a needs-auth MCP
         server, then register its now-available tools + rebuild the prompt so
-        its instructions enter the system prompt (the C2 late-connect note)."""
+        its instructions enter the system prompt (the C2 late-connect note).
+
+        The blocking OAuth flow runs on the MCP runtime loop and is AWAITED via
+        a wrapped future, so the agent-server MAIN loop stays responsive during
+        the (up to 300s) browser round-trip — the user can still interrupt
+        (B1). The registry/prompt mutations happen back on the main loop
+        (single-threaded, no race with an in-flight turn)."""
         name = str(server or "")
         rt = getattr(self, "_mcp_runtime", None)
         if rt is None or not name:
             self._reply(request_id, {"ok": False, "error": "no MCP runtime or server name"})
             return
-        result = rt.trigger_oauth(name)
+        try:
+            fut = rt.submit(rt.trigger_oauth_async(name))
+            result = await asyncio.wrap_future(fut)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] /mcp auth failed for %s", name)
+            result = {"ok": False, "error": f"auth failed: {exc}"}
         if result.get("ok"):
             reg = self.tool_registry
             if reg is not None:
@@ -983,12 +994,35 @@ class _AgentSession:
                         reg.register(mtool)
                     except Exception:  # noqa: BLE001
                         logger.debug("[agent-server] register MCP tool failed", exc_info=True)
+            # M1: a late-authed server needs the SAME elicitation +
+            # tools/list_changed wiring boot-time servers get (agent_server
+            # boot path) — else it silently can't elicit or push tool refreshes.
+            client = result.get("client")
+            if client is not None:
+                self._wire_mcp_client_handlers(rt, client, name)
             self._rebuild_base_prompt_for_mcp()  # late-connect → surface instructions
         self._reply(request_id, {
             "ok": bool(result.get("ok")),
             "error": result.get("error"),
             "pending_auth": rt.pending_auth(),
         })
+
+    def _wire_mcp_client_handlers(self, rt: Any, client: Any, name: str) -> None:
+        """Wire elicitation + (capability-gated) tools/list_changed handlers on
+        an MCP client — the same wiring the boot path applies, reused for a
+        late-authenticated server (M1)."""
+        try:
+            client.set_elicitation_handler(_make_elicitation_handler(self))
+        except Exception:  # noqa: BLE001
+            logger.debug("[agent-server] elicitation wiring failed for %s", name, exc_info=True)
+        try:
+            caps = getattr(client, "capabilities", None)
+            if getattr(caps, "tools_list_changed", False):
+                client.set_notification_handler(
+                    _make_mcp_notification_handler(rt, self, name)
+                )
+        except Exception:  # noqa: BLE001
+            logger.debug("[agent-server] list_changed wiring failed for %s", name, exc_info=True)
 
     def _do_set_thinking(self, request_id: object, action: object) -> None:
         """Toggle/set extended thinking (the original's ThinkingToggle). action:

--- a/src/server/mcp_runtime.py
+++ b/src/server/mcp_runtime.py
@@ -77,6 +77,10 @@ class McpRuntime:
         # the auth trigger instead of silently failing to connect.
         self.needs_auth: list[dict[str, Any]] = []
         self._auth_provider: Any = None
+        # Per-server locks serializing concurrent /mcp auth triggers so they
+        # can't double-register tools / duplicate server_infos / leak a client
+        # (m1). Created lazily on the runtime loop.
+        self._auth_locks: dict[str, Any] = {}
 
     def _run(self, coro: Any, timeout: float) -> Any:
         assert self._loop is not None
@@ -169,65 +173,90 @@ class McpRuntime:
         """Names of servers awaiting authentication (for the /mcp UI)."""
         return [e["name"] for e in self.needs_auth]
 
-    def trigger_oauth(self, name: str, *, open_browser: bool = True) -> dict[str, Any]:
-        """Run the OAuth flow for a needs-auth server, then reconnect + register
-        its tools (C4). Returns ``{ok, error?, tools?}``. Runs on the runtime's
-        dedicated loop so the reconnected client's streams stay loop-bound."""
-        if self._loop is None or self._auth_provider is None:
+    def submit(self, coro: Any) -> Any:
+        """Submit a coroutine to the runtime loop, returning a
+        ``concurrent.futures.Future`` the caller can ``await`` (via
+        ``asyncio.wrap_future``) WITHOUT blocking its own loop. This is how the
+        agent-server main loop runs the OAuth flow off-thread yet stays
+        responsive (B1)."""
+        assert self._loop is not None
+        return asyncio.run_coroutine_threadsafe(coro, self._loop)
+
+    async def trigger_oauth_async(
+        self, name: str, *, open_browser: bool = True
+    ) -> dict[str, Any]:
+        """Async OAuth flow for a needs-auth server → reconnect (C4). Runs ON
+        the runtime loop (all awaits, no blocking ``.result()``). Serialized
+        per-server (m1) so concurrent triggers can't double-register. Returns
+        ``{ok, error?, tools?, client?}`` (client for handler re-wiring, M1)."""
+        if self._auth_provider is None:
             return {"ok": False, "error": "MCP runtime has no auth provider"}
-        entry = next((e for e in self.needs_auth if e["name"] == name), None)
-        if entry is None:
-            return {"ok": False, "error": f"{name!r} is not awaiting authentication"}
-        scoped = entry["scoped"]
-        inner = getattr(scoped, "config", None)
-        server_url = getattr(inner, "url", None)
-        if not server_url:
-            return {"ok": False, "error": "OAuth requires an HTTP/SSE/WS server URL"}
-        try:
-            result = self._run(
-                self._auth_provider.acquire_token(
+        lock = self._auth_locks.get(name)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._auth_locks[name] = lock
+        async with lock:
+            entry = next((e for e in self.needs_auth if e["name"] == name), None)
+            if entry is None:
+                # a concurrent trigger already promoted it — treat as success-noop
+                if name in self.clients and name not in self.pending_auth():
+                    return {"ok": True, "tools": [], "client": self.clients.get(name)}
+                return {"ok": False, "error": f"{name!r} is not awaiting authentication"}
+            scoped = entry["scoped"]
+            inner = getattr(scoped, "config", None)
+            server_url = getattr(inner, "url", None)
+            if not server_url:
+                return {"ok": False, "error": "OAuth requires an HTTP/SSE/WS server URL"}
+            try:
+                result = await self._auth_provider.acquire_token(
                     server_name=name,
                     server_url=server_url,
                     auth_server_metadata_url=getattr(inner, "auth_server_metadata_url", None),
                     config_scope=getattr(scoped, "scope", None),
                     open_browser=open_browser,
-                ),
-                _OAUTH_TIMEOUT_S,
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("[mcp] OAuth flow failed for %s", name)
-            return {"ok": False, "error": f"OAuth flow failed: {exc}"}
-        if not getattr(result, "success", False):
-            return {"ok": False, "error": getattr(result, "error", None) or "authentication failed"}
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("[mcp] OAuth flow failed for %s", name)
+                return {"ok": False, "error": f"OAuth flow failed: {exc}"}
+            if not getattr(result, "success", False):
+                return {"ok": False, "error": getattr(result, "error", None) or "authentication failed"}
 
-        # Authenticated — reconnect with the now-cached token + register tools.
-        try:
-            from src.services.mcp.client import McpClient
+            # Authenticated — reconnect with the now-cached token.
+            try:
+                from src.services.mcp.client import McpClient
 
-            client = McpClient()
-            client.set_auth_provider(self._auth_provider)
-            connected = self._run(client.connect(name, scoped), _CONNECT_TIMEOUT_S)
-            if getattr(connected, "type", "") != "connected":
-                return {"ok": False, "error": "reconnect did not complete after auth"}
-            mcp_tools = self._run(client.list_tools(), _CONNECT_TIMEOUT_S)
-            # promote: drop the old client, register the connected one
-            old = self.clients.get(name)
-            if old is not None and old is not client:
-                try:
-                    self._run(old.close(), 5.0)
-                except Exception:  # noqa: BLE001
-                    pass
-            self.clients[name] = client
-            self.servers[name] = [t.name for t in mcp_tools]
-            self.server_infos.append(connected)
-            new_tools = [self._wrap(name, mt, client) for mt in mcp_tools]
-            self.tools.extend(new_tools)
-            self.needs_auth = [e for e in self.needs_auth if e["name"] != name]
-            logger.info("[mcp] %s authenticated (%d tools)", name, len(new_tools))
-            return {"ok": True, "tools": new_tools}
-        except Exception as exc:  # noqa: BLE001
-            logger.exception("[mcp] reconnect after auth failed for %s", name)
-            return {"ok": False, "error": f"reconnect failed: {exc}"}
+                client = McpClient()
+                client.set_auth_provider(self._auth_provider)
+                connected = await client.connect(name, scoped)
+                if getattr(connected, "type", "") != "connected":
+                    return {"ok": False, "error": "reconnect did not complete after auth"}
+                mcp_tools = await client.list_tools()
+                old = self.clients.get(name)
+                if old is not None and old is not client:
+                    try:
+                        await old.close()
+                    except Exception:  # noqa: BLE001
+                        pass
+                self.clients[name] = client
+                self.servers[name] = [t.name for t in mcp_tools]
+                self.server_infos.append(connected)
+                new_tools = [self._wrap(name, mt, client) for mt in mcp_tools]
+                self.tools.extend(new_tools)
+                self.needs_auth = [e for e in self.needs_auth if e["name"] != name]
+                logger.info("[mcp] %s authenticated (%d tools)", name, len(new_tools))
+                return {"ok": True, "tools": new_tools, "client": client}
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("[mcp] reconnect after auth failed for %s", name)
+                return {"ok": False, "error": f"reconnect failed: {exc}"}
+
+    def trigger_oauth(self, name: str, *, open_browser: bool = True) -> dict[str, Any]:
+        """Synchronous wrapper (tests / non-async callers) — blocks the caller's
+        thread on the runtime loop. The interactive agent-server path uses
+        ``trigger_oauth_async`` via ``submit`` instead, so it never freezes its
+        own loop (B1)."""
+        if self._loop is None:
+            return {"ok": False, "error": "MCP runtime not started"}
+        return self._run(self.trigger_oauth_async(name, open_browser=open_browser), _OAUTH_TIMEOUT_S)
 
     def _wrap(self, server: str, mcp_tool: Any, client: Any) -> Any:
         """Build a loop-correct sync Tool that dispatches to the connection loop."""

--- a/src/server/mcp_runtime.py
+++ b/src/server/mcp_runtime.py
@@ -31,6 +31,9 @@ logger = logging.getLogger(__name__)
 
 _CALL_TIMEOUT_S = 60.0
 _CONNECT_TIMEOUT_S = 30.0
+# OAuth needs a longer budget: the user opens a browser, authenticates, and the
+# local callback completes before the token exchange returns.
+_OAUTH_TIMEOUT_S = 300.0
 
 
 def _render_content(content: Any) -> str:
@@ -66,6 +69,14 @@ class McpRuntime:
         # (the UTILS-1 inert-wiring gap) — retained so the prompt build can
         # render the "# MCP Server Instructions" section (C2).
         self.server_infos: list[Any] = []
+        # Servers that returned needs-auth (OAuth) from connect() — retained
+        # (name, auth_url, scoped-config) so the runtime can surface a
+        # "run /mcp auth <server>" prompt and later trigger the flow (C4).
+        # Without an injected auth_provider the live path could never even
+        # detect needs-auth; now it can, and the server stays reachable for
+        # the auth trigger instead of silently failing to connect.
+        self.needs_auth: list[dict[str, Any]] = []
+        self._auth_provider: Any = None
 
     def _run(self, coro: Any, timeout: float) -> Any:
         assert self._loop is not None
@@ -101,12 +112,40 @@ class McpRuntime:
 
         from src.services.mcp.client import McpClient
 
+        # One shared auth provider for the whole runtime — so an OAuth server's
+        # connect() can detect + cache needs-auth (client.py consults
+        # self._auth_provider), and the /mcp auth trigger can later run the flow
+        # against the same token store (C4).
+        try:
+            from src.services.mcp.auth_provider import McpAuthProvider
+
+            self._auth_provider = McpAuthProvider()
+        except Exception:  # noqa: BLE001 — no auth provider ⇒ no OAuth, still works
+            logger.debug("[mcp] auth provider unavailable", exc_info=True)
+            self._auth_provider = None
+
         for name, scoped in enabled.items():
             try:
                 client = McpClient()
+                if self._auth_provider is not None:
+                    client.set_auth_provider(self._auth_provider)
                 connected = self._run(client.connect(name, scoped), _CONNECT_TIMEOUT_S)
-                mcp_tools = self._run(client.list_tools(), _CONNECT_TIMEOUT_S)
                 self.clients[name] = client
+                # An OAuth server returns needs-auth instead of connected:
+                # retain it (with its auth_url) + surface a prompt, and do NOT
+                # list_tools (there are none until the user authenticates).
+                if getattr(connected, "type", "") == "needs-auth":
+                    self.needs_auth.append({
+                        "name": name,
+                        "auth_url": getattr(connected, "auth_url", None),
+                        "scoped": scoped,
+                    })
+                    logger.info(
+                        "[mcp] %s needs authentication — run `/mcp auth %s`",
+                        name, name,
+                    )
+                    continue
+                mcp_tools = self._run(client.list_tools(), _CONNECT_TIMEOUT_S)
                 self.servers[name] = [t.name for t in mcp_tools]
                 # Keep the server info (name + instructions) for the prompt —
                 # only truly-connected servers carry instructions.
@@ -118,10 +157,77 @@ class McpRuntime:
             except Exception:  # noqa: BLE001 — one bad server must not sink the rest
                 logger.exception("[mcp] connect failed: %s", name)
 
-        if not self.tools:
+        # Keep the runtime alive if ANY server connected OR needs auth — a
+        # needs-auth-only runtime must survive so `/mcp auth` can trigger the
+        # flow (previously a tool-less runtime was torn down immediately).
+        if not self.tools and not self.needs_auth:
             self.shutdown()
             return False
         return True
+
+    def pending_auth(self) -> list[str]:
+        """Names of servers awaiting authentication (for the /mcp UI)."""
+        return [e["name"] for e in self.needs_auth]
+
+    def trigger_oauth(self, name: str, *, open_browser: bool = True) -> dict[str, Any]:
+        """Run the OAuth flow for a needs-auth server, then reconnect + register
+        its tools (C4). Returns ``{ok, error?, tools?}``. Runs on the runtime's
+        dedicated loop so the reconnected client's streams stay loop-bound."""
+        if self._loop is None or self._auth_provider is None:
+            return {"ok": False, "error": "MCP runtime has no auth provider"}
+        entry = next((e for e in self.needs_auth if e["name"] == name), None)
+        if entry is None:
+            return {"ok": False, "error": f"{name!r} is not awaiting authentication"}
+        scoped = entry["scoped"]
+        inner = getattr(scoped, "config", None)
+        server_url = getattr(inner, "url", None)
+        if not server_url:
+            return {"ok": False, "error": "OAuth requires an HTTP/SSE/WS server URL"}
+        try:
+            result = self._run(
+                self._auth_provider.acquire_token(
+                    server_name=name,
+                    server_url=server_url,
+                    auth_server_metadata_url=getattr(inner, "auth_server_metadata_url", None),
+                    config_scope=getattr(scoped, "scope", None),
+                    open_browser=open_browser,
+                ),
+                _OAUTH_TIMEOUT_S,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[mcp] OAuth flow failed for %s", name)
+            return {"ok": False, "error": f"OAuth flow failed: {exc}"}
+        if not getattr(result, "success", False):
+            return {"ok": False, "error": getattr(result, "error", None) or "authentication failed"}
+
+        # Authenticated — reconnect with the now-cached token + register tools.
+        try:
+            from src.services.mcp.client import McpClient
+
+            client = McpClient()
+            client.set_auth_provider(self._auth_provider)
+            connected = self._run(client.connect(name, scoped), _CONNECT_TIMEOUT_S)
+            if getattr(connected, "type", "") != "connected":
+                return {"ok": False, "error": "reconnect did not complete after auth"}
+            mcp_tools = self._run(client.list_tools(), _CONNECT_TIMEOUT_S)
+            # promote: drop the old client, register the connected one
+            old = self.clients.get(name)
+            if old is not None and old is not client:
+                try:
+                    self._run(old.close(), 5.0)
+                except Exception:  # noqa: BLE001
+                    pass
+            self.clients[name] = client
+            self.servers[name] = [t.name for t in mcp_tools]
+            self.server_infos.append(connected)
+            new_tools = [self._wrap(name, mt, client) for mt in mcp_tools]
+            self.tools.extend(new_tools)
+            self.needs_auth = [e for e in self.needs_auth if e["name"] != name]
+            logger.info("[mcp] %s authenticated (%d tools)", name, len(new_tools))
+            return {"ok": True, "tools": new_tools}
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[mcp] reconnect after auth failed for %s", name)
+            return {"ok": False, "error": f"reconnect failed: {exc}"}
 
     def _wrap(self, server: str, mcp_tool: Any, client: Any) -> Any:
         """Build a loop-correct sync Tool that dispatches to the connection loop."""

--- a/tests/test_mcp_auth_flow.py
+++ b/tests/test_mcp_auth_flow.py
@@ -23,8 +23,9 @@ def _scoped(url="https://mcp.example.com", enabled=True):
 
 
 def _tool(name="do_thing"):
+    # real contract is input_schema (McpToolSchema / _wrap), NOT camelCase
     return SimpleNamespace(name=name, description="d",
-                           inputSchema={"type": "object", "properties": {}})
+                           input_schema={"type": "object", "properties": {}})
 
 
 class _FakeAuthProvider:
@@ -144,45 +145,136 @@ class TestTriggerOAuth:
 
 
 class TestDoMcpAuthWiring:
-    def test_do_mcp_auth_registers_tools_and_rebuilds(self, monkeypatch):
-        # drive _AgentSession._do_mcp_auth with a fake runtime + registry
+    """_do_mcp_auth is now ASYNC (B1): it awaits rt.submit(trigger_oauth_async)
+    so the main loop stays responsive during the 300s browser wait, then
+    registers tools + wires handlers (M1) + rebuilds on the main loop."""
+
+    def _run_auth(self, result_dict, *, pending=None):
+        import asyncio
+        import concurrent.futures
+
         from src.server.agent_server import _AgentSession
 
-        registered = []
-        rebuilt = []
-        newtool = _tool("mcp__gh__do_thing")
+        registered, rebuilt, wired, replies = [], [], [], []
+
+        def _submit(coro):
+            f = concurrent.futures.Future()
+            f.set_result(result_dict)  # the fake resolves immediately
+            return f
 
         rt = SimpleNamespace(
-            trigger_oauth=lambda name: {"ok": True, "tools": [newtool]},
-            pending_auth=lambda: [],
+            submit=_submit,
+            trigger_oauth_async=lambda name: None,  # coro arg; fake submit ignores it
+            pending_auth=lambda: (pending or []),
         )
-        reg = SimpleNamespace(register=lambda t: registered.append(t.name))
-        replies = []
+        reg = SimpleNamespace(register=lambda t: registered.append(getattr(t, "name", t)))
         stub = SimpleNamespace(
             _mcp_runtime=rt, tool_registry=reg,
-            _reply=lambda rid, payload: replies.append(payload),
+            _reply=lambda rid, p: replies.append(p),
             _rebuild_base_prompt_for_mcp=lambda: rebuilt.append(True),
+            _wire_mcp_client_handlers=lambda rt_, cl, nm: wired.append(nm),
         )
-        _AgentSession._do_mcp_auth(stub, "r1", "gh")
+        asyncio.run(_AgentSession._do_mcp_auth(stub, "r1", "gh"))
+        return registered, rebuilt, wired, replies
+
+    def test_is_coroutine(self):
+        # B1: must be awaitable (the dispatch awaits it) so the main loop yields
+        import inspect
+
+        from src.server.agent_server import _AgentSession
+        assert inspect.iscoroutinefunction(_AgentSession._do_mcp_auth)
+
+    def test_success_registers_wires_rebuilds(self):
+        newtool = _tool("mcp__gh__do_thing")
+        registered, rebuilt, wired, replies = self._run_auth(
+            {"ok": True, "tools": [newtool], "client": object()})
         assert registered == ["mcp__gh__do_thing"]  # new tool registered live
-        assert rebuilt == [True]                     # prompt rebuilt (instructions surface)
+        assert wired == ["gh"]                        # M1: handlers wired on the client
+        assert rebuilt == [True]                      # prompt rebuilt (instructions surface)
         assert replies[0]["ok"] is True
 
-    def test_do_mcp_auth_failure_no_register(self, monkeypatch):
-        from src.server.agent_server import _AgentSession
-
-        registered = []
-        rt = SimpleNamespace(
-            trigger_oauth=lambda name: {"ok": False, "error": "nope"},
-            pending_auth=lambda: ["gh"],
-        )
-        reg = SimpleNamespace(register=lambda t: registered.append(t))
-        replies = []
-        stub = SimpleNamespace(
-            _mcp_runtime=rt, tool_registry=reg,
-            _reply=lambda rid, payload: replies.append(payload),
-            _rebuild_base_prompt_for_mcp=lambda: None,
-        )
-        _AgentSession._do_mcp_auth(stub, "r1", "gh")
-        assert registered == []  # nothing registered on failure
+    def test_failure_no_register_no_wire(self):
+        registered, rebuilt, wired, replies = self._run_auth(
+            {"ok": False, "error": "nope"}, pending=["gh"])
+        assert registered == [] and wired == [] and rebuilt == []
         assert replies[0]["ok"] is False and replies[0]["pending_auth"] == ["gh"]
+
+
+class TestWireMcpClientHandlers:
+    """M1: a late-authed client gets elicitation + (capability-gated)
+    list_changed handlers, matching the boot path."""
+
+    def test_wires_elicitation_and_gated_list_changed(self, monkeypatch):
+        from src.server import agent_server as mod
+
+        set_elic, set_notif = [], []
+        client = SimpleNamespace(
+            set_elicitation_handler=lambda h: set_elic.append(h),
+            set_notification_handler=lambda h: set_notif.append(h),
+            capabilities=SimpleNamespace(tools_list_changed=True),
+        )
+        monkeypatch.setattr(mod, "_make_elicitation_handler", lambda sess: "elic")
+        monkeypatch.setattr(mod, "_make_mcp_notification_handler",
+                            lambda rt, sess, name: "notif")
+        stub = SimpleNamespace()
+        mod._AgentSession._wire_mcp_client_handlers(stub, object(), client, "gh")
+        assert set_elic == ["elic"]           # elicitation always wired
+        assert set_notif == ["notif"]         # list_changed wired (capability advertised)
+
+    def test_list_changed_skipped_without_capability(self, monkeypatch):
+        from src.server import agent_server as mod
+
+        set_notif = []
+        client = SimpleNamespace(
+            set_elicitation_handler=lambda h: None,
+            set_notification_handler=lambda h: set_notif.append(h),
+            capabilities=SimpleNamespace(tools_list_changed=False),
+        )
+        monkeypatch.setattr(mod, "_make_elicitation_handler", lambda sess: "elic")
+        monkeypatch.setattr(mod, "_make_mcp_notification_handler",
+                            lambda rt, sess, name: "notif")
+        mod._AgentSession._wire_mcp_client_handlers(SimpleNamespace(), object(), client, "gh")
+        assert set_notif == []  # not advertised → not wired
+
+
+class TestConcurrentTriggerLock:
+    """m1 (coupled to the B1 async fix): concurrent /mcp auth triggers for the
+    same server must not double-register tools / duplicate server_infos. The
+    per-server asyncio.Lock serializes them."""
+
+    def test_concurrent_triggers_register_once(self, monkeypatch):
+        import asyncio
+
+        from src.server.mcp_runtime import McpRuntime
+
+        connected = SimpleNamespace(name="gh", type="connected", instructions="i")
+
+        class _FakeClient:
+            def set_auth_provider(self, p): pass
+            async def connect(self, name, scoped): return connected
+            async def list_tools(self): return [_tool("do_thing")]
+            async def close(self): pass
+
+        monkeypatch.setattr("src.services.mcp.client.McpClient", _FakeClient)
+
+        rt = McpRuntime()
+        rt._auth_provider = _FakeAuthProvider(succeed=True)
+        rt.needs_auth = [{"name": "gh", "auth_url": "x", "scoped": _scoped()}]
+        # _wrap captures self._loop for later dispatch; give it a throwaway loop
+        rt._loop = asyncio.new_event_loop()
+
+        async def go():
+            return await asyncio.gather(
+                rt.trigger_oauth_async("gh", open_browser=False),
+                rt.trigger_oauth_async("gh", open_browser=False),
+            )
+
+        try:
+            r1, r2 = asyncio.run(go())
+        finally:
+            rt._loop.close()
+        # exactly one promotion despite two concurrent triggers
+        assert len(rt.tools) == 1, f"double-registered: {len(rt.tools)}"
+        assert len(rt.server_infos) == 1
+        assert rt.pending_auth() == []
+        assert (r1["ok"], r2["ok"]) == (True, True)

--- a/tests/test_mcp_auth_flow.py
+++ b/tests/test_mcp_auth_flow.py
@@ -1,0 +1,188 @@
+"""Chapter C4 — make OAuth MCP servers reachable.
+
+The live McpRuntime path created McpClient() with NO auth_provider, so an
+OAuth server's needs-auth could never be detected — connect() failed silently
+and the machinery (trigger_oauth in the parallel, non-live MCPConnectionManager)
+was unreachable. These execute McpRuntime.start() + trigger_oauth against fakes
+and pin: needs-auth retained (not dropped), the runtime kept alive for the
+trigger, the OAuth flow → reconnect → tools promoted, and the _do_mcp_auth
+wiring (register tools + rebuild prompt).
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _scoped(url="https://mcp.example.com", enabled=True):
+    return SimpleNamespace(
+        config=SimpleNamespace(url=url, enabled=enabled, auth_server_metadata_url=None),
+        scope="user",
+    )
+
+
+def _tool(name="do_thing"):
+    return SimpleNamespace(name=name, description="d",
+                           inputSchema={"type": "object", "properties": {}})
+
+
+class _FakeAuthProvider:
+    def __init__(self, *, succeed=True):
+        self._succeed = succeed
+        self.acquire_calls = []
+
+    async def acquire_token(self, *, server_name, server_url, **kw):
+        self.acquire_calls.append(server_name)
+        if self._succeed:
+            return SimpleNamespace(success=True, token="tok", error=None)
+        return SimpleNamespace(success=False, token=None, error="user cancelled")
+
+
+class TestNeedsAuthRetention:
+    def _runtime(self, monkeypatch, connect_type, *, auth=None):
+        from src.server import mcp_runtime as mod
+
+        info = SimpleNamespace(name="gh", type=connect_type,
+                              auth_url="https://auth.example/x", instructions="use me")
+
+        class _FakeClient:
+            def set_auth_provider(self, p): self._p = p
+            async def connect(self, name, scoped): return info
+            async def list_tools(self): return [_tool()]
+            async def close(self): pass
+
+        monkeypatch.setattr("src.services.mcp.config.get_all_mcp_configs",
+                            lambda: {"gh": _scoped()})
+        monkeypatch.setattr("src.services.mcp.client.McpClient", _FakeClient)
+        if auth is not None:
+            monkeypatch.setattr(mod, "McpAuthProvider", lambda: auth, raising=False)
+            monkeypatch.setattr("src.services.mcp.auth_provider.McpAuthProvider",
+                                lambda: auth)
+        rt = mod.McpRuntime()
+        return rt
+
+    def test_needs_auth_retained_not_dropped(self, monkeypatch):
+        rt = self._runtime(monkeypatch, "needs-auth", auth=_FakeAuthProvider())
+        try:
+            assert rt.start() is True  # kept alive despite 0 tools
+            assert rt.pending_auth() == ["gh"]
+            assert rt.tools == []  # no list_tools for a needs-auth server
+        finally:
+            rt.shutdown()
+
+    def test_connected_still_works(self, monkeypatch):
+        rt = self._runtime(monkeypatch, "connected", auth=_FakeAuthProvider())
+        try:
+            assert rt.start() is True
+            assert rt.pending_auth() == []
+            assert len(rt.tools) == 1
+            assert [s.name for s in rt.server_infos] == ["gh"]
+        finally:
+            rt.shutdown()
+
+
+class TestTriggerOAuth:
+    def _runtime_needing_auth(self, monkeypatch, auth):
+        from src.server import mcp_runtime as mod
+
+        needs = SimpleNamespace(name="gh", type="needs-auth",
+                               auth_url="https://auth/x", instructions="use me")
+        connected = SimpleNamespace(name="gh", type="connected", instructions="use me")
+        state = {"authed": False}
+
+        class _FakeClient:
+            def set_auth_provider(self, p): self._p = p
+            async def connect(self, name, scoped):
+                return connected if state["authed"] else needs
+            async def list_tools(self): return [_tool("do_thing")]
+            async def close(self): pass
+
+        monkeypatch.setattr("src.services.mcp.config.get_all_mcp_configs",
+                            lambda: {"gh": _scoped()})
+        monkeypatch.setattr("src.services.mcp.client.McpClient", _FakeClient)
+        monkeypatch.setattr("src.services.mcp.auth_provider.McpAuthProvider",
+                            lambda: auth)
+        rt = mod.McpRuntime()
+        rt.start()
+        return rt, state
+
+    def test_trigger_success_reconnects_and_registers(self, monkeypatch):
+        auth = _FakeAuthProvider(succeed=True)
+        rt, state = self._runtime_needing_auth(monkeypatch, auth)
+        try:
+            assert rt.pending_auth() == ["gh"]
+            state["authed"] = True  # after auth, connect() returns connected
+            result = rt.trigger_oauth("gh", open_browser=False)
+            assert result["ok"] is True
+            assert auth.acquire_calls == ["gh"]
+            assert rt.pending_auth() == []  # promoted out of needs_auth
+            assert len(rt.tools) == 1
+            assert [s.name for s in rt.server_infos] == ["gh"]  # instructions now live
+        finally:
+            rt.shutdown()
+
+    def test_trigger_auth_failure_stays_pending(self, monkeypatch):
+        auth = _FakeAuthProvider(succeed=False)
+        rt, state = self._runtime_needing_auth(monkeypatch, auth)
+        try:
+            result = rt.trigger_oauth("gh", open_browser=False)
+            assert result["ok"] is False and "cancel" in result["error"].lower()
+            assert rt.pending_auth() == ["gh"]  # still awaiting
+            assert rt.tools == []
+        finally:
+            rt.shutdown()
+
+    def test_trigger_unknown_server(self, monkeypatch):
+        auth = _FakeAuthProvider()
+        rt, _ = self._runtime_needing_auth(monkeypatch, auth)
+        try:
+            result = rt.trigger_oauth("nonexistent", open_browser=False)
+            assert result["ok"] is False and "awaiting" in result["error"].lower()
+        finally:
+            rt.shutdown()
+
+
+class TestDoMcpAuthWiring:
+    def test_do_mcp_auth_registers_tools_and_rebuilds(self, monkeypatch):
+        # drive _AgentSession._do_mcp_auth with a fake runtime + registry
+        from src.server.agent_server import _AgentSession
+
+        registered = []
+        rebuilt = []
+        newtool = _tool("mcp__gh__do_thing")
+
+        rt = SimpleNamespace(
+            trigger_oauth=lambda name: {"ok": True, "tools": [newtool]},
+            pending_auth=lambda: [],
+        )
+        reg = SimpleNamespace(register=lambda t: registered.append(t.name))
+        replies = []
+        stub = SimpleNamespace(
+            _mcp_runtime=rt, tool_registry=reg,
+            _reply=lambda rid, payload: replies.append(payload),
+            _rebuild_base_prompt_for_mcp=lambda: rebuilt.append(True),
+        )
+        _AgentSession._do_mcp_auth(stub, "r1", "gh")
+        assert registered == ["mcp__gh__do_thing"]  # new tool registered live
+        assert rebuilt == [True]                     # prompt rebuilt (instructions surface)
+        assert replies[0]["ok"] is True
+
+    def test_do_mcp_auth_failure_no_register(self, monkeypatch):
+        from src.server.agent_server import _AgentSession
+
+        registered = []
+        rt = SimpleNamespace(
+            trigger_oauth=lambda name: {"ok": False, "error": "nope"},
+            pending_auth=lambda: ["gh"],
+        )
+        reg = SimpleNamespace(register=lambda t: registered.append(t))
+        replies = []
+        stub = SimpleNamespace(
+            _mcp_runtime=rt, tool_registry=reg,
+            _reply=lambda rid, payload: replies.append(payload),
+            _rebuild_base_prompt_for_mcp=lambda: None,
+        )
+        _AgentSession._do_mcp_auth(stub, "r1", "gh")
+        assert registered == []  # nothing registered on failure
+        assert replies[0]["ok"] is False and replies[0]["pending_auth"] == ["gh"]

--- a/tests/test_mcp_auth_flow.py
+++ b/tests/test_mcp_auth_flow.py
@@ -34,6 +34,10 @@ class _FakeAuthProvider:
         self.acquire_calls = []
 
     async def acquire_token(self, *, server_name, server_url, **kw):
+        import asyncio
+        await asyncio.sleep(0)  # yield inside the critical section so a
+        # concurrent trigger actually races for the per-server lock (so the
+        # concurrency test PROVES the lock, not just the re-check — c4-critic nit)
         self.acquire_calls.append(server_name)
         if self._succeed:
             return SimpleNamespace(success=True, token="tok", error=None)

--- a/tests/test_mcp_instructions_live_wiring.py
+++ b/tests/test_mcp_instructions_live_wiring.py
@@ -116,6 +116,12 @@ class TestRuntimeRetention:
             "src.services.mcp.config.get_all_mcp_configs", lambda: {"srv": scoped}
         )
         monkeypatch.setattr("src.services.mcp.client.McpClient", _FakeClient)
+        # C4: start() now constructs a real McpAuthProvider (which touches the
+        # token-store file) unless patched — keep these retention tests hermetic.
+        monkeypatch.setattr(
+            "src.services.mcp.auth_provider.McpAuthProvider",
+            lambda: SimpleNamespace(get_needs_auth_state=lambda n: None),
+        )
 
         rt = mod.McpRuntime()
         try:
@@ -148,6 +154,12 @@ class TestRuntimeRetention:
             "src.services.mcp.config.get_all_mcp_configs", lambda: {"srv": scoped}
         )
         monkeypatch.setattr("src.services.mcp.client.McpClient", _FakeClient)
+        # C4: start() now constructs a real McpAuthProvider (which touches the
+        # token-store file) unless patched — keep these retention tests hermetic.
+        monkeypatch.setattr(
+            "src.services.mcp.auth_provider.McpAuthProvider",
+            lambda: SimpleNamespace(get_needs_auth_state=lambda n: None),
+        )
 
         rt = mod.McpRuntime()
         try:

--- a/tests/test_mcp_instructions_live_wiring.py
+++ b/tests/test_mcp_instructions_live_wiring.py
@@ -102,6 +102,9 @@ class TestRuntimeRetention:
         )
 
         class _FakeClient:
+            def set_auth_provider(self, provider):  # C4: runtime now injects one
+                pass
+
             async def connect(self, name, scoped):
                 return info
 
@@ -131,6 +134,9 @@ class TestRuntimeRetention:
         )
 
         class _FakeClient:
+            def set_auth_provider(self, provider):  # C4: runtime now injects one
+                pass
+
             async def connect(self, name, scoped):
                 return needs_auth
 


### PR DESCRIPTION
## Summary

Chapter **C4 — make OAuth MCP servers reachable** (the named MCP-auth-flow chapter). The LIVE `McpRuntime` path created `McpClient()` with **no auth_provider**, so an OAuth server's needs-auth was never detected — `connect()` failed silently — and `trigger_oauth` existed only in the parallel, non-live `MCPConnectionManager`. So OAuth MCP servers were entirely unreachable. This wires the live path end-to-end.

- **mcp_runtime.py**: inject one shared `McpAuthProvider` into every client (so `connect()` detects + caches needs-auth); RETAIN needs-auth results (`needs_auth`); keep the runtime alive when a server needs auth. `trigger_oauth_async` (all-await, runs on the runtime loop, per-server `asyncio.Lock`) → acquire_token → reconnect → promote tools; `submit()` (run_coroutine_threadsafe → Future) + a thin sync wrapper; `pending_auth()`.
- **agent_server.py**: surface needs-auth at startup ("Run `/mcp auth <server>`"); a `mcp_auth` control request → **async** `_do_mcp_auth` that `await asyncio.wrap_future(rt.submit(rt.trigger_oauth_async(name)))` — the main loop stays responsive during the 300s browser wait — then registers tools + wires the late-connect handlers + rebuilds the prompt (the C2 late-connect note). `_wire_mcp_client_handlers` (elicitation + capability-gated list_changed).

## Critic rounds (2)
- R1 REVISE: **B1** (blocking) — the trigger froze the agent-server main loop for up to 300s (non-interruptible); **M1** — late-authed servers missed elicitation/list_changed wiring; **m1** — no per-server lock; m2/m3 test fidelity.
- R2 **APPROVE** — "all findings resolved... exactly the fix direction, cleanly executed." The concurrency test hardened to actually prove the lock (verified it fails when the lock is neutered).

## Verification
`tests/test_mcp_auth_flow.py` (11): needs-auth retained/kept-alive, trigger success→reconnect→promote, auth-failure stays-pending, unknown server, async `_do_mcp_auth` (is-coroutine + the submit/wrap_future seam), M1 handler wiring (elicitation always + list_changed gated/skipped), the per-server lock (racing fakes). Full suite at the 6-failure baseline (8045 passed). Security verified clean (auth_url pre-redacted; only server names surfaced; tokens keyring-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
