### PR TITLE
feat(bash): notify on background-bash completion (C5 Part 1)

### DIFF
--- a/src/tasks/local_shell.py
+++ b/src/tasks/local_shell.py
@@ -137,7 +137,28 @@ class LocalShellTask:
         if proc is None:
             return
         if proc.poll() is not None:
+            # Already dead → let the reaper deliver a natural completion
+            # notification (TS killTask gates on status === 'running',
+            # killShellTasks.ts:38-44).
             return
+        # Mark status='killed' + notified=True BEFORE the signal (TS killTask).
+        # This is the PRODUCTION kill path (TaskStop → stop_task → this), so the
+        # mark must live here — not in stop_background_bash, which stop_task
+        # only reaches AFTER the first SIGTERM has often already killed the
+        # process (its proc.poll() gate then bails before marking). Marking
+        # BEFORE os.killpg also closes the reaper-vs-killer race: the reaper is
+        # blocked in proc.wait() and cannot wake until the signal is delivered,
+        # by which point notified=True is committed — so the reaper's
+        # enqueue_shell_notification no-ops instead of sending a spurious
+        # "failed with exit code -15" (critic C5-P1 #3, reproduced 8/8).
+        from dataclasses import replace as _replace
+
+        def _mark_killed(prev: Any) -> Any:
+            if isinstance(prev, LocalShellTaskState):
+                return _replace(prev, status="killed", notified=True)
+            return prev
+
+        registry.update(task_id, _mark_killed)
         try:
             os.killpg(os.getpgid(proc.pid), 15)
         except (ProcessLookupError, PermissionError):

--- a/src/tool_system/tools/bash/background.py
+++ b/src/tool_system/tools/bash/background.py
@@ -175,7 +175,27 @@ def spawn_background_bash(
                     registry=context.runtime_tasks,
                 )
             except Exception:  # noqa: BLE001 — notification must not break reaping
-                pass
+                # FALLBACK: if the enqueue raised, the terminal state is still
+                # notified=False and the eviction sweeper (which keeps
+                # un-notified terminal tasks) would leak it forever. Mark it
+                # notified so it stays evictable — degrading to the OLD
+                # behavior (evictable, unsent) rather than a leak. This is
+                # strictly better than the pre-C5 silent-drop.
+                import logging as _logging
+                _logging.getLogger(__name__).debug(
+                    "[bg] shell completion notification failed", exc_info=True
+                )
+                try:
+                    from dataclasses import replace as _replace
+
+                    def _force_notified(prev: Any) -> Any:
+                        if isinstance(prev, LocalShellTaskState) and not prev.notified:
+                            return _replace(prev, notified=True)
+                        return prev
+
+                    context.runtime_tasks.update(task_id, _force_notified)
+                except Exception:  # noqa: BLE001
+                    pass
             # Mirror to the legacy dict in lockstep so old readers see the
             # exit code without round-tripping through runtime_tasks. The
             # legacy dict carries the chapter-10 status string too — older

--- a/src/tool_system/tools/bash/background.py
+++ b/src/tool_system/tools/bash/background.py
@@ -341,18 +341,10 @@ def stop_background_bash(context: ToolContext, task_id: str) -> bool:
     proc: subprocess.Popen | None = entry.get("_proc")
     if proc is None or proc.poll() is not None:
         return False
-    try:
-        # Kill the whole process group started with ``start_new_session=True``
-        # so that ``bash -lc "cmd"`` and any children terminate together.
-        os.killpg(os.getpgid(proc.pid), 15)
-    except (ProcessLookupError, PermissionError):
-        return False
-    # Atomically mark status='killed' + notified=True (TS killTask,
-    # killShellTasks.ts:38-44). Setting notified=True SUPPRESSES the reaper's
-    # later enqueue_shell_notification (it no-ops on notified=True), so a
-    # user-killed bg bash produces NO completion notification — instead of the
-    # spurious "failed with exit code N" the reaper would otherwise send
-    # (critic C5-P1 #3). _patch preserves an existing 'killed' status.
+    # Mark status='killed' + notified=True BEFORE the signal (defense-in-depth;
+    # the PRIMARY mark is in LocalShellTask.kill, the production path). Marking
+    # first suppresses the reaper's spurious "failed" notification and closes
+    # the reaper-vs-killer race (critic C5-P1 #3).
     try:
         from dataclasses import replace as _replace
 
