### PR TITLE
feat(goals): /goal + /subgoal completion-condition loop (CC docs/en/goal)

### DIFF
--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -289,6 +289,7 @@ def run_headless(options: HeadlessOptions) -> int:
     tool_context.ask_user = _noop_ask_user
 
     # Build the input iterator.
+    goal_mgr = None  # /goal loop state (single-prompt mode only)
     if options.input_format == "stream-json":
         inputs: Iterable[UserInputMessage] = StreamJsonReader(stdin)
     else:
@@ -298,7 +299,85 @@ def run_headless(options: HeadlessOptions) -> int:
         prompt_text = (prompt_text or "").strip()
         if not prompt_text:
             cli_error("error: no prompt provided (pass an argument or pipe stdin)", 2)
+
+        # /goal in -p mode (CC docs/en/goal §Run non-interactively): setting
+        # a goal runs the evaluate-continue loop to completion in this one
+        # invocation. Bare "/goal" and "/goal clear" print and exit —
+        # there's no persisted goal in a fresh -p process to inspect, but
+        # the forms must not be misread as conversation prompts.
+        if prompt_text.startswith("/goal"):
+            goal_arg = prompt_text[len("/goal"):].strip()
+            from src.goals import GoalManager, build_judge_callable
+            from src.goals.command import run_goal_command
+            from src.settings.settings import get_settings, load_settings
+
+            def _goal_set_gate() -> str | None:
+                # CC §Requirements: trusted workspace + hooks enabled, with
+                # the reason stated. Same gates as the agent-server.
+                if not getattr(tool_context, "workspace_trusted", False):
+                    return (
+                        "/goal requires a trusted workspace (the evaluator "
+                        "is part of the hooks system). Run clawcodex "
+                        "interactively once to accept the trust dialog."
+                    )
+                try:
+                    if not load_settings(cwd=str(workspace_root)).hooks.enabled:
+                        return (
+                            "/goal is unavailable because hooks are disabled "
+                            "(settings hooks.enabled=false)."
+                        )
+                except Exception:  # noqa: BLE001 — unreadable settings fail open
+                    pass
+                return None
+
+            try:
+                goal_max_turns = int(
+                    getattr(get_settings(), "goal_max_turns", 0) or 0
+                )
+            except Exception:  # noqa: BLE001
+                goal_max_turns = 0
+            _mgr = GoalManager(
+                session.session_id,
+                **({"default_max_turns": goal_max_turns} if goal_max_turns > 0 else {}),
+                judge=build_judge_callable(provider),
+            )
+            goal_result = run_goal_command(
+                _mgr, goal_arg, set_gate=_goal_set_gate,
+            )
+            if goal_result.kickoff:
+                if goal_result.notice:
+                    print(goal_result.notice, file=stderr)
+                goal_mgr = _mgr
+                prompt_text = goal_result.kickoff
+            else:
+                # status / clear / pause / resume / gate-refusal — print and
+                # exit without running a conversation turn.
+                out = goal_result.text or ""
+                print(out, file=stdout if goal_result.ok else stderr)
+                return 0 if goal_result.ok else 1
+
         inputs = [UserInputMessage(text=prompt_text, raw={"prompt": prompt_text})]
+
+    # /goal continuations are interleaved after the input that spawned them:
+    # the generator drains ``goal_continuations`` before pulling the next
+    # stdin item, so the loop below stays a single linear ``for``.
+    from collections import deque
+
+    goal_continuations: deque[str] = deque()
+
+    def _with_goal_continuations(
+        source: Iterable[UserInputMessage],
+    ) -> Iterable[UserInputMessage]:
+        for item in source:
+            yield item
+            while goal_continuations:
+                yield UserInputMessage(
+                    text=goal_continuations.popleft(),
+                    raw={"goal_continuation": True},
+                )
+
+    if goal_mgr is not None:
+        inputs = _with_goal_continuations(inputs)
 
     writer: StreamJsonWriter | None = None
     if options.output_format == "stream-json":
@@ -501,6 +580,32 @@ def run_headless(options: HeadlessOptions) -> int:
                 if writer is not None:
                     writer.write(AssistantEvent(text=result.response_text))
                 aggregate_text.append(result.response_text)
+
+                # ── /goal post-turn evaluation (single-prompt mode) ──────
+                # Single-threaded here, so the composed evaluate_after_turn
+                # is safe (no locking split needed). Progress goes to stderr
+                # so stdout stays the final answer.
+                if goal_mgr is not None and goal_mgr.is_active():
+                    from src.goals import collect_turn_evidence
+
+                    evidence = collect_turn_evidence(
+                        list(session.conversation.messages)
+                    ) or (result.response_text or "")
+                    tokens_now = int(
+                        usage_total.get("input_tokens", 0)
+                        + usage_total.get("output_tokens", 0)
+                    )
+                    decision = goal_mgr.evaluate_after_turn(
+                        evidence, tokens_now=tokens_now,
+                    )
+                    if decision.get("message"):
+                        print(f"[goal] {decision['message']}", file=stderr)
+                    if decision.get("should_continue") and decision.get(
+                        "continuation_prompt"
+                    ):
+                        goal_continuations.append(
+                            decision["continuation_prompt"]
+                        )
         except (AbortError, KeyboardInterrupt):
             # Cancellation from ANY point in the loop body lands here:
             # * ``AbortError`` from a cooperative unwind inside
@@ -526,6 +631,15 @@ def run_headless(options: HeadlessOptions) -> int:
                 )
     finally:
         restore_sigint()
+
+    # A -p goal run that ends without achieving the condition (budget pause,
+    # evaluator-timeout park, interrupt) exits non-zero so scripts can tell
+    # "loop finished" from "condition met". Achieved goals keep exit 0.
+    if goal_mgr is not None and exit_code == 0:
+        _goal_state = goal_mgr.state
+        if _goal_state is not None and _goal_state.status != "done":
+            print(f"[goal] not achieved: {goal_mgr.status_line()}", file=stderr)
+            exit_code = 1
 
     duration_ms = int((time.monotonic() - start) * 1000)
     final_text = "\n\n".join(t for t in aggregate_text if t).strip()

--- a/src/goals/__init__.py
+++ b/src/goals/__init__.py
@@ -1,0 +1,44 @@
+"""Session goals — the /goal completion-condition loop.
+
+Public surface re-exported from :mod:`src.goals.goals`.
+"""
+
+from src.goals.goals import (
+    CONTINUATION_PROMPT_TEMPLATE,
+    CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE,
+    DEFAULT_GOAL_MAX_TURNS,
+    DEFAULT_JUDGE_MAX_TOKENS,
+    DEFAULT_JUDGE_TIMEOUT_S,
+    GOAL_CLEAR_ALIASES,
+    GOAL_CONDITION_MAX_CHARS,
+    MAX_CONSECUTIVE_PARSE_FAILURES,
+    GoalJudgeTimeout,
+    GoalManager,
+    GoalState,
+    JUDGE_SYSTEM_PROMPT,
+    JUDGE_USER_PROMPT_TEMPLATE,
+    JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE,
+    build_judge_callable,
+    collect_turn_evidence,
+    judge_goal,
+)
+
+__all__ = [
+    "CONTINUATION_PROMPT_TEMPLATE",
+    "CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE",
+    "DEFAULT_GOAL_MAX_TURNS",
+    "DEFAULT_JUDGE_MAX_TOKENS",
+    "DEFAULT_JUDGE_TIMEOUT_S",
+    "GOAL_CLEAR_ALIASES",
+    "GOAL_CONDITION_MAX_CHARS",
+    "MAX_CONSECUTIVE_PARSE_FAILURES",
+    "GoalJudgeTimeout",
+    "GoalManager",
+    "GoalState",
+    "JUDGE_SYSTEM_PROMPT",
+    "JUDGE_USER_PROMPT_TEMPLATE",
+    "JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE",
+    "build_judge_callable",
+    "collect_turn_evidence",
+    "judge_goal",
+]

