### PR TITLE
feat(proxy): wire the CCR upstream proxy (C9, env-gated no-op by default)

### DIFF
--- a/src/entrypoints/agent_server_cli.py
+++ b/src/entrypoints/agent_server_cli.py
@@ -244,6 +244,11 @@ async def _serve_stdio(workspace: str, agent_config: AgentServerConfig) -> int:
     RESERVED for JSON frames (diagnostics go to ``stderr``); ``stdin`` EOF — the
     parent TUI going away — ends the session.
     """
+    # TS wires the proxy in the shared init.ts (ALL sessions), so both the HTTP
+    # (_serve) and stdio transports init it — else a CCR-remote stdio container's
+    # tool subprocesses would miss the proxy (critic C9 open-Q). No-op unless
+    # CLAUDE_CODE_REMOTE is set.
+    await _maybe_init_upstream_proxy()
     profile_checkpoint("agent_server_serve_start")
     # This transport serves exactly ONE session (the Ink client's child, or
     # a hand-run standalone). single_session unlocks the process-global
@@ -335,13 +340,13 @@ async def _maybe_init_upstream_proxy() -> None:
         )
         from src.utils.subprocess_env import register_upstream_proxy_env_fn
 
-        # Init FIRST, register the env provider only on success — so a failed
-        # init can't leave a provider registered that injects proxy vars for a
-        # relay that never started (critic C9 #3). init_upstream_proxy is the
-        # authority on _state; get_upstream_proxy_env reads it, so ordering is
-        # safe either way, but register-after-success removes the window.
-        await init_upstream_proxy()
+        # Register BEFORE init — exact TS order (init.ts:148-149). Safe in either
+        # order: get_upstream_proxy_env reads _state at CALL time and returns {}
+        # while DISABLED on a clean env, so a registered provider over a
+        # failed/pending init injects nothing (verified). The whole block is
+        # fail-open below.
         register_upstream_proxy_env_fn(get_upstream_proxy_env)
+        await init_upstream_proxy()
     except Exception:  # noqa: BLE001 — fail-open, mirror TS
         import logging
 

--- a/src/entrypoints/agent_server_cli.py
+++ b/src/entrypoints/agent_server_cli.py
@@ -335,8 +335,13 @@ async def _maybe_init_upstream_proxy() -> None:
         )
         from src.utils.subprocess_env import register_upstream_proxy_env_fn
 
-        register_upstream_proxy_env_fn(get_upstream_proxy_env)
+        # Init FIRST, register the env provider only on success — so a failed
+        # init can't leave a provider registered that injects proxy vars for a
+        # relay that never started (critic C9 #3). init_upstream_proxy is the
+        # authority on _state; get_upstream_proxy_env reads it, so ordering is
+        # safe either way, but register-after-success removes the window.
         await init_upstream_proxy()
+        register_upstream_proxy_env_fn(get_upstream_proxy_env)
     except Exception:  # noqa: BLE001 — fail-open, mirror TS
         import logging
 

--- a/src/entrypoints/agent_server_cli.py
+++ b/src/entrypoints/agent_server_cli.py
@@ -312,7 +312,41 @@ async def _serve_stdio(workspace: str, agent_config: AgentServerConfig) -> int:
     return 0
 
 
+async def _maybe_init_upstream_proxy() -> None:
+    """C9: when ``CLAUDE_CODE_REMOTE`` is set (a CCR remote deployment), start
+    the upstream CONNECT proxy and register its env provider so ``subprocess_env``
+    injects the proxy recipe into every spawned child.
+
+    Mirrors the TS remote bootstrap (``registerUpstreamProxyEnvFn`` +
+    ``initUpstreamProxy``, gated on ``CLAUDE_CODE_REMOTE``). The open TS build
+    strips this path, and ``init_upstream_proxy`` itself re-checks the env gate,
+    so with ``CLAUDE_CODE_REMOTE`` unset this is a pure no-op — default local
+    behaviour is unchanged. FAIL-OPEN: a proxy failure must not stop the server
+    from starting (a remote session degrades to direct rather than dying)."""
+    from src.utils.subprocess_env import _is_env_truthy
+
+    if not _is_env_truthy(os.environ.get("CLAUDE_CODE_REMOTE")):
+        return
+    try:
+        # Lazy import: keep asyncio/ssl/relay off the default startup path.
+        from src.upstreamproxy.upstream_proxy import (
+            get_upstream_proxy_env,
+            init_upstream_proxy,
+        )
+        from src.utils.subprocess_env import register_upstream_proxy_env_fn
+
+        register_upstream_proxy_env_fn(get_upstream_proxy_env)
+        await init_upstream_proxy()
+    except Exception:  # noqa: BLE001 — fail-open, mirror TS
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "[upstreamproxy] init failed; continuing without proxy", exc_info=True
+        )
+
+
 async def _serve(args, workspace: str, agent_config: AgentServerConfig) -> int:
+    await _maybe_init_upstream_proxy()
     index_path = Path.home() / ".clawcodex" / "server-sessions.json"
     index_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/upstreamproxy/upstream_proxy.py
+++ b/src/upstreamproxy/upstream_proxy.py
@@ -196,11 +196,10 @@ async def init_upstream_proxy(
 def get_upstream_proxy_env() -> dict[str, str]:
     """Env-var dict for child subprocesses (Bash/MCP/LSP/hooks).
 
