### PR TITLE
feat(tui): minimal vim editing engine for the composer (C13 Part 1)

### DIFF
--- a/ui-tui/src/__tests__/vimEngine.test.ts
+++ b/ui-tui/src/__tests__/vimEngine.test.ts
@@ -102,9 +102,14 @@ describe('operators', () => {
     expect(r.buffer.value).toBe('world')
     expect(r.state.mode).toBe('normal')
   })
-  it('cw deletes the word and enters insert', () => {
+  it('cw acts like ce (changes to word END, keeps trailing space) — :help cw', () => {
     const r = run('hello world', 0, ['c', 'w'])
-    expect(r.buffer.value).toBe('world')
+    expect(r.buffer.value).toBe(' world') // NOT 'world' — cw ≠ dw
+    expect(r.state.mode).toBe('insert')
+  })
+  it('cw on whitespace behaves like dw (no special case)', () => {
+    // cursor on the space between words → cw deletes the blank run + next word start
+    const r = run('a  b', 1, ['c', 'w'])
     expect(r.state.mode).toBe('insert')
   })
   it('de deletes to end of word (inclusive)', () => {
@@ -136,5 +141,78 @@ describe('count prefix', () => {
   })
   it('0 is a motion when no count is in progress', () => {
     expect(run('hello', 3, ['0']).buffer.cursor).toBe(0)
+  })
+})
+
+describe('linewise operators (critic MAJOR-2/-3)', () => {
+  const v = 'L1\nL2\nL3\nL4'
+  it('dj deletes the current AND next line', () => {
+    // cursor on L2 (offset 3), dj → delete L2+L3
+    expect(run(v, 3, ['d', 'j']).buffer.value).toBe('L1\nL4')
+  })
+  it('dk deletes the current AND previous line', () => {
+    expect(run(v, 6, ['d', 'k']).buffer.value).toBe('L1\nL4') // on L3, dk → L2+L3
+  })
+  it('dG deletes from the current line to the last', () => {
+    expect(run(v, 3, ['d', 'G']).buffer.value).toBe('L1') // L2..L4 gone
+  })
+  it('dgg deletes from the first line to the current', () => {
+    expect(run(v, 6, ['d', 'g', 'g']).buffer.value).toBe('L4') // L1..L3 gone
+  })
+  it('dd on the LAST line removes the preceding newline (no trailing empty line)', () => {
+    expect(run('abc\ndef', 4, ['d', 'd']).buffer.value).toBe('abc') // not 'abc\n'
+  })
+  it('2dd deleting the last two lines leaves no trailing newline', () => {
+    expect(run('L1\nL2\nL3', 3, ['2', 'd', 'd']).buffer.value).toBe('L1')
+  })
+  it('dd on a single-line buffer empties it', () => {
+    expect(run('only', 0, ['d', 'd']).buffer.value).toBe('')
+  })
+})
+
+describe('gg / G through the dispatcher', () => {
+  it('gg moves to the top', () => {
+    expect(run('a\nb\nc', 4, ['g', 'g']).buffer.cursor).toBe(0)
+  })
+  it('G moves to the last line', () => {
+    expect(run('a\nb\nc', 0, ['G']).buffer.cursor).toBe(4)
+  })
+  it('g + non-g cancels the prefix', () => {
+    const r = run('abc', 0, ['g', 'z'])
+    expect(r.state.pendingG).toBe(false)
+    expect(r.buffer.value).toBe('abc')
+  })
+})
+
+describe('WORD motions (E/B) and inclusive change', () => {
+  it('E jumps to end of WORD (whitespace-delimited)', () => {
+    expect(resolveMotion('E', 'a.b cd', 0)).toBe(2) // 'a.b' end
+  })
+  it('B jumps to start of previous WORD', () => {
+    expect(resolveMotion('B', 'a.b cd', 4)).toBe(0)
+  })
+  it('cW changes to end of WORD', () => {
+    expect(run('a.b cd', 0, ['c', 'W']).buffer.value).toBe(' cd')
+  })
+})
+
+describe('edge cases', () => {
+  it('empty buffer: motions and x are no-ops', () => {
+    expect(run('', 0, ['w']).buffer).toEqual({ value: '', cursor: 0 })
+    expect(run('', 0, ['x']).buffer.value).toBe('')
+  })
+  it('x never splits a surrogate pair (emoji)', () => {
+    const r = run('😀b', 0, ['x'])
+    expect(r.buffer.value).toBe('b') // whole emoji removed, no lone surrogate
+    expect(r.buffer.value.length).toBe(1)
+  })
+  it('l over an emoji advances a whole code point', () => {
+    // '😀b' — from 0, l lands on 'b' (offset 2), not mid-surrogate (offset 1)
+    expect(run('😀b', 0, ['l']).buffer.cursor).toBe(2)
+  })
+  it('combining mark stays with its base letter (word class)', () => {
+    // 'á' as base + combining acute: still one word, w moves past both to ' '/end
+    const s = 'áb c'
+    expect(resolveMotion('w', s, 0)).toBe(4) // past 'áb' to 'c'
   })
 })

--- a/ui-tui/src/__tests__/vimEngine.test.ts
+++ b/ui-tui/src/__tests__/vimEngine.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  applyMotion,
+  dispatchNormal,
+  initialVimState,
+  resolveMotion,
+  type Buffer,
+  type VimState,
+} from '../vim/engine.js'
+
+// Helper: run a sequence of keys through the NORMAL-mode dispatcher.
+function run(value: string, cursor: number, keys: string[]): { state: VimState; buffer: Buffer } {
+  let state = initialVimState()
+  let buffer: Buffer = { value, cursor }
+  for (const k of keys) {
+    const r = dispatchNormal(state, buffer, k)
+    state = r.state
+    buffer = r.buffer
+  }
+  return { state, buffer }
+}
+
+describe('motions', () => {
+  const v = 'hello world foo'
+  it('h/l move by one char, clamped to the line', () => {
+    expect(resolveMotion('l', v, 0)).toBe(1)
+    expect(resolveMotion('h', v, 0)).toBe(0) // clamped at start
+    expect(resolveMotion('h', v, 5)).toBe(4)
+  })
+  it('w jumps to next word start', () => {
+    expect(resolveMotion('w', v, 0)).toBe(6) // 'hello' -> 'world'
+    expect(resolveMotion('w', v, 6)).toBe(12) // 'world' -> 'foo'
+  })
+  it('b jumps to previous word start', () => {
+    expect(resolveMotion('b', v, 12)).toBe(6)
+    expect(resolveMotion('b', v, 6)).toBe(0)
+  })
+  it('e jumps to end of word (inclusive)', () => {
+    expect(resolveMotion('e', v, 0)).toBe(4) // last char of 'hello'
+    expect(resolveMotion('e', v, 6)).toBe(10) // last char of 'world'
+  })
+  it('0 and $ go to line ends', () => {
+    expect(resolveMotion('0', v, 8)).toBe(0)
+    expect(resolveMotion('$', v, 0)).toBe(v.length - 1)
+  })
+  it('w treats punctuation as its own word', () => {
+    const p = 'a.b c'
+    expect(resolveMotion('w', p, 0)).toBe(1) // 'a' -> '.'
+    expect(resolveMotion('w', p, 1)).toBe(2) // '.' -> 'b'
+    expect(resolveMotion('W', p, 0)).toBe(4) // WORD: 'a.b' -> 'c'
+  })
+  it('applyMotion applies count and stops when stuck', () => {
+    expect(applyMotion('w', v, 0, 2)).toBe(12) // hello -> world -> foo
+    expect(applyMotion('h', v, 2, 10)).toBe(0) // clamps, stops
+  })
+})
+
+describe('multiline motions', () => {
+  const v = 'abc\ndef\nghi'
+  it('j/k move between lines preserving column', () => {
+    expect(resolveMotion('j', v, 1)).toBe(5) // col 1 on line 2 => 'e'
+    expect(resolveMotion('k', v, 5)).toBe(1)
+  })
+  it('0/$ operate within the logical line', () => {
+    expect(resolveMotion('0', v, 5)).toBe(4) // start of line 2
+    expect(resolveMotion('$', v, 4)).toBe(6) // 'f'
+  })
+  it('G goes to last line, gg to top', () => {
+    expect(resolveMotion('G', v, 0)).toBe(8) // start of 'ghi'
+    expect(resolveMotion('gg', v, 8)).toBe(0)
+  })
+})
+
+describe('mode transitions', () => {
+  it('i/a/I/A enter insert mode at the right offset', () => {
+    expect(run('hello', 2, ['i']).state.mode).toBe('insert')
+    expect(run('hello', 2, ['a']).buffer.cursor).toBe(3)
+    expect(run('  hi', 3, ['I']).buffer.cursor).toBe(2) // first non-blank
+    expect(run('hello', 0, ['A']).buffer.cursor).toBe(5) // end of line
+  })
+  it('o/O open a new line and enter insert', () => {
+    const o = run('abc', 1, ['o'])
+    expect(o.buffer.value).toBe('abc\n')
+    expect(o.buffer.cursor).toBe(4)
+    expect(o.state.mode).toBe('insert')
+    const bigO = run('abc', 1, ['O'])
+    expect(bigO.buffer.value).toBe('\nabc')
+    expect(bigO.buffer.cursor).toBe(0)
+  })
+})
+
+describe('operators', () => {
+  it('x deletes the char under the cursor', () => {
+    expect(run('hello', 1, ['x']).buffer.value).toBe('hllo')
+  })
+  it('x with count deletes multiple, bounded by line', () => {
+    expect(run('hello', 0, ['3', 'x']).buffer.value).toBe('lo')
+  })
+  it('dw deletes to next word', () => {
+    const r = run('hello world', 0, ['d', 'w'])
+    expect(r.buffer.value).toBe('world')
+    expect(r.state.mode).toBe('normal')
+  })
+  it('cw deletes the word and enters insert', () => {
+    const r = run('hello world', 0, ['c', 'w'])
+    expect(r.buffer.value).toBe('world')
+    expect(r.state.mode).toBe('insert')
+  })
+  it('de deletes to end of word (inclusive)', () => {
+    expect(run('hello world', 0, ['d', 'e']).buffer.value).toBe(' world')
+  })
+  it('d$ / D delete to end of line', () => {
+    expect(run('hello world', 5, ['d', '$']).buffer.value).toBe('hello')
+    expect(run('hello world', 5, ['D']).buffer.value).toBe('hello')
+  })
+  it('dd deletes the whole line', () => {
+    expect(run('abc\ndef\nghi', 5, ['d', 'd']).buffer.value).toBe('abc\nghi')
+  })
+  it('2dw deletes two words', () => {
+    expect(run('one two three', 0, ['2', 'd', 'w']).buffer.value).toBe('three')
+  })
+  it('an invalid motion cancels a pending operator', () => {
+    const r = run('hello', 0, ['d', 'z'])
+    expect(r.buffer.value).toBe('hello') // unchanged
+    expect(r.state.pendingOperator).toBeNull()
+  })
+})
+
+describe('count prefix', () => {
+  it('accumulates multi-digit counts', () => {
+    // 12l would move 12 right but line is short → clamps to last char
+    const r = run('abcdefghijklmno', 0, ['1', '2', 'l'])
+    expect(r.buffer.cursor).toBe(12)
+    expect(r.state.count).toBe(0) // reset after use
+  })
+  it('0 is a motion when no count is in progress', () => {
+    expect(run('hello', 3, ['0']).buffer.cursor).toBe(0)
+  })
+})

--- a/ui-tui/src/__tests__/vimEngine.test.ts
+++ b/ui-tui/src/__tests__/vimEngine.test.ts
@@ -216,3 +216,29 @@ describe('edge cases', () => {
     expect(resolveMotion('w', s, 0)).toBe(4) // past 'áb' to 'c'
   })
 })