--- a/src/goals/command.py
+++ b/src/goals/command.py
@@ -1,0 +1,206 @@
+"""/goal + /subgoal subcommand parsing — shared by the agent-server control
+handler and the headless (-p) runner so the two surfaces cannot drift.
+
+The driver supplies the :class:`~src.goals.goals.GoalManager` plus the gate
+callables; this module owns the argument grammar and the user-facing copy.
+
+Claude Code grammar (docs/en/goal):
+
+    /goal                    → status
+    /goal status             → status (undocumented in CC but harmless)
+    /goal clear              → clear (aliases: stop, off, reset, none, cancel)
+    /goal <condition>        → set + kickoff turn
+
+Donor extras (hermes): pause, resume, done (clear alias), /subgoal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+from src.goals.goals import GOAL_CLEAR_ALIASES, GoalManager
+
+
+@dataclass
+class GoalCommandResult:
+    """Outcome of a /goal or /subgoal invocation.
+
+    ``kickoff`` is set only by a successful SET: the condition text the
+    driver must submit as the next user turn (CC: "Setting a goal starts a
+    turn immediately, with the condition itself as the directive").
+    ``notice`` is the system line to show alongside a kickoff.
+    """
+
+    ok: bool
+    text: str = ""
+    notice: str = ""
+    kickoff: Optional[str] = None
+    active: bool = False
+
+
+#: Returns an error string when /goal may not be used, else None.
+GoalGate = Callable[[], Optional[str]]
+
+
+def run_goal_command(
+    mgr: GoalManager,
+    arg: str,
+    *,
+    set_gate: Optional[GoalGate] = None,
+    baseline_tokens: int = 0,
+    baseline_cost_usd: float = 0.0,
+) -> GoalCommandResult:
+    """Execute a ``/goal`` invocation against ``mgr``.
+
+    ``set_gate`` runs only for the SET form (CC gates /goal on workspace
+    trust + hooks enabled and "tells you why instead of silently doing
+    nothing"); status/clear/pause/resume are always allowed so an existing
+    goal can be inspected or stopped even when the gate closes later.
+    """
+    arg = (arg or "").strip()
+    lower = arg.lower()
+
+    if not arg or lower == "status":
+        return GoalCommandResult(
+            ok=True, text=mgr.status_text(), active=mgr.is_active()
+        )
+
+    if lower in GOAL_CLEAR_ALIASES:
+        had = mgr.clear()
+        return GoalCommandResult(
+            ok=True,
+            text="✓ Goal cleared." if had else "No active goal.",
+            active=False,
+        )
+
+    if lower == "pause":
+        state = mgr.pause(reason="user-paused")
+        return GoalCommandResult(
+            ok=True,
+            text=(
+                f"⏸ Goal paused: {state.goal}" if state else "No goal set."
+            ),
+            active=False,
+        )
+
+    if lower == "resume":
+        state = mgr.resume()
+        if state is None:
+            return GoalCommandResult(
+                ok=True, text="No goal to resume.", active=False
+            )
+        return GoalCommandResult(
+            ok=True,
+            text=(
+                f"▶ Goal resumed (budget reset): {state.goal}\n"
+                "I'll take the next step when the current or next turn ends — "
+                "send any message to kick it off now."
+            ),
+            active=True,
+        )
+
+    # Otherwise: SET. Gate first (trust / hooks), then validate.
+    if set_gate is not None:
+        err = set_gate()
+        if err:
+            return GoalCommandResult(ok=False, text=err, active=mgr.is_active())
+
+    try:
+        state = mgr.set(
+            arg,
+            baseline_tokens=baseline_tokens,
+            baseline_cost_usd=baseline_cost_usd,
+        )
+    except ValueError as exc:
+        return GoalCommandResult(
+            ok=False, text=f"Invalid goal: {exc}", active=mgr.is_active()
+        )
+
+    notice = (
+        f"◎ Goal set ({state.max_turns}-turn budget): {state.goal}\n"
+        "After each turn, an evaluator model checks whether the condition "
+        "holds; I keep working until it does. The goal clears automatically "
+        "once met. Controls: /goal · /goal clear · /goal pause · /goal resume"
+    )
+    return GoalCommandResult(
+        ok=True, text=notice, notice=notice, kickoff=state.goal, active=True
+    )
+
+
+def run_subgoal_command(mgr: GoalManager, arg: str) -> GoalCommandResult:
+    """Execute a ``/subgoal`` invocation against ``mgr``.
+
+    Grammar: ``/subgoal`` (list) · ``/subgoal <text>`` (append) ·
+    ``/subgoal remove <n>`` (1-based) · ``/subgoal clear``.
+    """
+    arg = (arg or "").strip()
+
+    if not mgr.has_goal():
+        return GoalCommandResult(
+            ok=False,
+            text="No active goal. Set one with /goal <condition>.",
+            active=False,
+        )
+
+    if not arg:
+        return GoalCommandResult(
+            ok=True,
+            text=f"{mgr.status_line()}\n{mgr.render_subgoals()}",
+            active=mgr.is_active(),
+        )
+
+    tokens = arg.split(None, 1)
+    verb = tokens[0].lower()
+    rest = tokens[1].strip() if len(tokens) > 1 else ""
+
+    if verb == "remove":
+        if not rest:
+            return GoalCommandResult(ok=False, text="Usage: /subgoal remove <n>")
+        try:
+            idx = int(rest.split()[0])
+        except ValueError:
+            return GoalCommandResult(
+                ok=False,
+                text="/subgoal remove: <n> must be an integer (1-based index).",
+            )
+        try:
+            removed = mgr.remove_subgoal(idx)
+        except (IndexError, RuntimeError) as exc:
+            return GoalCommandResult(ok=False, text=f"/subgoal remove: {exc}")
+        return GoalCommandResult(
+            ok=True, text=f"✓ Removed subgoal {idx}: {removed}",
+            active=mgr.is_active(),
+        )
+
+    if verb == "clear" and not rest:
+        try:
+            prev = mgr.clear_subgoals()
+        except RuntimeError as exc:
+            return GoalCommandResult(ok=False, text=f"/subgoal clear: {exc}")
+        return GoalCommandResult(
+            ok=True,
+            text=(
+                f"✓ Cleared {prev} subgoal{'s' if prev != 1 else ''}."
+                if prev else "No subgoals to clear."
+            ),
+            active=mgr.is_active(),
+        )
+
+    try:
+        added = mgr.add_subgoal(arg)
+    except (RuntimeError, ValueError) as exc:
+        return GoalCommandResult(ok=False, text=f"/subgoal: {exc}")
+    count = len(mgr.state.subgoals) if mgr.state else 0
+    return GoalCommandResult(
+        ok=True,
+        text=(
+            f"✓ Added subgoal {count}: {added}\n"
+            "The evaluator now requires evidence for it before calling the "
+            "goal done."
+        ),
+        active=mgr.is_active(),
+    )
+
+
+__all__ = ["GoalCommandResult", "run_goal_command", "run_subgoal_command"]

--- a/src/goals/goals.py
+++ b/src/goals/goals.py
@@ -1,0 +1,1067 @@
+"""Session goals — the /goal completion-condition loop (Ralph loop).
+
+Port of Claude Code's ``/goal`` command (docs/en/goal) with
+``reference_projects/hermes-agent/hermes_cli/goals.py`` as the engineering
+donor. A goal is a free-form completion condition that stays active across
+turns. After each turn completes, a small side-model call ("the evaluator")
+judges whether the condition is satisfied by what the agent has surfaced in
+the conversation. If not, the driver feeds a continuation prompt back into
+the same session and keeps working until the goal is achieved, the turn
+budget is exhausted, the user pauses/clears it, or real user input preempts
+the loop.
+
+Design notes / invariants (kept from the donor):
+
+- The continuation prompt is a NORMAL user message enqueued through the
+  driver's existing queue. No system-prompt mutation, no toolset swap —
+  prompt caching stays intact.
+- Judge failures are fail-OPEN: ``continue``. A broken judge must not wedge
+  progress; the turn budget is the backstop.
+- Real user input preempts the continuation prompt (the driver checks its
+  queue before enqueueing); the judge re-runs after that turn anyway.
+- This module has zero dependency on the agent-server or headless runner —
+  both wire the same :class:`GoalManager` in and own persistence (the
+  agent-server session file) and event emission.
+
+Claude Code fidelity notes:
+
+- ``/goal`` bare shows status (condition, running duration, turns evaluated,
+  token spend, the evaluator's most recent reason); after achievement the
+  status shows the achieved record (docs/en/goal §Check status).
+- A "no" verdict's reason is included in the continuation prompt as guidance
+  for the next turn (§How evaluation works).
+- The condition is capped at 4,000 characters (§Write an effective condition).
+- ``clear`` aliases: stop/off/reset/none/cancel (CC) + done (donor).
+- Deviation: CC ships without a turn budget; this port keeps the donor's
+  budget (default 20, ``goal_max_turns`` setting) as a runaway backstop —
+  hitting it pauses the goal with a ``/goal resume`` hint instead of
+  spending unbounded tokens.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Constants & defaults
+# ──────────────────────────────────────────────────────────────────────
+
+#: Turn budget backstop (donor default). CC ships unbounded; the budget
+#: pauses (never clears) so ``/goal resume`` continues with a fresh budget.
+DEFAULT_GOAL_MAX_TURNS = 20
+
+#: Claude Code's documented condition cap (docs/en/goal).
+GOAL_CONDITION_MAX_CHARS = 4000
+
+#: Judge output budget. The judge returns a one-line JSON verdict, but
+#: reasoning models (deepseek-v4, qwq, …) burn tokens on hidden reasoning
+#: before emitting the visible JSON — tight caps truncate the JSON and trip
+#: the parse-failure auto-pause (donor: goals.py DEFAULT_JUDGE_MAX_TOKENS).
+DEFAULT_JUDGE_MAX_TOKENS = 4096
+
+#: Cap on the conversation evidence sent to the judge.
+JUDGE_EVIDENCE_MAX_CHARS = 4000
+
+#: After this many consecutive judge *parse* failures (empty output /
+#: non-JSON), the loop auto-pauses. API / transport errors do NOT count —
+#: those are transient and fail open. Guards against small models that
+#: cannot follow the strict JSON reply contract.
+MAX_CONSECUTIVE_PARSE_FAILURES = 3
+
+#: Hard bound on one evaluator call (donor: DEFAULT_JUDGE_TIMEOUT). A hung
+#: judge must not wedge the driver — on timeout the loop PARKS (no
+#: continuation) with the goal left active, instead of hermes's plain
+#: fail-open-continue, so a dead evaluator can't drive blind turns.
+DEFAULT_JUDGE_TIMEOUT_S = 30.0
+
+#: ``/goal <alias>`` forms that clear the goal. CC: clear/stop/off/reset/
+#: none/cancel (docs/en/goal §Clear a goal); donor adds done.
+GOAL_CLEAR_ALIASES = frozenset(
+    {"clear", "stop", "off", "reset", "none", "cancel", "done"}
+)
+
+
+CONTINUATION_PROMPT_TEMPLATE = (
+    "[Continuing toward your standing goal]\n"
+    "Goal: {goal}\n\n"
+    "Evaluator: the goal is not met yet — {reason}\n\n"
+    "Continue working toward this goal. Take the next concrete step. "
+    "If you believe the goal is complete, state so explicitly — and show "
+    "the concrete evidence (command output, file contents, test result) — "
+    "then stop. If you are blocked and need input from the user, say so "
+    "clearly and stop."
+)
+
+# Used when the user has added one or more /subgoal criteria. Surfaced to
+# the agent verbatim so it sees what to target on the next turn, and to the
+# judge so the verdict considers them too.
+CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE = (
+    "[Continuing toward your standing goal]\n"
+    "Goal: {goal}\n\n"
+    "Additional criteria the user added mid-loop:\n"
+    "{subgoals_block}\n\n"
+    "Evaluator: the goal is not met yet — {reason}\n\n"
+    "Continue working toward the goal AND all additional criteria. Take "
+    "the next concrete step. If you believe the goal and every additional "
+    "criterion are complete, state so explicitly — with concrete evidence — "
+    "and stop. If you are blocked and need input from the user, say so "
+    "clearly and stop."
+)
+
+
+JUDGE_SYSTEM_PROMPT = (
+    "You are a strict judge evaluating whether an autonomous agent has "
+    "achieved a user's stated goal. The goal is a CONDITION the agent must "
+    "MAKE true by working — not a claim to verify. You receive the goal "
+    "text and a transcript excerpt of the agent's most recent turn (its "
+    "messages and tool results). Decide one of two verdicts.\n\n"
+    "DONE — only when one of these holds:\n"
+    "- The excerpt shows concrete evidence the goal's condition NOW holds "
+    "(command output, file contents, test results — not just a claim), OR\n"
+    "- The agent is genuinely blocked by something OUTSIDE its control "
+    "(missing credentials, contradictory instructions, a decision only "
+    "the user can make) and says so. The condition merely being false "
+    "right now is NOT a block — if the agent could make it true by "
+    "working (creating a file, fixing code, running a command), the "
+    "verdict is CONTINUE, even when the agent itself claims the goal "
+    "'cannot be satisfied'.\n\n"
+    "CONTINUE — not done, and there is a concrete next step the agent can "
+    "take right now. This is the default when in doubt.\n\n"
+    "Reply ONLY with a single JSON object on one line. Shapes:\n"
+    '{"verdict": "done", "reason": "<one sentence>"}\n'
+    '{"verdict": "continue", "reason": "<one sentence>"}\n'
+    "The legacy shape {\"done\": <true|false>, \"reason\": \"...\"} is "
+    "also accepted (true=done, false=continue)."
+)
+
+
+JUDGE_USER_PROMPT_TEMPLATE = (
+    "Goal:\n{goal}\n\n"
+    "Agent's most recent turn (transcript excerpt):\n{response}\n\n"
+    "Current time: {current_time}\n\n"
+    "Is the goal satisfied — done or continue?"
+)
+
+# Used when the user has added /subgoal criteria. The judge must evaluate
+# ALL of them being met, not just the original goal.
+JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE = (
+    "Goal:\n{goal}\n\n"
+    "Additional criteria the user added mid-loop (all must also be "
+    "satisfied for the goal to be DONE):\n{subgoals_block}\n\n"
+    "Agent's most recent turn (transcript excerpt):\n{response}\n\n"
+    "Current time: {current_time}\n\n"
+    "Decision: For each numbered criterion above, find concrete evidence "
+    "in the excerpt that the criterion is satisfied. Do not accept generic "
+    "phrases like 'all requirements met' — require specific evidence (a "
+    "file contents excerpt, an output line, a command result). If ANY "
+    "criterion lacks specific evidence, the goal is NOT done — return "
+    "CONTINUE.\n\n"
+    "Is the goal AND every additional criterion satisfied?"
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# State
+# ──────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class GoalState:
+    """Serializable per-session goal state."""
+
+    goal: str
+    status: str = "active"          # active | paused | done | cleared
+    turns_used: int = 0
+    max_turns: int = DEFAULT_GOAL_MAX_TURNS
+    created_at: float = 0.0
+    last_turn_at: float = 0.0
+    achieved_at: float = 0.0
+    last_verdict: Optional[str] = None   # done | continue | skipped
+    last_reason: Optional[str] = None
+    paused_reason: Optional[str] = None
+    consecutive_parse_failures: int = 0
+    # User-added criteria appended mid-loop via /subgoal. When non-empty the
+    # judge prompt and continuation prompt both include them.
+    subgoals: list[str] = field(default_factory=list)
+    # Token/cost odometer readings captured when the goal was set, so status
+    # can report spend attributable to the goal (CC status shows token
+    # spend). The driver supplies the readings (bootstrap cost accumulators).
+    baseline_tokens: int = 0
+    baseline_cost_usd: float = 0.0
+    # Spend recorded at the last evaluation (so an achieved/cleared record
+    # can still report totals after the baseline counters move on).
+    spent_tokens: int = 0
+    spent_cost_usd: float = 0.0
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "GoalState":
+        raw_subgoals = data.get("subgoals") or []
+        subgoals: list[str] = []
+        if isinstance(raw_subgoals, list):
+            subgoals = [str(s).strip() for s in raw_subgoals if str(s).strip()]
+        return cls(
+            goal=str(data.get("goal", "")),
+            status=str(data.get("status", "active")),
+            turns_used=int(data.get("turns_used", 0) or 0),
+            max_turns=int(data.get("max_turns", DEFAULT_GOAL_MAX_TURNS)
+                          or DEFAULT_GOAL_MAX_TURNS),
+            created_at=float(data.get("created_at", 0.0) or 0.0),
+            last_turn_at=float(data.get("last_turn_at", 0.0) or 0.0),
+            achieved_at=float(data.get("achieved_at", 0.0) or 0.0),
+            last_verdict=data.get("last_verdict"),
+            last_reason=data.get("last_reason"),
+            paused_reason=data.get("paused_reason"),
+            consecutive_parse_failures=int(
+                data.get("consecutive_parse_failures", 0) or 0
+            ),
+            subgoals=subgoals,
+            baseline_tokens=int(data.get("baseline_tokens", 0) or 0),
+            baseline_cost_usd=float(data.get("baseline_cost_usd", 0.0) or 0.0),
+            spent_tokens=int(data.get("spent_tokens", 0) or 0),
+            spent_cost_usd=float(data.get("spent_cost_usd", 0.0) or 0.0),
+        )
+
+    def render_subgoals_block(self) -> str:
+        if not self.subgoals:
+            return ""
+        return "\n".join(
+            f"- {i}. {text}" for i, text in enumerate(self.subgoals, start=1)
+        )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Judge
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _truncate(text: str, limit: int) -> str:
+    if not text:
+        return ""
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "… [truncated]"
+
+
+_JSON_OBJECT_RE = re.compile(r"\{.*?\}", re.DOTALL)
+
+
+def _parse_judge_response(raw: str) -> tuple[str, str, bool]:
+    """Parse the judge's reply. Fail-open on unusable output.
+
+    Returns ``(verdict, reason, parse_failed)`` where ``verdict`` is
+    ``"done"`` or ``"continue"`` and ``parse_failed`` is True when the reply
+    couldn't be interpreted as the expected JSON verdict (empty body, prose,
+    malformed JSON). Callers use it to auto-pause after N consecutive parse
+    failures so a weak judge model doesn't silently burn the budget.
+
+    Accepts both the ``{"verdict": ...}`` shape and the legacy
+    ``{"done": <bool>}`` shape (donor contract).
+    """
+    if not raw:
+        return "continue", "judge returned empty response", True
+
+    text = raw.strip()
+
+    # Strip markdown code fences the model may wrap JSON in.
+    if text.startswith("```"):
+        text = text.strip("`")
+        nl = text.find("\n")
+        if nl != -1:
+            text = text[nl + 1:]
+
+    data: Optional[dict[str, Any]] = None
+    try:
+        data = json.loads(text)
+    except Exception:  # noqa: BLE001 — fall through to first-object scan
+        match = _JSON_OBJECT_RE.search(text)
+        if match:
+            try:
+                data = json.loads(match.group(0))
+            except Exception:  # noqa: BLE001
+                data = None
+
+    if not isinstance(data, dict):
+        return (
+            "continue",
+            f"judge reply was not JSON: {_truncate(raw, 200)!r}",
+            True,
+        )
+
+    reason = str(data.get("reason") or "").strip() or "no reason provided"
+
+    verdict_raw = data.get("verdict")
+    if isinstance(verdict_raw, str):
+        verdict = verdict_raw.strip().lower()
+    else:
+        done_val = data.get("done")
+        if isinstance(done_val, str):
+            done = done_val.strip().lower() in {"true", "yes", "1", "done"}
+        else:
+            done = bool(done_val)
+        verdict = "done" if done else "continue"
+
+    if verdict not in {"done", "continue"}:
+        verdict = "continue"
+    return verdict, reason, False
+
+
+#: The judge callable contract: ``(system, user) -> raw reply text or None``.
+JudgeCallable = Callable[[str, str], Optional[str]]
+
+
+class GoalJudgeTimeout(Exception):
+    """The evaluator call exceeded its hard time bound."""
+
+
+def judge_goal(
+    goal: str,
+    evidence: str,
+    *,
+    judge: Optional[JudgeCallable],
+    subgoals: Optional[list[str]] = None,
+) -> tuple[str, str, bool]:
+    """Ask the evaluator whether the goal is satisfied.
+
+    Returns ``(verdict, reason, parse_failed)`` — verdict is ``"done"``,
+    ``"continue"``, ``"timeout"``, or ``"skipped"`` (empty goal).
+    Deliberately fail-open: a fast judge error returns
+    ``("continue", ..., False)`` so a broken judge doesn't wedge progress —
+    the turn budget and the parse-failure auto-pause are the backstops. A
+    :class:`GoalJudgeTimeout` is the exception: it returns ``"timeout"`` so
+    the driver PARKS the loop (goal stays active, no continuation) instead
+    of blindly looping on a hung evaluator.
+    """
+    if not goal.strip():
+        return "skipped", "empty goal", False
+    if not evidence.strip():
+        # No substantive output this turn — almost certainly not done yet.
+        return "continue", "empty response (nothing to evaluate)", False
+    if judge is None:
+        return "continue", "no evaluator configured", False
+
+    clean_subgoals = [s.strip() for s in (subgoals or []) if s and s.strip()]
+    current_time = datetime.now(tz=timezone.utc).astimezone().strftime(
+        "%Y-%m-%d %H:%M:%S %Z"
+    )
+    if clean_subgoals:
+        subgoals_block = "\n".join(
+            f"- {i}. {text}" for i, text in enumerate(clean_subgoals, start=1)
+        )
+        prompt = JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE.format(
+            goal=_truncate(goal, 2000),
+            subgoals_block=_truncate(subgoals_block, 2000),
+            response=_truncate(evidence, JUDGE_EVIDENCE_MAX_CHARS),
+            current_time=current_time,
+        )
+    else:
+        prompt = JUDGE_USER_PROMPT_TEMPLATE.format(
+            goal=_truncate(goal, 2000),
+            response=_truncate(evidence, JUDGE_EVIDENCE_MAX_CHARS),
+            current_time=current_time,
+        )
+
+    try:
+        raw = judge(JUDGE_SYSTEM_PROMPT, prompt) or ""
+    except GoalJudgeTimeout:
+        logger.info("goal judge: timed out — parking the loop")
+        return (
+            "timeout",
+            f"evaluator timed out after {int(DEFAULT_JUDGE_TIMEOUT_S)}s",
+            False,
+        )
+    except Exception as exc:  # noqa: BLE001 — transport errors fail open
+        logger.info("goal judge: call failed (%s) — continuing", exc)
+        return "continue", f"judge error: {type(exc).__name__}", False
+
+    verdict, reason, parse_failed = _parse_judge_response(raw)
+    logger.info(
+        "goal judge: verdict=%s reason=%s", verdict, _truncate(reason, 120)
+    )
+    return verdict, reason, parse_failed
+
+
+def build_judge_callable(
+    provider: Any, *, timeout_s: float = DEFAULT_JUDGE_TIMEOUT_S
+) -> JudgeCallable:
+    """Wrap a provider into the judge contract, hard-bounded by ``timeout_s``.
+
+    Follows the port's small-fast-model side-call convention
+    (``services/tool_use_summary._resolve_summary_model`` /
+    ``memdir/find_relevant_memories._resolve_recall_model``): pin
+    ``settings.small_fast_model`` only when the session provider is the
+    first-party Anthropic provider (CC parity — the evaluator "defaults to
+    Haiku"); every other provider falls back to the session model, because
+    the shipped small_fast_model default is an Anthropic id that would 400
+    elsewhere.
+
+    Uses the provider's synchronous ``chat`` — the call sites (agent-server
+    worker thread, headless between-query loop) are sync contexts with no
+    running event loop, and the judge is a short blocking side call. The
+    call runs on a helper thread joined with ``timeout_s``: a hung HTTP
+    call raises :class:`GoalJudgeTimeout` here instead of wedging the
+    driver. The leaked helper thread is daemon-pooled and dies with the
+    SDK's own HTTP timeout; no ``timeout`` kwarg is forwarded because not
+    every provider ``chat`` tolerates unknown per-request kwargs, and a
+    TypeError would silently disable judging for the whole goal.
+    """
+
+    def _judge(system: str, user: str) -> Optional[str]:
+        if provider is None or not hasattr(provider, "chat"):
+            return None
+        kwargs: dict[str, Any] = {
+            "system": system,
+            "max_tokens": DEFAULT_JUDGE_MAX_TOKENS,
+        }
+        model = _resolve_judge_model(provider)
+        if model:
+            kwargs["model"] = model
+
+        # Plain daemon thread, NOT ThreadPoolExecutor: concurrent.futures
+        # atexit-joins its (non-daemon) workers, so a judge thread hung on a
+        # dead socket would block interpreter exit. A daemon thread just
+        # dies with the process.
+        import threading
+
+        box: dict[str, Any] = {}
+
+        def _call() -> None:
+            try:
+                box["response"] = provider.chat(
+                    [{"role": "user", "content": user}], **kwargs
+                )
+            except BaseException as exc:  # noqa: BLE001 — re-raised on the caller
+                box["error"] = exc
+
+        t = threading.Thread(target=_call, name="goal-judge", daemon=True)
+        t.start()
+        t.join(timeout=timeout_s)
+        if t.is_alive():
+            raise GoalJudgeTimeout(f"evaluator exceeded {timeout_s:.0f}s")
+        if "error" in box:
+            raise box["error"]
+        response = box.get("response")
+        if response is None:
+            return None
+        return (getattr(response, "content", "") or "").strip() or None
+
+    return _judge
+
+
+def _resolve_judge_model(provider: Any) -> Optional[str]:
+    """The small-fast-model pin for the evaluator side query. Returns None
+    to signal session-model fallback. Never raises."""
+    try:
+        from src.providers.anthropic_provider import AnthropicProvider
+
+        if not isinstance(provider, AnthropicProvider):
+            return None
+        from src.settings.settings import get_settings
+
+        model = (getattr(get_settings(), "small_fast_model", "") or "").strip()
+        return model or None
+    except Exception:  # noqa: BLE001 — a settings/import failure must not block judging
+        return None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Evidence collection
+# ──────────────────────────────────────────────────────────────────────
+
+
+def collect_turn_evidence(
+    messages: list[Any],
+    *,
+    limit_chars: int = JUDGE_EVIDENCE_MAX_CHARS,
+    max_messages: int = 30,
+) -> str:
+    """Flatten the tail of the conversation into a judge-readable excerpt.
+
+    CC's evaluator "judges your condition against what Claude has surfaced
+    in the conversation" — the proof (a test run, a build exit code) usually
+    lives in TOOL RESULTS, not the final assistant sentence. Walk backwards
+    from the end until the previous real user prompt (bounded at
+    ``max_messages``), collecting assistant text and short tool_result
+    excerpts, newest last. The final assistant text is always included even
+    when the char budget is tight.
+
+    ``messages`` are conversation entries with ``role``/``content`` attrs or
+    keys (str content or content-block lists). Never raises.
+    """
+    try:
+        collected: list[str] = []  # built oldest→newest after the walk
+        walked = 0
+        for msg in reversed(messages or []):
+            if walked >= max_messages:
+                break
+            walked += 1
+            role = getattr(msg, "role", None)
+            content = getattr(msg, "content", None)
+            if role is None and isinstance(msg, dict):
+                role = msg.get("role")
+                content = msg.get("content")
+            is_meta = bool(getattr(msg, "isMeta", False) or (
+                isinstance(msg, dict) and msg.get("isMeta")
+            ))
+
+            if role == "user":
+                # Tool-result carrier messages are part of the turn; a real
+                # user prompt (plain text, non-meta) is the turn boundary.
+                parts: list[str] = []
+                if isinstance(content, list):
+                    has_tool_result = False
+                    for block in content:
+                        btype = _block_get(block, "type")
+                        if btype == "tool_result":
+                            has_tool_result = True
+                            body = _flatten_block_text(
+                                _block_get(block, "content")
+                            )
+                            if body:
+                                parts.append(
+                                    f"[tool result] {_truncate(body, 400)}"
+                                )
+                    if not has_tool_result and not is_meta:
+                        break  # multimodal real prompt — turn boundary
+                    collected.append("\n".join(parts))
+                    continue
+                if is_meta:
+                    continue
+                break  # plain-text real user prompt — turn boundary
+
+            if role == "assistant":
+                parts = []
+                if isinstance(content, str):
+                    if content.strip():
+                        parts.append(content.strip())
+                elif isinstance(content, list):
+                    for block in content:
+                        btype = _block_get(block, "type")
+                        if btype == "text":
+                            text = str(_block_get(block, "text") or "").strip()
+                            if text:
+                                parts.append(text)
+                        elif btype == "tool_use":
+                            name = _block_get(block, "name") or "tool"
+                            parts.append(f"[called tool: {name}]")
+                if parts:
+                    collected.append("\n".join(parts))
+
+        collected.reverse()
+        if not collected:
+            return ""
+        # Budget: keep the newest content — trim from the oldest entries.
+        out: list[str] = []
+        remaining = limit_chars
+        for chunk in reversed(collected):
+            if remaining <= 0:
+                break
+            take = chunk[-remaining:] if len(chunk) > remaining else chunk
+            out.append(take)
+            remaining -= len(take) + 1
+        out.reverse()
+        return "\n".join(out).strip()
+    except Exception:  # noqa: BLE001 — evidence is best-effort
+        logger.debug("goal evidence collection failed", exc_info=True)
+        return ""
+
+
+def _block_get(block: Any, key: str) -> Any:
+    if isinstance(block, dict):
+        return block.get(key)
+    return getattr(block, key, None)
+
+
+def _flatten_block_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for b in content:
+            t = _block_get(b, "text")
+            if isinstance(t, str) and t:
+                parts.append(t)
+        return "\n".join(parts)
+    return str(content or "")
+
+
+# ──────────────────────────────────────────────────────────────────────
+# GoalManager — the orchestration surface the drivers talk to
+# ──────────────────────────────────────────────────────────────────────
+
+
+class GoalManager:
+    """Per-session goal state + continuation decisions.
+
+    The agent-server and headless runner each hold one per session. The
+    manager owns no I/O: persistence is via ``state.to_dict()`` /
+    :meth:`restore`, judging via the injected ``judge`` callable, and
+    token/cost readings are supplied by the driver at evaluation time.
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        *,
+        default_max_turns: int = DEFAULT_GOAL_MAX_TURNS,
+        judge: Optional[JudgeCallable] = None,
+        now: Callable[[], float] = time.time,
+    ) -> None:
+        self.session_id = session_id
+        self.default_max_turns = int(default_max_turns or DEFAULT_GOAL_MAX_TURNS)
+        self.judge = judge
+        self._now = now
+        self._state: Optional[GoalState] = None
+
+    # --- introspection ------------------------------------------------
+
+    @property
+    def state(self) -> Optional[GoalState]:
+        return self._state
+
+    def is_active(self) -> bool:
+        return self._state is not None and self._state.status == "active"
+
+    def has_goal(self) -> bool:
+        return self._state is not None and self._state.status in {
+            "active", "paused",
+        }
+
+    def status_text(self) -> str:
+        """Multi-line status block for ``/goal`` with no arguments (CC
+        §Check status: condition, duration, turns evaluated, token spend,
+        most recent reason; or the achieved record)."""
+        s = self._state
+        if s is None or s.status == "cleared":
+            return "No active goal. Set one with /goal <condition>."
+        turns = f"{s.turns_used}/{s.max_turns}"
+        if s.status == "done":
+            dur = _fmt_duration(
+                (s.achieved_at or s.last_turn_at or s.created_at) - s.created_at
+            )
+            lines = [
+                f"✓ Goal achieved: {s.goal}",
+                f"  Duration: {dur} · Turns evaluated: {turns}"
+                f" · Tokens: {_fmt_tokens(s.spent_tokens)}"
+                f" · Cost: ${s.spent_cost_usd:.4f}",
+            ]
+            if s.last_reason:
+                lines.append(f"  Evaluator: {s.last_reason}")
+            return "\n".join(lines)
+        dur = _fmt_duration(self._now() - s.created_at)
+        sub = (
+            f" · Subgoals: {len(s.subgoals)}" if s.subgoals else ""
+        )
+        if s.status == "paused":
+            head = f"⏸ Goal (paused — {s.paused_reason or 'user-paused'}): {s.goal}"
+            hint = "  Use /goal resume to continue, or /goal clear to stop."
+        else:
+            head = f"◎ Goal (active): {s.goal}"
+            hint = ""
+        lines = [
+            head,
+            f"  Running: {dur} · Turns evaluated: {turns}"
+            f" · Tokens: {_fmt_tokens(s.spent_tokens)}"
+            f" · Cost: ${s.spent_cost_usd:.4f}{sub}",
+        ]
+        if s.last_reason:
+            lines.append(f"  Evaluator: {s.last_reason}")
+        if hint:
+            lines.append(hint)
+        return "\n".join(lines)
+
+    def status_line(self) -> str:
+        """One-line status (transcript/status-bar friendly)."""
+        s = self._state
+        if s is None or s.status == "cleared":
+            return "No active goal. Set one with /goal <condition>."
+        turns = f"{s.turns_used}/{s.max_turns} turns"
+        if s.status == "active":
+            return f"◎ Goal (active, {turns}): {s.goal}"
+        if s.status == "paused":
+            extra = f" — {s.paused_reason}" if s.paused_reason else ""
+            return f"⏸ Goal (paused, {turns}{extra}): {s.goal}"
+        if s.status == "done":
+            return f"✓ Goal achieved ({turns}): {s.goal}"
+        return f"Goal ({s.status}, {turns}): {s.goal}"
+
+    # --- mutation -----------------------------------------------------
+
+    def set(
+        self,
+        goal: str,
+        *,
+        max_turns: Optional[int] = None,
+        baseline_tokens: int = 0,
+        baseline_cost_usd: float = 0.0,
+    ) -> GoalState:
+        goal = (goal or "").strip()
+        if not goal:
+            raise ValueError("goal text is empty")
+        if len(goal) > GOAL_CONDITION_MAX_CHARS:
+            raise ValueError(
+                f"goal condition is too long "
+                f"({len(goal)} > {GOAL_CONDITION_MAX_CHARS} characters)"
+            )
+        state = GoalState(
+            goal=goal,
+            status="active",
+            turns_used=0,
+            max_turns=int(max_turns) if max_turns else self.default_max_turns,
+            created_at=self._now(),
+            baseline_tokens=int(baseline_tokens or 0),
+            baseline_cost_usd=float(baseline_cost_usd or 0.0),
+        )
+        self._state = state
+        return state
+
+    def clear(self) -> bool:
+        """Clear the goal. Returns whether an active/paused goal existed."""
+        had = self.has_goal()
+        if self._state is not None:
+            self._state.status = "cleared"
+            self._state = None
+        return had
+
+    def pause(self, reason: str = "user-paused") -> Optional[GoalState]:
+        if not self._state or self._state.status not in {"active", "paused"}:
+            return None
+        self._state.status = "paused"
+        self._state.paused_reason = reason
+        return self._state
+
+    def resume(self, *, reset_budget: bool = True) -> Optional[GoalState]:
+        if not self._state or self._state.status not in {"active", "paused"}:
+            return None
+        self._state.status = "active"
+        self._state.paused_reason = None
+        self._state.consecutive_parse_failures = 0
+        if reset_budget:
+            self._state.turns_used = 0
+        return self._state
+
+    def mark_done(self, reason: str) -> None:
+        if not self._state:
+            return
+        self._state.status = "done"
+        self._state.last_verdict = "done"
+        self._state.last_reason = reason
+        self._state.achieved_at = self._now()
+
+    # --- /subgoal user controls ---------------------------------------
+
+    def add_subgoal(self, text: str) -> str:
+        if self._state is None or not self.has_goal():
+            raise RuntimeError("no active goal")
+        text = (text or "").strip()
+        if not text:
+            raise ValueError("subgoal text is empty")
+        self._state.subgoals.append(text)
+        return text
+
+    def remove_subgoal(self, index_1based: int) -> str:
+        if self._state is None or not self.has_goal():
+            raise RuntimeError("no active goal")
+        idx = int(index_1based) - 1
+        if idx < 0 or idx >= len(self._state.subgoals):
+            raise IndexError(
+                f"index out of range (1..{len(self._state.subgoals)})"
+            )
+        return self._state.subgoals.pop(idx)
+
+    def clear_subgoals(self) -> int:
+        if self._state is None or not self.has_goal():
+            raise RuntimeError("no active goal")
+        prev = len(self._state.subgoals)
+        self._state.subgoals = []
+        return prev
+
+    def render_subgoals(self) -> str:
+        if self._state is None:
+            return "(no active goal)"
+        if not self._state.subgoals:
+            return "(no subgoals — use /subgoal <text> to add criteria)"
+        return self._state.render_subgoals_block()
+
+    # --- persistence bridge (driver-owned store) -----------------------
+
+    def restore(
+        self, data: dict[str, Any], *, reset_counters: bool = True
+    ) -> Optional[GoalState]:
+        """Restore a persisted goal (CC §Resume with an active goal: only
+        an ACTIVE goal is restored; turn count, timer, and spend baseline
+        reset). Returns the restored state or None."""
+        try:
+            state = GoalState.from_dict(data)
+        except Exception:  # noqa: BLE001 — a corrupt record must not break resume
+            logger.debug("goal restore failed", exc_info=True)
+            return None
+        if state.status != "active" or not state.goal.strip():
+            return None
+        if reset_counters:
+            state.turns_used = 0
+            state.created_at = self._now()
+            state.last_turn_at = 0.0
+            state.consecutive_parse_failures = 0
+            state.spent_tokens = 0
+            state.spent_cost_usd = 0.0
+            # The driver re-baselines tokens/cost after restore.
+        self._state = state
+        return state
+
+    def rebaseline(self, *, tokens: int, cost_usd: float) -> None:
+        if self._state is None:
+            return
+        self._state.baseline_tokens = int(tokens or 0)
+        self._state.baseline_cost_usd = float(cost_usd or 0.0)
+
+    # --- the main entry point called after every turn -----------------
+
+    def evaluate_after_turn(
+        self,
+        evidence: str,
+        *,
+        tokens_now: int = 0,
+        cost_now_usd: float = 0.0,
+    ) -> dict[str, Any]:
+        """Run the judge and update state. Returns a decision dict:
+
+        - ``status``: goal status after the update
+        - ``should_continue``: bool — the driver should fire another turn
+        - ``continuation_prompt``: str or None
+        - ``verdict``: done | continue | timeout | skipped | inactive
+        - ``reason``: str
+        - ``message``: user-visible one-liner to surface
+
+        Single-threaded convenience (headless runner, tests). A
+        multi-threaded driver (the agent-server worker) must split the
+        phases itself for double-checked locking: read ``state`` under its
+        lock, call :func:`judge_goal` OUTSIDE the lock (network call),
+        then :meth:`apply_verdict` under the lock again.
+        """
+        state = self._state
+        if state is None or state.status != "active":
+            return _INACTIVE_DECISION | {
+                "status": state.status if state else None,
+            }
+
+        verdict, reason, parse_failed = judge_goal(
+            state.goal,
+            evidence,
+            judge=self.judge,
+            subgoals=list(state.subgoals) or None,
+        )
+        return self.apply_verdict(
+            verdict, reason, parse_failed,
+            tokens_now=tokens_now, cost_now_usd=cost_now_usd,
+            expected_state=state,
+        )
+
+    def apply_verdict(
+        self,
+        verdict: str,
+        reason: str,
+        parse_failed: bool,
+        *,
+        tokens_now: int = 0,
+        cost_now_usd: float = 0.0,
+        expected_state: Optional[GoalState] = None,
+    ) -> dict[str, Any]:
+        """Apply a judge verdict to the state and return the decision dict.
+
+        ``expected_state`` is the state snapshot the judge ran against: if
+        the live state has been replaced or deactivated meanwhile (a
+        concurrent ``/goal clear`` / new ``/goal`` set / pause), the stale
+        verdict is DISCARDED and an inactive decision returned — the caller
+        must never act on a verdict for a goal the user has since changed.
+        """
+        state = self._state
+        if state is None or state.status != "active":
+            return _INACTIVE_DECISION | {
+                "status": state.status if state else None,
+            }
+        if expected_state is not None and state is not expected_state:
+            return _INACTIVE_DECISION | {
+                "status": state.status,
+                "reason": "goal changed during evaluation",
+            }
+
+        state.turns_used += 1
+        state.last_turn_at = self._now()
+        if tokens_now:
+            state.spent_tokens = max(0, int(tokens_now) - state.baseline_tokens)
+        if cost_now_usd:
+            state.spent_cost_usd = max(
+                0.0, float(cost_now_usd) - state.baseline_cost_usd
+            )
+
+        state.last_verdict = verdict
+        state.last_reason = reason
+
+        # Track consecutive judge parse failures. Reset on any usable reply,
+        # including transport errors (parse_failed=False), so a flaky network
+        # doesn't trip the auto-pause meant for bad judge models.
+        if parse_failed:
+            state.consecutive_parse_failures += 1
+        else:
+            state.consecutive_parse_failures = 0
+
+        if verdict == "timeout":
+            # A hung evaluator PARKS the loop: goal stays active, no
+            # continuation — the next completed turn re-evaluates. (A fast
+            # transport error fail-opens to continue instead; see judge_goal.)
+            return {
+                "status": "active",
+                "should_continue": False,
+                "continuation_prompt": None,
+                "verdict": "timeout",
+                "reason": reason,
+                "message": (
+                    f"⏳ Goal evaluator timed out — the goal stays active; "
+                    f"I'll re-evaluate at the end of the next turn. ({reason})"
+                ),
+            }
+
+        if verdict == "done":
+            self.mark_done(reason)
+            return {
+                "status": "done",
+                "should_continue": False,
+                "continuation_prompt": None,
+                "verdict": "done",
+                "reason": reason,
+                "message": f"✓ Goal achieved: {reason}",
+            }
+
+        if state.consecutive_parse_failures >= MAX_CONSECUTIVE_PARSE_FAILURES:
+            state.status = "paused"
+            state.paused_reason = (
+                f"evaluator returned unparseable output "
+                f"{state.consecutive_parse_failures} turns in a row"
+            )
+            return {
+                "status": "paused",
+                "should_continue": False,
+                "continuation_prompt": None,
+                "verdict": verdict,
+                "reason": reason,
+                "message": (
+                    f"⏸ Goal paused — the evaluator model "
+                    f"({state.consecutive_parse_failures} turns) isn't "
+                    "returning the required JSON verdict. Configure "
+                    "`small_fast_model` to a stricter model, then "
+                    "/goal resume to continue."
+                ),
+            }
+
+        if state.turns_used >= state.max_turns:
+            state.status = "paused"
+            state.paused_reason = (
+                f"turn budget exhausted ({state.turns_used}/{state.max_turns})"
+            )
+            return {
+                "status": "paused",
+                "should_continue": False,
+                "continuation_prompt": None,
+                "verdict": verdict,
+                "reason": reason,
+                "message": (
+                    f"⏸ Goal paused — {state.turns_used}/{state.max_turns} "
+                    "turns used. Use /goal resume to keep going, or "
+                    "/goal clear to stop."
+                ),
+            }
+
+        return {
+            "status": "active",
+            "should_continue": True,
+            "continuation_prompt": self.next_continuation_prompt(reason),
+            "verdict": verdict,
+            "reason": reason,
+            "message": (
+                f"↻ Continuing toward goal "
+                f"({state.turns_used}/{state.max_turns}): {reason}"
+            ),
+        }
+
+    def next_continuation_prompt(self, reason: str = "") -> Optional[str]:
+        if not self._state or self._state.status != "active":
+            return None
+        reason = (reason or self._state.last_reason or "not done yet").strip()
+        if self._state.subgoals:
+            return CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE.format(
+                goal=self._state.goal,
+                subgoals_block=self._state.render_subgoals_block(),
+                reason=reason,
+            )
+        return CONTINUATION_PROMPT_TEMPLATE.format(
+            goal=self._state.goal, reason=reason,
+        )
+
+
+#: Decision returned when there is no active goal to evaluate.
+_INACTIVE_DECISION: dict[str, Any] = {
+    "status": None,
+    "should_continue": False,
+    "continuation_prompt": None,
+    "verdict": "inactive",
+    "reason": "no active goal",
+    "message": "",
+}
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Rendering helpers
+# ──────────────────────────────────────────────────────────────────────
+
+
+def _fmt_duration(seconds: float) -> str:
+    seconds = max(0, int(seconds))
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes, secs = divmod(seconds, 60)
+    if minutes < 60:
+        return f"{minutes}m {secs}s"
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours}h {minutes}m"
+
+
+def _fmt_tokens(n: int) -> str:
+    n = max(0, int(n))
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+__all__ = [
+    "DEFAULT_GOAL_MAX_TURNS",
+    "DEFAULT_JUDGE_MAX_TOKENS",
+    "DEFAULT_JUDGE_TIMEOUT_S",
+    "GOAL_CLEAR_ALIASES",
+    "GOAL_CONDITION_MAX_CHARS",
+    "MAX_CONSECUTIVE_PARSE_FAILURES",
+    "JUDGE_SYSTEM_PROMPT",
+    "JUDGE_USER_PROMPT_TEMPLATE",
+    "JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE",
+    "CONTINUATION_PROMPT_TEMPLATE",
+    "CONTINUATION_PROMPT_WITH_SUBGOALS_TEMPLATE",
+    "GoalJudgeTimeout",
+    "GoalManager",
+    "GoalState",
+    "build_judge_callable",
+    "collect_turn_evidence",
+    "judge_goal",
+]

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -167,6 +167,10 @@ class _AgentSession:
     _knowledge_enabled: bool = True  # the original's knowledgeGraphEnabled (default on)
     _knowledge_semantic: bool = False  # opt-in model-based extraction (vs heuristic)
     _bgtasks: Any = None  # BackgroundTasks registry (lazy), the original's Ctrl+B runs
+    # /goal — session-scoped completion-condition loop (src/goals). Built
+    # lazily by _goal_manager(); the worker's post-turn hook evaluates it and
+    # enqueues continuation turns. Persisted in the session file for /resume.
+    _goal_mgr: Any = None
 
     # Worker + cross-thread coordination.
     _inbox: _queue.Queue = field(default_factory=_queue.Queue)
@@ -266,6 +270,20 @@ class _AgentSession:
             with self._lock:
                 abort = self._current_abort
                 pendings = list(self._pending.values())
+                # ESC during a goal run auto-pauses the goal (donor
+                # semantics, critic R4): without this, the interrupted turn
+                # skips its continuation but the goal stays armed and the
+                # loop silently resurrects at the end of the user's next
+                # turn. /goal resume re-arms deliberately. Deviation from
+                # CC (which keeps the goal active) — documented.
+                goal_paused = False
+                if self._goal_mgr is not None and self._goal_mgr.is_active():
+                    try:
+                        self._goal_mgr.pause(reason="interrupted (ESC)")
+                        goal_paused = True
+                    except Exception:  # noqa: BLE001
+                        logger.debug("[agent-server] goal pause on interrupt failed",
+                                     exc_info=True)
             # Release any in-flight permission ask NOW so the worker unblocks
             # immediately rather than at permission_timeout_s (proposal §7: ESC
             # during a permission prompt must both deny the pending ask AND
@@ -275,6 +293,16 @@ class _AgentSession:
                 pending.event.set()
             if abort is not None:
                 abort.abort("user_interrupt")
+            if goal_paused:
+                self._save_session()
+                self._emit({
+                    "type": "system",
+                    "subtype": "goal_status",
+                    "session_id": self.session_id,
+                    "message": ("⏸ Goal paused — turn interrupted. Use "
+                                "/goal resume to continue, or /goal clear to stop."),
+                    "goal_active": False,
+                })
             return
         if subtype == "set_permission_mode":
             mode = inner.get("mode")
@@ -589,6 +617,12 @@ class _AgentSession:
             )
             self._reply(request_id, {"servers": servers})
             return
+        if subtype == "goal":
+            self._do_goal_command(request_id, inner.get("arg"))
+            return
+        if subtype == "subgoal":
+            self._do_subgoal_command(request_id, inner.get("arg"))
+            return
         if subtype == "clear":
             # Reset the conversation so /clear actually starts a fresh context
             # (not just the client screen). Idle-only.
@@ -600,6 +634,26 @@ class _AgentSession:
             try:
                 if self.session is not None:
                     self.session.conversation.clear()
+                # /clear removes an active goal (CC docs/en/goal §Clear a
+                # goal: "Running /clear to start a new conversation also
+                # removes any active goal"). Under _lock — the worker's
+                # post-turn hook shares this state. The on-disk strip makes
+                # the clear DURABLE: /clear + immediate quit must not leave
+                # an active goal in the session file for --resume to
+                # restore (critic suggestion 2; _save_session can't do it —
+                # it early-returns on the now-empty conversation).
+                if self._goal_mgr is not None:
+                    try:
+                        with self._lock:
+                            self._goal_mgr.clear()
+                        f = _sessions_dir() / f"{self.session_id}.json"
+                        if f.exists():
+                            data = json.loads(f.read_text(encoding="utf-8"))
+                            if data.pop("goal", None) is not None:
+                                f.write_text(json.dumps(data), encoding="utf-8")
+                    except Exception:  # noqa: BLE001 — never break /clear
+                        logger.debug("[agent-server] goal clear on /clear failed",
+                                     exc_info=True)
                 # Fresh conversation, fresh odometer (token/cost totals are
                 # process-wide spend and deliberately survive /clear).
                 self._stats_turns = 0
@@ -717,6 +771,19 @@ class _AgentSession:
                 # from a persisted notification/hook-context message).
                 "turns": self._stats_turns,
             }
+            # /goal state rides the session file so --resume restores an
+            # ACTIVE goal (CC docs/en/goal §Resume). Snapshot under _lock —
+            # the worker's post-turn hook mutates the same state.
+            if self._goal_mgr is not None:
+                try:
+                    with self._lock:
+                        goal_state = self._goal_mgr.state
+                        goal_dict = goal_state.to_dict() if goal_state else None
+                    if goal_dict:
+                        payload["goal"] = goal_dict
+                except Exception:  # noqa: BLE001 — goal snapshot is best-effort
+                    logger.debug("[agent-server] goal snapshot failed",
+                                 exc_info=True)
             # ch03 round-4 GAP B — the live persister carries the cost
             # block (schema owner: cost_restore.build_cost_block, matching
             # the /resume reader) so accumulated cost survives restarts.
@@ -1510,6 +1577,40 @@ class _AgentSession:
                     self.emit_init()
                 except Exception:  # noqa: BLE001
                     logger.debug("[agent-server] init re-emit after mode flip failed", exc_info=True)
+            # /goal restore (CC docs/en/goal §Resume with an active goal):
+            # only an ACTIVE goal carries over; turn count, timer, and the
+            # token-spend baseline reset. Achieved/cleared goals stay gone.
+            goal_notice = None
+            saved_goal = data.get("goal")
+            if isinstance(saved_goal, dict):
+                try:
+                    mgr = self._goal_manager()
+                    snapshot_now = _cost_snapshot()
+                    with self._lock:
+                        restored = mgr.restore(saved_goal)
+                        if restored is not None:
+                            mgr.rebaseline(
+                                tokens=self._usage_token_total(snapshot_now),
+                                cost_usd=float(
+                                    snapshot_now.get("total_cost_usd", 0.0) or 0.0
+                                ),
+                            )
+                    if restored is not None:
+                        goal_notice = (
+                            f"◎ Goal restored (counters reset): {restored.goal}\n"
+                            "I'll keep working toward it after your next "
+                            "message. /goal clear to stop."
+                        )
+                        self._emit({
+                            "type": "system",
+                            "subtype": "goal_status",
+                            "session_id": self.session_id,
+                            "message": goal_notice,
+                            "goal_active": True,
+                        })
+                except Exception:  # noqa: BLE001 — a bad goal record must not break resume
+                    logger.debug("[agent-server] goal restore failed",
+                                 exc_info=True)
             self._reply(request_id, {
                 "ok": True,
                 "count": len(conv.messages),
@@ -1520,6 +1621,7 @@ class _AgentSession:
                 "session_turns": self._stats_turns,
                 "cost": _cost_snapshot(),
                 **({"mode_banner": mode_banner} if mode_banner else {}),
+                **({"goal_notice": goal_notice} if goal_notice else {}),
             })
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] resume failed")
@@ -1763,6 +1865,229 @@ class _AgentSession:
             behavior="deny", message=str(reply.get("message", "")) or "denied by user"
         )
 
+    # ─── /goal — completion-condition loop (src/goals) ─────────────────────
+
+    def _goal_manager(self) -> Any:
+        """The session's GoalManager, built lazily. Never raises."""
+        if self._goal_mgr is None:
+            from src.goals import DEFAULT_GOAL_MAX_TURNS, GoalManager
+
+            max_turns = DEFAULT_GOAL_MAX_TURNS
+            try:
+                from src.settings.settings import get_settings
+
+                configured = int(getattr(get_settings(), "goal_max_turns", 0) or 0)
+                if configured > 0:
+                    max_turns = configured
+            except Exception:  # noqa: BLE001 — settings must not block /goal
+                logger.debug("[agent-server] goal_max_turns read failed",
+                             exc_info=True)
+            self._goal_mgr = GoalManager(
+                self.session_id, default_max_turns=max_turns,
+            )
+        # Judge rebound on every call so a mid-goal /model or /provider
+        # switch is picked up (the callable closes over the provider object).
+        try:
+            from src.goals import build_judge_callable
+
+            self._goal_mgr.judge = build_judge_callable(self.provider)
+        except Exception:  # noqa: BLE001
+            logger.debug("[agent-server] goal judge bind failed", exc_info=True)
+        return self._goal_mgr
+
+    def _goal_set_gate(self) -> str | None:
+        """CC docs/en/goal §Requirements: /goal needs an accepted trust
+        dialog and the hooks framework enabled — "the command tells you why
+        instead of silently doing nothing". Returns the reason, or None."""
+        if not getattr(self.tool_context, "workspace_trusted", False):
+            return (
+                "/goal requires a trusted workspace (the evaluator is part "
+                "of the hooks system). Accept the trust dialog for this "
+                "workspace, then set the goal again."
+            )
+        try:
+            from src.settings.settings import load_settings
+
+            if not load_settings(cwd=self.cwd).hooks.enabled:
+                return (
+                    "/goal is unavailable because hooks are disabled "
+                    "(settings hooks.enabled=false — the evaluator is part "
+                    "of the hooks system)."
+                )
+        except Exception:  # noqa: BLE001 — unreadable settings fail open (enabled)
+            logger.debug("[agent-server] hooks.enabled read failed",
+                         exc_info=True)
+        return None
+
+    @staticmethod
+    def _usage_token_total(snapshot: dict) -> int:
+        """Total input+output tokens across the cost snapshot's model_usage."""
+        total = 0
+        try:
+            for usage in (snapshot.get("model_usage") or {}).values():
+                total += int(usage.get("input_tokens", 0) or 0)
+                total += int(usage.get("output_tokens", 0) or 0)
+        except Exception:  # noqa: BLE001
+            return 0
+        return total
+
+    def _do_goal_command(self, request_id: object, arg: object) -> None:
+        """Control handler for /goal. Allowed while a turn is RUNNING —
+        /goal clear must be able to stop a runaway loop (the /clear control
+        is idle-only, so it can't)."""
+        try:
+            from src.goals.command import run_goal_command
+
+            mgr = self._goal_manager()
+            snapshot = _cost_snapshot()
+            # Under _lock: the worker's post-turn hook reads/mutates the
+            # same state (critic R1). run_goal_command is pure state ops —
+            # no I/O — so the critical section is short.
+            with self._lock:
+                result = run_goal_command(
+                    mgr,
+                    str(arg or ""),
+                    set_gate=self._goal_set_gate,
+                    baseline_tokens=self._usage_token_total(snapshot),
+                    baseline_cost_usd=float(snapshot.get("total_cost_usd", 0.0) or 0.0),
+                )
+            self._save_session()
+            reply: dict[str, Any] = {
+                "ok": result.ok,
+                "text": result.text,
+                "active": result.active,
+            }
+            if result.kickoff:
+                reply["notice"] = result.notice
+                reply["kickoff"] = result.kickoff
+            if not result.ok:
+                reply["error"] = result.text
+            self._reply(request_id, reply)
+        except Exception as exc:  # noqa: BLE001 — a goal bug must not kill the control channel
+            logger.exception("[agent-server] goal command failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _do_subgoal_command(self, request_id: object, arg: object) -> None:
+        try:
+            from src.goals.command import run_subgoal_command
+
+            mgr = self._goal_manager()
+            with self._lock:
+                result = run_subgoal_command(mgr, str(arg or ""))
+            self._save_session()
+            reply: dict[str, Any] = {
+                "ok": result.ok,
+                "text": result.text,
+                "active": result.active,
+            }
+            if not result.ok:
+                reply["error"] = result.text
+            self._reply(request_id, reply)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] subgoal command failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _maybe_continue_goal(self, outcome: dict | None) -> None:
+        """Post-turn goal hook (worker thread) — the port of hermes
+        tui_gateway's "/goal continuation" block and the observable behavior
+        of CC's session-scoped Stop-hook evaluator (docs/en/goal §How
+        evaluation works).
+
+        Runs after real user turns and __goal__ continuation turns (NOT
+        after btw side-questions or internal notification turns — judging a
+        goal against a background-task recap would entangle two self-driving
+        loops). Skips when: no active goal, the turn was cancelled/errored
+        (CC's no-Stop-hooks-on-error guard), the response is empty, or user
+        input is already queued (preemption — the judge re-runs after their
+        turn anyway; slash commands ride the control channel and never
+        queue here, matching hermes's "slash commands don't preempt" rule).
+
+        Concurrency (critic R1): goal state is shared with the control
+        plane (/goal set|clear|pause on the asyncio loop), so this uses
+        double-checked locking — snapshot + preflight under ``_lock``, the
+        judge network call OUTSIDE the lock, verdict application +
+        continuation enqueue back under the lock with an ``expected_state``
+        identity check so a mid-judge clear/replace discards the stale
+        verdict. Never raises.
+        """
+        try:
+            if not outcome or outcome.get("subtype") != "success":
+                return
+            response_text = str(outcome.get("response_text") or "")
+            if not response_text.strip():
+                return
+
+            # ── preflight under the lock ──────────────────────────────
+            with self._lock:
+                mgr = self._goal_mgr
+                if mgr is None or not mgr.is_active():
+                    return
+                # Best-effort preemption, not a hard barrier: send_to_agent
+                # puts user messages into _inbox WITHOUT _lock, so one can
+                # land between the apply-block's empty() re-check and its
+                # put() — order [user, __goal__], and one stale continuation
+                # runs after the user's turn. Self-correcting: a queued
+                # __goal__ item keeps this preflight returning early (at
+                # most one ever queued), and the worker's staleness drop
+                # kills it outright if the goal was cleared meanwhile.
+                if not self._inbox.empty():
+                    return  # user input pending — their turn wins
+                state_snapshot = mgr.state
+                goal_text = state_snapshot.goal
+                subgoals = list(state_snapshot.subgoals)
+            # Rebind the judge to the CURRENT provider (mid-goal /model
+            # switches). Outside the lock: touches settings/imports only.
+            mgr = self._goal_manager()
+
+            from src.goals import collect_turn_evidence, judge_goal
+
+            evidence = ""
+            try:
+                evidence = collect_turn_evidence(
+                    list(self.session.conversation.messages)
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug("[agent-server] goal evidence failed", exc_info=True)
+            if not evidence:
+                evidence = response_text
+
+            # ── judge OUTSIDE the lock (bounded network call) ─────────
+            verdict, reason, parse_failed = judge_goal(
+                goal_text, evidence, judge=mgr.judge,
+                subgoals=subgoals or None,
+            )
+
+            snapshot = _cost_snapshot()
+            # ── apply + enqueue back under the lock ───────────────────
+            with self._lock:
+                decision = mgr.apply_verdict(
+                    verdict, reason, parse_failed,
+                    tokens_now=self._usage_token_total(snapshot),
+                    cost_now_usd=float(snapshot.get("total_cost_usd", 0.0) or 0.0),
+                    expected_state=state_snapshot,
+                )
+                should_continue = bool(decision.get("should_continue"))
+                continuation = decision.get("continuation_prompt") or ""
+                if should_continue and continuation and self._inbox.empty():
+                    # Internal-turn semantics downstream: no UserPromptSubmit
+                    # hooks, no ultracode reminder, no memory recall, no
+                    # stats-odometer tick — loop machinery, not a user prompt.
+                    self._inbox.put({"__goal__": True, "content": continuation})
+            self._save_session()  # persist turns_used/verdict/achieved state
+
+            message = decision.get("message") or ""
+            if message:
+                self._emit({
+                    "type": "system",
+                    "subtype": "goal_status",
+                    "session_id": self.session_id,
+                    "message": message,
+                    "goal_active": bool(mgr.is_active()),
+                })
+        except Exception:  # noqa: BLE001 — the goal loop must never kill the worker
+            logger.debug("[agent-server] goal continuation hook failed",
+                         exc_info=True)
+
     # ─── worker thread (runs query() turns) ────────────────────────────────
 
     def start(self) -> None:
@@ -1789,9 +2114,29 @@ class _AgentSession:
             if isinstance(item, dict) and item.get("__btw__"):  # side question (/btw)
                 self._run_turn(item.get("content"), btw=True)
                 continue
+            if isinstance(item, dict) and item.get("__goal__"):
+                # /goal continuation — internal-turn semantics (no UPS hooks,
+                # no ultracode reminder, no recall, no odometer tick), but
+                # the post-turn goal hook still evaluates it so the loop
+                # keeps going until the evaluator says done.
+                # Staleness drop: a /goal clear|pause that landed while this
+                # continuation sat queued must win — running it would spend
+                # a full model turn on a dead goal (hermes clears pending
+                # synthetic continuations from its FIFO for the same race).
+                with self._lock:
+                    goal_live = (
+                        self._goal_mgr is not None and self._goal_mgr.is_active()
+                    )
+                if not goal_live:
+                    continue
+                outcome = self._run_turn(item.get("content"), internal=True)
+                self._maybe_continue_goal(outcome)
+                self._deliver_task_notifications()
+                continue
             if not isinstance(item, (str, list)):  # str prompt, or multimodal blocks
                 continue
-            self._run_turn(item)
+            outcome = self._run_turn(item)
+            self._maybe_continue_goal(outcome)
             # A task that finished while the turn ran is delivered right after.
             self._deliver_task_notifications()
         self._close_stream()
@@ -1929,8 +2274,11 @@ class _AgentSession:
                          exc_info=True)
             return None
 
-    def _run_turn(self, prompt, btw: bool = False, internal: bool = False) -> None:
+    def _run_turn(self, prompt, btw: bool = False, internal: bool = False) -> dict | None:
         # prompt: str | list[ContentBlock]
+        # Returns a small outcome dict {"subtype", "response_text"} for the
+        # worker's post-turn goal hook (None-safe there: a missed path
+        # degrades to "no continuation", never an error).
         # btw=True → a "side question" (the original's /btw): run with full context
         # but DON'T persist the Q&A, so the main conversation isn't interrupted.
         # internal=True → a system-generated turn (task-notification delivery):
@@ -1944,7 +2292,7 @@ class _AgentSession:
                 result=self.init_error, is_error=True, error=self.init_error,
                 session_turns=self._stats_turns,
             ))
-            return
+            return {"subtype": "error", "response_text": ""}
 
         # ch05 round-4 GAP B (critic m1) — parse the '+500k' budget from the
         # ORIGINAL prompt BEFORE ultracode augmentation: the reminder is
@@ -1984,7 +2332,7 @@ class _AgentSession:
                     result="", is_error=False, duration_ms=0,
                     session_turns=self._stats_turns,
                 ))