-    When the proxy is enabled: returns the 9-var recipe
+    When the proxy is enabled: returns the 8-var recipe
     (``HTTPS_PROXY``/``https_proxy``/``NO_PROXY``/``no_proxy``/
     ``SSL_CERT_FILE``/``NODE_EXTRA_CA_CERTS``/``REQUESTS_CA_BUNDLE``/
-    ``CURL_CA_BUNDLE``). The TS recipe also sets ``proxy`` in lowercase
-    via ``HTTPS_PROXY`` lowercase variant; we follow the same pattern.
+    ``CURL_CA_BUNDLE``) — matching the TS 8-key recipe exactly.
 
     When the proxy is disabled: if the parent already has both
     ``HTTPS_PROXY`` and ``SSL_CERT_FILE`` set, we inherit those

--- a/src/utils/subprocess_env.py
+++ b/src/utils/subprocess_env.py
@@ -81,26 +81,34 @@ def subprocess_env(base: dict[str, str] | None = None) -> dict[str, str]:
     ``CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`` is truthy, the scrub set (+ ``INPUT_``
     twins) is removed; otherwise ``base`` is returned unchanged (parity with
     TS's non-gated pass-through). Always returns a fresh dict."""
-    env = dict(os.environ if base is None else base)
-    if _is_env_truthy(env.get("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB")):
-        for key in _GHA_SUBPROCESS_SCRUB:
-            env.pop(key, None)
-            env.pop(f"INPUT_{key}", None)  # the GitHub-Action input twin
-    # Merge the upstream-proxy recipe AFTER the scrub (TS subprocessEnv order),
-    # so an injected HTTPS_PROXY / *_CA_BUNDLE isn't stripped. No-op unless the
-    # CCR-remote entrypoint registered a provider. Best-effort: a proxy-env
-    # failure must never break child-process spawning.
+    # Upstream-proxy recipe first (no-op unless a provider is registered); the
+    # SCRUB runs LAST so it stays authoritative — a provider can never
+    # re-introduce a scrubbed secret. Mirrors TS subprocessEnv.ts:85-98 exactly
+    # ({...env, ...proxyEnv} THEN the delete loop). Best-effort: a proxy-env
+    # failure can't break child spawning.
+    proxy_env: dict[str, str] = {}
     if _upstream_proxy_env_fn is not None:
         try:
-            proxy_env = _upstream_proxy_env_fn()
-            if proxy_env:
-                env.update(proxy_env)
+            proxy_env = _upstream_proxy_env_fn() or {}
         except Exception:  # noqa: BLE001 — proxy env must not break spawning
             import logging
 
             logging.getLogger(__name__).debug(
                 "[upstreamproxy] env provider failed", exc_info=True
             )
+            proxy_env = {}
+
+    env = dict(os.environ if base is None else base)
+    if not _is_env_truthy(env.get("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB")):
+        if proxy_env:
+            env.update(proxy_env)  # non-gated pass-through + proxy merge
+        return env
+    # Scrub gate ON: merge proxy, THEN strip the secret set (+ INPUT_ twins) —
+    # so even a misbehaving provider can't leak a scrubbed key into the child.
+    env.update(proxy_env)
+    for key in _GHA_SUBPROCESS_SCRUB:
+        env.pop(key, None)
+        env.pop(f"INPUT_{key}", None)  # the GitHub-Action input twin
     return env
 
 

--- a/src/utils/subprocess_env.py
+++ b/src/utils/subprocess_env.py
@@ -8,15 +8,37 @@ cannot read a credential via shell expansion (``${ANTHROPIC_API_KEY}``) in a
 subprocess. Gated because ``claude-code-action`` sets the flag; a plain local
 CLI leaves the env untouched (parity with TS).
 
-NOTE: TS's ``subprocessEnv`` also merges the upstream-proxy env
-(``registerUpstreamProxyEnvFn``). That half is intentionally NOT wired here —
-the port's upstreamproxy is unwired (the deferred CCR-remote-proxy chapter);
-when it lands, merge ``get_upstream_proxy_env()`` into the base below.
+TS's ``subprocessEnv`` also merges the upstream-proxy env via
+``registerUpstreamProxyEnvFn`` (subprocessEnv.ts) — an indirection so this
+module doesn't statically import ``upstreamproxy`` (which pulls asyncio/ssl/the
+relay). C9 wires that: the CCR-remote entrypoint registers
+``get_upstream_proxy_env`` when ``CLAUDE_CODE_REMOTE`` is set, and
+``subprocess_env`` merges its result AFTER the scrub (so the injected
+``HTTPS_PROXY``/``*_CA_BUNDLE`` recipe survives the anti-exfiltration strip).
+Default (no registration) → the merge is a no-op and behaviour is unchanged.
 """
 
 from __future__ import annotations
 
 import os
+from typing import Callable
+
+#: Registered by the CCR-remote entrypoint (register_upstream_proxy_env_fn).
+#: ``None`` in every non-remote build — the merge below is then a no-op, so the
+#: default subprocess environment is byte-for-byte unchanged.
+_upstream_proxy_env_fn: Callable[[], dict[str, str]] | None = None
+
+
+def register_upstream_proxy_env_fn(fn: Callable[[], dict[str, str]] | None) -> None:
+    """Register (or clear with ``None``) the upstream-proxy env provider.
+
+    Port of ``registerUpstreamProxyEnvFn`` (subprocessEnv.ts): the CCR-remote
+    entrypoint passes ``get_upstream_proxy_env`` so ``subprocess_env`` can inject
+    the proxy recipe into every spawned child WITHOUT this module statically
+    importing the upstreamproxy package. Idempotent; test-only callers clear it
+    with ``None``."""
+    global _upstream_proxy_env_fn
+    _upstream_proxy_env_fn = fn
 
 # Verbatim from subprocessEnv.ts GHA_SUBPROCESS_SCRUB (23 vars).
 _GHA_SUBPROCESS_SCRUB: tuple[str, ...] = (
@@ -60,12 +82,26 @@ def subprocess_env(base: dict[str, str] | None = None) -> dict[str, str]:
     twins) is removed; otherwise ``base`` is returned unchanged (parity with
     TS's non-gated pass-through). Always returns a fresh dict."""
     env = dict(os.environ if base is None else base)