@@ -362,6 +354,12 @@ def stop_background_bash(context: ToolContext, task_id: str) -> bool:
             return prev
 
         context.runtime_tasks.update(task_id, _mark_killed)
-    except Exception:  # noqa: BLE001 — the SIGTERM already succeeded
+    except Exception:  # noqa: BLE001
         pass
+    try:
+        # Kill the whole process group started with ``start_new_session=True``
+        # so that ``bash -lc "cmd"`` and any children terminate together.
+        os.killpg(os.getpgid(proc.pid), 15)
+    except (ProcessLookupError, PermissionError):
+        return False
     return True

--- a/src/tool_system/tools/bash/background.py
+++ b/src/tool_system/tools/bash/background.py
@@ -141,7 +141,14 @@ def spawn_background_bash(
                 from dataclasses import replace
 
                 from src.tasks.eviction import schedule_eviction
-                new_status = "completed" if rc == 0 else "failed"
+                # Preserve a 'killed' status set by stop_background_bash (a
+                # user kill) — don't reclassify it as 'failed' from the SIGTERM
+                # exit code (critic C5-P1 #3). Its notified=True (set at kill)
+                # also makes the enqueue below a no-op.
+                new_status = (
+                    "killed" if getattr(prev, "status", None) == "killed"
+                    else ("completed" if rc == 0 else "failed")
+                )
                 # C5 Part 1: terminal state is left ``notified=False`` — the
                 # forward-trap ``notified=True`` (which pre-suppressed any
                 # completion notification, per the ch10 WI-2 comment) is
@@ -173,6 +180,8 @@ def spawn_background_bash(
                     status="completed" if rc == 0 else "failed",
                     output_file=str(output_path),
                     registry=context.runtime_tasks,
+                    exit_code=rc,
+                    tool_use_id=getattr(context, "tool_use_id", None),
                 )
             except Exception:  # noqa: BLE001 — notification must not break reaping
                 # FALLBACK: if the enqueue raised, the terminal state is still
@@ -338,4 +347,21 @@ def stop_background_bash(context: ToolContext, task_id: str) -> bool:
         os.killpg(os.getpgid(proc.pid), 15)
     except (ProcessLookupError, PermissionError):
         return False
+    # Atomically mark status='killed' + notified=True (TS killTask,
+    # killShellTasks.ts:38-44). Setting notified=True SUPPRESSES the reaper's
+    # later enqueue_shell_notification (it no-ops on notified=True), so a
+    # user-killed bg bash produces NO completion notification — instead of the
+    # spurious "failed with exit code N" the reaper would otherwise send
+    # (critic C5-P1 #3). _patch preserves an existing 'killed' status.
+    try:
+        from dataclasses import replace as _replace
+
+        def _mark_killed(prev: Any) -> Any:
+            if isinstance(prev, LocalShellTaskState):
+                return _replace(prev, status="killed", notified=True)
+            return prev
+
+        context.runtime_tasks.update(task_id, _mark_killed)
+    except Exception:  # noqa: BLE001 — the SIGTERM already succeeded
+        pass
     return True

--- a/src/tool_system/tools/bash/background.py
+++ b/src/tool_system/tools/bash/background.py
@@ -142,32 +142,40 @@ def spawn_background_bash(
 
                 from src.tasks.eviction import schedule_eviction
                 new_status = "completed" if rc == 0 else "failed"
+                # C5 Part 1: terminal state is left ``notified=False`` — the
+                # forward-trap ``notified=True`` (which pre-suppressed any
+                # completion notification, per the ch10 WI-2 comment) is
+                # REMOVED. enqueue_shell_notification below atomically sets
+                # notified=True AND sends (TS framework.ts:289 +
+                # BashTool/prompt.ts:285-287 "you will be notified when it
+                # completes"). The eviction sweeper's notify-before-evict guard
+                # (eviction.py:97) now correctly keeps the entry until the
+                # notification is delivered, then reclaims it.
                 terminal = replace(
                     prev,
                     exit_code=rc,
                     finished_at=finished_at,
                     end_time=finished_at,
                     status=new_status,
-                    # ch10 round-4 WI-2 — a background bash task has no async
-                    # completion notification (it is polled via TaskOutput),
-                    # so mark it ``notified`` on the terminal transition;
-                    # otherwise the eviction sweeper's notify-before-evict
-                    # guard would keep it forever. The grace period
-                    # (PANEL_GRACE_SECONDS) still gives the model time to read
-                    # the output before the entry is reclaimed. Without this
-                    # (and the schedule_eviction below) terminal bash tasks
-                    # accumulated unbounded and lingered in /tasks.
-                    # FORWARD-TRAP (critic m1): this unconditionally marks
-                    # notified. If a bash completion notification is later
-                    # ported (TS enqueueShellNotification), REMOVE this line —
-                    # otherwise the check-and-set here pre-suppresses that
-                    # notification. Semantically analogous to TS
-                    # markTaskNotified today (marks notified WITHOUT sending).
-                    notified=True,
                 )
                 return schedule_eviction(terminal)
 
             context.runtime_tasks.update(task_id, _patch)
+            # Deliver the completion notification (C5 Part 1): atomically
+            # check-and-set notified + enqueue. A no-op if already notified
+            # (e.g. a TaskStop already delivered), so it's duplicate-safe.
+            try:
+                from src.utils.task_notification import enqueue_shell_notification
+
+                enqueue_shell_notification(
+                    task_id=task_id,
+                    description=description or command,
+                    status="completed" if rc == 0 else "failed",
+                    output_file=str(output_path),
+                    registry=context.runtime_tasks,
+                )
+            except Exception:  # noqa: BLE001 — notification must not break reaping
+                pass
             # Mirror to the legacy dict in lockstep so old readers see the
             # exit code without round-tripping through runtime_tasks. The
             # legacy dict carries the chapter-10 status string too — older

--- a/src/utils/task_notification.py
+++ b/src/utils/task_notification.py
@@ -50,6 +50,60 @@ def _build_summary(description: str, status: NotificationStatus, error: str | No
     return f'Agent "{description}" was stopped'
 
 
+#: Prefix identifying a background-bash summary to the UI collapse transform
+#: ("N background commands completed"). TS
+#: LocalShellTask.tsx:22-23,131-133 keys the collapse on this exact string.
+BACKGROUND_BASH_SUMMARY_PREFIX = "Background command "
+
+
+def _build_shell_summary(
+    description: str, status: NotificationStatus, exit_code: int | None
+) -> str:
+    """Mirror TS ``enqueueShellNotification`` (LocalShellTask.tsx:145-157):
+    ``Background command "<desc>" completed (exit code N)`` /
+    ``... failed with exit code N`` / ``... was stopped`` (killed). The exit
+    code is included only when known (TS's ``exitCode !== undefined``)."""
+    if status == "completed":
+        tail = f" (exit code {exit_code})" if exit_code is not None else ""
+        return f'{BACKGROUND_BASH_SUMMARY_PREFIX}"{description}" completed{tail}'
+    if status == "failed":
+        tail = f" with exit code {exit_code}" if exit_code is not None else ""
+        return f'{BACKGROUND_BASH_SUMMARY_PREFIX}"{description}" failed{tail}'
+    return f'{BACKGROUND_BASH_SUMMARY_PREFIX}"{description}" was stopped'
+
+
+def build_shell_notification_xml(
+    *,
+    task_id: str,
+    description: str,
+    status: NotificationStatus,
+    output_file: str,
+    exit_code: int | None = None,
+    tool_use_id: str | None = None,
+) -> str:
+    """The ``<task-notification>`` envelope for a background BASH task
+    (LocalShellTask.tsx:160-166). Unlike the agent builder, the summary is
+    XML-ESCAPED — a bg command routinely contains ``< > & |`` (and ``_reap``
+    uses ``description or command``), so a raw summary would produce a
+    malformed envelope. Pure function (no mutation/enqueue)."""
+    from xml.sax.saxutils import escape as _xml_escape
+
+    summary = _xml_escape(_build_shell_summary(description, status, exit_code))
+    tool_use_line = (
+        f"\n<{TOOL_USE_ID_TAG}>{tool_use_id}</{TOOL_USE_ID_TAG}>"
+        if tool_use_id
+        else ""
+    )
+    return (
+        f"<{TASK_NOTIFICATION_TAG}>\n"
+        f"<{TASK_ID_TAG}>{task_id}</{TASK_ID_TAG}>{tool_use_line}\n"
+        f"<{OUTPUT_FILE_TAG}>{output_file}</{OUTPUT_FILE_TAG}>\n"
+        f"<{STATUS_TAG}>{status}</{STATUS_TAG}>\n"
+        f"<{SUMMARY_TAG}>{summary}</{SUMMARY_TAG}>\n"
+        f"</{TASK_NOTIFICATION_TAG}>"
+    )
+
+
 def build_task_notification_xml(
     *,
     task_id: str,
@@ -171,7 +225,8 @@ def enqueue_shell_notification(
     status: NotificationStatus,
     output_file: str,
     registry: "RuntimeTaskRegistry",
-    error: str | None = None,
+    exit_code: int | None = None,
+    tool_use_id: str | None = None,
 ) -> bool:
     """Atomically check-and-set ``notified`` on a background BASH task, then
     enqueue its completion notification.
@@ -203,12 +258,13 @@ def enqueue_shell_notification(
     if not should_enqueue:
         return False
 
-    xml = build_task_notification_xml(
+    xml = build_shell_notification_xml(
         task_id=task_id,
         description=description,
         status=status,
         output_file=output_file,
-        error=error,
+        exit_code=exit_code,
+        tool_use_id=tool_use_id,
     )
     enqueue_pending_notification(value=xml, mode="task-notification")
     return True
@@ -217,6 +273,8 @@ def enqueue_shell_notification(
 __all__ = [
     "NotificationStatus",
     "build_task_notification_xml",
+    "build_shell_notification_xml",
+    "BACKGROUND_BASH_SUMMARY_PREFIX",
     "enqueue_agent_notification",
     "enqueue_shell_notification",
 ]

--- a/src/utils/task_notification.py
+++ b/src/utils/task_notification.py
@@ -164,8 +164,59 @@ def enqueue_agent_notification(
     return True
 
 
+def enqueue_shell_notification(
+    *,
+    task_id: str,
+    description: str,
+    status: NotificationStatus,
+    output_file: str,
+    registry: "RuntimeTaskRegistry",
+    error: str | None = None,
+) -> bool:
+    """Atomically check-and-set ``notified`` on a background BASH task, then
+    enqueue its completion notification.
+
+    Port of the TS task-framework notification for background shell tasks
+    (``utils/task/framework.ts:280-289`` enqueues a ``task-notification`` when a
+    task reaches a terminal state; ``BashTool/prompt.ts:285-287`` promises "you
+    will be notified when it completes — do not poll"). The port previously
+    marked the terminal state ``notified=True`` WITHOUT sending (the forward
+    trap in ``background.py``), so a ``run_in_background`` bash finishing while
+    the model was away went unannounced. The check-and-set here is the single
+    duplicate-delivery guard, exactly as ``enqueue_agent_notification`` — but
+    gated on ``LocalShellTaskState`` (the bash task type) instead of
+    ``LocalAgentTaskState``."""
+    from src.tasks.local_shell import LocalShellTaskState
+
+    should_enqueue = False
+
+    def _mark_notified(prev: Any) -> Any:
+        nonlocal should_enqueue
+        if not isinstance(prev, LocalShellTaskState):
+            return prev
+        if prev.notified:
+            return prev
+        should_enqueue = True
+        return replace(prev, notified=True)
+
+    registry.update(task_id, _mark_notified)
+    if not should_enqueue:
+        return False
+
+    xml = build_task_notification_xml(
+        task_id=task_id,
+        description=description,
+        status=status,
+        output_file=output_file,
+        error=error,
+    )
+    enqueue_pending_notification(value=xml, mode="task-notification")
+    return True
+
+
 __all__ = [
     "NotificationStatus",
     "build_task_notification_xml",
     "enqueue_agent_notification",
+    "enqueue_shell_notification",
 ]

--- a/tests/test_shell_completion_notification.py
+++ b/tests/test_shell_completion_notification.py
@@ -83,3 +83,102 @@ def test_wrong_task_type_not_notified():
     )
     assert sent is False  # not a LocalShellTaskState → no-op
     assert reg.state.notified is False
+
+
+class TestSummaryContent:
+    """critic C5-P1 #1/#2: the model-facing summary must be shell-specific
+    ("Background command"), carry the exit code, and be XML-escaped."""
+
+    def test_completed_summary_has_prefix_and_exit_code(self):
+        from src.utils.task_notification import build_shell_notification_xml
+        x = build_shell_notification_xml(
+            task_id="b1", description="run tests", status="completed",
+            output_file="/tmp/b1.log", exit_code=0)
+        assert '<summary>Background command "run tests" completed (exit code 0)</summary>' in x
+        assert "Agent" not in x  # not the agent builder
+
+    def test_failed_summary_has_exit_code_not_unknown_error(self):
+        from src.utils.task_notification import build_shell_notification_xml
+        x = build_shell_notification_xml(
+            task_id="b2", description="build", status="failed",
+            output_file="/tmp/b2.log", exit_code=1)
+        assert '"build" failed with exit code 1' in x
+        assert "Unknown error" not in x
+
+    def test_killed_summary(self):
+        from src.utils.task_notification import build_shell_notification_xml
+        x = build_shell_notification_xml(
+            task_id="b3", description="server", status="killed",
+            output_file="/tmp/b3.log")
+        assert '"server" was stopped' in x
+
+    def test_metachars_escaped(self):
+        # #2: a bg command with < > & must not produce a malformed envelope
+        from src.utils.task_notification import build_shell_notification_xml
+        x = build_shell_notification_xml(
+            task_id="b4", description="cat <in >out && echo hi", status="completed",
+            output_file="/tmp/b4.log", exit_code=0)
+        assert "&lt;in &gt;out &amp;&amp;" in x
+        assert "<in >out" not in x  # raw metachars would break the XML
+
+
+class TestSpawnReapIntegration:
+    """critic #4: a REAL spawn_background_bash → reap → notification, not just
+    the unit builder."""
+
+    def test_bg_bash_completion_notifies_the_model(self, tmp_path):
+        import time
+        from pathlib import Path
+
+        from src.tool_system.context import ToolContext, ToolUseOptions
+        from src.tool_system.tools.bash.background import spawn_background_bash
+
+        clear_pending_notifications()
+        ctx = ToolContext(workspace_root=tmp_path)
+        ctx.options = ToolUseOptions(tools=[])
+        out = spawn_background_bash(
+            command="exit 3", cwd=Path(str(tmp_path)),
+            description="quick fail", context=ctx,
+        )
+        task_id = out["backgroundTaskId"]
+        # wait for the reap thread to deliver
+        for _ in range(100):
+            if peek_pending_notifications():
+                break
+            time.sleep(0.05)
+        q = peek_pending_notifications()
+        assert q, "no completion notification delivered"
+        joined = "\n".join(str(n) for n in q)
+        assert 'Background command "quick fail" failed with exit code 3' in joined
+        clear_pending_notifications()
+
+
+class TestKillSuppressesNotification:
+    """critic #3: a user kill (stop_background_bash) sets notified=True, so the
+    reaper sends NO notification — matching TS killTask."""
+
+    def test_kill_marks_killed_and_notified(self, tmp_path):
+        import time
+        from pathlib import Path
+
+        from src.tool_system.context import ToolContext, ToolUseOptions
+        from src.tool_system.tools.bash.background import (
+            spawn_background_bash,
+            stop_background_bash,
+        )
+
+        clear_pending_notifications()
+        ctx = ToolContext(workspace_root=tmp_path)
+        ctx.options = ToolUseOptions(tools=[])
+        out = spawn_background_bash(
+            command="sleep 30", cwd=Path(str(tmp_path)),
+            description="long job", context=ctx,
+        )
+        task_id = out["backgroundTaskId"]
+        assert stop_background_bash(ctx, task_id) is True
+        st = ctx.runtime_tasks.get(task_id)
+        assert st is not None and st.status == "killed" and st.notified is True
+        # give the reaper a moment; it must NOT send a notification (notified=True)
+        time.sleep(0.3)
+        assert peek_pending_notifications() == [], "kill produced a spurious notification"
+        clear_pending_notifications()

--- a/tests/test_shell_completion_notification.py
+++ b/tests/test_shell_completion_notification.py
@@ -1,0 +1,85 @@
+"""Chapter C5 Part 1 — background-bash completion notification.
+
+TS notifies when a run_in_background bash task reaches a terminal state
+(utils/task/framework.ts:289 + BashTool/prompt.ts:285-287 "you will be
+notified when it completes — do not poll"). The port marked the terminal
+state notified=True WITHOUT sending (the forward-trap) → a bg bash finishing
+while the model was away went unannounced. enqueue_shell_notification closes
+it: atomic check-and-set on LocalShellTaskState + enqueue, duplicate-safe.
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.tasks.local_shell import LocalShellTaskState
+from src.utils.message_queue_manager import (
+    clear_pending_notifications,
+    peek_pending_notifications,
+)
+from src.utils.task_notification import enqueue_shell_notification
+
+
+class _Registry:
+    """Minimal RuntimeTaskRegistry-shaped stub: update(id, mutator)."""
+    def __init__(self, state):
+        self._states = {state.id: state}
+
+    def update(self, task_id, mutator):
+        cur = self._states.get(task_id)
+        if cur is not None:
+            self._states[task_id] = mutator(cur)
+
+    def get(self, task_id):
+        return self._states.get(task_id)
+
+
+@pytest.fixture(autouse=True)
+def _clean_queue():
+    clear_pending_notifications()
+    yield
+    clear_pending_notifications()
+
+
+def _shell(task_id="b1", notified=False):
+    return LocalShellTaskState(
+        id=task_id, description="run tests", command="pytest",
+        output_path=f"/tmp/{task_id}.log", output_file=f"/tmp/{task_id}.log",
+        status="completed", exit_code=0, notified=notified, start_time=0.0,
+    )
+
+
+def test_enqueues_on_terminal_and_marks_notified():
+    reg = _Registry(_shell())
+    sent = enqueue_shell_notification(
+        task_id="b1", description="run tests", status="completed",
+        output_file="/tmp/b1.log", registry=reg,
+    )
+    assert sent is True
+    assert reg.get("b1").notified is True  # check-and-set
+    q = peek_pending_notifications()
+    assert q and any("b1" in str(n) for n in q)  # the completion XML enqueued
+
+
+def test_duplicate_safe_no_second_notification():
+    reg = _Registry(_shell(notified=True))  # already notified (e.g. TaskStop did it)
+    sent = enqueue_shell_notification(
+        task_id="b1", description="run tests", status="completed",
+        output_file="/tmp/b1.log", registry=reg,
+    )
+    assert sent is False
+    assert peek_pending_notifications() == []  # no duplicate
+
+
+def test_wrong_task_type_not_notified():
+    from types import SimpleNamespace
+
+    class _Reg:
+        def __init__(self): self.state = SimpleNamespace(notified=False)
+        def update(self, tid, mut): self.state = mut(self.state)
+    reg = _Reg()
+    sent = enqueue_shell_notification(
+        task_id="x", description="d", status="completed",
+        output_file="/tmp/x.log", registry=reg,
+    )
+    assert sent is False  # not a LocalShellTaskState → no-op
+    assert reg.state.notified is False

--- a/tests/test_shell_completion_notification.py
+++ b/tests/test_shell_completion_notification.py
@@ -157,7 +157,38 @@ class TestKillSuppressesNotification:
     """critic #3: a user kill (stop_background_bash) sets notified=True, so the
     reaper sends NO notification — matching TS killTask."""
 
-    def test_kill_marks_killed_and_notified(self, tmp_path):
+    def test_stop_task_kill_suppresses_notification(self, tmp_path):
+        # THE PRODUCTION PATH (what TaskStop uses): stop_task → LocalShellTask.kill.
+        # The critic reproduced a spurious "failed with exit code -15" 8/8 here
+        # because the mark used to live only in stop_background_bash, which
+        # stop_task bypasses. The mark is now in LocalShellTask.kill BEFORE the
+        # signal → the reaper's notification no-ops.
+        import asyncio
+        import time
+        from pathlib import Path
+
+        from src.tasks.stop_task import stop_task
+        from src.tool_system.context import ToolContext, ToolUseOptions
+        from src.tool_system.tools.bash.background import spawn_background_bash
+
+        clear_pending_notifications()
+        ctx = ToolContext(workspace_root=tmp_path)
+        ctx.options = ToolUseOptions(tools=[])
+        out = spawn_background_bash(
+            command="sleep 30", cwd=Path(str(tmp_path)),
+            description="long job", context=ctx,
+        )
+        task_id = out["backgroundTaskId"]
+        asyncio.run(stop_task(task_id, ctx))
+        st = ctx.runtime_tasks.get(task_id)
+        assert st is not None and st.status == "killed" and st.notified is True
+        time.sleep(0.4)  # let the reaper settle
+        assert peek_pending_notifications() == [], \
+            f"kill produced a spurious notification: {peek_pending_notifications()}"
+        clear_pending_notifications()
+
+    def test_direct_stop_background_bash_also_marks(self, tmp_path):
+        # the defense-in-depth mark in stop_background_bash still works directly
         import time
         from pathlib import Path
 
@@ -178,7 +209,6 @@ class TestKillSuppressesNotification:
         assert stop_background_bash(ctx, task_id) is True
         st = ctx.runtime_tasks.get(task_id)
         assert st is not None and st.status == "killed" and st.notified is True
-        # give the reaper a moment; it must NOT send a notification (notified=True)
         time.sleep(0.3)
-        assert peek_pending_notifications() == [], "kill produced a spurious notification"
+        assert peek_pending_notifications() == []
         clear_pending_notifications()


### PR DESCRIPTION
## Summary

**C5 Part 1 — notify on background-bash completion** (the tools-critic's "do first"; first half of the Monitor-tool chapter). TS notifies when a `run_in_background` bash task reaches a terminal state (`utils/task/framework.ts:289`; `BashTool/prompt.ts:285-287` "you will be notified when it completes — do not poll"). The port marked the terminal state `notified=True` **without sending** — the documented forward-trap in `background.py` (ch10 WI-2) — so a bg bash finishing while the model was away went unannounced.

- **task_notification.py**: `enqueue_shell_notification` (atomic check-and-set on `LocalShellTaskState` + enqueue) + `build_shell_notification_xml` / `_build_shell_summary` — the faithful shell payload (`enqueueShellNotification`, LocalShellTask.tsx:105-172): `Background command "<desc>" completed (exit code N)` / `... failed with exit code N` / `... was stopped`, **XML-escaped** (`escapeXml` parity), exit code only-when-known. `BACKGROUND_BASH_SUMMARY_PREFIX`.
- **background.py**: removed the forward-trap `notified=True`; the reaper calls `enqueue_shell_notification` (exit_code + tool_use_id threaded) — the eviction sweeper's notify-before-evict guard keeps the entry until delivery, then reclaims it. Leak-fallback: force `notified=True` if the enqueue raises.
- **local_shell.py**: `LocalShellTask.kill` now marks `status='killed' + notified=True` **before** `os.killpg` (TS `killTask`) — the production `TaskStop → stop_task → impl.kill` path — so a user kill produces **no** notification (was a spurious "failed"). Race-free (the reaper is blocked in `proc.wait()` until after `notified=True` commits).

## Critic rounds (3)
- R1 REVISE: the plumbing was right but the model-facing payload was wrong — mislabeled "Agent", dropped exit code, "Unknown error", unescaped XML, spurious kill notification.
- R2 REVISE: #3 (kill) still fired 8/8 through the real path — the mark was in `stop_background_bash`, which `stop_task` bypasses.
- **APPROVE** — moved the mark into `LocalShellTask.kill` before the signal: "0/8 on the real path (was 8/8)... race-free... all four findings resolved."

## Verification
`tests/test_shell_completion_notification.py` (10): summary-content snapshots (prefix + exit code + not-"Agent"), metachar XML-escaping, a real `spawn_background_bash → reap` integration (exit 3 → the delivered notification), and a real `stop_task`-driven kill-suppression test. 195 bg/shell/kill/eviction tests green; prior-commit full suites at the 6-failure baseline (8037/8045 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