+
+describe('failed vertical motion aborts the operator (critic re-review MAJOR)', () => {
+  it('dj on a single-line buffer is a NO-OP (does not wipe the input)', () => {
+    const r = run('hello', 2, ['d', 'j'])
+    expect(r.buffer.value).toBe('hello') // not ''
+    expect(r.state.mode).toBe('normal')
+    expect(r.state.pendingOperator).toBeNull()
+  })
+  it('dk on a single-line buffer is a NO-OP', () => {
+    expect(run('hello', 2, ['d', 'k']).buffer.value).toBe('hello')
+  })
+  it('dj on the LAST line is a no-op', () => {
+    expect(run('a\nb\nc', 4, ['d', 'j']).buffer.value).toBe('a\nb\nc')
+  })
+  it('dk on the FIRST line is a no-op', () => {
+    expect(run('a\nb\nc', 0, ['d', 'k']).buffer.value).toBe('a\nb\nc')
+  })
+  it('cj on a single-line buffer aborts WITHOUT entering insert', () => {
+    const r = run('hello', 2, ['c', 'j'])
+    expect(r.buffer.value).toBe('hello')
+    expect(r.state.mode).toBe('normal') // not insert
+  })
+  it('dj still works mid-buffer (not over-guarded)', () => {
+    expect(run('a\nb\nc', 0, ['d', 'j']).buffer.value).toBe('c')
+  })
+})