-    if not _is_env_truthy(env.get("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB")):
-        return env
-    for key in _GHA_SUBPROCESS_SCRUB:
-        env.pop(key, None)
-        env.pop(f"INPUT_{key}", None)  # the GitHub-Action input twin
+    if _is_env_truthy(env.get("CLAUDE_CODE_SUBPROCESS_ENV_SCRUB")):
+        for key in _GHA_SUBPROCESS_SCRUB:
+            env.pop(key, None)
+            env.pop(f"INPUT_{key}", None)  # the GitHub-Action input twin
+    # Merge the upstream-proxy recipe AFTER the scrub (TS subprocessEnv order),
+    # so an injected HTTPS_PROXY / *_CA_BUNDLE isn't stripped. No-op unless the
+    # CCR-remote entrypoint registered a provider. Best-effort: a proxy-env
+    # failure must never break child-process spawning.
+    if _upstream_proxy_env_fn is not None:
+        try:
+            proxy_env = _upstream_proxy_env_fn()
+            if proxy_env:
+                env.update(proxy_env)
+        except Exception:  # noqa: BLE001 — proxy env must not break spawning
+            import logging
+
+            logging.getLogger(__name__).debug(
+                "[upstreamproxy] env provider failed", exc_info=True
+            )
     return env
 
 
