### PR TITLE
feat(tools): the Monitor tool — stream shell output with backpressure (C5 Part 2)

### DIFF
--- a/src/reference_data/ts_tool_names.json
+++ b/src/reference_data/ts_tool_names.json
@@ -125,6 +125,9 @@
     },
     "Write": {
       "python_name": "Write"
+    },
+    "Monitor": {
+      "python_name": "Monitor"
     }
   },
   "not_yet_implemented": [

--- a/src/server/task_notifications.py
+++ b/src/server/task_notifications.py
@@ -157,11 +157,40 @@ _TURN_PREAMBLE = (
 )
 
 
+_STREAMING_PREAMBLE = (
+    "<system-reminder>\n"
+    "One or more background tasks you are monitoring produced new output "
+    "(delivered below as <task-notification> envelopes with "
+    "<status>running</status>). These are STILL RUNNING — do not report them as "
+    "finished. They are system events, not a new request the user typed. Note "
+    "anything important in the streamed <summary>; if nothing needs action, you "
+    "may simply continue. Use TaskStop to end a monitor you no longer need.\n"
+    "</system-reminder>"
+)
+
+
+def _is_running_envelope(xml: str) -> bool:
+    return (_field(xml, STATUS_TAG) or "").strip().lower() == "running"
+
+
 def build_notification_turn(notifications: list[str]) -> str:
     """Assemble drained ``<task-notification>`` envelopes into a single agent
-    turn: a guiding preamble followed by the raw envelopes."""
-    body = "\n\n".join(n.strip() for n in notifications if n and n.strip())
-    return f"{_TURN_PREAMBLE}\n\n{body}"
+    turn: a guiding preamble followed by the raw envelopes.
+
+    The preamble is status-aware (critic C5-P2 major): a batch that is ENTIRELY
+    live monitor updates (status=running) must NOT be framed as "finished" — a
+    running monitor streamed through the completion path would otherwise drive
+    the model to declare it done every drain. A pure-running batch gets the
+    streaming preamble; any finished task in the batch keeps the completion
+    preamble (its framing is what those tasks need)."""
+    items = [n.strip() for n in notifications if n and n.strip()]
+    body = "\n\n".join(items)
+    preamble = (
+        _STREAMING_PREAMBLE
+        if items and all(_is_running_envelope(n) for n in items)
+        else _TURN_PREAMBLE
+    )
+    return f"{preamble}\n\n{body}"
 
 
 __all__ = [

--- a/src/tool_system/tools/__init__.py
+++ b/src/tool_system/tools/__init__.py
@@ -23,6 +23,7 @@ from .send_message import SendMessageTool
 from .send_user_message import SendUserMessageTool
 from .skill import SkillTool
 from .sleep import SleepTool
+from .monitor import MonitorTool
 from .structured_output import StructuredOutputTool
 from .task_stop import TaskStopTool
 from .tasks_v2 import (
@@ -44,6 +45,7 @@ ALL_STATIC_TOOLS: list[Tool] = [
     AdvisorTool,
     AskUserQuestionTool,
     BashTool,
+    MonitorTool,
     BriefTool,
     ClipboardReadTool,
     ClipboardWriteTool,
@@ -120,6 +122,7 @@ __all__ = [
     "SkillTool",
     "SleepTool",
     "StatusTool",
+    "MonitorTool",
     "StructuredOutputTool",
     "TaskCreateTool",
     "TaskGetTool",

--- a/src/tool_system/tools/bash/bash_tool.py
+++ b/src/tool_system/tools/bash/bash_tool.py
@@ -238,15 +238,16 @@ def _bash_validate_input(
     return ValidationResult.ok()
 
 
-def _bash_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
-    command = tool_input["command"]
-    if not isinstance(command, str) or not command.strip():
-        raise ToolInputError("command must be a non-empty string")
-    if "\x00" in command:
-        raise ToolInputError("command contains NUL byte")
+def bash_command_safety_guard(command: str) -> None:
+    """Pre-spawn safety for any shell command run through the bash machinery:
+    the hardcoded-dangerous-pattern block + the C8 sandbox hard-gate.
 
-    # Defense-in-depth: block obviously dangerous commands even when called
-    # directly (bypassing the registry's check_permissions flow).
+    Shared by ``_bash_call`` (foreground + run_in_background) AND the Monitor
+    tool, which spawns via ``spawn_background_bash`` directly — so Monitor
+    can't be a way around these guards (critic C5-P2). Raises
+    ``ToolPermissionError`` to refuse; the sandbox check is best-effort (a
+    settings problem must not crash the tool), but a hard-gate refusal always
+    propagates."""
     for pat in _HARDCODED_DANGEROUS_PATTERNS:
         if pat.search(command):
             raise ToolPermissionError("refusing to run potentially dangerous command")
@@ -255,8 +256,7 @@ def _bash_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
     # ``sandbox.enabled`` setting maps onto TS's documented sandbox-unavailable
     # path (sandboxTypes.ts:96-103). failIfUnavailable → REFUSE (the
     # managed-settings hard gate: never silently run unsandboxed); otherwise
-    # warn once and proceed unsandboxed. Best-effort: a settings problem must
-    # not crash a plain bash call.
+    # warn once and proceed unsandboxed.
     try:
         from src.permissions.sandbox_guard import (
             sandbox_hard_gate_error,
@@ -271,11 +271,25 @@ def _bash_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
         warn_if_unsandboxed_once(_settings)
     except ToolPermissionError:
         raise
-    except Exception:  # noqa: BLE001 — the guard must never break bash
+    except Exception:  # noqa: BLE001 — the guard must never break the tool
         import logging as _logging
         _logging.getLogger(__name__).debug(
             "[sandbox] guard check failed", exc_info=True
         )
+
+
+def _bash_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+    command = tool_input["command"]
+    if not isinstance(command, str) or not command.strip():
+        raise ToolInputError("command must be a non-empty string")
+    if "\x00" in command:
+        raise ToolInputError("command contains NUL byte")
+
+    # Defense-in-depth: block obviously dangerous commands + apply the C8
+    # sandbox hard-gate. Shared with the Monitor tool (which spawns via
+    # spawn_background_bash directly, bypassing this function) — so the guards
+    # can't drift and Monitor can't be a hole around them.
+    bash_command_safety_guard(command)
 
     explicit_cwd = tool_input.get("cwd")
     if explicit_cwd is not None:

--- a/src/tool_system/tools/monitor.py
+++ b/src/tool_system/tools/monitor.py
@@ -102,12 +102,16 @@ def _stream_output(
         sent = 0
         path = Path(output_path)
 
-        def _drain() -> int:
+        def _drain(final: bool = False) -> int:
             """Enqueue the new whole lines (if any); return 1 if it enqueued.
 
             Reads at most ``_MONITOR_MAX_READ_BYTES`` from the current offset —
             never the whole file — so a firehose command can't OOM the agent
-            (TS getTaskOutputDelta bounds each read the same way)."""
+            (TS getTaskOutputDelta bounds each read the same way).
+
+            ``final=True`` (the terminal drain) emits any trailing partial line
+            too, so a command whose last output has no newline (``printf done``)
+            isn't lost (critic C5-P2 #3.ii)."""
             nonlocal pos
             try:
                 with open(path, "rb") as fh:
@@ -120,13 +124,24 @@ def _stream_output(
             read_n = len(raw)  # advance the offset by BYTES read (offset arithmetic
             pos += read_n      # stays in bytes; decode replacement can't drift it)
             chunk = raw.decode("utf-8", "replace")
-            if "\n" not in chunk:
-                # No complete line yet — rewind so the partial is re-read next poll.
-                pos -= read_n
-                return 0
-            body, _, tail = chunk.rpartition("\n")
-            pos -= len(tail.encode("utf-8"))
-            lines = body.strip("\n")
+            if "\n" in chunk:
+                if final:
+                    lines = chunk  # include the trailing partial on the last drain
+                else:
+                    body, _, tail = chunk.rpartition("\n")
+                    pos -= len(tail.encode("utf-8"))  # hold the partial for next poll
+                    lines = body
+            else:
+                # No newline in this window. Normally hold the partial for the
+                # next poll — UNLESS this is the final drain, or the window is
+                # FULL (a single line longer than the read cap would otherwise
+                # stall forever with no progress; critic C5-P2 #3.i). In those
+                # cases emit what we have so the stream keeps moving.
+                if not final and read_n < _MONITOR_MAX_READ_BYTES:
+                    pos -= read_n
+                    return 0
+                lines = chunk
+            lines = lines.strip("\n")
             if not lines:
                 return 0
             # Per-notification size bound (critic C5-P2 #1): keep the TAIL (the
@@ -147,7 +162,7 @@ def _stream_output(
             sent += _drain()
             if sent >= _MONITOR_MAX_NOTIFICATIONS:
                 # BACKPRESSURE: too many events → auto-stop the monitor.
-                _drain()
+                _drain(final=True)
                 _kill_monitor_task(task_id, context)
                 enqueue_pending_notification(
                     value=_monitor_notification_xml(
@@ -163,11 +178,11 @@ def _stream_output(
             if state is None:
                 return
             if status is not None and status != "running":
-                _drain()  # final drain so the last lines aren't lost
+                _drain(final=True)  # final drain: emit the last (maybe partial) lines
                 return
             time.sleep(_POLL_INTERVAL_S)
         # Deadline — stop the shell so it doesn't linger past the monitor.
-        _drain()
+        _drain(final=True)
         _kill_monitor_task(task_id, context)
     except Exception:  # noqa: BLE001 — a monitor poller must NEVER crash the app
         logger.debug("monitor poller failed for %s", task_id, exc_info=True)

--- a/src/tool_system/tools/monitor.py
+++ b/src/tool_system/tools/monitor.py
@@ -1,5 +1,5 @@
 """The ``Monitor`` tool (C5 Part 2) — stream a shell command's stdout to the
-model as ``<monitor-output>`` notifications (~1s polling), rather than the
+model as render-path <task-notification> envelopes (~1s polling), rather than the
 single completion notification the Bash ``run_in_background`` path delivers.
 
 Port of ``typescript/src/tools/MonitorTool/MonitorTool.ts`` (MONITOR_TOOL flag
@@ -40,6 +40,39 @@ _MONITOR_MAX_NOTIFICATIONS = 100
 #: notifications. Truncate each to the tail so a single notification can't
 #: blow the conversation (critic C5-P2 #1: bound bytes, not just count).
 _MONITOR_MAX_NOTIFICATION_BYTES = 8 * 1024
+#: Max bytes read from the output file PER poll (TS diskOutput.ts:23
+#: DEFAULT_MAX_READ_BYTES = 8 MiB). ``read_bytes()`` on the whole file is an
+#: OOM vector for a firehose command; seek to the offset and read a bounded
+#: chunk instead (critic C5-P2 #1).
+_MONITOR_MAX_READ_BYTES = 8 * 1024 * 1024
+
+
+def _monitor_notification_xml(task_id: str, output_file: str, lines: str) -> str:
+    """A ``<task-notification>`` envelope with ``status=running`` carrying a
+    streamed batch (critic C5-P2 major: the invented ``<monitor-output>`` tag
+    was incompatible with the render path — parse_task_id found no ``<task-id>``
+    child and the banner mis-rendered). Uses the real envelope structure the
+    drain path parses (``<task-id>/<output-file>/<status>/<summary>``); the
+    ``running`` status makes ``build_notification_turn`` frame it as a live
+    update, not a completion."""
+    from xml.sax.saxutils import escape as _esc
+
+    from src.constants.xml import (
+        OUTPUT_FILE_TAG,
+        STATUS_TAG,
+        SUMMARY_TAG,
+        TASK_ID_TAG,
+        TASK_NOTIFICATION_TAG,
+    )
+
+    return (
+        f"<{TASK_NOTIFICATION_TAG}>\n"
+        f"<{TASK_ID_TAG}>{_esc(task_id)}</{TASK_ID_TAG}>\n"
+        f"<{OUTPUT_FILE_TAG}>{_esc(output_file)}</{OUTPUT_FILE_TAG}>\n"
+        f"<{STATUS_TAG}>running</{STATUS_TAG}>\n"
+        f"<{SUMMARY_TAG}>{_esc(lines)}</{SUMMARY_TAG}>\n"
+        f"</{TASK_NOTIFICATION_TAG}>"
+    )
 
 
 def _kill_monitor_task(task_id: str, context: ToolContext) -> None:
@@ -58,7 +91,7 @@ def _stream_output(
     *, task_id: str, output_path: str, context: ToolContext, description: str
 ) -> None:
     """Tail ``output_path`` and enqueue each new batch of whole lines as a
-    ``<monitor-output>`` notification. Stops when the task leaves ``running``
+    <task-notification> envelope (status=running). Stops when the task leaves ``running``
     (after a final drain), the 30-minute deadline passes, OR the notification
     cap is hit (auto-stop backpressure). Never raises."""
     try:
@@ -70,19 +103,26 @@ def _stream_output(
         path = Path(output_path)
 
         def _drain() -> int:
-            """Enqueue the new whole lines (if any); return 1 if it enqueued."""
+            """Enqueue the new whole lines (if any); return 1 if it enqueued.
+
+            Reads at most ``_MONITOR_MAX_READ_BYTES`` from the current offset —
+            never the whole file — so a firehose command can't OOM the agent
+            (TS getTaskOutputDelta bounds each read the same way)."""
             nonlocal pos
             try:
-                data = path.read_bytes()
+                with open(path, "rb") as fh:
+                    fh.seek(pos)
+                    raw = fh.read(_MONITOR_MAX_READ_BYTES)  # bounded read
             except OSError:
                 return 0
-            if len(data) <= pos:
+            if not raw:
                 return 0
-            chunk = data[pos:].decode("utf-8", "replace")
-            pos = len(data)
+            read_n = len(raw)  # advance the offset by BYTES read (offset arithmetic
+            pos += read_n      # stays in bytes; decode replacement can't drift it)
+            chunk = raw.decode("utf-8", "replace")
             if "\n" not in chunk:
                 # No complete line yet — rewind so the partial is re-read next poll.
-                pos -= len(chunk.encode("utf-8"))
+                pos -= read_n
                 return 0
             body, _, tail = chunk.rpartition("\n")
             pos -= len(tail.encode("utf-8"))
@@ -97,13 +137,8 @@ def _stream_output(
                 kept = encoded[-_MONITOR_MAX_NOTIFICATION_BYTES:].decode("utf-8", "replace")
                 dropped = len(encoded) - _MONITOR_MAX_NOTIFICATION_BYTES
                 lines = f"…[{dropped} earlier bytes truncated]…\n{kept}"
-            from xml.sax.saxutils import escape as _esc
-
             enqueue_pending_notification(
-                value=(
-                    f'<monitor-output task="{_esc(task_id)}" '
-                    f'description="{_esc(description)}">\n{_esc(lines)}\n</monitor-output>'
-                ),
+                value=_monitor_notification_xml(task_id, output_path, lines),
                 mode="task-notification",
             )
             return 1
@@ -115,13 +150,11 @@ def _stream_output(
                 _drain()
                 _kill_monitor_task(task_id, context)
                 enqueue_pending_notification(
-                    value=(
-                        f'<monitor-output task="{task_id}" description="{description}">\n'
+                    value=_monitor_notification_xml(
+                        task_id, output_path,
                         f"Monitor auto-stopped after {sent} notifications "
                         f"(too many events). Re-run with a tighter filter "
-                        f"(e.g. grep) if you still need to watch this.\n"
-                        f"</monitor-output>"
-                    ),
+                        f"(e.g. grep) if you still need to watch this."),
                     mode="task-notification",
                 )
                 return
@@ -226,9 +259,9 @@ MonitorTool: Tool = build_tool(
         "automatically stopped — restart with a tighter filter if that happens."
     ),
     description="Stream a shell command's output as notifications.",
-    max_result_size_chars=2000,
+    max_result_size_chars=10_000,  # TS MonitorTool.ts:51
     is_read_only=lambda _input: False,
-    is_concurrency_safe=lambda _input: False,
+    is_concurrency_safe=lambda _input: True,  # TS MonitorTool.ts:54 (fire-and-forget spawn)
     to_auto_classifier_input=lambda input_data: (input_data or {}).get("command", ""),
     # Monitor runs an arbitrary shell command — gate it exactly like Bash
     # (TS MonitorTool.checkPermissions delegates to bashToolHasPermission).

--- a/src/tool_system/tools/monitor.py
+++ b/src/tool_system/tools/monitor.py
@@ -47,14 +47,17 @@ _MONITOR_MAX_NOTIFICATION_BYTES = 8 * 1024
 _MONITOR_MAX_READ_BYTES = 8 * 1024 * 1024
 
 
-def _monitor_notification_xml(task_id: str, output_file: str, lines: str) -> str:
-    """A ``<task-notification>`` envelope with ``status=running`` carrying a
-    streamed batch (critic C5-P2 major: the invented ``<monitor-output>`` tag
-    was incompatible with the render path — parse_task_id found no ``<task-id>``
-    child and the banner mis-rendered). Uses the real envelope structure the
-    drain path parses (``<task-id>/<output-file>/<status>/<summary>``); the
-    ``running`` status makes ``build_notification_turn`` frame it as a live
-    update, not a completion."""
+def _monitor_notification_xml(
+    task_id: str, output_file: str, lines: str, status: str = "running"
+) -> str:
+    """A ``<task-notification>`` envelope carrying a streamed batch (critic
+    C5-P2 major: the invented ``<monitor-output>`` tag was incompatible with the
+    render path — parse_task_id found no ``<task-id>`` child and the banner
+    mis-rendered). Uses the real envelope structure the drain path parses
+    (``<task-id>/<output-file>/<status>/<summary>``). ``status="running"`` (the
+    streaming default) makes ``build_notification_turn`` frame it as a live
+    update; the terminal auto-stop notice passes ``status="killed"`` so it gets
+    the completion framing instead (critic C5-P2 minor #3)."""
     from xml.sax.saxutils import escape as _esc
 
     from src.constants.xml import (
@@ -69,7 +72,7 @@ def _monitor_notification_xml(task_id: str, output_file: str, lines: str) -> str
         f"<{TASK_NOTIFICATION_TAG}>\n"
         f"<{TASK_ID_TAG}>{_esc(task_id)}</{TASK_ID_TAG}>\n"
         f"<{OUTPUT_FILE_TAG}>{_esc(output_file)}</{OUTPUT_FILE_TAG}>\n"
-        f"<{STATUS_TAG}>running</{STATUS_TAG}>\n"
+        f"<{STATUS_TAG}>{_esc(status)}</{STATUS_TAG}>\n"
         f"<{SUMMARY_TAG}>{_esc(lines)}</{SUMMARY_TAG}>\n"
         f"</{TASK_NOTIFICATION_TAG}>"
     )
@@ -94,6 +97,15 @@ def _stream_output(
     <task-notification> envelope (status=running). Stops when the task leaves ``running``
     (after a final drain), the 30-minute deadline passes, OR the notification
     cap is hit (auto-stop backpressure). Never raises."""
+    # DELIBERATE DIVERGENCE from TS (accepted as port scope, c5p2-critic APPROVE):
+    # each drain enqueues a <task-notification> that the drain loop turns into an
+    # internal model turn, whereas TS injects monitor deltas as passive
+    # task_status/deltaSummary ATTACHMENTS that ride the next natural turn
+    # (attachments.ts / framework.ts). Building that attachment pipeline for one
+    # tool is out of scope; the cost here is bounded (≤ _MONITOR_MAX_NOTIFICATIONS
+    # turns then auto-stop, and ZERO for a quiet monitor since a drain only fires
+    # on new output). If turn-per-drain ever bites, rate-limit monitor turns or
+    # lower the cap rather than "fixing" this by accident.
     try:
         from src.utils.message_queue_manager import enqueue_pending_notification
 
@@ -165,11 +177,15 @@ def _stream_output(
                 _drain(final=True)
                 _kill_monitor_task(task_id, context)
                 enqueue_pending_notification(
+                    # status="killed": this notice is TERMINAL (the monitor just
+                    # stopped), so it takes the completion framing, not the
+                    # "STILL RUNNING" streaming preamble (critic C5-P2 minor #3).
                     value=_monitor_notification_xml(
                         task_id, output_path,
                         f"Monitor auto-stopped after {sent} notifications "
                         f"(too many events). Re-run with a tighter filter "
-                        f"(e.g. grep) if you still need to watch this."),
+                        f"(e.g. grep) if you still need to watch this.",
+                        status="killed"),
                     mode="task-notification",
                 )
                 return

--- a/src/tool_system/tools/monitor.py
+++ b/src/tool_system/tools/monitor.py
@@ -34,6 +34,12 @@ _POLL_INTERVAL_S = 1.0
 #: auto-stops (kills the shell + sends a final notice). Bounds a chatty
 #: monitor's conversation footprint (tools-critic: an unbounded poller floods).
 _MONITOR_MAX_NOTIFICATIONS = 100
+#: Per-notification SIZE cap (bytes of streamed body). The count cap alone
+#: doesn't bound a FIREHOSE — one poll batches all new lines into one
+#: notification, so a command dumping megabytes/second sends few-but-huge
+#: notifications. Truncate each to the tail so a single notification can't
+#: blow the conversation (critic C5-P2 #1: bound bytes, not just count).
+_MONITOR_MAX_NOTIFICATION_BYTES = 8 * 1024
 
 
 def _kill_monitor_task(task_id: str, context: ToolContext) -> None:
@@ -83,6 +89,14 @@ def _stream_output(
             lines = body.strip("\n")
             if not lines:
                 return 0
+            # Per-notification size bound (critic C5-P2 #1): keep the TAIL (the
+            # newest output is what a watcher cares about) + a truncation
+            # marker, so a firehose can't emit one giant notification.
+            encoded = lines.encode("utf-8")
+            if len(encoded) > _MONITOR_MAX_NOTIFICATION_BYTES:
+                kept = encoded[-_MONITOR_MAX_NOTIFICATION_BYTES:].decode("utf-8", "replace")
+                dropped = len(encoded) - _MONITOR_MAX_NOTIFICATION_BYTES
+                lines = f"…[{dropped} earlier bytes truncated]…\n{kept}"
             from xml.sax.saxutils import escape as _esc
 
             enqueue_pending_notification(
@@ -131,6 +145,15 @@ def _monitor_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResul
     description = tool_input.get("description") or "Monitor shell command"
     if not isinstance(command, str) or not command.strip():
         raise ToolInputError("command must be a non-empty string")
+
+    # Monitor spawns via spawn_background_bash DIRECTLY (not _bash_call), so it
+    # must apply the same pre-spawn safety — the hardcoded-dangerous-pattern
+    # block + the C8 sandbox hard-gate — or it's a way around them (critic
+    # C5-P2). check_permissions covers the permission RULES; this covers the
+    # hard safety gates that live below the permission layer.
+    from .bash.bash_tool import bash_command_safety_guard
+
+    bash_command_safety_guard(command)
 
     from .bash.background import spawn_background_bash
 

--- a/src/tool_system/tools/monitor.py
+++ b/src/tool_system/tools/monitor.py
@@ -1,0 +1,215 @@
+"""The ``Monitor`` tool (C5 Part 2) — stream a shell command's stdout to the
+model as ``<monitor-output>`` notifications (~1s polling), rather than the
+single completion notification the Bash ``run_in_background`` path delivers.
+
+Port of ``typescript/src/tools/MonitorTool/MonitorTool.ts`` (MONITOR_TOOL flag
+= true, build.ts:43). Reuses ``spawn_background_bash`` (the same detached shell
++ reaper) + ``enqueue_pending_notification`` (the shared queue the model drains
+each turn). The novel pieces are (1) the per-monitor polling thread that tails
+the output file and (2) BACKPRESSURE: a monitor that produces too many
+notifications is AUTO-STOPPED — the exact guard the tools-round critic required
+(an unbounded streamer floods the conversation). TS: "Monitors that produce too
+many events are automatically stopped."
+"""
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+from ..build_tool import Tool, build_tool
+from ..context import ToolContext
+from ..errors import ToolInputError
+from ..protocol import ToolResult
+from .bash.bash_tool import _bash_check_permissions
+
+logger = logging.getLogger(__name__)
+
+MONITOR_TOOL_NAME = "Monitor"
+_MONITOR_TIMEOUT_S = 30 * 60  # 30 minutes (TS MONITOR_TIMEOUT_MS)
+_POLL_INTERVAL_S = 1.0
+#: BACKPRESSURE cap — after this many streamed notifications the monitor
+#: auto-stops (kills the shell + sends a final notice). Bounds a chatty
+#: monitor's conversation footprint (tools-critic: an unbounded poller floods).
+_MONITOR_MAX_NOTIFICATIONS = 100
+
+
+def _kill_monitor_task(task_id: str, context: ToolContext) -> None:
+    """Best-effort kill of the underlying shell (auto-stop / timeout)."""
+    try:
+        import asyncio
+
+        from src.tasks.local_shell import LocalShellTask
+
+        asyncio.run(LocalShellTask().kill(task_id, context.runtime_tasks))
+    except Exception:  # noqa: BLE001
+        logger.debug("monitor kill failed for %s", task_id, exc_info=True)
+
+
+def _stream_output(
+    *, task_id: str, output_path: str, context: ToolContext, description: str
+) -> None:
+    """Tail ``output_path`` and enqueue each new batch of whole lines as a
+    ``<monitor-output>`` notification. Stops when the task leaves ``running``
+    (after a final drain), the 30-minute deadline passes, OR the notification
+    cap is hit (auto-stop backpressure). Never raises."""
+    try:
+        from src.utils.message_queue_manager import enqueue_pending_notification
+
+        deadline = time.monotonic() + _MONITOR_TIMEOUT_S
+        pos = 0
+        sent = 0
+        path = Path(output_path)
+
+        def _drain() -> int:
+            """Enqueue the new whole lines (if any); return 1 if it enqueued."""
+            nonlocal pos
+            try:
+                data = path.read_bytes()
+            except OSError:
+                return 0
+            if len(data) <= pos:
+                return 0
+            chunk = data[pos:].decode("utf-8", "replace")
+            pos = len(data)
+            if "\n" not in chunk:
+                # No complete line yet — rewind so the partial is re-read next poll.
+                pos -= len(chunk.encode("utf-8"))
+                return 0
+            body, _, tail = chunk.rpartition("\n")
+            pos -= len(tail.encode("utf-8"))
+            lines = body.strip("\n")
+            if not lines:
+                return 0
+            from xml.sax.saxutils import escape as _esc
+
+            enqueue_pending_notification(
+                value=(
+                    f'<monitor-output task="{_esc(task_id)}" '
+                    f'description="{_esc(description)}">\n{_esc(lines)}\n</monitor-output>'
+                ),
+                mode="task-notification",
+            )
+            return 1
+
+        while time.monotonic() < deadline:
+            sent += _drain()
+            if sent >= _MONITOR_MAX_NOTIFICATIONS:
+                # BACKPRESSURE: too many events → auto-stop the monitor.
+                _drain()
+                _kill_monitor_task(task_id, context)
+                enqueue_pending_notification(
+                    value=(
+                        f'<monitor-output task="{task_id}" description="{description}">\n'
+                        f"Monitor auto-stopped after {sent} notifications "
+                        f"(too many events). Re-run with a tighter filter "
+                        f"(e.g. grep) if you still need to watch this.\n"
+                        f"</monitor-output>"
+                    ),
+                    mode="task-notification",
+                )
+                return
+            state = context.runtime_tasks.get(task_id)
+            status = getattr(state, "status", None)
+            if state is None:
+                return
+            if status is not None and status != "running":
+                _drain()  # final drain so the last lines aren't lost
+                return
+            time.sleep(_POLL_INTERVAL_S)
+        # Deadline — stop the shell so it doesn't linger past the monitor.
+        _drain()
+        _kill_monitor_task(task_id, context)
+    except Exception:  # noqa: BLE001 — a monitor poller must NEVER crash the app
+        logger.debug("monitor poller failed for %s", task_id, exc_info=True)
+
+
+def _monitor_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+    command = tool_input.get("command")
+    description = tool_input.get("description") or "Monitor shell command"
+    if not isinstance(command, str) or not command.strip():
+        raise ToolInputError("command must be a non-empty string")
+
+    from .bash.background import spawn_background_bash
+
+    cwd = Path(getattr(context, "cwd", None) or ".")
+    spawned = spawn_background_bash(
+        command=command, cwd=cwd, description=description, context=context
+    )
+    task_id = spawned.get("backgroundTaskId") or ""
+    # The output path lives on the registered task state (spawn writes to
+    # <tmp>/clawcodex-bg/<task_id>.log).
+    state = context.runtime_tasks.get(task_id)
+    output_path = getattr(state, "output_path", None) or getattr(state, "output_file", "")
+
+    # Start the per-monitor streaming poller (daemon so it never blocks exit).
+    threading.Thread(
+        target=_stream_output,
+        kwargs={
+            "task_id": task_id,
+            "output_path": output_path,
+            "context": context,
+            "description": description,
+        },
+        name=f"monitor-{task_id}",
+        daemon=True,
+    ).start()
+
+    return ToolResult(
+        name=MONITOR_TOOL_NAME,
+        output={
+            "taskId": task_id,
+            "outputFile": output_path,
+            "message": (
+                f"Monitor task started with ID: {task_id}. Output is being "
+                f"streamed to: {output_path}. You will receive notifications "
+                f"as new output lines appear (~1s polling). Use TaskStop to "
+                f"end monitoring when done."
+            ),
+        },
+    )
+
+
+MonitorTool: Tool = build_tool(
+    name=MONITOR_TOOL_NAME,
+    input_schema={
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "command": {
+                "type": "string",
+                "description": "The shell command to run and monitor",
+            },
+            "description": {
+                "type": "string",
+                "description": (
+                    "Clear, concise description of what this command does in "
+                    "active voice."
+                ),
+            },
+        },
+        "required": ["command", "description"],
+    },
+    call=_monitor_call,
+    prompt=(
+        "Execute a shell command in the background and stream its stdout "
+        "line-by-line as notifications. Each polling interval (~1s), new "
+        "output lines are delivered to you. Use this for monitoring logs, "
+        "watching build output, or observing long-running processes. For "
+        "one-shot 'wait until done' commands, prefer Bash with "
+        "run_in_background instead. Monitors that produce too many events are "
+        "automatically stopped — restart with a tighter filter if that happens."
+    ),
+    description="Stream a shell command's output as notifications.",
+    max_result_size_chars=2000,
+    is_read_only=lambda _input: False,
+    is_concurrency_safe=lambda _input: False,
+    to_auto_classifier_input=lambda input_data: (input_data or {}).get("command", ""),
+    # Monitor runs an arbitrary shell command — gate it exactly like Bash
+    # (TS MonitorTool.checkPermissions delegates to bashToolHasPermission).
+    check_permissions=_bash_check_permissions,
+)
+
+__all__ = ["MonitorTool", "MONITOR_TOOL_NAME"]

--- a/tests/tools/test_monitor_tool.py
+++ b/tests/tools/test_monitor_tool.py
@@ -1,0 +1,154 @@
+"""Chapter C5 Part 2 — the Monitor tool (streaming + backpressure).
+
+Port of MonitorTool.ts: stream a shell command's stdout to the model as
+~1s notifications. The novel + critical piece (the tools-round critic deferred
+the first attempt because it lacked this): BACKPRESSURE — a monitor producing
+too many notifications is auto-stopped, bounding its conversation footprint.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from src.tool_system.tools.monitor import (
+    MONITOR_TOOL_NAME,
+    MonitorTool,
+    _stream_output,
+)
+from src.utils.message_queue_manager import (
+    clear_pending_notifications,
+    peek_pending_notifications,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    clear_pending_notifications()
+    yield
+    clear_pending_notifications()
+
+
+class _Reg:
+    """A runtime-tasks stub whose status the test controls."""
+    def __init__(self, status="running"):
+        self._status = status
+        self.killed = False
+
+    def get(self, task_id):
+        return SimpleNamespace(status=self._status, output_path="x")
+
+    def stop(self):
+        self._status = "completed"
+
+
+def test_registered_and_named():
+    assert MonitorTool.name == "Monitor" == MONITOR_TOOL_NAME
+    assert MonitorTool.is_read_only({}) is False
+    assert MonitorTool.is_concurrency_safe({}) is False
+
+
+class TestStreaming:
+    def test_new_lines_become_notifications(self, tmp_path, monkeypatch):
+        log = tmp_path / "b.log"
+        log.write_text("line1\nline2\n")
+        reg = _Reg(status="completed")  # already terminal → drains once + stops
+        ctx = SimpleNamespace(runtime_tasks=reg)
+        _stream_output(task_id="b1", output_path=str(log), context=ctx,
+                       description="tail log")
+        q = peek_pending_notifications()
+        joined = "\n".join(str(n) for n in q)
+        assert "monitor-output" in joined
+        assert "line1" in joined and "line2" in joined
+
+    def test_partial_line_held_until_complete(self, tmp_path):
+        log = tmp_path / "b.log"
+        log.write_text("partial-no-newline")  # no \n → nothing streamed
+        reg = _Reg(status="completed")
+        ctx = SimpleNamespace(runtime_tasks=reg)
+        _stream_output(task_id="b2", output_path=str(log), context=ctx, description="d")
+        assert peek_pending_notifications() == []  # partial not emitted
+
+    def test_metachars_escaped(self, tmp_path):
+        log = tmp_path / "b.log"
+        log.write_text("error: a < b && c > d\n")
+        reg = _Reg(status="completed")
+        ctx = SimpleNamespace(runtime_tasks=reg)
+        _stream_output(task_id="b3", output_path=str(log), context=ctx, description="d")
+        joined = "\n".join(str(n) for n in peek_pending_notifications())
+        assert "&lt; b &amp;&amp; c &gt;" in joined  # escaped
+        assert "< b &&" not in joined
+
+
+class TestBackpressure:
+    """THE critical guard: a monitor producing too many notifications auto-stops
+    (kill + a final notice) — the tools-critic's requirement my earlier version
+    lacked."""
+
+    def test_auto_stops_after_cap(self, tmp_path, monkeypatch):
+        import src.tool_system.tools.monitor as mod
+
+        # tiny cap so the test is fast
+        monkeypatch.setattr(mod, "_MONITOR_MAX_NOTIFICATIONS", 3)
+        monkeypatch.setattr(mod, "_POLL_INTERVAL_S", 0.0)
+
+        log = tmp_path / "b.log"
+        # a file that keeps growing so every poll drains a new line
+        killed = {"v": False}
+
+        class _GrowingReg:
+            def __init__(self):
+                self._n = 0
+            def get(self, task_id):
+                # append a new line each poll so _drain always has output
+                self._n += 1
+                log.write_text("".join(f"line{i}\n" for i in range(self._n + 5)))
+                return SimpleNamespace(status="running", output_path=str(log))
+
+        monkeypatch.setattr(mod, "_kill_monitor_task",
+                            lambda tid, ctx: killed.__setitem__("v", True))
+        log.write_text("line0\n")
+        ctx = SimpleNamespace(runtime_tasks=_GrowingReg())
+        _stream_output(task_id="bk", output_path=str(log), context=ctx, description="chatty")
+
+        assert killed["v"] is True, "backpressure did not kill the monitor"
+        joined = "\n".join(str(n) for n in peek_pending_notifications())
+        assert "auto-stopped" in joined and "too many events" in joined
+
+    def test_no_auto_stop_under_cap(self, tmp_path, monkeypatch):
+        import src.tool_system.tools.monitor as mod
+
+        monkeypatch.setattr(mod, "_MONITOR_MAX_NOTIFICATIONS", 100)
+        killed = {"v": False}
+        monkeypatch.setattr(mod, "_kill_monitor_task",
+                            lambda tid, ctx: killed.__setitem__("v", True))
+        log = tmp_path / "b.log"
+        log.write_text("just one line\n")
+        reg = _Reg(status="completed")  # terminal after first drain
+        ctx = SimpleNamespace(runtime_tasks=reg)
+        _stream_output(task_id="b", output_path=str(log), context=ctx, description="quiet")
+        assert killed["v"] is False  # under cap → not auto-stopped
+        joined = "\n".join(str(n) for n in peek_pending_notifications())
+        assert "auto-stopped" not in joined
+
+
+class TestLifecycle:
+    def test_stops_when_task_leaves_running(self, tmp_path):
+        log = tmp_path / "b.log"
+        log.write_text("a\n")
+        reg = _Reg(status="completed")
+        ctx = SimpleNamespace(runtime_tasks=reg)
+        # returns promptly (doesn't loop forever) because status != running
+        _stream_output(task_id="b", output_path=str(log), context=ctx, description="d")
+        assert "a" in "\n".join(str(n) for n in peek_pending_notifications())
+
+    def test_stops_when_task_evicted(self, tmp_path):
+        log = tmp_path / "b.log"
+        log.write_text("a\n")
+
+        class _GoneReg:
+            def get(self, task_id):
+                return None  # evicted
+        ctx = SimpleNamespace(runtime_tasks=_GoneReg())
+        _stream_output(task_id="b", output_path=str(log), context=ctx, description="d")
+        # returns without hanging; the first drain may have emitted the line

--- a/tests/tools/test_monitor_tool.py
+++ b/tests/tools/test_monitor_tool.py
@@ -64,13 +64,27 @@ class TestStreaming:
         assert "<task-id>b1</task-id>" in joined  # parse_task_id can correlate
         assert "line1" in joined and "line2" in joined
 
-    def test_partial_line_held_until_complete(self, tmp_path):
+    def test_partial_line_held_while_running_flushed_on_completion(self, tmp_path, monkeypatch):
+        # A partial (no-newline) line is HELD on a mid-stream (non-final) drain,
+        # then FLUSHED on the final drain when the task completes (critic #3.ii).
+        import src.tool_system.tools.monitor as mod
+        monkeypatch.setattr(mod, "_POLL_INTERVAL_S", 0.0)
         log = tmp_path / "b.log"
-        log.write_text("partial-no-newline")  # no \n → nothing streamed
-        reg = _Reg(status="completed")
-        ctx = SimpleNamespace(runtime_tasks=reg)
+        log.write_text("partial-no-newline")  # no \n
+
+        class _RunThenDone:
+            def __init__(self): self._n = 0
+            def get(self, task_id):
+                self._n += 1
+                # first poll: running (partial held); then completed (final flush)
+                return SimpleNamespace(
+                    status="running" if self._n < 2 else "completed",
+                    output_path=str(log))
+        ctx = SimpleNamespace(runtime_tasks=_RunThenDone())
         _stream_output(task_id="b2", output_path=str(log), context=ctx, description="d")
-        assert peek_pending_notifications() == []  # partial not emitted
+        # the partial is surfaced on completion (final flush)
+        joined = "\n".join(str(n) for n in peek_pending_notifications())
+        assert "partial-no-newline" in joined
 
     def test_metachars_escaped(self, tmp_path):
         log = tmp_path / "b.log"
@@ -243,3 +257,40 @@ class TestRenderPathCompat:
             output_file="/tmp/b.log", exit_code=0)
         turn = build_notification_turn([done])
         assert "have finished" in turn and "STILL RUNNING" not in turn
+
+
+class TestFinalDrainAndLongLine:
+    """critic C5-P2 #3: final partial line surfaced on completion; a single
+    line longer than the read window doesn't stall forever."""
+
+    def test_final_partial_line_surfaced(self, tmp_path):
+        # a command whose last output has NO trailing newline (printf done)
+        log = tmp_path / "b.log"
+        log.write_text("first\nno-newline-tail")  # 'no-newline-tail' has no \n
+        reg = _Reg(status="completed")  # terminal → final drain
+        ctx = SimpleNamespace(runtime_tasks=reg)
+        _stream_output(task_id="b", output_path=str(log), context=ctx, description="d")
+        joined = "\n".join(str(n) for n in peek_pending_notifications())
+        assert "no-newline-tail" in joined  # the trailing partial is not lost
+
+    def test_long_line_over_read_window_makes_progress(self, tmp_path, monkeypatch):
+        import src.tool_system.tools.monitor as mod
+        monkeypatch.setattr(mod, "_MONITOR_MAX_READ_BYTES", 100)  # tiny window
+        log = tmp_path / "b.log"
+        log.write_text("Y" * 500)  # a 500-byte single line, no newline, still running
+        emitted = {"n": 0}
+
+        class _OneShotReg:
+            def __init__(self): self._calls = 0
+            def get(self, task_id):
+                self._calls += 1
+                # running for the first couple polls, then terminal
+                return SimpleNamespace(
+                    status="running" if self._calls < 3 else "completed",
+                    output_path=str(log))
+        monkeypatch.setattr(mod, "_POLL_INTERVAL_S", 0.0)
+        ctx = SimpleNamespace(runtime_tasks=_OneShotReg())
+        _stream_output(task_id="b", output_path=str(log), context=ctx, description="d")
+        # the full-window no-newline line was emitted (progress made), not stalled
+        joined = "\n".join(str(n) for n in peek_pending_notifications())
+        assert "Y" in joined

--- a/tests/tools/test_monitor_tool.py
+++ b/tests/tools/test_monitor_tool.py
@@ -45,7 +45,7 @@ class _Reg:
 def test_registered_and_named():
     assert MonitorTool.name == "Monitor" == MONITOR_TOOL_NAME
     assert MonitorTool.is_read_only({}) is False
-    assert MonitorTool.is_concurrency_safe({}) is False
+    assert MonitorTool.is_concurrency_safe({}) is True  # TS: fire-and-forget spawn
 
 
 class TestStreaming:
@@ -58,7 +58,10 @@ class TestStreaming:
                        description="tail log")
         q = peek_pending_notifications()
         joined = "\n".join(str(n) for n in q)
-        assert "monitor-output" in joined
+        # a render-path-compatible <task-notification> with status=running
+        assert "<task-notification>" in joined
+        assert "<status>running</status>" in joined
+        assert "<task-id>b1</task-id>" in joined  # parse_task_id can correlate
         assert "line1" in joined and "line2" in joined
 
     def test_partial_line_held_until_complete(self, tmp_path):
@@ -203,3 +206,40 @@ class TestSizeBound:
         assert "last-line" in joined            # the tail is kept
         # the emitted body is bounded (not the full 5000 X's)
         assert joined.count("X") < 500
+
+
+class TestRenderPathCompat:
+    """critic C5-P2 major: the streamed envelope must be understood by the
+    port's drain/render path — parse_task_id correlates, render_banner renders,
+    and a pure-running batch is framed as streaming (not 'finished')."""
+
+    def test_envelope_parses_and_renders(self, tmp_path):
+        from src.server.task_notifications import (
+            build_notification_turn,
+            parse_task_id,
+            render_banner,
+        )
+        log = tmp_path / "b.log"
+        log.write_text("hello from monitor\n")
+        reg = _Reg(status="completed")
+        ctx = SimpleNamespace(runtime_tasks=reg)
+        _stream_output(task_id="mon1", output_path=str(log), context=ctx, description="d")
+        env = str(peek_pending_notifications()[0])
+        # parse_task_id correlates (was None with the <monitor-output> tag)
+        assert parse_task_id(env) == "mon1"
+        # render_banner surfaces the streamed line (not "Background task finished")
+        banner = "\n".join(render_banner(env, None))
+        assert "hello from monitor" in banner
+        # a pure-running batch → streaming preamble, NOT "finished"
+        turn = build_notification_turn([env])
+        assert "STILL RUNNING" in turn and "have finished" not in turn
+
+    def test_finished_batch_keeps_completion_preamble(self):
+        # a real completion envelope still gets the finished framing
+        from src.server.task_notifications import build_notification_turn
+        from src.utils.task_notification import build_shell_notification_xml
+        done = build_shell_notification_xml(
+            task_id="b", description="build", status="completed",
+            output_file="/tmp/b.log", exit_code=0)
+        turn = build_notification_turn([done])
+        assert "have finished" in turn and "STILL RUNNING" not in turn

--- a/tests/tools/test_monitor_tool.py
+++ b/tests/tools/test_monitor_tool.py
@@ -152,3 +152,54 @@ class TestLifecycle:
         ctx = SimpleNamespace(runtime_tasks=_GoneReg())
         _stream_output(task_id="b", output_path=str(log), context=ctx, description="d")
         # returns without hanging; the first drain may have emitted the line
+
+
+class TestMonitorSafetyGuards:
+    """critic C5-P2 #5: Monitor spawns via spawn_background_bash directly, so it
+    must NOT be a way around the bash safety guards (hardcoded-dangerous + the
+    C8 sandbox hard-gate) that live in _bash_call."""
+
+    def _ctx(self, tmp_path):
+        from src.tool_system.context import ToolContext, ToolUseOptions
+        ctx = ToolContext(workspace_root=tmp_path)
+        ctx.options = ToolUseOptions(tools=[])
+        return ctx
+
+    def test_dangerous_command_refused(self, tmp_path):
+        from src.tool_system.errors import ToolPermissionError
+        from src.tool_system.tools.monitor import _monitor_call
+        # a command matching _HARDCODED_DANGEROUS_PATTERNS must be refused
+        with pytest.raises(ToolPermissionError, match="dangerous"):
+            _monitor_call({"command": "rm -rf /", "description": "boom"},
+                          self._ctx(tmp_path))
+
+    def test_sandbox_hard_gate_refused(self, tmp_path, monkeypatch):
+        from src.settings.types import SettingsSchema
+        from src.tool_system.errors import ToolPermissionError
+        from src.tool_system.tools.monitor import _monitor_call
+
+        hard = SettingsSchema.from_dict({"sandbox": {"enabled": True, "failIfUnavailable": True}})
+        monkeypatch.setattr("src.settings.settings.get_settings", lambda *a, **k: hard)
+        with pytest.raises(ToolPermissionError):
+            _monitor_call({"command": "tail -f log", "description": "watch"},
+                          self._ctx(tmp_path))
+
+
+class TestSizeBound:
+    """critic C5-P2 #1: a single poll batches all new lines into one
+    notification, so the count cap doesn't bound a firehose — each notification
+    is size-capped (tail kept + truncation marker)."""
+
+    def test_huge_burst_truncated(self, tmp_path, monkeypatch):
+        import src.tool_system.tools.monitor as mod
+        monkeypatch.setattr(mod, "_MONITOR_MAX_NOTIFICATION_BYTES", 200)
+        log = tmp_path / "b.log"
+        log.write_text("X" * 5000 + "\nlast-line\n")  # one huge burst
+        reg = _Reg(status="completed")
+        ctx = SimpleNamespace(runtime_tasks=reg)
+        _stream_output(task_id="b", output_path=str(log), context=ctx, description="firehose")
+        joined = "\n".join(str(n) for n in peek_pending_notifications())
+        assert "truncated" in joined            # the marker
+        assert "last-line" in joined            # the tail is kept
+        # the emitted body is bounded (not the full 5000 X's)
+        assert joined.count("X") < 500


### PR DESCRIPTION
## Summary

**C5 Part 2 — the Monitor tool** (`typescript/src/tools/MonitorTool/MonitorTool.ts`, MONITOR_TOOL=true). Completes the Monitor-tool chapter: run a shell command in the background and STREAM its stdout to the model as ~1s `<task-notification>` updates, instead of the single completion notification the Bash `run_in_background` path delivers (C5 Part 1). The tools-round critic DEFERRED an earlier attempt for lacking backpressure; this ships it with backpressure done right.

- **`src/tool_system/tools/monitor.py`** (new): the tool (spawns via `spawn_background_bash`, same detached shell + Part-1 reaper) + a daemon polling thread that tails the output file and emits each new batch of whole lines. Registered in `ALL_STATIC_TOOLS`; Monitor added to the `getAllBaseTools` parity snapshot.
- **BACKPRESSURE** (the deferred requirement): (1) count cap — after `_MONITOR_MAX_NOTIFICATIONS` (100) the monitor AUTO-STOPS (kills the shell + a terminal notice); (2) byte cap — bounded `seek + read(8 MiB)` per poll (= TS `DEFAULT_MAX_READ_BYTES`, no whole-file `read_bytes` OOM vector) + an 8 KiB per-notification tail cap.
- **Safety** (critic): Monitor spawns via `spawn_background_bash` directly, so it must not bypass `_bash_call`'s guards — extracted `bash_command_safety_guard` (hardcoded-dangerous-pattern block + C8 sandbox hard-gate), called from BOTH `_bash_call` and `_monitor_call`.
- **Delivery** (critic): emits a real `<task-notification status=running>` the drain path understands (`parse_task_id` correlates, `render_banner` renders); `build_notification_turn` is status-aware — a pure-running batch gets a streaming preamble ("STILL RUNNING — do not report as finished"), finished tasks keep the completion preamble.

## Critic (4 rounds, APPROVE)
Caught, in sequence: the missing backpressure, a **sandbox/dangerous-command bypass** (Monitor spawning around the bash guards), a **`read_bytes` OOM vector**, and an **envelope incompatible with its own render path** (lost correlation + a running monitor framed "finished" every drain). Final: "APPROVE — all blocking and major findings resolved and verified; 266 tests green; the delivery design is shippable." The full TS passive-attachment path is a documented, deliberate scope divergence (not a blocker).

## Verification
`tests/tools/test_monitor_tool.py` (15): streaming, both backpressure dimensions (count auto-stop + byte truncation + bounded read), safety guards through Monitor (`rm -rf /` + sandbox hard-gate refused), render-path compat (`parse_task_id`/`render_banner`/`build_notification_turn`), lifecycle, final-drain flush, long-line progress, terminal auto-stop status. Prior-commit full suites at the 6-failure baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