--- a/ui-tui/src/vim/engine.ts
+++ b/ui-tui/src/vim/engine.ts
@@ -1,0 +1,379 @@
+/**
+ * Minimal vim editing engine for the ui-tui composer — C13 Part 1.
+ *
+ * Ports the SEMANTICS of the original vim engine (typescript/src/vim/:
+ * motions.ts / operators.ts / transitions.ts) onto the composer's simple
+ * `{ value: string; cursor: number }` text model, rather than the original's
+ * 1554-line `Cursor` class (which ui-tui does not have). The cursor is a
+ * character offset into `value` (code units — the composer's model).
+ *
+ * This is the PURE-LOGIC core: mode state, motions, operators, and the
+ * NORMAL-mode key dispatcher, all side-effect-free and unit-testable. The
+ * composer wiring (intercepting keys in NORMAL mode) is Part 2.
+ */
+
+export type VimMode = 'normal' | 'insert'
+export type Operator = 'd' | 'c' // delete, change (yank omitted — no register yet)
+
+export interface Buffer {
+  value: string
+  cursor: number
+}
+
+export interface VimState {
+  mode: VimMode
+  /** A pending operator awaiting a motion (e.g. `d` then `w`), else null. */
+  pendingOperator: Operator | null
+  /** The numeric count prefix being typed (e.g. `3` in `3w`), or 0 if none. */
+  count: number
+}
+
+export function initialVimState(): VimState {
+  return { mode: 'normal', pendingOperator: null, count: 0 }
+}
+
+// ── character classes (vim word semantics) ───────────────────────────────────
+
+type CharClass = 'blank' | 'word' | 'punct'
+
+function classOf(ch: string): CharClass {
+  if (ch === '' || /\s/.test(ch)) return 'blank'
+  // vim "word" chars: letters, digits, underscore. Everything else is punct.
+  if (/[\p{L}\p{N}_]/u.test(ch)) return 'word'
+  return 'punct'
+}
+
+const isBlank = (ch: string): boolean => classOf(ch) === 'blank'
+
+// ── line helpers (cursor is an offset into a possibly-multiline value) ────────
+
+function lineStart(value: string, cursor: number): number {
+  const nl = value.lastIndexOf('\n', cursor - 1)
+  return nl === -1 ? 0 : nl + 1
+}
+
+function lineEnd(value: string, cursor: number): number {
+  const nl = value.indexOf('\n', cursor)
+  return nl === -1 ? value.length : nl
+}
+
+// ── motions: (value, cursor) → target offset ─────────────────────────────────
+
+/** Move one char left, clamped to the start of the current logical line. */
+function left(value: string, cursor: number): number {
+  return Math.max(lineStart(value, cursor), cursor - 1)
+}
+
+/**
+ * Move one char right. In NORMAL mode the cursor rests ON a character, so the
+ * rightmost valid resting position is the last char (end-1), not the newline.
+ */
+function right(value: string, cursor: number): number {
+  const end = lineEnd(value, cursor)
+  return Math.min(end === cursor ? end : end - 1 + 0, Math.min(cursor + 1, end))
+}
+
+function startOfLine(value: string, cursor: number): number {
+  return lineStart(value, cursor)
+}
+
+function firstNonBlank(value: string, cursor: number): number {
+  let i = lineStart(value, cursor)
+  const end = lineEnd(value, cursor)
+  while (i < end && isBlank(value[i]!)) i++
+  return i
+}
+
+/** `$` — last char of the logical line (the resting position in NORMAL). */
+function endOfLine(value: string, cursor: number): number {
+  const end = lineEnd(value, cursor)
+  const start = lineStart(value, cursor)
+  return end > start ? end - 1 : start
+}
+
+/** `w` — start of the next word (word/punct run), skipping blanks. */
+function nextWord(value: string, cursor: number): number {
+  const n = value.length
+  let i = cursor
+  if (i >= n) return n
+  const startClass = classOf(value[i]!)
+  // move past the current run (of the same non-blank class)
+  if (startClass !== 'blank') {
+    while (i < n && classOf(value[i]!) === startClass) i++
+  }
+  // skip blanks to the next word start
+  while (i < n && isBlank(value[i]!)) i++
+  return i
+}
+
+/** `W` — start of the next WORD (whitespace-delimited). */
+function nextWORD(value: string, cursor: number): number {
+  const n = value.length
+  let i = cursor
+  while (i < n && !isBlank(value[i]!)) i++
+  while (i < n && isBlank(value[i]!)) i++
+  return i
+}
+
+/** `b` — start of the current/previous word. */
+function prevWord(value: string, cursor: number): number {
+  let i = cursor - 1
+  while (i > 0 && isBlank(value[i]!)) i--
+  if (i <= 0) return Math.max(0, i)
+  const cls = classOf(value[i]!)
+  while (i > 0 && classOf(value[i - 1]!) === cls) i--
+  return Math.max(0, i)
+}
+
+/** `e` — end of the current/next word (inclusive target). */
+function endOfWord(value: string, cursor: number): number {
+  const n = value.length
+  let i = cursor + 1
+  while (i < n && isBlank(value[i]!)) i++
+  if (i >= n) return Math.max(cursor, n - 1)
+  const cls = classOf(value[i]!)
+  while (i + 1 < n && classOf(value[i + 1]!) === cls) i++
+  return i
+}
+
+function downLine(value: string, cursor: number): number {
+  const end = lineEnd(value, cursor)
+  if (end >= value.length) return cursor // no line below
+  const col = cursor - lineStart(value, cursor)
+  const nextStart = end + 1
+  const nextEnd = lineEnd(value, nextStart)
+  return Math.min(nextStart + col, Math.max(nextStart, nextEnd - 1 + (nextEnd === nextStart ? 1 : 0)))
+}
+
+function upLine(value: string, cursor: number): number {
+  const start = lineStart(value, cursor)
+  if (start === 0) return cursor // no line above
+  const col = cursor - start
+  const prevEnd = start - 1
+  const prevStart = lineStart(value, prevEnd)
+  return Math.min(prevStart + col, Math.max(prevStart, prevEnd - 1 + (prevEnd === prevStart ? 1 : 0)))
+}
+
+const INCLUSIVE = new Set(['e', 'E', '$'])
+const LINEWISE = new Set(['j', 'k', 'G', 'gg'])
+
+export function isInclusiveMotion(key: string): boolean {
+  return INCLUSIVE.has(key)
+}
+export function isLinewiseMotion(key: string): boolean {
+  return LINEWISE.has(key)
+}
+
+/** Resolve a single motion key to a target offset (count applied by caller). */
+export function resolveMotion(key: string, value: string, cursor: number): number {
+  switch (key) {
+    case 'h': return left(value, cursor)
+    case 'l': return right(value, cursor)
+    case 'j': return downLine(value, cursor)
+    case 'k': return upLine(value, cursor)
+    case 'w': return nextWord(value, cursor)
+    case 'W': return nextWORD(value, cursor)
+    case 'b': return prevWord(value, cursor)
+    case 'e': return endOfWord(value, cursor)
+    case '0': return startOfLine(value, cursor)
+    case '^': return firstNonBlank(value, cursor)
+    case '$': return endOfLine(value, cursor)
+    case 'G': return Math.max(0, value.length ? value.lastIndexOf('\n') + 1 : 0)
+    case 'gg': return 0
+    default: return cursor
+  }
+}
+
+/** Apply a motion `count` times (stops early if it can't advance). */
+export function applyMotion(key: string, value: string, cursor: number, count: number): number {
+  let pos = cursor
+  for (let i = 0; i < Math.max(1, count); i++) {
+    const next = resolveMotion(key, value, pos)
+    if (next === pos) break
+    pos = next
+  }
+  return pos
+}
+
+// ── operators: (buffer, motion) → new buffer ─────────────────────────────────
+
+/** The [start, end) span an operator+motion deletes. */
+export function operatorSpan(
+  key: string, value: string, cursor: number, count: number,
+): { start: number; end: number } {
+  if (isLinewiseMotion(key)) {
+    // linewise: whole current line(s) including trailing newline
+    const start = lineStart(value, cursor)
+    let end = lineEnd(value, cursor)
+    end = end < value.length ? end + 1 : end
+    return { start, end }
+  }
+  const target = applyMotion(key, value, cursor, count)
+  let start = Math.min(cursor, target)
+  let end = Math.max(cursor, target)
+  if (isInclusiveMotion(key)) end += 1 // inclusive motions eat the target char
+  return { start, end: Math.min(end, value.length) }
+}
+
+/** `dd` — delete the whole current line (linewise). */
+export function deleteLine(value: string, cursor: number, count: number): Buffer {
+  let start = lineStart(value, cursor)
+  let end = start
+  for (let i = 0; i < Math.max(1, count); i++) {
+    end = lineEnd(value, end)
+    if (end < value.length) end += 1
+    else break
+  }
+  const newValue = value.slice(0, start) + value.slice(end)
+  // cursor lands at the first non-blank of the line now at `start` (clamped)
+  const cur = Math.min(start, Math.max(0, newValue.length - 1))
+  return { value: newValue, cursor: clampNormal(newValue, cur) }
+}
+
+// ── NORMAL-mode dispatch ─────────────────────────────────────────────────────
+
+/** Clamp a cursor to a valid NORMAL-mode resting offset (on a char, not past). */
+export function clampNormal(value: string, cursor: number): number {
+  if (value.length === 0) return 0
+  const c = Math.max(0, Math.min(cursor, value.length))
+  // don't rest on a newline or past end-of-line
+  const ls = lineStart(value, c)
+  const le = lineEnd(value, c)
+  if (c >= le && le > ls) return le - 1
+  return c
+}
+
+const MOTION_KEYS = new Set(['h', 'l', 'j', 'k', 'w', 'W', 'b', 'e', '0', '^', '$', 'G'])
+
+export interface DispatchResult {
+  state: VimState
+  buffer: Buffer
+  /** True if the key was consumed by the engine (don't pass to the composer). */
+  handled: boolean
+}
+
+/**
+ * Feed one key to the engine in NORMAL mode (or a pending-operator state).
+ * Returns the new state+buffer and whether the key was handled. INSERT-mode
+ * keys are NOT handled here (the composer edits directly); only `Escape`
+ * returns to NORMAL.
+ */
+export function dispatchNormal(state: VimState, buffer: Buffer, key: string): DispatchResult {
+  const unhandled = { state, buffer, handled: false }
+
+  // digit count prefix (1-9, or 0 only when a count is in progress)
+  if (/^[1-9]$/.test(key) || (key === '0' && state.count > 0)) {
+    return {
+      state: { ...state, count: state.count * 10 + Number(key) },
+      buffer,
+      handled: true,
+    }
+  }
+  const count = state.count || 1
+
+  // pending operator: the next motion (or repeated operator) completes it
+  if (state.pendingOperator) {
+    const op = state.pendingOperator
+    // `dd` / `cc` — doubled operator = linewise current line
+    if (key === op || (op === 'c' && key === 'c') || (op === 'd' && key === 'd')) {
+      const nb = deleteLine(buffer.value, buffer.cursor, count)
+      return {
+        state: { mode: op === 'c' ? 'insert' : 'normal', pendingOperator: null, count: 0 },
+        buffer: nb,
+        handled: true,
+      }
+    }
+    if (MOTION_KEYS.has(key)) {
+      const span = operatorSpan(key, buffer.value, buffer.cursor, count)
+      const newValue = buffer.value.slice(0, span.start) + buffer.value.slice(span.end)
+      const nb = { value: newValue, cursor: span.start }
+      return {
+        state: { mode: op === 'c' ? 'insert' : 'normal', pendingOperator: null, count: 0 },
+        buffer: op === 'c' ? nb : { ...nb, cursor: clampNormal(newValue, nb.cursor) },
+        handled: true,
+      }
+    }
+    // invalid motion after operator → cancel the operator
+    return { state: { ...state, pendingOperator: null, count: 0 }, buffer, handled: true }
+  }
+
+  // plain motion
+  if (MOTION_KEYS.has(key)) {
+    const cur = applyMotion(key, buffer.value, buffer.cursor, count)
+    return {
+      state: { ...state, count: 0 },
+      buffer: { ...buffer, cursor: clampNormal(buffer.value, cur) },
+      handled: true,
+    }
+  }
+
+  switch (key) {
+    case 'i': // insert before cursor
+      return { state: { mode: 'insert', pendingOperator: null, count: 0 }, buffer, handled: true }
+    case 'a': // insert after cursor
+      return {
+        state: { mode: 'insert', pendingOperator: null, count: 0 },
+        buffer: { ...buffer, cursor: Math.min(buffer.cursor + 1, buffer.value.length) },
+        handled: true,
+      }
+    case 'I': // insert at first non-blank
+      return {
+        state: { mode: 'insert', pendingOperator: null, count: 0 },
+        buffer: { ...buffer, cursor: firstNonBlank(buffer.value, buffer.cursor) },
+        handled: true,
+      }
+    case 'A': // insert at end of line
+      return {
+        state: { mode: 'insert', pendingOperator: null, count: 0 },
+        buffer: { ...buffer, cursor: lineEnd(buffer.value, buffer.cursor) },
+        handled: true,
+      }
+    case 'o': { // open a line below
+      const le = lineEnd(buffer.value, buffer.cursor)
+      const nv = buffer.value.slice(0, le) + '\n' + buffer.value.slice(le)
+      return {
+        state: { mode: 'insert', pendingOperator: null, count: 0 },
+        buffer: { value: nv, cursor: le + 1 },
+        handled: true,
+      }
+    }
+    case 'O': { // open a line above
+      const ls = lineStart(buffer.value, buffer.cursor)
+      const nv = buffer.value.slice(0, ls) + '\n' + buffer.value.slice(ls)
+      return {
+        state: { mode: 'insert', pendingOperator: null, count: 0 },
+        buffer: { value: nv, cursor: ls },
+        handled: true,
+      }
+    }
+    case 'x': { // delete char under cursor
+      if (buffer.cursor >= buffer.value.length) return { state: { ...state, count: 0 }, buffer, handled: true }
+      let end = buffer.cursor
+      for (let i = 0; i < count && end < buffer.value.length && buffer.value[end] !== '\n'; i++) end++
+      const nv = buffer.value.slice(0, buffer.cursor) + buffer.value.slice(end)
+      return {
+        state: { ...state, count: 0 },
+        buffer: { value: nv, cursor: clampNormal(nv, buffer.cursor) },
+        handled: true,
+      }
+    }
+    case 'd':
+    case 'c':
+      // PRESERVE the count into the pending-operator state so `2dw` deletes two
+      // words (the count before an operator applies to the operator+motion).
+      return { state: { ...state, pendingOperator: key as Operator, count: state.count }, buffer, handled: true }
+    case 'D': { // delete to end of line
+      const le = lineEnd(buffer.value, buffer.cursor)
+      const nv = buffer.value.slice(0, buffer.cursor) + buffer.value.slice(le)
+      return { state: { ...state, count: 0 }, buffer: { value: nv, cursor: clampNormal(nv, buffer.cursor) }, handled: true }
+    }
+    case 'C': { // change to end of line
+      const le = lineEnd(buffer.value, buffer.cursor)
+      const nv = buffer.value.slice(0, buffer.cursor) + buffer.value.slice(le)
+      return { state: { mode: 'insert', pendingOperator: null, count: 0 }, buffer: { value: nv, cursor: buffer.cursor }, handled: true }
+    }
+    default:
+      // unknown key in NORMAL: consume it (vim swallows unmapped keys), reset count
+      return { state: { ...state, count: 0 }, buffer, handled: true }
+  }
+}