-__all__ = ["subprocess_env"]
+__all__ = ["subprocess_env", "register_upstream_proxy_env_fn"]

--- a/tests/test_c9_upstream_proxy_wiring.py
+++ b/tests/test_c9_upstream_proxy_wiring.py
@@ -70,3 +70,37 @@ class TestEntrypointGuard:
         asyncio.run(_maybe_init_upstream_proxy())
         # no provider was registered (the gate short-circuited before import)
         assert se._upstream_proxy_env_fn is None
+
+
+class TestHalfRegisteredSafety:
+    """critic C9 #3: a FAILED init must not leave a provider registered that
+    injects proxy vars for a relay that never started. The entrypoint registers
+    only AFTER init succeeds; and even the provider itself returns {} when the
+    proxy state is DISABLED (with a clean env)."""
+
+    def test_failed_init_leaves_no_registration(self, monkeypatch):
+        import src.entrypoints.agent_server_cli as cli
+        from src.utils import subprocess_env as se
+
+        monkeypatch.setenv("CLAUDE_CODE_REMOTE", "1")
+        se.register_upstream_proxy_env_fn(None)
+
+        async def _boom():
+            raise RuntimeError("relay bind failed")
+        # patch the imported init to fail
+        monkeypatch.setattr(
+            "src.upstreamproxy.upstream_proxy.init_upstream_proxy", _boom)
+        asyncio.run(cli._maybe_init_upstream_proxy())
+        # fail-open AND no provider registered → subprocess_env stays a no-op
+        assert se._upstream_proxy_env_fn is None
+        se.register_upstream_proxy_env_fn(None)
+
+    def test_disabled_state_returns_empty_recipe(self, monkeypatch):
+        from src.upstreamproxy.upstream_proxy import (
+            get_upstream_proxy_env,
+            reset_for_tests,
+        )
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+        reset_for_tests()  # DISABLED
+        assert get_upstream_proxy_env() == {}