-                return
+                return {"subtype": "success", "response_text": ""}
             if ups is not None and ups.prevented:
                 # preventContinuation → KEEP the prompt in context + push an
                 # "Operation stopped by hook" note; no query (TS :213-224).
@@ -1998,7 +2346,7 @@ class _AgentSession:
                     result="", is_error=False, duration_ms=0,
                     session_turns=self._stats_turns,
                 ))
-                return
+                return {"subtype": "success", "response_text": ""}
             if ups is not None:
                 _ups_contexts = list(ups.additional_contexts)
 
@@ -2117,7 +2465,7 @@ class _AgentSession:
                 duration_ms=int((time.monotonic() - start) * 1000),
                 session_turns=self._stats_turns,
             ))
-            return
+            return {"subtype": "cancelled", "response_text": ""}
         except Exception as exc:  # noqa: BLE001 - one bad turn must not kill the session
             logger.exception("[agent-server] turn failed")
             self._emit(_result_message(
@@ -2127,7 +2475,7 @@ class _AgentSession:
                 duration_ms=int((time.monotonic() - start) * 1000),
                 session_turns=self._stats_turns,
             ))
-            return
+            return {"subtype": "error", "response_text": ""}
         finally:
             with self._lock:
                 self._current_abort = None
@@ -2163,6 +2511,7 @@ class _AgentSession:
             session_turns=self._stats_turns,
         ))
         self._save_session()  # persist for /resume