--- a/ui-tui/src/vim/engine.ts
+++ b/ui-tui/src/vim/engine.ts
@@ -26,10 +26,12 @@ export interface VimState {
   pendingOperator: Operator | null
   /** The numeric count prefix being typed (e.g. `3` in `3w`), or 0 if none. */
   count: number
+  /** True after a lone `g` is pressed, awaiting the second key (`gg`). */
+  pendingG: boolean
 }
 
 export function initialVimState(): VimState {
-  return { mode: 'normal', pendingOperator: null, count: 0 }
+  return { mode: 'normal', pendingOperator: null, count: 0, pendingG: false }
 }
 
 // ── character classes (vim word semantics) ───────────────────────────────────
@@ -38,12 +40,21 @@ type CharClass = 'blank' | 'word' | 'punct'
 
 function classOf(ch: string): CharClass {
   if (ch === '' || /\s/.test(ch)) return 'blank'
-  // vim "word" chars: letters, digits, underscore. Everything else is punct.
-  if (/[\p{L}\p{N}_]/u.test(ch)) return 'word'
+  // vim "word" chars: letters, marks, digits, underscore (matches the
+  // reference VIM_WORD_CHAR_REGEX — \p{M} keeps combining marks with their
+  // base letter). Everything else is punct.
+  if (/[\p{L}\p{M}\p{N}_]/u.test(ch)) return 'word'
   return 'punct'
 }
 
 const isBlank = (ch: string): boolean => classOf(ch) === 'blank'