--- a/tests/test_c9_upstream_proxy_wiring.py
+++ b/tests/test_c9_upstream_proxy_wiring.py
@@ -1,0 +1,72 @@
+"""C9 — CCR upstream-proxy wiring (env-gated, no-op by default).
+
+The register-fn indirection (subprocess_env ← get_upstream_proxy_env) + the
+guarded entrypoint init. The MOST important assertion is the default no-op:
+with CLAUDE_CODE_REMOTE unset, nothing changes.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.utils.subprocess_env import (
+    register_upstream_proxy_env_fn,
+    subprocess_env,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_registration():
+    register_upstream_proxy_env_fn(None)
+    yield
+    register_upstream_proxy_env_fn(None)
+
+
+class TestDefaultNoOp:
+    def test_no_provider_registered_env_unchanged(self):
+        # THE default path: no provider → subprocess_env is byte-for-byte the base
+        base = {"PATH": "/usr/bin", "FOO": "bar"}
+        assert subprocess_env(base) == base
+
+    def test_provider_returning_empty_is_noop(self):
+        register_upstream_proxy_env_fn(lambda: {})
+        base = {"PATH": "/usr/bin"}
+        assert subprocess_env(base) == base
+
+
+class TestProxyMerge:
+    def test_registered_provider_merges_proxy_vars(self):
+        register_upstream_proxy_env_fn(
+            lambda: {"HTTPS_PROXY": "http://127.0.0.1:9", "SSL_CERT_FILE": "/ca.pem"})
+        out = subprocess_env({"PATH": "/usr/bin"})
+        assert out["HTTPS_PROXY"] == "http://127.0.0.1:9"
+        assert out["SSL_CERT_FILE"] == "/ca.pem"
+        assert out["PATH"] == "/usr/bin"
+
+    def test_proxy_vars_survive_the_scrub(self):
+        # proxy env is merged AFTER the scrub, so an injected recipe isn't stripped
+        register_upstream_proxy_env_fn(lambda: {"HTTPS_PROXY": "http://127.0.0.1:9"})
+        base = {"CLAUDE_CODE_SUBPROCESS_ENV_SCRUB": "1",
+                "ANTHROPIC_API_KEY": "secret", "HTTPS_PROXY": ""}
+        out = subprocess_env(base)
+        assert "ANTHROPIC_API_KEY" not in out          # scrubbed
+        assert out["HTTPS_PROXY"] == "http://127.0.0.1:9"  # merged, survives
+
+    def test_provider_failure_is_fail_open(self):
+        def _boom():
+            raise RuntimeError("proxy down")
+        register_upstream_proxy_env_fn(_boom)
+        # must not raise — spawning can't be broken by a proxy-env failure
+        out = subprocess_env({"PATH": "/usr/bin"})
+        assert out["PATH"] == "/usr/bin"
+
+
+class TestEntrypointGuard:
+    def test_maybe_init_noop_without_env(self, monkeypatch):
+        from src.entrypoints.agent_server_cli import _maybe_init_upstream_proxy
+        from src.utils import subprocess_env as se
+        monkeypatch.delenv("CLAUDE_CODE_REMOTE", raising=False)
+        asyncio.run(_maybe_init_upstream_proxy())
+        # no provider was registered (the gate short-circuited before import)
+        assert se._upstream_proxy_env_fn is None

--- a/tests/test_c9_upstream_proxy_wiring.py
+++ b/tests/test_c9_upstream_proxy_wiring.py
@@ -78,22 +78,38 @@ class TestHalfRegisteredSafety:
     only AFTER init succeeds; and even the provider itself returns {} when the
     proxy state is DISABLED (with a clean env)."""
 
-    def test_failed_init_leaves_no_registration(self, monkeypatch):
+    def test_failed_init_is_safe_disabled_state_injects_nothing(self, monkeypatch):
+        # Register-first (TS parity): a failed init CAN leave the provider
+        # registered, but that's safe — the disabled _state returns {} on a
+        # clean env, so subprocess_env injects nothing.
         import src.entrypoints.agent_server_cli as cli
+        from src.upstreamproxy.upstream_proxy import reset_for_tests
         from src.utils import subprocess_env as se
 
         monkeypatch.setenv("CLAUDE_CODE_REMOTE", "1")
+        monkeypatch.delenv("HTTPS_PROXY", raising=False)
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
         se.register_upstream_proxy_env_fn(None)
+        reset_for_tests()  # DISABLED
 
         async def _boom():
             raise RuntimeError("relay bind failed")
-        # patch the imported init to fail
         monkeypatch.setattr(
             "src.upstreamproxy.upstream_proxy.init_upstream_proxy", _boom)
         asyncio.run(cli._maybe_init_upstream_proxy())