+        return {"subtype": "success", "response_text": result.response_text or ""}
 
     async def shutdown(self) -> None:
         self._stop.set()

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -117,6 +117,11 @@ class SettingsSchema:
     # vacuous and let /model mutate provider selection.
     model_provider: str = ""
     small_fast_model: str = ""
+    # /goal turn-budget backstop (src/goals). Claude Code ships the goal
+    # loop unbounded; the port pauses the goal after this many evaluated
+    # turns so a mis-judging evaluator can't spend unbounded tokens —
+    # ``/goal resume`` continues with a fresh budget. 0/negative → default.
+    goal_max_turns: int = 20
     # Advisor — reviewer tool. Empty string = unset (no /advisor).
     # Persisted analogue of TS appState.advisorModel; the /advisor slash
     # command writes here, and _call_model_sync reads from here at request

--- a/tests/entrypoints/test_headless_goal.py
+++ b/tests/entrypoints/test_headless_goal.py
@@ -1,0 +1,226 @@
+"""Headless /goal loop: ``clawcodex -p "/goal <condition>"`` runs the
+evaluate-continue loop to completion in one invocation (CC docs/en/goal
+§Run non-interactively).
+
+Reuses test_headless_cli.py's fake-wiring pattern. The FakeProvider's script
+queue serves BOTH the conversation turns (the query loop calls
+``provider.chat``) and the evaluator side-calls (``build_judge_callable``
+also calls ``provider.chat``), so scripts interleave: turn, judge, turn,
+judge, …
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from src.entrypoints import HeadlessOptions, run_headless
+from src.entrypoints import headless as headless_mod
+from src.providers.base import ChatResponse
+
+
+class _FakeProvider:
+    def __init__(self, api_key: str, base_url=None, model=None, *, responses=None):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.model = model or "fake-model"
+        self._responses = list(responses or [])
+        self.calls: list[dict] = []
+
+    def chat(self, messages, tools=None, **kwargs):
+        self.calls.append({"messages": messages, "kwargs": kwargs})
+        if not self._responses:
+            raise AssertionError("FakeProvider ran out of scripted responses")
+        return self._responses.pop(0)
+
+    def chat_stream(self, messages, tools=None, **kwargs):
+        raise NotImplementedError
+
+
+class _FakeRegistry:
+    def list_tools(self):
+        return []
+
+
+class _Wiring:
+    """Fixture handle: ``script`` feeds providers created after it's filled;
+    ``created`` records every provider instance for call inspection."""
+
+    def __init__(self) -> None:
+        self.script: list[ChatResponse] = []
+        self.created: list[_FakeProvider] = []
+
+    # list-ish conveniences so tests read naturally
+    def extend(self, items) -> None:
+        self.script.extend(items)
+
+    def append(self, item) -> None:
+        self.script.append(item)
+
+
+@pytest.fixture
+def fake_wiring(monkeypatch):
+    wiring = _Wiring()
+
+    def _fake_provider_class(provider_name):
+        def _ctor(api_key, base_url=None, model=None):
+            p = _FakeProvider(api_key, base_url, model, responses=list(wiring.script))
+            wiring.created.append(p)
+            return p
+
+        return _ctor
+
+    monkeypatch.setattr(headless_mod, "get_provider_class", _fake_provider_class)
+    monkeypatch.setattr(
+        headless_mod,
+        "get_provider_config",
+        lambda name: {"api_key": "test-key", "default_model": "fake-model"},
+    )
+    monkeypatch.setattr(headless_mod, "get_default_provider", lambda: "anthropic")
+    monkeypatch.setattr(
+        "src.entrypoints.provider_validation.get_provider_validation_error",
+        lambda name: None,
+    )
+    monkeypatch.setattr(
+        headless_mod, "build_default_registry", lambda provider=None: _FakeRegistry()
+    )
+    # /goal gates: trust the tmp workspace; hooks enabled regardless of the
+    # developer machine's real settings. The fake returns a REAL
+    # SettingsSchema (defaults: hooks enabled) so every other load_settings
+    # caller in the turn path keeps working, and the get_settings cache is
+    # reset around the test so the fake can't leak into later tests.
+    import src.settings.settings as settings_mod
+    from src.settings.types import SettingsSchema
+
+    monkeypatch.setattr(
+        "src.services.startup_gates.check_trust_accepted", lambda root: True
+    )
+    monkeypatch.setattr(
+        settings_mod, "load_settings", lambda *a, **k: SettingsSchema()
+    )
+    monkeypatch.setattr(settings_mod, "_settings_cache", None)
+    yield wiring
+    settings_mod._settings_cache = None
+
+
+def _text(text: str) -> ChatResponse:
+    return ChatResponse(
+        content=text,
+        model="fake-model",
+        usage={"input_tokens": 5, "output_tokens": 3},
+        finish_reason="end_turn",
+        tool_uses=None,
+    )
+
+
+def _run(prompt: str, tmp_path, **opt_kwargs):
+    stdout, stderr = io.StringIO(), io.StringIO()
+    code = run_headless(HeadlessOptions(
+        prompt=prompt,
+        output_format="text",
+        stdout=stdout,
+        stderr=stderr,
+        workspace_root=tmp_path,
+        **opt_kwargs,
+    ))
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+def test_goal_loop_runs_until_evaluator_says_done(fake_wiring, tmp_path):
+    fake_wiring.extend([
+        _text("first attempt — still failing"),                       # turn 1
+        _text('{"verdict": "continue", "reason": "tests still red"}'),  # judge 1
+        _text("fixed everything; tests pass"),                        # turn 2
+        _text('{"verdict": "done", "reason": "tests green"}'),        # judge 2
+    ])
+    code, out, err = _run("/goal make the tests pass", tmp_path)
+    assert code == 0
+    # Both conversation turns aggregate to stdout; goal progress on stderr.
+    assert "first attempt" in out
+    assert "fixed everything" in out
+    assert "Goal set" in err
+    assert "↻" in err and "tests still red" in err
+    assert "✓ Goal achieved" in err
+
+
+def test_goal_continuation_prompt_carries_reason(fake_wiring, tmp_path):
+    fake_wiring.extend([
+        _text("attempt"),
+        _text('{"verdict": "continue", "reason": "missing the docs entry"}'),
+        _text("done now"),
+        _text('{"verdict": "done", "reason": "ok"}'),
+    ])
+    code, _, _ = _run("/goal write the docs", tmp_path)
+    assert code == 0
+    provider = fake_wiring.created[0]
+    assert not provider._responses  # every scripted response was consumed
+
+    def _flat(call) -> str:
+        return "\n".join(
+            str(m.get("content", "") if isinstance(m, dict) else getattr(m, "content", ""))
+            for m in call["messages"]
+        )
+
+    continuation_turns = [
+        c for c in provider.calls
+        if "[Continuing toward your standing goal]" in _flat(c)
+    ]
+    assert continuation_turns, "no continuation turn reached the provider"
+    text = _flat(continuation_turns[-1])
+    assert "Goal: write the docs" in text
+    assert "missing the docs entry" in text  # evaluator reason as guidance
+    # Judge side-calls carry the strict-JSON system prompt; conversation
+    # turns must not.
+    judge_calls = [
+        c for c in provider.calls
+        if "strict judge" in str(c["kwargs"].get("system", ""))
+    ]
+    assert len(judge_calls) == 2
+
+
+def test_goal_budget_exhaustion_exits_nonzero(fake_wiring, tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "src.settings.settings.get_settings",
+        lambda *a, **k: __import__("types").SimpleNamespace(goal_max_turns=2),
+    )
+    fake_wiring.extend([
+        _text("attempt 1"),
+        _text('{"verdict": "continue", "reason": "nope"}'),
+        _text("attempt 2"),
+        _text('{"verdict": "continue", "reason": "still nope"}'),
+        # budget 2 exhausted after judge 2 — no further calls
+    ])
+    code, out, err = _run("/goal unreachable condition", tmp_path)
+    assert code == 1
+    assert "turns used" in err  # budget pause message
+    assert "not achieved" in err
+
+
+def test_bare_goal_prints_status_without_running_a_turn(fake_wiring, tmp_path):
+    code, out, err = _run("/goal", tmp_path)
+    assert code == 0
+    assert "No active goal" in out
+
+
+def test_goal_clear_prints_and_exits(fake_wiring, tmp_path):
+    code, out, err = _run("/goal clear", tmp_path)
+    assert code == 0
+    assert "No active goal" in out
+
+
+def test_goal_untrusted_workspace_refused(fake_wiring, tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "src.services.startup_gates.check_trust_accepted", lambda root: False
+    )
+    code, out, err = _run("/goal do something", tmp_path)
+    assert code == 1
+    assert "trusted workspace" in err
+
+
+def test_plain_prompt_unaffected_by_goal_machinery(fake_wiring, tmp_path):
+    fake_wiring.append(_text("plain answer"))
+    code, out, err = _run("just a question", tmp_path)
+    assert code == 0
+    assert "plain answer" in out
+    assert "[goal]" not in err

--- a/tests/goals/test_goal_manager.py
+++ b/tests/goals/test_goal_manager.py
@@ -1,0 +1,605 @@
+"""Unit coverage for the /goal core: GoalState, judge parsing, GoalManager
+transitions, evaluation matrix, continuation prompts, evidence collection,
+and the shared /goal · /subgoal command grammar."""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from src.goals.command import run_goal_command, run_subgoal_command
+from src.goals.goals import (
+    CONTINUATION_PROMPT_TEMPLATE,
+    GOAL_CLEAR_ALIASES,
+    GOAL_CONDITION_MAX_CHARS,
+    GoalManager,
+    GoalState,
+    MAX_CONSECUTIVE_PARSE_FAILURES,
+    _parse_judge_response,
+    collect_turn_evidence,
+    judge_goal,
+)
+
+
+def _mgr(judge=None, **kwargs) -> GoalManager:
+    return GoalManager("sess-1", judge=judge, **kwargs)
+
+
+def _judge_returning(payload: str):
+    return lambda system, user: payload
+
+
+# ── judge reply parsing ────────────────────────────────────────────────
+
+
+class TestParseJudgeResponse(unittest.TestCase):
+    def test_clean_json_done(self) -> None:
+        v, r, failed = _parse_judge_response(
+            '{"verdict": "done", "reason": "tests pass"}'
+        )
+        self.assertEqual(v, "done")
+        self.assertEqual(r, "tests pass")
+        self.assertFalse(failed)
+
+    def test_clean_json_continue(self) -> None:
+        v, _, failed = _parse_judge_response(
+            '{"verdict": "continue", "reason": "lint still failing"}'
+        )
+        self.assertEqual(v, "continue")
+        self.assertFalse(failed)
+
+    def test_json_in_markdown_fence(self) -> None:
+        raw = '```json\n{"verdict": "done", "reason": "ok"}\n```'
+        v, r, failed = _parse_judge_response(raw)
+        self.assertEqual(v, "done")
+        self.assertEqual(r, "ok")
+        self.assertFalse(failed)
+
+    def test_json_embedded_in_prose(self) -> None:
+        raw = 'Sure! Here is my verdict: {"verdict": "continue", "reason": "wip"} hope that helps'
+        v, r, failed = _parse_judge_response(raw)
+        self.assertEqual(v, "continue")
+        self.assertEqual(r, "wip")
+        self.assertFalse(failed)
+
+    def test_legacy_done_bool(self) -> None:
+        v, _, failed = _parse_judge_response('{"done": true, "reason": "x"}')
+        self.assertEqual(v, "done")
+        self.assertFalse(failed)
+        v, _, _ = _parse_judge_response('{"done": false, "reason": "x"}')
+        self.assertEqual(v, "continue")
+
+    def test_legacy_done_string_values(self) -> None:
+        v, _, _ = _parse_judge_response('{"done": "yes", "reason": "x"}')
+        self.assertEqual(v, "done")
+        v, _, _ = _parse_judge_response('{"done": "no", "reason": "x"}')
+        self.assertEqual(v, "continue")
+
+    def test_unknown_verdict_falls_back_to_continue(self) -> None:
+        v, _, failed = _parse_judge_response(
+            '{"verdict": "maybe", "reason": "?"}'
+        )
+        self.assertEqual(v, "continue")
+        self.assertFalse(failed)
+
+    def test_empty_is_parse_failure(self) -> None:
+        v, _, failed = _parse_judge_response("")
+        self.assertEqual(v, "continue")
+        self.assertTrue(failed)
+
+    def test_prose_is_parse_failure(self) -> None:
+        v, _, failed = _parse_judge_response("The goal seems done to me!")
+        self.assertEqual(v, "continue")
+        self.assertTrue(failed)
+
+    def test_missing_reason_defaults(self) -> None:
+        _, r, _ = _parse_judge_response('{"verdict": "done"}')
+        self.assertEqual(r, "no reason provided")
+
+
+# ── judge_goal orchestration ───────────────────────────────────────────
+
+
+class TestJudgeGoal(unittest.TestCase):
+    def test_empty_goal_skipped(self) -> None:
+        v, _, failed = judge_goal("", "output", judge=_judge_returning("{}"))
+        self.assertEqual(v, "skipped")
+        self.assertFalse(failed)
+
+    def test_empty_evidence_continues(self) -> None:
+        v, r, failed = judge_goal("do x", "  ", judge=_judge_returning("{}"))
+        self.assertEqual(v, "continue")
+        self.assertIn("empty response", r)
+        self.assertFalse(failed)
+
+    def test_no_judge_continues(self) -> None:
+        v, r, failed = judge_goal("do x", "output", judge=None)
+        self.assertEqual(v, "continue")
+        self.assertIn("no evaluator", r)
+        self.assertFalse(failed)
+
+    def test_judge_exception_fails_open_not_parse_failure(self) -> None:
+        def boom(system, user):
+            raise RuntimeError("api down")
+
+        v, r, failed = judge_goal("do x", "output", judge=boom)
+        self.assertEqual(v, "continue")
+        self.assertIn("judge error", r)
+        self.assertFalse(failed)
+
+    def test_subgoals_reach_the_prompt(self) -> None:
+        seen: dict[str, str] = {}
+
+        def capture(system, user):
+            seen["user"] = user
+            return '{"verdict": "continue", "reason": "wip"}'
+
+        judge_goal("main goal", "output", judge=capture, subgoals=["extra one"])
+        self.assertIn("extra one", seen["user"])
+        self.assertIn("every additional criterion", seen["user"])
+
+    def test_goal_and_evidence_truncated(self) -> None:
+        seen: dict[str, str] = {}
+
+        def capture(system, user):
+            seen["user"] = user
+            return '{"verdict": "continue", "reason": "wip"}'
+
+        judge_goal("g" * 5000, "e" * 10000, judge=capture)
+        self.assertLess(len(seen["user"]), 8000)
+
+
+# ── build_judge_callable ───────────────────────────────────────────────
+
+
+class TestBuildJudgeCallable(unittest.TestCase):
+    def test_returns_content_and_pins_no_model_for_non_anthropic(self) -> None:
+        from src.goals.goals import build_judge_callable
+
+        calls: dict = {}
+
+        class P:
+            def chat(self, messages, **kwargs):
+                calls.update(kwargs)
+                return SimpleNamespace(content=' {"verdict":"done","reason":"x"} ')
+
+        out = build_judge_callable(P())("sys", "user")
+        self.assertEqual(out, '{"verdict":"done","reason":"x"}')
+        self.assertNotIn("model", calls)  # session-model fallback
+        self.assertEqual(calls["system"], "sys")
+
+    def test_hung_call_raises_timeout_on_daemon_thread(self) -> None:
+        import threading
+
+        from src.goals.goals import GoalJudgeTimeout, build_judge_callable
+
+        release = threading.Event()
+
+        class Hung:
+            def chat(self, messages, **kwargs):
+                release.wait(10)
+                return SimpleNamespace(content="late")
+
+        judge = build_judge_callable(Hung(), timeout_s=0.2)
+        with self.assertRaises(GoalJudgeTimeout):
+            judge("sys", "user")
+        release.set()  # unblock the daemon thread
+
+    def test_provider_error_propagates_for_fail_open(self) -> None:
+        from src.goals.goals import build_judge_callable
+
+        class Boom:
+            def chat(self, messages, **kwargs):
+                raise RuntimeError("api down")
+
+        with self.assertRaises(RuntimeError):
+            build_judge_callable(Boom())("sys", "user")
+        # judge_goal turns that into a fail-open continue:
+        v, r, failed = judge_goal(
+            "goal", "evidence", judge=build_judge_callable(Boom())
+        )
+        self.assertEqual(v, "continue")
+        self.assertFalse(failed)
+
+
+# ── GoalManager state machine ──────────────────────────────────────────
+
+
+class TestGoalManager(unittest.TestCase):
+    def test_initial_no_goal(self) -> None:
+        m = _mgr()
+        self.assertFalse(m.is_active())
+        self.assertFalse(m.has_goal())
+        self.assertIn("No active goal", m.status_text())
+
+    def test_set_then_status(self) -> None:
+        m = _mgr()
+        st = m.set("ship the feature")
+        self.assertEqual(st.status, "active")
+        self.assertTrue(m.is_active())
+        self.assertIn("ship the feature", m.status_text())
+        self.assertIn("Turns evaluated: 0/", m.status_text())
+
+    def test_set_rejects_empty(self) -> None:
+        with self.assertRaises(ValueError):
+            _mgr().set("   ")
+
+    def test_set_rejects_over_cap(self) -> None:
+        with self.assertRaises(ValueError):
+            _mgr().set("x" * (GOAL_CONDITION_MAX_CHARS + 1))
+
+    def test_set_replaces_existing(self) -> None:
+        m = _mgr()
+        m.set("first")
+        m.state.turns_used = 5
+        st = m.set("second")
+        self.assertEqual(st.goal, "second")
+        self.assertEqual(st.turns_used, 0)
+
+    def test_pause_resume_resets_budget(self) -> None:
+        m = _mgr()
+        m.set("goal")
+        m.state.turns_used = 7
+        m.pause()
+        self.assertFalse(m.is_active())
+        self.assertTrue(m.has_goal())
+        st = m.resume()
+        self.assertEqual(st.status, "active")
+        self.assertEqual(st.turns_used, 0)
+
+    def test_pause_after_done_is_noop(self) -> None:
+        m = _mgr()
+        m.set("goal")
+        m.mark_done("achieved")
+        self.assertIsNone(m.pause())
+        self.assertIsNone(m.resume())
+
+    def test_clear(self) -> None:
+        m = _mgr()
+        m.set("goal")
+        self.assertTrue(m.clear())
+        self.assertFalse(m.has_goal())
+        self.assertFalse(m.clear())
+
+    def test_achieved_status_record(self) -> None:
+        m = _mgr()
+        m.set("goal")
+        m.mark_done("evidence shown")
+        text = m.status_text()
+        self.assertIn("✓ Goal achieved", text)
+        self.assertIn("evidence shown", text)
+
+
+# ── evaluation matrix ──────────────────────────────────────────────────
+
+
+class TestEvaluateAfterTurn(unittest.TestCase):
+    def test_inactive(self) -> None:
+        d = _mgr().evaluate_after_turn("output")
+        self.assertEqual(d["verdict"], "inactive")
+        self.assertFalse(d["should_continue"])
+
+    def test_done_marks_and_stops(self) -> None:
+        m = _mgr(judge=_judge_returning('{"verdict": "done", "reason": "all pass"}'))
+        m.set("goal")
+        d = m.evaluate_after_turn("tests: 10 passed")
+        self.assertEqual(d["verdict"], "done")
+        self.assertFalse(d["should_continue"])
+        self.assertEqual(m.state.status, "done")
+        self.assertIn("✓ Goal achieved", d["message"])
+
+    def test_continue_under_budget(self) -> None:
+        m = _mgr(judge=_judge_returning('{"verdict": "continue", "reason": "2 tests failing"}'))
+        m.set("goal")
+        d = m.evaluate_after_turn("wip")
+        self.assertTrue(d["should_continue"])
+        self.assertIn("Goal: goal", d["continuation_prompt"])
+        self.assertIn("2 tests failing", d["continuation_prompt"])
+        self.assertEqual(m.state.turns_used, 1)
+
+    def test_budget_exhaustion_pauses(self) -> None:
+        m = _mgr(judge=_judge_returning('{"verdict": "continue", "reason": "wip"}'))
+        m.set("goal", max_turns=2)
+        d1 = m.evaluate_after_turn("wip")
+        self.assertTrue(d1["should_continue"])
+        d2 = m.evaluate_after_turn("wip")
+        self.assertFalse(d2["should_continue"])
+        self.assertEqual(d2["status"], "paused")
+        self.assertIn("/goal resume", d2["message"])
+
+    def test_parse_failures_pause_after_threshold(self) -> None:
+        m = _mgr(judge=_judge_returning("not json at all"))
+        m.set("goal", max_turns=50)
+        for i in range(MAX_CONSECUTIVE_PARSE_FAILURES - 1):
+            d = m.evaluate_after_turn("wip")
+            self.assertTrue(d["should_continue"], f"iteration {i}")
+        d = m.evaluate_after_turn("wip")
+        self.assertFalse(d["should_continue"])
+        self.assertEqual(d["status"], "paused")
+        self.assertIn("evaluator", d["message"])
+
+    def test_parse_failure_counter_resets_on_good_reply(self) -> None:
+        replies = iter([
+            "junk", "junk",
+            '{"verdict": "continue", "reason": "ok"}',
+            "junk", "junk",
+        ])
+        m = _mgr(judge=lambda s, u: next(replies))
+        m.set("goal", max_turns=50)
+        for _ in range(5):
+            d = m.evaluate_after_turn("wip")
+        # Never hit 3 consecutive failures — still active.
+        self.assertTrue(d["should_continue"])
+        self.assertEqual(m.state.status, "active")
+
+    def test_transport_errors_do_not_count_as_parse_failures(self) -> None:
+        def boom(s, u):
+            raise RuntimeError("network")
+
+        m = _mgr(judge=boom)
+        m.set("goal", max_turns=50)
+        for _ in range(MAX_CONSECUTIVE_PARSE_FAILURES + 2):
+            d = m.evaluate_after_turn("wip")
+        self.assertTrue(d["should_continue"])
+        self.assertEqual(m.state.status, "active")
+
+    def test_token_spend_tracked_from_baseline(self) -> None:
+        m = _mgr(judge=_judge_returning('{"verdict": "continue", "reason": "wip"}'))
+        m.set("goal", baseline_tokens=1000, baseline_cost_usd=0.10)
+        m.evaluate_after_turn("wip", tokens_now=1500, cost_now_usd=0.15)
+        self.assertEqual(m.state.spent_tokens, 500)
+        self.assertAlmostEqual(m.state.spent_cost_usd, 0.05, places=6)
+
+
+# ── continuation prompts ───────────────────────────────────────────────
+
+
+class TestContinuationPrompt(unittest.TestCase):
+    def test_plain_shape(self) -> None:
+        m = _mgr()
+        m.set("write the docs")
+        p = m.next_continuation_prompt("intro missing")
+        self.assertEqual(
+            p,
+            CONTINUATION_PROMPT_TEMPLATE.format(
+                goal="write the docs", reason="intro missing"
+            ),
+        )
+
+    def test_subgoals_shape(self) -> None:
+        m = _mgr()
+        m.set("write the docs")
+        m.add_subgoal("add examples")
+        p = m.next_continuation_prompt("wip")
+        self.assertIn("Additional criteria", p)
+        self.assertIn("- 1. add examples", p)
+
+    def test_none_when_inactive(self) -> None:
+        m = _mgr()
+        self.assertIsNone(m.next_continuation_prompt("x"))
+
+
+# ── subgoal ops ────────────────────────────────────────────────────────
+
+
+class TestSubgoals(unittest.TestCase):
+    def test_add_remove_clear(self) -> None:
+        m = _mgr()
+        m.set("goal")
+        m.add_subgoal("one")
+        m.add_subgoal("two")
+        self.assertEqual(m.remove_subgoal(1), "one")
+        self.assertEqual(m.clear_subgoals(), 1)
+
+    def test_requires_goal(self) -> None:
+        m = _mgr()
+        with self.assertRaises(RuntimeError):
+            m.add_subgoal("x")
+
+    def test_remove_out_of_range(self) -> None:
+        m = _mgr()
+        m.set("goal")
+        with self.assertRaises(IndexError):
+            m.remove_subgoal(1)
+
+    def test_empty_rejected(self) -> None:
+        m = _mgr()
+        m.set("goal")
+        with self.assertRaises(ValueError):
+            m.add_subgoal("  ")
+
+
+# ── persistence bridge ─────────────────────────────────────────────────
+
+
+class TestPersistence(unittest.TestCase):
+    def test_round_trip(self) -> None:
+        m = _mgr()
+        m.set("goal text")
+        m.add_subgoal("crit")
+        m.state.turns_used = 3
+        data = m.state.to_dict()
+
+        m2 = _mgr()
+        st = m2.restore(data, reset_counters=False)
+        self.assertIsNotNone(st)
+        self.assertEqual(st.goal, "goal text")
+        self.assertEqual(st.turns_used, 3)
+        self.assertEqual(st.subgoals, ["crit"])
+
+    def test_restore_resets_counters(self) -> None:
+        m = _mgr()
+        m.set("goal")
+        m.state.turns_used = 9
+        m.state.spent_tokens = 12345
+        data = m.state.to_dict()
+
+        m2 = _mgr()
+        st = m2.restore(data)  # reset_counters=True default
+        self.assertEqual(st.turns_used, 0)
+        self.assertEqual(st.spent_tokens, 0)
+        self.assertTrue(m2.is_active())
+
+    def test_only_active_goals_restore(self) -> None:
+        m = _mgr()
+        m.set("goal")
+        m.mark_done("done")
+        data = m.state.to_dict()
+        self.assertIsNone(_mgr().restore(data))
+
+        m3 = _mgr()
+        m3.set("goal2")
+        m3.pause()
+        self.assertIsNone(_mgr().restore(m3.state.to_dict()))
+
+    def test_corrupt_record_ignored(self) -> None:
+        self.assertIsNone(_mgr().restore({"goal": ""}))
+        self.assertIsNone(_mgr().restore({"status": []}))  # type: ignore[dict-item]
+
+
+# ── evidence collection ────────────────────────────────────────────────
+
+
+def _m(role: str, content, is_meta: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(role=role, content=content, isMeta=is_meta)
+
+
+class TestCollectTurnEvidence(unittest.TestCase):
+    def test_collects_since_last_user_prompt(self) -> None:
+        msgs = [
+            _m("user", "old prompt"),
+            _m("assistant", "old answer"),
+            _m("user", "run the tests"),
+            _m("assistant", [
+                {"type": "text", "text": "Running tests."},
+                {"type": "tool_use", "name": "Bash", "id": "t1", "input": {}},
+            ]),
+            _m("user", [{
+                "type": "tool_result", "tool_use_id": "t1",
+                "content": "10 passed, 0 failed",
+            }]),
+            _m("assistant", "All tests pass."),
+        ]
+        ev = collect_turn_evidence(msgs)
+        self.assertIn("All tests pass.", ev)
+        self.assertIn("10 passed, 0 failed", ev)
+        self.assertIn("[called tool: Bash]", ev)
+        self.assertNotIn("old answer", ev)
+
+    def test_meta_user_messages_do_not_end_walk(self) -> None:
+        msgs = [
+            _m("user", "prompt"),
+            _m("assistant", "answer one"),
+            _m("user", "<system-reminder>ctx</system-reminder>", is_meta=True),
+            _m("assistant", "answer two"),
+        ]
+        ev = collect_turn_evidence(msgs)
+        self.assertIn("answer one", ev)
+        self.assertIn("answer two", ev)
+
+    def test_char_budget_keeps_newest(self) -> None:
+        msgs = [
+            _m("user", "prompt"),
+            _m("assistant", "A" * 5000),
+            _m("assistant", "FINAL ANSWER"),
+        ]
+        ev = collect_turn_evidence(msgs, limit_chars=500)
+        self.assertIn("FINAL ANSWER", ev)
+        self.assertLessEqual(len(ev), 600)
+
+    def test_empty_and_junk_safe(self) -> None:
+        self.assertEqual(collect_turn_evidence([]), "")
+        self.assertEqual(collect_turn_evidence([SimpleNamespace()]), "")
+
+
+# ── shared command grammar ─────────────────────────────────────────────
+
+
+class TestGoalCommand(unittest.TestCase):
+    def test_bare_status(self) -> None:
+        r = run_goal_command(_mgr(), "")
+        self.assertTrue(r.ok)
+        self.assertIn("No active goal", r.text)
+        self.assertIsNone(r.kickoff)
+
+    def test_set_returns_kickoff_and_notice(self) -> None:
+        m = _mgr()
+        r = run_goal_command(m, "make the build green")
+        self.assertTrue(r.ok)
+        self.assertEqual(r.kickoff, "make the build green")
+        self.assertIn("Goal set", r.notice)
+        self.assertTrue(m.is_active())
+
+    def test_all_clear_aliases(self) -> None:
+        for alias in sorted(GOAL_CLEAR_ALIASES):
+            m = _mgr()
+            run_goal_command(m, "some goal")
+            r = run_goal_command(m, alias)
+            self.assertTrue(r.ok, alias)
+            self.assertIn("cleared", r.text.lower(), alias)
+            self.assertFalse(m.has_goal(), alias)
+
+    def test_pause_and_resume(self) -> None:
+        m = _mgr()
+        run_goal_command(m, "some goal")
+        r = run_goal_command(m, "pause")
+        self.assertIn("paused", r.text.lower())
+        r = run_goal_command(m, "resume")
+        self.assertIn("resumed", r.text.lower())
+        self.assertTrue(m.is_active())
+
+    def test_set_gate_blocks_set_only(self) -> None:
+        m = _mgr()
+        gate = lambda: "/goal requires a trusted workspace."  # noqa: E731
+        r = run_goal_command(m, "do things", set_gate=gate)
+        self.assertFalse(r.ok)
+        self.assertIn("trusted workspace", r.text)
+        self.assertFalse(m.has_goal())
+        # status/clear still allowed under a closed gate
+        r = run_goal_command(m, "", set_gate=gate)
+        self.assertTrue(r.ok)
+        r = run_goal_command(m, "clear", set_gate=gate)
+        self.assertTrue(r.ok)
+
+    def test_case_insensitive_subcommands(self) -> None:
+        m = _mgr()
+        run_goal_command(m, "goal")
+        r = run_goal_command(m, "CLEAR")
+        self.assertIn("cleared", r.text.lower())
+
+    def test_condition_cap_surfaced(self) -> None:
+        r = run_goal_command(_mgr(), "x" * (GOAL_CONDITION_MAX_CHARS + 1))
+        self.assertFalse(r.ok)
+        self.assertIn("Invalid goal", r.text)
+
+
+class TestSubgoalCommand(unittest.TestCase):
+    def test_requires_goal(self) -> None:
+        r = run_subgoal_command(_mgr(), "extra")
+        self.assertFalse(r.ok)
+        self.assertIn("No active goal", r.text)
+
+    def test_add_list_remove_clear(self) -> None:
+        m = _mgr()
+        m.set("goal")
+        r = run_subgoal_command(m, "first criterion")
+        self.assertTrue(r.ok)
+        self.assertIn("Added subgoal 1", r.text)
+        r = run_subgoal_command(m, "")
+        self.assertIn("first criterion", r.text)
+        r = run_subgoal_command(m, "remove 1")
+        self.assertIn("Removed subgoal 1", r.text)
+        run_subgoal_command(m, "again")
+        r = run_subgoal_command(m, "clear")
+        self.assertIn("Cleared 1 subgoal", r.text)
+
+    def test_remove_validation(self) -> None:
+        m = _mgr()
+        m.set("goal")
+        self.assertFalse(run_subgoal_command(m, "remove").ok)
+        self.assertFalse(run_subgoal_command(m, "remove x").ok)
+        self.assertFalse(run_subgoal_command(m, "remove 4").ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/server/test_goal_control.py
+++ b/tests/server/test_goal_control.py
@@ -1,0 +1,489 @@
+"""Agent-server /goal wiring: the ``goal``/``subgoal`` controls, the worker's
+post-turn continuation hook (double-checked locking, preemption, stale-verdict
+discard, timeout parking), interrupt auto-pause, /clear integration, and
+save/resume persistence. Critic-required coverage from the design review:
+race, judge-timeout, interrupt, and continuation-decoration tests."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.goals import GoalJudgeTimeout
+from src.server.agent_server import (
+    AgentServerConfig,
+    _AgentSession,
+    _SHUTDOWN,
+)
+
+
+def _judge_returning(payload: str):
+    return lambda system, user: payload
+
+
+def _make_session(trusted: bool = True) -> tuple[_AgentSession, list[dict]]:
+    emitted: list[dict] = []
+    sess = _AgentSession(
+        session_id="goal-sess", cwd="/tmp",
+        config=AgentServerConfig(single_session=False),
+        loop=MagicMock(), out_queue=MagicMock(),
+    )
+    sess._emit = lambda env: emitted.append(env)  # type: ignore[method-assign]
+    sess.session = MagicMock()
+    sess.session.conversation.messages = []
+    sess.tool_context = SimpleNamespace(workspace_trusted=trusted)
+    sess._save_session = lambda: None  # type: ignore[method-assign]
+    return sess, emitted
+
+
+def _set_goal(sess: _AgentSession, text: str = "make it green", judge=None) -> None:
+    """Activate a goal directly through the manager (bypasses the gate)."""
+    mgr = sess._goal_manager()
+    mgr.set(text)
+    if judge is not None:
+        mgr.judge = judge
+    # Pin the judge: _goal_manager() rebinds from the (mock) provider on
+    # every call, which would clobber a test's scripted judge.
+    sess._goal_manager = lambda: mgr  # type: ignore[method-assign]
+
+
+def _control(sess: _AgentSession, subtype: str, **params) -> None:
+    asyncio.run(sess._handle_control_request({
+        "type": "control_request",
+        "request_id": "req-1",
+        "request": {"subtype": subtype, **params},
+    }))
+
+
+def _last_reply(emitted: list[dict]) -> dict:
+    for env in reversed(emitted):
+        if env.get("type") == "control_response":
+            return env["response"]["response"]
+    raise AssertionError(f"no control_response in {emitted!r}")
+
+
+def _goal_events(emitted: list[dict]) -> list[dict]:
+    return [e for e in emitted if e.get("subtype") == "goal_status"]
+
+
+# ── goal control ───────────────────────────────────────────────────────
+
+
+class TestGoalControl(unittest.TestCase):
+    def test_set_replies_with_kickoff_and_notice(self) -> None:
+        sess, emitted = _make_session()
+        with patch.object(_AgentSession, "_goal_set_gate", return_value=None):
+            _control(sess, "goal", arg="ship the feature")
+        reply = _last_reply(emitted)
+        self.assertTrue(reply["ok"])
+        self.assertEqual(reply["kickoff"], "ship the feature")
+        self.assertIn("Goal set", reply["notice"])
+        self.assertTrue(reply["active"])
+        self.assertTrue(sess._goal_mgr.is_active())
+
+    def test_bare_goal_is_status(self) -> None:
+        sess, emitted = _make_session()
+        _control(sess, "goal", arg="")
+        reply = _last_reply(emitted)
+        self.assertTrue(reply["ok"])
+        self.assertIn("No active goal", reply["text"])
+        self.assertNotIn("kickoff", reply)
+
+    def test_clear_aliases_clear(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess)
+        _control(sess, "goal", arg="cancel")
+        reply = _last_reply(emitted)
+        self.assertTrue(reply["ok"])
+        self.assertIn("cleared", reply["text"].lower())
+        self.assertFalse(sess._goal_mgr.has_goal())
+
+    def test_untrusted_workspace_refuses_set_with_reason(self) -> None:
+        sess, emitted = _make_session(trusted=False)
+        _control(sess, "goal", arg="do the thing")
+        reply = _last_reply(emitted)
+        self.assertFalse(reply["ok"])
+        self.assertIn("trusted workspace", reply["error"])
+        self.assertIsNone(sess._goal_mgr.state)
+        # status and clear still answer under a closed gate
+        _control(sess, "goal", arg="")
+        self.assertTrue(_last_reply(emitted)["ok"])
+
+    def test_hooks_disabled_refuses_set_with_reason(self) -> None:
+        sess, emitted = _make_session(trusted=True)
+        fake_settings = SimpleNamespace(hooks=SimpleNamespace(enabled=False))
+        with patch("src.settings.settings.load_settings", return_value=fake_settings):
+            _control(sess, "goal", arg="do the thing")
+        reply = _last_reply(emitted)
+        self.assertFalse(reply["ok"])
+        self.assertIn("hooks are disabled", reply["error"])
+
+    def test_subgoal_control(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess)
+        _control(sess, "subgoal", arg="also update docs")
+        reply = _last_reply(emitted)
+        self.assertTrue(reply["ok"])
+        self.assertIn("Added subgoal 1", reply["text"])
+        self.assertEqual(sess._goal_mgr.state.subgoals, ["also update docs"])
+
+    def test_clear_control_clears_goal(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess)
+        sess.session.conversation.clear = MagicMock()
+        with patch("src.server.agent_server._cost_snapshot", return_value={}):
+            _control(sess, "clear")
+        reply = _last_reply(emitted)
+        self.assertTrue(reply["ok"])
+        self.assertFalse(sess._goal_mgr.has_goal())
+
+    def test_clear_control_strips_goal_from_disk(self) -> None:
+        """/clear + immediate quit must not leave an active goal for
+        --resume to restore — the handler strips the on-disk goal key
+        (the normal save path can't: the conversation is now empty)."""
+        import src.server.agent_server as srv
+
+        with __import__("tempfile").TemporaryDirectory() as td:
+            tmp = __import__("pathlib").Path(td)
+            f = tmp / "goal-sess.json"
+            f.write_text(json.dumps({
+                "session_id": "goal-sess",
+                "conversation": {"messages": [{"role": "user", "content": "x"}]},
+                "goal": {"goal": "old goal", "status": "active"},
+            }))
+            with patch.object(srv, "_sessions_dir", return_value=tmp):
+                sess, emitted = _make_session()
+                _set_goal(sess, "old goal")
+                sess.session.conversation.clear = MagicMock()
+                with patch("src.server.agent_server._cost_snapshot", return_value={}):
+                    _control(sess, "clear")
+            self.assertTrue(_last_reply(emitted)["ok"])
+            self.assertNotIn("goal", json.loads(f.read_text()))
+
+
+# ── interrupt auto-pause ───────────────────────────────────────────────
+
+
+class TestInterruptPausesGoal(unittest.TestCase):
+    def test_interrupt_pauses_active_goal_and_emits_status(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess)
+        _control(sess, "interrupt")
+        self.assertEqual(sess._goal_mgr.state.status, "paused")
+        events = _goal_events(emitted)
+        self.assertTrue(events and "paused" in events[-1]["message"].lower())
+        self.assertFalse(events[-1]["goal_active"])
+
+    def test_interrupt_without_goal_is_silent(self) -> None:
+        sess, emitted = _make_session()
+        _control(sess, "interrupt")
+        self.assertEqual(_goal_events(emitted), [])
+
+
+# ── post-turn continuation hook ────────────────────────────────────────
+
+
+class TestMaybeContinueGoal(unittest.TestCase):
+    def test_continue_enqueues_marked_continuation(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess, judge=_judge_returning(
+            '{"verdict": "continue", "reason": "tests still red"}'
+        ))
+        sess._maybe_continue_goal({"subtype": "success", "response_text": "wip"})
+        item = sess._inbox.get_nowait()
+        self.assertTrue(item.get("__goal__"))
+        self.assertIn("tests still red", item["content"])
+        events = _goal_events(emitted)
+        self.assertTrue(events and events[-1]["message"].startswith("↻"))
+        self.assertTrue(events[-1]["goal_active"])
+
+    def test_done_marks_goal_and_does_not_enqueue(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess, judge=_judge_returning(
+            '{"verdict": "done", "reason": "all pass"}'
+        ))
+        sess._maybe_continue_goal({"subtype": "success", "response_text": "10 passed"})
+        self.assertTrue(sess._inbox.empty())
+        self.assertEqual(sess._goal_mgr.state.status, "done")
+        events = _goal_events(emitted)
+        self.assertTrue(events and events[-1]["message"].startswith("✓"))
+        self.assertFalse(events[-1]["goal_active"])
+
+    def test_queued_user_input_preempts(self) -> None:
+        sess, _ = _make_session()
+        _set_goal(sess, judge=_judge_returning(
+            '{"verdict": "continue", "reason": "wip"}'
+        ))
+        sess._inbox.put("a real user prompt")
+        sess._maybe_continue_goal({"subtype": "success", "response_text": "wip"})
+        # Only the user prompt is queued — no continuation stacked behind it,
+        # and no judge turn was even counted (preflight bailed).
+        self.assertEqual(sess._inbox.get_nowait(), "a real user prompt")
+        self.assertTrue(sess._inbox.empty())
+        self.assertEqual(sess._goal_mgr.state.turns_used, 0)
+
+    def test_cancelled_and_error_turns_skip_judging(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess, judge=_judge_returning(
+            '{"verdict": "continue", "reason": "wip"}'
+        ))
+        sess._maybe_continue_goal({"subtype": "cancelled", "response_text": ""})
+        sess._maybe_continue_goal({"subtype": "error", "response_text": ""})
+        sess._maybe_continue_goal(None)  # None-safe (critic R6)
+        self.assertTrue(sess._inbox.empty())
+        self.assertEqual(sess._goal_mgr.state.turns_used, 0)
+        self.assertEqual(_goal_events(emitted), [])
+
+    def test_clear_during_judge_discards_stale_verdict(self) -> None:
+        """Critic R1: a /goal clear that lands while the judge is in flight
+        must win — the stale verdict is discarded and nothing is enqueued."""
+        sess, _ = _make_session()
+
+        def judge_that_races_a_clear(system: str, user: str) -> str:
+            # Simulates the control plane clearing the goal mid-judge (the
+            # judge runs OUTSIDE the lock, so this interleaving is real).
+            with sess._lock:
+                sess._goal_mgr.clear()
+            return '{"verdict": "continue", "reason": "stale"}'
+
+        _set_goal(sess, judge=judge_that_races_a_clear)
+        sess._maybe_continue_goal({"subtype": "success", "response_text": "wip"})
+        self.assertTrue(sess._inbox.empty())
+        self.assertFalse(sess._goal_mgr.has_goal())
+
+    def test_replaced_goal_during_judge_discards_stale_verdict(self) -> None:
+        sess, _ = _make_session()
+
+        def judge_that_races_a_new_set(system: str, user: str) -> str:
+            with sess._lock:
+                sess._goal_mgr.set("a brand new goal")
+            return '{"verdict": "done", "reason": "stale done"}'
+
+        _set_goal(sess, judge=judge_that_races_a_new_set)
+        sess._maybe_continue_goal({"subtype": "success", "response_text": "wip"})
+        # The stale DONE must not mark the NEW goal done.
+        self.assertEqual(sess._goal_mgr.state.status, "active")
+        self.assertEqual(sess._goal_mgr.state.goal, "a brand new goal")
+        self.assertEqual(sess._goal_mgr.state.turns_used, 0)
+        self.assertTrue(sess._inbox.empty())
+
+    def test_judge_timeout_parks_without_continuation(self) -> None:
+        """Critic R2: a hung evaluator parks the loop — goal stays active,
+        no continuation, and the worker returns promptly."""
+        sess, emitted = _make_session()
+
+        def hung_judge(system: str, user: str) -> str:
+            raise GoalJudgeTimeout("evaluator exceeded 30s")
+
+        _set_goal(sess, judge=hung_judge)
+        sess._maybe_continue_goal({"subtype": "success", "response_text": "wip"})
+        self.assertTrue(sess._inbox.empty())
+        self.assertEqual(sess._goal_mgr.state.status, "active")
+        events = _goal_events(emitted)
+        self.assertTrue(events and "timed out" in events[-1]["message"])
+
+    def test_concurrent_clear_thread_never_yields_continuation(self) -> None:
+        """True two-thread race: worker judging while the control plane
+        clears. Whatever the interleaving, no continuation may survive a
+        clear."""
+        sess, _ = _make_session()
+        judge_entered = threading.Event()
+        release_judge = threading.Event()
+
+        def blocking_judge(system: str, user: str) -> str:
+            judge_entered.set()
+            release_judge.wait(timeout=5)
+            return '{"verdict": "continue", "reason": "late"}'
+
+        _set_goal(sess, judge=blocking_judge)
+        worker = threading.Thread(
+            target=sess._maybe_continue_goal,
+            args=({"subtype": "success", "response_text": "wip"},),
+        )
+        worker.start()
+        self.assertTrue(judge_entered.wait(timeout=5))
+        with sess._lock:  # the control-plane path
+            sess._goal_mgr.clear()
+        release_judge.set()
+        worker.join(timeout=5)
+        self.assertFalse(worker.is_alive())
+        self.assertTrue(sess._inbox.empty())
+
+
+# ── worker routing of continuation items ───────────────────────────────
+
+
+class TestWorkerGoalRouting(unittest.TestCase):
+    def test_goal_item_runs_internal_and_reevaluates(self) -> None:
+        """Continuations run with internal-turn semantics (no UPS hooks, no
+        ultracode reminder, no odometer tick — critic R3) and re-enter the
+        goal hook so the loop keeps going."""
+        sess, _ = _make_session()
+        _set_goal(sess)  # the worker's staleness check drops items for dead goals
+        calls: list[tuple] = []
+
+        def fake_run_turn(prompt, btw=False, internal=False):
+            calls.append(("turn", prompt, btw, internal))
+            return {"subtype": "success", "response_text": "ok"}
+
+        sess._run_turn = fake_run_turn  # type: ignore[method-assign]
+        sess._maybe_continue_goal = lambda outcome: calls.append(("goal", outcome))  # type: ignore[method-assign]
+        sess._deliver_task_notifications = lambda: False  # type: ignore[method-assign]
+
+        sess._inbox.put({"__goal__": True, "content": "[Continuing…]"})
+        sess._inbox.put(_SHUTDOWN)
+        sess._run_worker()
+
+        self.assertEqual(calls[0], ("turn", "[Continuing…]", False, True))
+        self.assertEqual(calls[1][0], "goal")
+        self.assertEqual(calls[1][1], {"subtype": "success", "response_text": "ok"})
+
+    def test_real_turn_feeds_outcome_to_goal_hook(self) -> None:
+        sess, _ = _make_session()
+        calls: list[tuple] = []
+        sess._run_turn = lambda prompt, btw=False, internal=False: (  # type: ignore[method-assign]
+            calls.append(("turn", prompt, internal)) or {"subtype": "success", "response_text": "hi"}
+        )
+        sess._maybe_continue_goal = lambda outcome: calls.append(("goal", outcome))  # type: ignore[method-assign]
+        sess._deliver_task_notifications = lambda: False  # type: ignore[method-assign]
+
+        sess._inbox.put("a user prompt")
+        sess._inbox.put(_SHUTDOWN)
+        sess._run_worker()
+
+        self.assertEqual(calls[0], ("turn", "a user prompt", False))
+        self.assertEqual(calls[1], ("goal", {"subtype": "success", "response_text": "hi"}))
+
+    def test_queued_continuation_dropped_after_clear(self) -> None:
+        """A /goal clear that lands while a continuation sits queued must
+        drop it — no model turn runs for a dead goal (worker staleness
+        check; hermes clears pending synthetic continuations likewise)."""
+        sess, _ = _make_session()
+        _set_goal(sess)
+        turns: list = []
+        sess._run_turn = lambda *a, **k: (  # type: ignore[method-assign]
+            turns.append(a) or {"subtype": "success", "response_text": "x"}
+        )
+        sess._maybe_continue_goal = lambda outcome: None  # type: ignore[method-assign]
+        sess._deliver_task_notifications = lambda: False  # type: ignore[method-assign]
+
+        sess._inbox.put({"__goal__": True, "content": "[Continuing…]"})
+        with sess._lock:
+            sess._goal_mgr.clear()
+        sess._inbox.put(_SHUTDOWN)
+        sess._run_worker()
+
+        self.assertEqual(turns, [])
+
+    def test_internal_notification_turns_do_not_hit_goal_hook(self) -> None:
+        """Critic R5: judging a goal against a background-task recap would
+        entangle two self-driving loops — _deliver_task_notifications never
+        routes into _maybe_continue_goal."""
+        sess, _ = _make_session()
+        hook_calls: list = []
+        sess._maybe_continue_goal = lambda outcome: hook_calls.append(outcome)  # type: ignore[method-assign]
+        sess._run_turn = lambda *a, **k: {"subtype": "success", "response_text": "recap"}  # type: ignore[method-assign]
+
+        with patch(
+            "src.utils.message_queue_manager.drain_pending_notifications",
+            return_value=[SimpleNamespace(value="<task-notification id='t1'/>")],
+        ):
+            delivered = sess._deliver_task_notifications()
+        self.assertTrue(delivered)
+        self.assertEqual(hook_calls, [])
+
+
+# ── persistence: save + resume ─────────────────────────────────────────
+
+
+class TestGoalPersistence(unittest.TestCase):
+    def test_save_session_carries_goal_and_resume_restores_it(self) -> None:
+        import src.server.agent_server as srv
+
+        with __import__("tempfile").TemporaryDirectory() as td:
+            tmp = __import__("pathlib").Path(td)
+            with patch.object(srv, "_sessions_dir", return_value=tmp):
+                sess, _ = _make_session()
+                # A real-enough conversation for save/restore.
+                from src.agent.conversation import Conversation
+
+                conv = Conversation()
+                conv.add_user_message("kick")
+                sess.session = SimpleNamespace(conversation=conv)
+                sess._save_session = _AgentSession._save_session.__get__(sess)
+                _set_goal(sess, "finish the port")
+                sess._goal_mgr.state.turns_used = 4
+                sess._save_session()
+
+                saved = json.loads((tmp / "goal-sess.json").read_text())
+                self.assertEqual(saved["goal"]["goal"], "finish the port")
+                self.assertEqual(saved["goal"]["turns_used"], 4)
+
+                # Fresh session resumes it with counters reset (CC §Resume).
+                sess2, emitted2 = _make_session()
+                sess2.session = SimpleNamespace(conversation=Conversation())
+                sess2._save_session = lambda: None  # type: ignore[method-assign]
+                asyncio.run(sess2._handle_control_request({
+                    "type": "control_request",
+                    "request_id": "r9",
+                    "request": {"subtype": "resume", "session_id": "goal-sess"},
+                }))
+                reply = _last_reply(emitted2)
+                self.assertTrue(reply["ok"])
+                self.assertIn("goal_notice", reply)
+                self.assertTrue(sess2._goal_mgr.is_active())
+                self.assertEqual(sess2._goal_mgr.state.goal, "finish the port")
+                self.assertEqual(sess2._goal_mgr.state.turns_used, 0)
+
+    def test_achieved_goal_not_restored(self) -> None:
+        import src.server.agent_server as srv
+
+        with __import__("tempfile").TemporaryDirectory() as td:
+            tmp = __import__("pathlib").Path(td)
+            with patch.object(srv, "_sessions_dir", return_value=tmp):
+                sess, _ = _make_session()
+                from src.agent.conversation import Conversation
+
+                conv = Conversation()
+                conv.add_user_message("kick")
+                sess.session = SimpleNamespace(conversation=conv)
+                sess._save_session = _AgentSession._save_session.__get__(sess)
+                _set_goal(sess, "done goal")
+                sess._goal_mgr.mark_done("achieved")
+                sess._save_session()
+
+                sess2, emitted2 = _make_session()
+                sess2.session = SimpleNamespace(conversation=Conversation())
+                sess2._save_session = lambda: None  # type: ignore[method-assign]
+                asyncio.run(sess2._handle_control_request({
+                    "type": "control_request",
+                    "request_id": "r9",
+                    "request": {"subtype": "resume", "session_id": "goal-sess"},
+                }))
+                reply = _last_reply(emitted2)
+                self.assertTrue(reply["ok"])
+                self.assertNotIn("goal_notice", reply)
+                self.assertFalse(
+                    sess2._goal_mgr is not None and sess2._goal_mgr.is_active()
+                )
+
+
+class TestUsageTokenTotal(unittest.TestCase):
+    def test_sums_model_usage(self) -> None:
+        snap = {"model_usage": {
+            "m1": {"input_tokens": 10, "output_tokens": 5},
+            "m2": {"input_tokens": 1, "output_tokens": 2},
+        }}
+        self.assertEqual(_AgentSession._usage_token_total(snap), 18)
+
+    def test_junk_safe(self) -> None:
+        self.assertEqual(_AgentSession._usage_token_total({}), 0)
+        self.assertEqual(_AgentSession._usage_token_total({"model_usage": None}), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui-tui/src/__tests__/goalCommand.test.ts
+++ b/ui-tui/src/__tests__/goalCommand.test.ts
@@ -1,0 +1,178 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// /goal adapter coverage: dispatchSlash('goal'|'subgoal') ↔ the backend
+// `goal`/`subgoal` control subtypes (hermes send/exec contract), and the
+// system/goal_status → status.update kind:'goal' event mapping the ported
+// createGatewayEventHandler renders.
+const harness = vi.hoisted(() => ({ proc: null as null | EventEmitter, spawnCalls: [] as unknown[][] }))
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => {
+    harness.spawnCalls.push(args)
+
+    return harness.proc
+  }
+}))
+
+import { GatewayClient } from '../gatewayClient.js'
+
+class FakeProc extends EventEmitter {
+  kill = vi.fn()
+  stderr = new PassThrough()
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+
+  sent: any[] = []
+
+  constructor() {
+    super()
+    this.stdin.on('data', chunk => {
+      for (const line of String(chunk).split('\n')) {
+        if (line.trim()) {
+          this.sent.push(JSON.parse(line))
+        }
+      }
+    })
+  }
+
+  line(obj: unknown): void {
+    this.stdout.write(JSON.stringify(obj) + '\n')
+  }
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+describe('/goal gateway adapter', () => {
+  const prevWs = process.env.CLAWCODEX_WORKSPACE
+  let events: any[]
+  let gw: GatewayClient
+  let proc: FakeProc
+
+  beforeEach(() => {
+    process.env.CLAWCODEX_WORKSPACE = '/ws'
+    proc = new FakeProc()
+    harness.proc = proc
+    harness.spawnCalls = []
+    events = []
+    gw = new GatewayClient()
+    gw.on('event', (e: any) => events.push(e))
+    gw.start()
+    gw.drain()
+  })
+
+  afterEach(() => {
+    gw.kill()
+
+    if (prevWs === undefined) {delete process.env.CLAWCODEX_WORKSPACE}
+    else {process.env.CLAWCODEX_WORKSPACE = prevWs}
+  })
+
+  const replyToLastControl = async (response: unknown) => {
+    await flush()
+    const req = proc.sent.at(-1)
+
+    expect(req?.type).toBe('control_request')
+    proc.line({
+      response: { request_id: req.request_id, response, subtype: 'success' },
+      type: 'control_response'
+    })
+    await flush()
+  }
+
+  it('SET maps a kickoff reply to the hermes send contract', async () => {
+    const p = gw.request('command.dispatch', { arg: 'ship the feature', name: 'goal' })
+    await replyToLastControl({
+      active: true,
+      kickoff: 'ship the feature',
+      notice: '◎ Goal set (20-turn budget): ship the feature',
+      ok: true,
+      text: '◎ Goal set (20-turn budget): ship the feature'
+    })
+
+    const d: any = await p
+
+    expect(proc.sent.at(-1).request).toEqual({ arg: 'ship the feature', subtype: 'goal' })
+    expect(d.type).toBe('send')
+    expect(d.message).toBe('ship the feature')
+    expect(d.notice).toContain('Goal set')
+  })
+
+  it('status/clear replies map to exec output', async () => {
+    const p = gw.request('command.dispatch', { arg: 'status', name: 'goal' })
+    await replyToLastControl({ active: false, ok: true, text: 'No active goal. Set one with /goal <condition>.' })
+
+    const d: any = await p
+
+    expect(d.type).toBe('exec')
+    expect(d.output).toContain('No active goal')
+  })
+
+  it('gate refusals surface the reason as exec output', async () => {
+    const p = gw.request('command.dispatch', { arg: 'do things', name: 'goal' })
+    await replyToLastControl({ active: false, error: '/goal requires a trusted workspace.', ok: false, text: '/goal requires a trusted workspace.' })
+
+    const d: any = await p
+
+    expect(d.type).toBe('exec')
+    expect(d.output).toContain('trusted workspace')
+  })
+
+  it('slash.exec form routes /goal the same way', async () => {
+    const p = gw.request('slash.exec', { command: 'goal pause', session_id: 's1' })
+    await replyToLastControl({ active: false, ok: true, text: '⏸ Goal paused: x' })
+
+    const d: any = await p
+
+    expect(proc.sent.at(-1).request).toEqual({ arg: 'pause', subtype: 'goal' })
+    expect(d.type).toBe('exec')
+    expect(d.output).toContain('paused')
+  })
+
+  it('subgoal maps to the subgoal control', async () => {
+    const p = gw.request('command.dispatch', { arg: 'also update docs', name: 'subgoal' })
+    await replyToLastControl({ active: true, ok: true, text: '✓ Added subgoal 1: also update docs' })
+
+    const d: any = await p
+
+    expect(proc.sent.at(-1).request).toEqual({ arg: 'also update docs', subtype: 'subgoal' })
+    expect(d.type).toBe('exec')
+    expect(d.output).toContain('Added subgoal 1')
+  })
+
+  it('system/goal_status maps to status.update kind goal', async () => {
+    proc.line({
+      goal_active: true,
+      message: '↻ Continuing toward goal (1/20): tests still red',
+      session_id: 's1',
+      subtype: 'goal_status',
+      type: 'system'
+    })
+    await flush()
+
+    const ev = events.find(e => e.type === 'status.update')
+
+    expect(ev).toBeTruthy()
+    expect(ev.payload.kind).toBe('goal')
+    expect(ev.payload.text).toContain('Continuing toward goal')
+  })
+
+  it('/goal and /subgoal are in the slash catalog', async () => {
+    proc.line({
+      cwd: '/ws', model: 'm', protocol_version: '0.1.0', session_id: 's1',
+      subtype: 'init', tools: [], type: 'system'
+    })
+    await flush()
+    // Workflow-command fetch rides the catalog request; answer it empty.
+    const catalogP = gw.request<any>('commands.catalog', {})
+    await replyToLastControl({ commands: [] })
+
+    const catalog = await catalogP
+
+    expect(catalog.canon['/goal']).toBe('/goal')
+    expect(catalog.canon['/subgoal']).toBe('/subgoal')
+    expect(catalog.hints['/goal']).toContain('condition')
+  })
+})

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -275,6 +275,12 @@ const SLASHES: ReadonlyArray<{ desc: string; hint?: string; name: string }> = [
   { desc: 'Search / manage the knowledge base', hint: '[status|list|clear|enable|disable]', name: '/knowledge' },
   { desc: 'Browse and inspect available skills', hint: '[list | inspect <name> | search <query>]', name: '/skills' },
   { desc: 'View or set the plan', hint: '[<text>]', name: '/plan' },
+  {
+    desc: 'Set a completion condition Claude keeps working toward',
+    hint: '[<condition> | status | clear | pause | resume]',
+    name: '/goal'
+  },
+  { desc: 'Add or manage extra criteria on the active goal', hint: '[<text> | remove <n> | clear]', name: '/subgoal' },
   { desc: 'Generate session insights', name: '/insights' },
   { desc: 'List or start background agents', name: '/bg' },
   { desc: 'Resume a past session', name: '/resume' },
@@ -984,6 +990,30 @@ export class GatewayClient extends EventEmitter {
         return out(r?.plan ? `Plan:\n${r.plan}` : 'No plan set.')
       }
 
+      case 'goal': {
+        // Hermes /goal contract: SET replies carry a kickoff — the app
+        // renders the notice as a system line and submits the condition as
+        // the first goal turn ({type:'send'} in createSlashHandler). Every
+        // other subcommand (status/clear/pause/resume) is plain exec text.
+        const r = (await this.controlQuery('goal', { arg: arg ?? '' })) as any
+
+        if (!r || Object.keys(r).length === 0) {return out('goal: backend not ready')}
+
+        if (r.ok && typeof r.kickoff === 'string' && r.kickoff) {
+          return { message: r.kickoff, notice: typeof r.notice === 'string' ? r.notice : undefined, type: 'send' }
+        }
+
+        return out(String(r.text ?? r.error ?? 'goal: no response'))
+      }
+
+      case 'subgoal': {
+        const r = (await this.controlQuery('subgoal', { arg: arg ?? '' })) as any
+
+        if (!r || Object.keys(r).length === 0) {return out('subgoal: backend not ready')}
+
+        return out(String(r.text ?? r.error ?? 'subgoal: no response'))
+      }
+
       case 'rename': {
         const r = (await this.controlQuery('rename', { name: arg })) as any
 
@@ -1237,6 +1267,14 @@ export class GatewayClient extends EventEmitter {
           this.publish({
             payload: { task_id: String(msg.task_id ?? 'task'), text: String(msg.message ?? '') },
             type: 'background.complete'
+          })
+        } else if (msg.subtype === 'goal_status') {
+          // /goal verdict line ("✓ Goal achieved" / "↻ Continuing" / "⏸ …").
+          // kind:'goal' routes to the hermes-ported handler in
+          // createGatewayEventHandler (sys transcript line + brief status).
+          this.publish({
+            payload: { kind: 'goal', text: String(msg.message ?? '') },
+            type: 'status.update'
           })
         }
 


### PR DESCRIPTION
## /goal — session completion-condition loop (CC docs/en/goal), hermes-architecture port

Implements Claude Code's `/goal` command: set a completion condition and clawcodex keeps
working toward it across turns without per-step prompting. After each turn a small
side-model call (the evaluator) judges the condition against a transcript excerpt; a
"no" feeds a continuation prompt (with the evaluator's reason as guidance) back into the
session; a "yes" auto-clears the goal and records the achieved state. Engineering donor:
`reference_projects/hermes-agent` (`hermes_cli/goals.py` + the tui_gateway post-turn
hook), per `my-docs/goal-commands/hermes-goal-command-deep-dive.md`.

### Command surface

- `/goal <condition>` — set (replaces existing; ≤4,000 chars per CC), kickoff turn starts
  immediately with the condition as the directive
- `/goal` — status: condition, running duration, turns evaluated, token/cost spend since
  set, the evaluator's most recent reason; achieved record after completion
- `/goal clear` — aliases `stop|off|reset|none|cancel` (CC) + `done` (donor)
- `/goal pause` / `/goal resume` — donor extras; resume resets the turn budget
- `/subgoal [<text> | remove <n> | clear]` — extra acceptance criteria woven into both
  the judge prompt (evidence required per criterion) and the continuation prompt
- `/clear` also removes an active goal (CC); `--resume`/`/resume` restores an ACTIVE goal
  with turn count, timer, and spend baseline reset (achieved/cleared goals stay gone)
- Headless: `clawcodex -p "/goal <condition>"` runs the loop to completion in one
  invocation; goal progress on stderr; exit 0 only when achieved
- Gates (CC §Requirements): trusted workspace + hooks enabled, with the reason stated

### Architecture

Server-level post-turn loop (hermes pattern), not an in-query Stop hook: the port's hook
executor runs only command-type hooks (no prompt-hook lane), an in-query loop would die
at the per-query `max_turns=50` cap, and the agent-server already self-initiates turns
(task-notification delivery) — the continuation enqueue follows that precedent.

- `src/goals/` (new): `GoalState`, judge prompts + strict-JSON parse (legacy
  `{"done": bool}` accepted; fenced/embedded JSON tolerated), `judge_goal` (fail-OPEN on
  transport errors; `GoalJudgeTimeout` parks), `build_judge_callable` (small-fast-model
  pin via the same convention as tool_use_summary/memdir — Anthropic-only pin, session
  model otherwise; 30s hard bound on a helper thread), `collect_turn_evidence`
  (assistant text + tool_result excerpts back to the last real user prompt — CC: the
  evaluator judges "what Claude has surfaced in the conversation"), `GoalManager` with
  the evaluate/apply split for double-checked locking, `src/goals/command.py` (shared
  /goal + /subgoal grammar for server + headless).
- `src/server/agent_server.py`: `goal`/`subgoal` controls (usable while a turn runs — the
  escape hatch for a runaway loop), worker post-turn hook `_maybe_continue_goal`
  (preflight under `_lock` → judge outside the lock → `apply_verdict` under the lock with
  an `expected_state` identity check so a mid-judge clear/replace discards the stale
  verdict → single queued continuation max), continuations ride the inbox as
  `{"__goal__": True, …}` and run with internal-turn semantics (no UserPromptSubmit
  hooks, no ultracode reminder, no memory recall, no stats-odometer tick), interrupt
  auto-pauses the goal (donor semantics; deliberate CC deviation — no silent
  resurrection after ESC), evaluation skipped after internal notification turns,
  `goal_status` system events, session-file persistence + resume restore.
- `src/entrypoints/headless.py`: `/goal` prefix handling for `-p`, generator-interleaved
  continuations, per-turn evaluation, non-zero exit when not achieved.
- `ui-tui/src/gatewayClient.ts`: `/goal` + `/subgoal` in SLASHES, dispatch cases mapping
  the hermes send/exec contract (`{type:'send', notice, message}` kickoff — the ported
  createSlashHandler + `status.update kind:'goal'` renderer were already in the tree
  from the hermes TUI port and light up unchanged).
- `src/settings/types.py`: `goal_max_turns` (default 20). Deliberate CC deviation: CC
  ships the loop unbounded; the budget pauses (never clears) with a `/goal resume` hint
  as a runaway backstop. Evaluator parse failures ×3 also auto-pause (donor).

### Deferred (documented)

Completion contracts + `/goal draft`, wait barriers (`/goal wait <pid>`), stream-json
input-mode goal handling, a persistent `◎ goal active` stats-line chip (transient
status + transcript lines cover it), judge cost in /cost totals.

### Tests

- `tests/goals/test_goal_manager.py` — 61: parse shapes, evaluation matrix (done /
  continue / budget-pause / 3×parse-failure pause / timeout park / inactive),
  continuation prompts, subgoals, persistence round-trip + counter reset, command
  grammar incl. every clear alias and gate behavior.
- `tests/server/test_goal_control.py` — 26: controls, trust/hooks gates, interrupt
  pause, /clear integration, continuation enqueue + marker, preemption, stale-verdict
  discard (single-thread interleavings AND a true two-thread blocking-judge race),
  judge-timeout park, worker routing (`internal=True` decorations; notification turns
  never judged), save/resume restore, queued-continuation staleness drop, durable /clear disk strip.
- `tests/entrypoints/test_headless_goal.py` — 7: full -p loop with a scripted provider
  (turn/judge interleave), continuation carries the reason, budget → exit 1, bare
  /goal + clear forms, untrusted refusal, plain prompts untouched.
- `ui-tui/src/__tests__/goalCommand.test.ts` — 7: send/exec mapping, slash.exec routing,
  goal_status → status.update kind goal, catalog entries.

### Live end-to-end (real provider)

Headless: `clawcodex -p "/goal The file goal_probe.txt exists … prove it by cat"` —
turn 1 the agent stalled asking "Would you like me to create it?" (the exact failure
mode /goal fixes), evaluator returned ↻ not-met with reason, turn 2 created + proved the
file, evaluator returned ✓ achieved, exit 0, probe content exact.

TUI: pyte-driven run of the built client against the worktree backend — `◎ Goal set
(20-turn budget)` system line, kickoff turn ran `Bash(ls)` → `Write(tui_probe.txt)` →
`Bash(cat)` through the real UI, and the verdict line rendered:
`✓ Goal achieved: The agent created the file and confirmed via cat output that it
contains exactly 'TUI-OK-7'.` An earlier TUI run exposed a weak-judge false-DONE (the
agent misread the condition as a verification request and claimed it "cannot be
satisfied"; the evaluator's blocked-clause accepted that) — the judge prompt now states
that a condition the agent could make true by working is CONTINUE, even when the agent
claims otherwise; the rerun proved the fix live.

Two critic review rounds per project convention: design REVISE → all 7 required
changes implemented (lock discipline, judge timeout, continuation marker/decorations,
interrupt pause, notification-turn skip, None-safety + typed setting, race/timeout
tests); implementation **APPROVE**, with its optional hardening applied too (daemon
judge thread — a leaked ThreadPoolExecutor worker would have blocked interpreter exit;
durable /clear via an on-disk goal-key strip; best-effort-preemption comment; lockfile
churn kept out of the commit). The critic also independently confirmed the
queued-continuation staleness drop that landed mid-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