+
+/** Advance one CODE POINT right from `i` (never splits a surrogate pair). */
+function nextCodePoint(value: string, i: number): number {
+  if (i >= value.length) return value.length
+  const cp = value.codePointAt(i)
+  return i + (cp !== undefined && cp > 0xffff ? 2 : 1)
+}
 
 // ── line helpers (cursor is an offset into a possibly-multiline value) ────────
 
@@ -66,11 +77,26 @@ function left(value: string, cursor: number): number {
 
 /**
  * Move one char right. In NORMAL mode the cursor rests ON a character, so the
- * rightmost valid resting position is the last char (end-1), not the newline.
+ * rightmost valid resting position is the last char of the line (`end - 1`),
+ * not the newline. On an empty line the only position is the line start.
  */
 function right(value: string, cursor: number): number {
+  const start = lineStart(value, cursor)
   const end = lineEnd(value, cursor)
-  return Math.min(end === cursor ? end : end - 1 + 0, Math.min(cursor + 1, end))
+  // rest position of the LAST char = start of its code point (so `l` never
+  // lands between a surrogate pair)
+  const maxRest = end > start ? prevCodePointStart(value, end) : start
+  return Math.min(nextCodePoint(value, cursor), maxRest)
+}
+
+/** Start offset of the code point ENDING at `end` (i.e. the last char's start). */
+function prevCodePointStart(value: string, end: number): number {
+  if (end <= 0) return 0
+  const prev = end - 1
+  // if value[prev] is a low surrogate, step back one more to its high surrogate
+  const code = value.charCodeAt(prev)
+  if (code >= 0xdc00 && code <= 0xdfff && prev > 0) return prev - 1
+  return prev
 }
 
 function startOfLine(value: string, cursor: number): number {
@@ -136,6 +162,24 @@ function endOfWord(value: string, cursor: number): number {
   return i
 }
 
+/** `B` — start of the current/previous WORD (whitespace-delimited). */
+function prevWORD(value: string, cursor: number): number {
+  let i = cursor - 1
+  while (i > 0 && isBlank(value[i]!)) i--
+  while (i > 0 && !isBlank(value[i - 1]!)) i--
+  return Math.max(0, i)
+}
+
+/** `E` — end of the current/next WORD (inclusive, whitespace-delimited). */
+function endOfWORD(value: string, cursor: number): number {
+  const n = value.length
+  let i = cursor + 1
+  while (i < n && isBlank(value[i]!)) i++
+  if (i >= n) return Math.max(cursor, n - 1)
+  while (i + 1 < n && !isBlank(value[i + 1]!)) i++
+  return i
+}
+
 function downLine(value: string, cursor: number): number {
   const end = lineEnd(value, cursor)
   if (end >= value.length) return cursor // no line below
@@ -156,6 +200,8 @@ function upLine(value: string, cursor: number): number {
 
 const INCLUSIVE = new Set(['e', 'E', '$'])
 const LINEWISE = new Set(['j', 'k', 'G', 'gg'])
+// gg is NOT in this set: it's resolvable but reached via the two-key `g` prefix
+// in dispatchNormal, not a single MOTION_KEYS entry.
 
 export function isInclusiveMotion(key: string): boolean {
   return INCLUSIVE.has(key)
@@ -174,7 +220,9 @@ export function resolveMotion(key: string, value: string, cursor: number): numbe
     case 'w': return nextWord(value, cursor)
     case 'W': return nextWORD(value, cursor)
     case 'b': return prevWord(value, cursor)
+    case 'B': return prevWORD(value, cursor)
     case 'e': return endOfWord(value, cursor)
+    case 'E': return endOfWORD(value, cursor)
     case '0': return startOfLine(value, cursor)
     case '^': return firstNonBlank(value, cursor)
     case '$': return endOfLine(value, cursor)
@@ -202,10 +250,14 @@ export function operatorSpan(
   key: string, value: string, cursor: number, count: number,
 ): { start: number; end: number } {
   if (isLinewiseMotion(key)) {
-    // linewise: whole current line(s) including trailing newline
-    const start = lineStart(value, cursor)
-    let end = lineEnd(value, cursor)
-    end = end < value.length ? end + 1 : end
+    // linewise: from the current line's start THROUGH the line the motion
+    // lands on (dj = 2 lines, dG = to last line), inclusive, plus the trailing
+    // newline. Ignoring the target was the bug — dj/dk/dG only ate one line.
+    const target = applyMotion(key, value, cursor, count)
+    let start = Math.min(lineStart(value, cursor), lineStart(value, target))
+    let end = Math.max(lineEnd(value, cursor), lineEnd(value, target))
+    if (end < value.length) end += 1 // eat the trailing newline
+    else if (start > 0 && value[start - 1] === '\n') start -= 1 // at EOF, eat the preceding one
     return { start, end }
   }
   const target = applyMotion(key, value, cursor, count)
@@ -224,6 +276,10 @@ export function deleteLine(value: string, cursor: number, count: number): Buffer
     if (end < value.length) end += 1
     else break
   }
+  // If the deletion runs to EOF, also eat the PRECEDING newline so the last
+  // line's removal doesn't leave a trailing empty line ("abc\ndef" -dd-> "abc",
+  // not "abc\n"). Mirrors the reference executeLineOp guard.
+  if (end >= value.length && start > 0 && value[start - 1] === '\n') start -= 1
   const newValue = value.slice(0, start) + value.slice(end)
   // cursor lands at the first non-blank of the line now at `start` (clamped)
   const cur = Math.min(start, Math.max(0, newValue.length - 1))
@@ -243,7 +299,7 @@ export function clampNormal(value: string, cursor: number): number {
   return c
 }
 
-const MOTION_KEYS = new Set(['h', 'l', 'j', 'k', 'w', 'W', 'b', 'e', '0', '^', '$', 'G'])
+const MOTION_KEYS = new Set(['h', 'l', 'j', 'k', 'w', 'W', 'b', 'B', 'e', 'E', '0', '^', '$', 'G'])
 
 export interface DispatchResult {
   state: VimState
@@ -257,9 +313,45 @@ export interface DispatchResult {
  * Returns the new state+buffer and whether the key was handled. INSERT-mode
  * keys are NOT handled here (the composer edits directly); only `Escape`
  * returns to NORMAL.
+ *
+ * CONTRACT: the caller must only invoke this when `state.mode === 'normal'`
+ * (Part-2 wiring gates on mode). It does not re-check the mode itself.
+ *
+ * LIMITATION (documented, acceptable for "minimal"): a stacked count like
+ * `2d3w` is not multiplied (vim = 6 words); the digits after the operator
+ * concatenate with the pre-operator count. Both single-count forms (`2dw`,
+ * `d3w`) are correct — only the doubled form is off.
  */
 export function dispatchNormal(state: VimState, buffer: Buffer, key: string): DispatchResult {
-  const unhandled = { state, buffer, handled: false }
+  // `g` prefix: a lone `g` arms pendingG; the next `g` is the `gg` motion
+  // (top of buffer), honoring a pending operator (dgg = delete to top,
+  // linewise). Any other key after `g` cancels the prefix.
+  if (state.pendingG) {
+    const cleared = { ...state, pendingG: false }
+    if (key === 'g') {
+      if (state.pendingOperator) {
+        const op = state.pendingOperator
+        const span = operatorSpan('gg', buffer.value, buffer.cursor, state.count || 1)
+        const newValue = buffer.value.slice(0, span.start) + buffer.value.slice(span.end)
+        return {
+          state: { mode: op === 'c' ? 'insert' : 'normal', pendingOperator: null, count: 0, pendingG: false },
+          buffer: op === 'c' ? { value: newValue, cursor: span.start }
+            : { value: newValue, cursor: clampNormal(newValue, span.start) },
+          handled: true,
+        }
+      }
+      return {
+        state: { ...cleared, count: 0 },
+        buffer: { ...buffer, cursor: 0 },
+        handled: true,
+      }
+    }
+    // `g` + other → cancel the prefix and swallow (minimal: no other g-commands)
+    return { state: { ...cleared, count: 0, pendingOperator: null }, buffer, handled: true }
+  }
+  if (key === 'g') {
+    return { state: { ...state, pendingG: true }, buffer, handled: true }
+  }
 
   // digit count prefix (1-9, or 0 only when a count is in progress)
   if (/^[1-9]$/.test(key) || (key === '0' && state.count > 0)) {
@@ -278,23 +370,31 @@ export function dispatchNormal(state: VimState, buffer: Buffer, key: string): Di
     if (key === op || (op === 'c' && key === 'c') || (op === 'd' && key === 'd')) {
       const nb = deleteLine(buffer.value, buffer.cursor, count)
       return {
-        state: { mode: op === 'c' ? 'insert' : 'normal', pendingOperator: null, count: 0 },
+        state: { mode: op === 'c' ? 'insert' : 'normal', pendingOperator: null, count: 0, pendingG: false },
         buffer: nb,
         handled: true,
       }
     }
     if (MOTION_KEYS.has(key)) {
-      const span = operatorSpan(key, buffer.value, buffer.cursor, count)
+      // vim special case (:help cw): `cw`/`cW` on a word acts like `ce`/`cE` —
+      // change to the END of the word, NOT the start of the next word (so it
+      // doesn't swallow the trailing whitespace). Only when the cursor is on a
+      // non-blank char; on whitespace, cw behaves like dw.
+      let motionKey = key
+      if (op === 'c' && (key === 'w' || key === 'W') && !isBlank(buffer.value[buffer.cursor] ?? '')) {
+        motionKey = key === 'w' ? 'e' : 'E'
+      }
+      const span = operatorSpan(motionKey, buffer.value, buffer.cursor, count)
       const newValue = buffer.value.slice(0, span.start) + buffer.value.slice(span.end)
       const nb = { value: newValue, cursor: span.start }
       return {
-        state: { mode: op === 'c' ? 'insert' : 'normal', pendingOperator: null, count: 0 },
+        state: { mode: op === 'c' ? 'insert' : 'normal', pendingOperator: null, count: 0, pendingG: false },
         buffer: op === 'c' ? nb : { ...nb, cursor: clampNormal(newValue, nb.cursor) },
         handled: true,
       }
     }
     // invalid motion after operator → cancel the operator
-    return { state: { ...state, pendingOperator: null, count: 0 }, buffer, handled: true }
+    return { state: { ...state, pendingOperator: null, count: 0, pendingG: false }, buffer, handled: true }
   }
 
   // plain motion
@@ -309,22 +409,22 @@ export function dispatchNormal(state: VimState, buffer: Buffer, key: string): Di
 
   switch (key) {
     case 'i': // insert before cursor
-      return { state: { mode: 'insert', pendingOperator: null, count: 0 }, buffer, handled: true }
+      return { state: { mode: 'insert', pendingOperator: null, count: 0, pendingG: false }, buffer, handled: true }
     case 'a': // insert after cursor
       return {
-        state: { mode: 'insert', pendingOperator: null, count: 0 },
+        state: { mode: 'insert', pendingOperator: null, count: 0, pendingG: false },
         buffer: { ...buffer, cursor: Math.min(buffer.cursor + 1, buffer.value.length) },
         handled: true,
       }
     case 'I': // insert at first non-blank
       return {
-        state: { mode: 'insert', pendingOperator: null, count: 0 },
+        state: { mode: 'insert', pendingOperator: null, count: 0, pendingG: false },
         buffer: { ...buffer, cursor: firstNonBlank(buffer.value, buffer.cursor) },
         handled: true,
       }
     case 'A': // insert at end of line
       return {
-        state: { mode: 'insert', pendingOperator: null, count: 0 },
+        state: { mode: 'insert', pendingOperator: null, count: 0, pendingG: false },
         buffer: { ...buffer, cursor: lineEnd(buffer.value, buffer.cursor) },
         handled: true,
       }
@@ -332,7 +432,7 @@ export function dispatchNormal(state: VimState, buffer: Buffer, key: string): Di
       const le = lineEnd(buffer.value, buffer.cursor)
       const nv = buffer.value.slice(0, le) + '\n' + buffer.value.slice(le)
       return {
-        state: { mode: 'insert', pendingOperator: null, count: 0 },
+        state: { mode: 'insert', pendingOperator: null, count: 0, pendingG: false },
         buffer: { value: nv, cursor: le + 1 },
         handled: true,
       }
@@ -341,15 +441,17 @@ export function dispatchNormal(state: VimState, buffer: Buffer, key: string): Di
       const ls = lineStart(buffer.value, buffer.cursor)
       const nv = buffer.value.slice(0, ls) + '\n' + buffer.value.slice(ls)
       return {
-        state: { mode: 'insert', pendingOperator: null, count: 0 },
+        state: { mode: 'insert', pendingOperator: null, count: 0, pendingG: false },
         buffer: { value: nv, cursor: ls },
         handled: true,
       }
     }
-    case 'x': { // delete char under cursor
+    case 'x': { // delete char under cursor (by CODE POINT — never split a pair)
       if (buffer.cursor >= buffer.value.length) return { state: { ...state, count: 0 }, buffer, handled: true }
       let end = buffer.cursor
-      for (let i = 0; i < count && end < buffer.value.length && buffer.value[end] !== '\n'; i++) end++
+      for (let i = 0; i < count && end < buffer.value.length && buffer.value[end] !== '\n'; i++) {
+        end = nextCodePoint(buffer.value, end)
+      }
       const nv = buffer.value.slice(0, buffer.cursor) + buffer.value.slice(end)
       return {
         state: { ...state, count: 0 },
@@ -370,7 +472,7 @@ export function dispatchNormal(state: VimState, buffer: Buffer, key: string): Di
     case 'C': { // change to end of line
       const le = lineEnd(buffer.value, buffer.cursor)
       const nv = buffer.value.slice(0, buffer.cursor) + buffer.value.slice(le)
-      return { state: { mode: 'insert', pendingOperator: null, count: 0 }, buffer: { value: nv, cursor: buffer.cursor }, handled: true }
+      return { state: { mode: 'insert', pendingOperator: null, count: 0, pendingG: false }, buffer: { value: nv, cursor: buffer.cursor }, handled: true }
     }
     default:
       // unknown key in NORMAL: consume it (vim swallows unmapped keys), reset count

--- a/ui-tui/src/vim/engine.ts
+++ b/ui-tui/src/vim/engine.ts
@@ -376,6 +376,15 @@ export function dispatchNormal(state: VimState, buffer: Buffer, key: string): Di
       }
     }
     if (MOTION_KEYS.has(key)) {
+      // A FAILED vertical motion aborts the whole operator (vim no-op): `dj` on
+      // the last line / `dk` on the first line (incl. a single-line buffer)
+      // must NOT delete the current line — otherwise `dj` in a one-line chat
+      // composer wipes the entire input. Mirrors executeOperatorMotion's
+      // `if (target.equals(cursor)) return`. Scoped to j/k (dd/cc are the
+      // doubled-operator path; dG/dgg are real jumps). Critic C13 re-review.
+      if ((key === 'j' || key === 'k') && applyMotion(key, buffer.value, buffer.cursor, count) === buffer.cursor) {
+        return { state: { ...state, pendingOperator: null, count: 0 }, buffer, handled: true }
+      }
       // vim special case (:help cw): `cw`/`cW` on a word acts like `ce`/`cE` —
       // change to the END of the word, NOT the start of the next word (so it
       // doesn't swallow the trailing whitespace). Only when the cursor is on a


### PR DESCRIPTION
## Summary

**C13 Part 1 — a minimal vim editing engine for the ui-tui composer.** The last deferred parity chapter. The original vim engine (`typescript/src/vim/`: motions/operators/textObjects/transitions, 1513 LOC) is built on the 1554-line `Cursor` class, which ui-tui lacks — and ui-tui's composer uses a simpler `{value, cursor}` text model. Rather than port `Cursor` + reconcile two text models (3000+ LOC + architectural work), this ports the vim **semantics** onto `{value, cursor}` as a pure-logic, unit-testable engine. Part 1 is the engine; Part 2 (wiring `dispatchNormal` into `textInput.tsx`) is a scoped follow-on.

**`ui-tui/src/vim/engine.ts`:**
- Mode state (normal/insert) + pending-operator + count + `g`-prefix `VimState`.
- **Motions** on `(value, cursor)`: `h/l/j/k` (column-preserving, code-point-safe), `w/W/b/B/e/E` (vim word-vs-WORD char-class semantics, faithful to `nextVimWord`/`endOfVimWord`/`prevVimWord`), `0/^/$`, `gg/G`. Inclusive (`e/E/$`) and linewise (`j/k/G/gg`) classification mirrors the reference.
- **Operators**: `x` (count, line-bounded, code-point-safe), `d`/`c` + motion, `dd`/`cc`, `D`/`C`; `cw`≡`ce` (`:help cw`); linewise ranges through the motion target; EOF trailing-newline handling; a **failed `j`/`k` motion aborts the operator** (no composer-wipe). `i/a/I/A/o/O` insert-entry.
- `dispatchNormal(state, buffer, key) → {state, buffer, handled}` — the NORMAL-mode reducer.
- Unicode: `\p{M}` in the word class; `x`/`l`/`right` advance by **code point** (never split a surrogate — emoji-safe).

## Critic (4 rounds → APPROVE)
Independently re-ran ~55 cases against the committed engine. Caught, across rounds: `cw`-eats-whitespace (should be `ce`), `dj/dk/dG` deleting only one line, `dd`-at-EOF leaving a blank line, and — the sharpest — that my *own* linewise-range fix introduced data loss (`dj` in a one-line composer wiping the input). Final: "all findings verified fixed… the scope call was the right architecture… Ship it." Documented deferrals: stacked `2d3w` count, the rare `dG/dgg`-already-at-target edge.

## Verification
`ui-tui/src/__tests__/vimEngine.test.ts` (47): motions (punctuation boundaries, multiline columns, WORD variants), mode transitions, operators (`dw/cw≡ce/de/d$/dd/2dw/2dd/dj/dk/dG/dgg`), the **failed-j/k-aborts** boundary cases (single-line/last-line/first-line/`cj`-no-insert), `gg` through dispatch, empty buffer, emoji surrogate-safety, combining marks, counts. All green; project typechecks clean. (The ui-tui suite's 8-9 pre-existing failures are a flaky terminal-width/timing baseline unrelated to this isolated module.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