-        # fail-open AND no provider registered → subprocess_env stays a no-op
-        assert se._upstream_proxy_env_fn is None
+        # fail-open; even if the provider registered, subprocess_env is a no-op
+        assert subprocess_env({"PATH": "/usr/bin"}) == {"PATH": "/usr/bin"}
         se.register_upstream_proxy_env_fn(None)
+
+    def test_scrub_is_authoritative_over_a_misbehaving_provider(self):
+        # MAJOR-A / TS parity: the scrub runs LAST, so even a provider that
+        # (wrongly) returns a scrubbed secret can't leak it into the child.
+        register_upstream_proxy_env_fn(lambda: {"ANTHROPIC_API_KEY": "leaked",
+                                                 "HTTPS_PROXY": "http://127.0.0.1:9"})
+        out = subprocess_env({"CLAUDE_CODE_SUBPROCESS_ENV_SCRUB": "1"})
+        assert "ANTHROPIC_API_KEY" not in out       # scrub wins over the provider
+        assert out["HTTPS_PROXY"] == "http://127.0.0.1:9"  # proxy var survives
+        register_upstream_proxy_env_fn(None)
 
     def test_disabled_state_returns_empty_recipe(self, monkeypatch):
         from src.upstreamproxy.upstream_proxy import (


### PR DESCRIPTION
## Summary

**C9 — wire the CCR upstream proxy** (env-gated, no-op by default). The port ported `src/upstreamproxy/upstream_proxy.py` (`init_upstream_proxy` + `get_upstream_proxy_env`, gated on `CLAUDE_CODE_REMOTE`) but left it UNWIRED — zero live callers, and `subprocess_env` carried a documented TODO. This restores the genuine parity the open TS build has (`init.ts:140-156` + `subprocessEnv.ts:79-99`; `CLAUDE_CODE_REMOTE` appears in 30 TS files).

- **`src/utils/subprocess_env.py`**: `register_upstream_proxy_env_fn(fn)` + a provider slot (mirrors TS `registerUpstreamProxyEnvFn` — no static import of the asyncio/ssl/relay graph). `subprocess_env` merges the proxy recipe FIRST, then runs the scrub loop LAST so the anti-exfiltration scrub stays **authoritative** — exact TS `subprocessEnv.ts:85-98` order (a provider can't re-introduce a scrubbed secret).
- **`src/entrypoints/agent_server_cli.py`**: `_maybe_init_upstream_proxy()` — when `CLAUDE_CODE_REMOTE` is truthy, `registerUpstreamProxyEnvFn` **then** `await init_upstream_proxy()` (exact `init.ts:148-149` order), fail-open. Called from BOTH `_serve` (HTTP) and `_serve_stdio` — matching TS's shared `init.ts` for all sessions.

**Default behaviour unchanged**: with `CLAUDE_CODE_REMOTE` unset (every local build), no provider is registered and `subprocess_env` is byte-for-byte the base; the entrypoint short-circuits before any import. Zero blast radius — the value is that a CCR-remote deployment's ported proxy actually engages.

## Critic (2 rounds → APPROVE)
Corrected two real errors of mine: my "open build strips this" premise (a worktree-grep artifact — `typescript/` is main-only; the open build HAS the wiring) and my pre-emptive init-first reorder (a parity regression on a false premise — register-first is already safe since a disabled proxy returns `{}`). Both MAJORs fixed to exact TS parity and verified line-by-line: "Both MAJORs correctly and faithfully resolved… Default no-op airtight. Ship it."

## Verification
`tests/test_c9_upstream_proxy_wiring.py` (9): default no-op (env byte-for-byte unchanged / empty-provider no-op), proxy-var merge, **scrub-authoritative** (a provider returning `ANTHROPIC_API_KEY` is stripped while `HTTPS_PROXY` survives), fail-open, failed-init-injects-nothing, disabled-returns-empty, entrypoint-guard-noop. 49 subprocess/scrub/upstream_proxy tests green; prior-commit full suite at the 6-failure baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
