### PR TITLE
feat(advisor): restore /advisor in the agent-server + Ink TUI (post-hermes-port)

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -626,6 +626,9 @@ class _AgentSession:
         if subtype == "subgoal":
             self._do_subgoal_command(request_id, inner.get("arg"))
             return
+        if subtype == "advisor":
+            self._do_advisor_command(request_id, inner.get("arg"))
+            return
         if subtype == "clear":
             # Reset the conversation so /clear actually starts a fresh context
             # (not just the client screen). Idle-only.
@@ -2051,6 +2054,67 @@ class _AgentSession:
             self._reply(request_id, reply)
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] subgoal command failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _do_advisor_command(self, request_id: object, arg: object) -> None:
+        """Control handler for /advisor — configure the reviewer model.
+
+        Bridges to the command-system implementation (advisor_command_call),
+        which owns the full grammar: bare status query, ``<provider>:<model>
+        [--client]``, ``--client`` / ``--no-client`` alone, ``off`` /
+        ``unset``. The command reads only ``provider`` (mode decision +
+        main-loop model) and ``app_state_store`` off the context; the
+        remaining CommandContext fields are required positionally but
+        unused here.
+
+        ``app_state_store`` is deliberately None even though single-session
+        transports carry one: ``seed_app_state_from_settings`` doesn't seed
+        the advisor fields, so a store-preferred read is blind to config
+        persisted by a prior session ("/advisor" reports not-set while the
+        advisor fires), and a store-preferred ``off`` write is swallowed by
+        the persistence handlers' equality-skip (defaults → defaults).
+        With no store, every helper reads AND writes user settings directly
+        (+ cache invalidation) — the same channel the query layer's
+        activation check reads (src/query/query.py).
+
+        Reply shape: transport-level ``ok`` is True whenever the command
+        ran; command-level rejections (unknown provider, bad grammar) ride
+        ``text`` like every other command output. Only an exception or the
+        multi-session gate produces ``ok: False`` + ``error``.
+        """
+        # /advisor persists user-level settings (~/.clawcodex/config.json),
+        # and the query layer reads them globally — on the multi-session WS
+        # transport one client's /advisor would flip the advisor for every
+        # session on this host. Same gate as the other user-settings writers
+        # (the app-state store is only wired when single_session).
+        if not self.config.single_session:
+            self._reply(request_id, {
+                "ok": False,
+                "error": "/advisor is only available on single-session "
+                         "(stdio) transports — it persists user-level "
+                         "settings.",
+            })
+            return
+        try:
+            from src.command_system.builtins import advisor_command_call
+            from src.command_system.types import CommandContext
+
+            ctx = CommandContext(
+                workspace_root=Path(self.cwd),
+                cwd=Path(self.cwd),
+                conversation=getattr(self.session, "conversation", None),
+                cost_tracker=None,
+                history=None,
+                app_state_store=None,
+                provider=self.provider,
+            )
+            result = advisor_command_call(str(arg or ""), ctx)
+            self._reply(request_id, {
+                "ok": True,
+                "text": str(getattr(result, "value", "") or ""),
+            })
+        except Exception as exc:  # noqa: BLE001 — must not kill the control channel
+            logger.exception("[agent-server] advisor command failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
 
     def _maybe_continue_goal(self, outcome: dict | None) -> None:

--- a/src/tool_system/tools/advisor.py
+++ b/src/tool_system/tools/advisor.py
@@ -95,15 +95,21 @@ def _advisor_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResul
 
 # The schema sent to the API is built in ``src/utils/advisor.py`` via
 # ``build_client_advisor_tool_schema`` — kept there alongside the
-# server-side schema so both wire formats live in one place. The
-# ``input_schema`` here mirrors that exactly so registry validation
-# (``validate_json_schema``) accepts the empty-args call.
+# server-side schema so both wire formats live in one place. That
+# ADVERTISED schema stays strict (additionalProperties: False) so the
+# model is told the tool takes no parameters. The DISPATCH schema here
+# is deliberately tolerant: registry validation (registry.py:152) runs
+# it against whatever the model actually emitted, some workers put junk
+# fields on no-arg calls (observed live: deepseek-v4-pro sending
+# ``{"parameters": ...}``), and ``_advisor_call`` ignores its input
+# entirely — failing the whole consultation over an ignored field
+# trades a working advisor for schema pedantry.
 AdvisorTool: Tool = build_tool(
     name="advisor",
     input_schema={
         "type": "object",
         "properties": {},
-        "additionalProperties": False,
+        "additionalProperties": True,
     },
     call=_advisor_call,
     prompt="",

--- a/tests/integration/test_advisor_smoke.py
+++ b/tests/integration/test_advisor_smoke.py
@@ -83,6 +83,10 @@ def _set_advisor(value: str) -> None:
     # server-side path; tests overriding to a non-anthropic provider
     # would need to set this explicitly.
     sub["advisor_provider"] = "anthropic" if value else ""
+    # advisor_enabled master switch (default False) — added after this
+    # helper was written; without it decide_advisor_mode is INACTIVE and
+    # the beta header never attaches.
+    sub["advisor_enabled"] = bool(value)
     cfg["settings"] = sub
     mgr.save_global(cfg)
     invalidate_settings_cache()

--- a/tests/server/test_advisor_control.py
+++ b/tests/server/test_advisor_control.py
@@ -1,0 +1,236 @@
+"""Agent-server /advisor wiring: the ``advisor`` control bridges to the
+command-system implementation (advisor_command_call) with the session's
+provider, replying ``{ok, text}``. Covers: bare status query, set
+(``<provider>:<model>``), off/unset round-trip, unknown-provider error
+text, the exception guard on the control channel, the restart case
+(config persisted by a prior session must be visible and clearable even
+though the session's seeded app-state store doesn't carry advisor
+fields), and the multi-session transport gate."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from src.server.agent_server import AgentServerConfig, _AgentSession
+
+
+class _IsolatedConfig:
+    """Redirect ALL config persistence to a tmp dir.
+
+    Same idiom as tests/test_advisor_command.py::_IsolatedEnv — the
+    module-level path constants in ``src/config.py`` are read via the
+    module reference at write time, so they're swapped in place and
+    restored on exit. Seeds a ``providers`` map so the /advisor
+    ``<provider>:<model>`` validation has real keys to accept.
+    """
+
+    def __enter__(self):
+        import src.config as cfg_mod
+        self._cfg_mod = cfg_mod
+        self._tmp = Path(tempfile.mkdtemp(prefix="advisor_ctl_"))
+        self._saved = (
+            cfg_mod.GLOBAL_CONFIG_FILE,
+            cfg_mod.HISTORY_FILE,
+            cfg_mod.GLOBAL_CONFIG_DIR,
+        )
+        cfg_mod.GLOBAL_CONFIG_FILE = self._tmp / ".clawcodex" / "config.json"
+        cfg_mod.HISTORY_FILE = self._tmp / ".clawcodex" / "history.jsonl"
+        cfg_mod.GLOBAL_CONFIG_DIR = self._tmp / ".clawcodex"
+        cfg_mod._default_manager = None
+
+        self._saved_env = os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
+        from src.settings.settings import invalidate_settings_cache
+        invalidate_settings_cache()
+
+        mgr = cfg_mod._get_default_manager()
+        cfg = mgr.load_global()
+        cfg["providers"] = {
+            "deepseek": {
+                "api_key": "k",
+                "base_url": "https://api.deepseek.com",
+                "default_model": "deepseek-v4-pro",
+            },
+            "zai": {
+                "api_key": "k",
+                "base_url": "https://api.z.ai/api/coding/paas/v4",
+                "default_model": "glm-5.2",
+            },
+        }
+        mgr.save_global(cfg)
+        return self
+
+    def __exit__(self, *a):
+        cfg_mod = self._cfg_mod
+        (
+            cfg_mod.GLOBAL_CONFIG_FILE,
+            cfg_mod.HISTORY_FILE,
+            cfg_mod.GLOBAL_CONFIG_DIR,
+        ) = self._saved
+        cfg_mod._default_manager = None
+        if self._saved_env is not None:
+            os.environ["CLAUDE_CODE_DISABLE_ADVISOR_TOOL"] = self._saved_env
+        from src.settings.settings import invalidate_settings_cache
+        invalidate_settings_cache()
+
+
+def _make_session(single_session: bool = True) -> tuple[_AgentSession, list[dict]]:
+    # single_session=True matches the production stdio transport (the TUI
+    # child) — the only transport /advisor is available on.
+    emitted: list[dict] = []
+    sess = _AgentSession(
+        session_id="advisor-sess", cwd="/tmp",
+        config=AgentServerConfig(single_session=single_session),
+        loop=MagicMock(), out_queue=MagicMock(),
+    )
+    sess._emit = lambda env: emitted.append(env)  # type: ignore[method-assign]
+    # A 3P-looking provider (plain mock ≠ AnthropicProvider) with the
+    # test's target main-loop model — decide_advisor_mode lands client-side.
+    provider = MagicMock()
+    provider.model = "deepseek-v4-pro"
+    sess.provider = provider
+    return sess, emitted
+
+
+def _control(sess: _AgentSession, subtype: str, **params) -> None:
+    asyncio.run(sess._handle_control_request({
+        "type": "control_request",
+        "request_id": "req-1",
+        "request": {"subtype": subtype, **params},
+    }))
+
+
+def _last_reply(emitted: list[dict]) -> dict:
+    for env in reversed(emitted):
+        if env.get("type") == "control_response":
+            return env["response"]["response"]
+    raise AssertionError(f"no control_response in {emitted!r}")
+
+
+class TestAdvisorControl(unittest.TestCase):
+    def test_bare_advisor_reports_unset_status(self) -> None:
+        with _IsolatedConfig():
+            sess, emitted = _make_session()
+            _control(sess, "advisor", arg="")
+            reply = _last_reply(emitted)
+            self.assertTrue(reply["ok"])
+            self.assertIn("Advisor: not set", reply["text"])
+
+    def test_set_then_off_round_trip(self) -> None:
+        with _IsolatedConfig():
+            sess, emitted = _make_session()
+            _control(sess, "advisor", arg="zai:glm-5.2")
+            reply = _last_reply(emitted)
+            self.assertTrue(reply["ok"])
+            self.assertIn("Advisor set to zai:glm-5.2", reply["text"])
+            self.assertIn("client-side", reply["text"])
+
+            # The write must be visible to the query layer's read channel.
+            from src.settings.settings import get_settings
+            s = get_settings()
+            self.assertEqual(s.advisor_model, "glm-5.2")
+            self.assertEqual(s.advisor_provider, "zai")
+            self.assertTrue(s.advisor_enabled)
+
+            _control(sess, "advisor", arg="off")
+            reply = _last_reply(emitted)
+            self.assertTrue(reply["ok"])
+            self.assertIn("Advisor disabled", reply["text"])
+            self.assertFalse(get_settings().advisor_enabled)
+
+    def test_status_after_set_reports_active_pair(self) -> None:
+        with _IsolatedConfig():
+            sess, emitted = _make_session()
+            _control(sess, "advisor", arg="zai:glm-5.2")
+            _control(sess, "advisor", arg="")
+            reply = _last_reply(emitted)
+            self.assertTrue(reply["ok"])
+            self.assertIn("zai:glm-5.2", reply["text"])
+            self.assertIn("client-side", reply["text"])
+
+    def test_unknown_provider_is_a_command_level_error(self) -> None:
+        with _IsolatedConfig():
+            sess, emitted = _make_session()
+            _control(sess, "advisor", arg="nosuch:glm-5.2")
+            reply = _last_reply(emitted)
+            # Transport-level ok — the grammar error is the command's text.
+            self.assertTrue(reply["ok"])
+            self.assertIn("Unknown provider", reply["text"])
+            from src.settings.settings import get_settings
+            self.assertFalse(get_settings().advisor_enabled)
+
+    def test_exception_replies_error_instead_of_killing_channel(self) -> None:
+        sess, emitted = _make_session()
+        with patch(
+            "src.command_system.builtins.advisor_command_call",
+            side_effect=RuntimeError("boom"),
+        ):
+            _control(sess, "advisor", arg="")
+        reply = _last_reply(emitted)
+        self.assertFalse(reply["ok"])
+        self.assertIn("boom", reply["error"])
+
+    def test_restart_sees_and_clears_persisted_config(self) -> None:
+        """Regression (critic issue 1): a session booted AFTER /advisor was
+        persisted must report the configured pair and be able to turn it
+        off — even though ``seed_app_state_from_settings`` doesn't seed
+        advisor fields into the session's app-state store. The bridge must
+        therefore not read/write through the (advisor-blind) store."""
+        with _IsolatedConfig():
+            # A prior session persisted an advisor config.
+            import src.config as cfg_mod
+            from src.settings.settings import invalidate_settings_cache
+            mgr = cfg_mod._get_default_manager()
+            cfg = mgr.load_global()
+            cfg["settings"] = {
+                "advisor_model": "glm-5.2",
+                "advisor_provider": "zai",
+                "advisor_enabled": True,
+            }
+            mgr.save_global(cfg)
+            invalidate_settings_cache()
+
+            # Boot a fresh session the way _build_runtime wires it: a store
+            # seeded from settings (which carries NO advisor fields).
+            sess, emitted = _make_session()
+            from src.state.app_state import (
+                create_app_state_store,
+                seed_app_state_from_settings,
+            )
+            sess.app_state_store = create_app_state_store(
+                seed_app_state_from_settings("deepseek")
+            )
+
+            # Status must reflect the persisted config, not store defaults.
+            _control(sess, "advisor", arg="")
+            reply = _last_reply(emitted)
+            self.assertTrue(reply["ok"])
+            self.assertIn("zai:glm-5.2", reply["text"])
+            self.assertNotIn("not set", reply["text"])
+
+            # Off must actually persist the disable.
+            _control(sess, "advisor", arg="off")
+            reply = _last_reply(emitted)
+            self.assertTrue(reply["ok"])
+            self.assertIn("Advisor disabled", reply["text"])
+            from src.settings.settings import get_settings
+            self.assertFalse(get_settings().advisor_enabled)
+            self.assertFalse(get_settings().advisor_model)
+
+    def test_multi_session_transport_is_refused(self) -> None:
+        """/advisor persists user-level settings; on the multi-session WS
+        transport that would flip the advisor for every session on the
+        host (critic issue 2). The control must refuse."""
+        sess, emitted = _make_session(single_session=False)
+        _control(sess, "advisor", arg="zai:glm-5.2")
+        reply = _last_reply(emitted)
+        self.assertFalse(reply["ok"])
+        self.assertIn("single-session", reply["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_advisor_client_side.py
+++ b/tests/test_advisor_client_side.py
@@ -592,6 +592,26 @@ class TestClientAdvisorToolSchema(unittest.TestCase):
             schema["input_schema"].get("additionalProperties"), False
         )
 
+    def test_dispatch_schema_tolerates_junk_input_fields(self) -> None:
+        """The ADVERTISED schema is strict (models are told: no params),
+        but the DISPATCH schema must tolerate junk — observed live:
+        deepseek-v4-pro emitting ``{"parameters": ...}`` on the no-arg
+        call. Registry validation runs the dispatch schema against the
+        model's actual input; a hard failure there kills the whole
+        consultation over a field the handler never reads."""
+        from src.tool_system.schema_validation import validate_json_schema
+        from src.tool_system.tools.advisor import AdvisorTool
+
+        # Must not raise for the shapes models actually emit.
+        validate_json_schema({}, AdvisorTool.input_schema, root_name="advisor")
+        validate_json_schema(
+            {"parameters": {}}, AdvisorTool.input_schema, root_name="advisor"
+        )
+        validate_json_schema(
+            {"query": "review my plan"}, AdvisorTool.input_schema,
+            root_name="advisor",
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_advisor_command.py
+++ b/tests/test_advisor_command.py
@@ -101,7 +101,7 @@ class _IsolatedEnv:
         cfg_mod.GLOBAL_CONFIG_DIR = self._tmp / ".clawcodex"
         cfg_mod._default_manager = None
 
-        os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
+        self._saved_env = os.environ.pop("CLAUDE_CODE_DISABLE_ADVISOR_TOOL", None)
         from src.settings.settings import invalidate_settings_cache
         invalidate_settings_cache()
         return self
@@ -112,6 +112,8 @@ class _IsolatedEnv:
         cfg_mod.HISTORY_FILE = self._saved_history_path
         cfg_mod.GLOBAL_CONFIG_DIR = self._saved_global_path.parent
         cfg_mod._default_manager = None
+        if self._saved_env is not None:
+            os.environ["CLAUDE_CODE_DISABLE_ADVISOR_TOOL"] = self._saved_env
         from src.settings.settings import invalidate_settings_cache
         invalidate_settings_cache()
 

--- a/ui-tui/src/__tests__/advisorCommand.test.ts
+++ b/ui-tui/src/__tests__/advisorCommand.test.ts
@@ -1,0 +1,142 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// /advisor adapter coverage: dispatchSlash('advisor') ↔ the backend `advisor`
+// control subtype (exec contract — the command's text is always printed as a
+// system line), plus its presence in the slash catalog/menu.
+const harness = vi.hoisted(() => ({ proc: null as null | EventEmitter, spawnCalls: [] as unknown[][] }))
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => {
+    harness.spawnCalls.push(args)
+
+    return harness.proc
+  }
+}))
+
+import { GatewayClient } from '../gatewayClient.js'
+
+class FakeProc extends EventEmitter {
+  kill = vi.fn()
+  stderr = new PassThrough()
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+
+  sent: any[] = []
+
+  constructor() {
+    super()
+    this.stdin.on('data', chunk => {
+      for (const line of String(chunk).split('\n')) {
+        if (line.trim()) {
+          this.sent.push(JSON.parse(line))
+        }
+      }
+    })
+  }
+
+  line(obj: unknown): void {
+    this.stdout.write(JSON.stringify(obj) + '\n')
+  }
+}
+
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+describe('/advisor gateway adapter', () => {
+  const prevWs = process.env.CLAWCODEX_WORKSPACE
+  let events: any[]
+  let gw: GatewayClient
+  let proc: FakeProc
+
+  beforeEach(() => {
+    process.env.CLAWCODEX_WORKSPACE = '/ws'
+    proc = new FakeProc()
+    harness.proc = proc
+    harness.spawnCalls = []
+    events = []
+    gw = new GatewayClient()
+    gw.on('event', (e: any) => events.push(e))
+    gw.start()
+    gw.drain()
+  })
+
+  afterEach(() => {
+    gw.kill()
+
+    if (prevWs === undefined) {delete process.env.CLAWCODEX_WORKSPACE}
+    else {process.env.CLAWCODEX_WORKSPACE = prevWs}
+  })
+
+  const replyToLastControl = async (response: unknown) => {
+    await flush()
+    const req = proc.sent.at(-1)
+
+    expect(req?.type).toBe('control_request')
+    proc.line({
+      response: { request_id: req.request_id, response, subtype: 'success' },
+      type: 'control_response'
+    })
+    await flush()
+  }
+
+  it('SET maps to the advisor control and prints the reply text', async () => {
+    const p = gw.request('command.dispatch', { arg: 'zai:glm-5.2', name: 'advisor' })
+    await replyToLastControl({
+      ok: true,
+      text: 'Advisor set to zai:glm-5.2. Will run client-side (separate API call).'
+    })
+
+    const d: any = await p
+
+    expect(proc.sent.at(-1).request).toEqual({ arg: 'zai:glm-5.2', subtype: 'advisor' })
+    expect(d.type).toBe('exec')
+    expect(d.output).toContain('Advisor set to zai:glm-5.2')
+    expect(d.output).toContain('client-side')
+  })
+
+  it('bare /advisor is a status query with an empty arg', async () => {
+    const p = gw.request('command.dispatch', { name: 'advisor' })
+    await replyToLastControl({ ok: true, text: 'Advisor: not set' })
+
+    const d: any = await p
+
+    expect(proc.sent.at(-1).request).toEqual({ arg: '', subtype: 'advisor' })
+    expect(d.type).toBe('exec')
+    expect(d.output).toContain('Advisor: not set')
+  })
+
+  it('slash.exec form routes /advisor the same way', async () => {
+    const p = gw.request('slash.exec', { command: 'advisor off', session_id: 's1' })
+    await replyToLastControl({ ok: true, text: 'Advisor disabled (was zai:glm-5.2).' })
+
+    const d: any = await p
+
+    expect(proc.sent.at(-1).request).toEqual({ arg: 'off', subtype: 'advisor' })
+    expect(d.type).toBe('exec')
+    expect(d.output).toContain('Advisor disabled')
+  })
+
+  it('backend error replies surface their error text', async () => {
+    const p = gw.request('command.dispatch', { arg: '', name: 'advisor' })
+    await replyToLastControl({ error: 'boom', ok: false })
+
+    const d: any = await p
+
+    expect(d.type).toBe('exec')
+    expect(d.output).toContain('boom')
+  })
+
+  it('/advisor appears in the slash completion menu with its hint', async () => {
+    const p = gw.request('complete.slash', { text: '/adv' })
+    // complete.slash first fetches the backend's workflow commands.
+    await replyToLastControl({ commands: [] })
+
+    const r: any = await p
+    const item = r.items.find((i: any) => i.text === '/advisor')
+
+    expect(item).toBeDefined()
+    expect(item.hint).toContain('<provider>:<model>')
+  })
+})

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -271,6 +271,11 @@ const SLASHES: ReadonlyArray<{ desc: string; hint?: string; name: string }> = [
     name: '/effort'
   },
   { desc: 'Switch the provider', hint: '[<provider>]', name: '/provider' },
+  {
+    desc: 'Configure the advisor reviewer model (consulted mid-task by the worker)',
+    hint: '[<provider>:<model> [--client] | --no-client | off|unset]',
+    name: '/advisor'
+  },
   { desc: 'List running and recent dynamic workflows', name: '/workflows' },
   { desc: 'Search / manage the knowledge base', hint: '[status|list|clear|enable|disable]', name: '/knowledge' },
   { desc: 'Browse and inspect available skills', hint: '[list | inspect <name> | search <query>]', name: '/skills' },
@@ -840,6 +845,14 @@ export class GatewayClient extends EventEmitter {
     const out = (output: string) => ({ output, type: 'exec' })
 
     switch (name) {
+      case 'advisor': {
+        const r = (await this.controlQuery('advisor', { arg: arg ?? '' })) as any
+
+        if (!r || Object.keys(r).length === 0) {return out('advisor: backend not ready')}
+
+        return out(String(r.text ?? r.error ?? 'advisor: no response'))
+      }
+
       case 'clear': {
         const r = await this.controlQuery('clear', {})
         this.publishSessionStats(r)


### PR DESCRIPTION
## Summary

Brings back the `/advisor` slash command — configure a stronger reviewer model that the worker consults mid-task via the `advisor` tool — which was stranded when the Python REPL/Textual TUI were deleted (#566) and the UI moved to the hermes-ported Ink TUI. The advisor core (command grammar, query-layer activation, tool dispatcher, client-side executor) survived intact; this PR restores the user-facing wiring plus three correctness fixes found along the way.

## Changes

- **agent-server**: new `advisor` control_request subtype → `_do_advisor_command`, bridging to the existing `advisor_command_call` (same pattern as goal/subgoal). Replies `{ok, text}`.
  - **Gated on `single_session`**: `/advisor` persists user-level settings which the query layer reads globally — a client-supplied `--http` session must not flip the advisor for every session on the host.
  - **`app_state_store=None` deliberately**: `seed_app_state_from_settings` doesn't seed advisor fields and the store persistence handlers equality-skip default→default writes, so a store-preferred read was restart-blind (`/advisor` said "not set" while the advisor fired) and `off` never persisted. Settings is the single source of truth. ⚠️ The underlying store gaps (no advisor seeding at `src/state/app_state.py:528`, three read helpers shadowing settings without fallback at `builtins.py:554/:605/:649`) remain in shared code — documented at the bridge, backstopped by `test_restart_sees_and_clears_persisted_config`, relevant only if a store-carrying surface is re-wired.
- **Ink TUI** (`gatewayClient.ts`): `/advisor` SLASHES entry (drives slash menu, catalog, ghost hint) + `dispatchSlash` case → `controlQuery('advisor', {arg})`.
- **AdvisorTool dispatch schema** tolerates junk input fields (`additionalProperties: True`): observed live, deepseek-v4-pro emits `{"parameters": ...}` on the no-arg call and registry validation hard-failed the whole consultation. The API-advertised schema stays strict (`build_client_advisor_tool_schema` — models are still told "no parameters"); `_advisor_call` never reads its input.
- **Smoke-test fix**: `_set_advisor` in `tests/integration/test_advisor_smoke.py` predates the `advisor_enabled` master switch and never set it — the 2 beta-header smoke tests have been red since e404a79. Test-only fix (the product flips the switch on `/advisor` set — covered by `test_set_then_off_round_trip`).

Note: `/advisor` runs mid-turn by design (matches `/goal` semantics and the old REPL behavior) — the settings flip affects the in-flight turn's next model call.

## Testing

- **Live e2e ×2 with the target pairing** (deepseek-v4-pro main loop, `zai:glm-5.2` advisor, client-side mode):
  - NDJSON server level: status → set → worker `tool_use(name=advisor)` → GLM-5.2 returned structured Gaps/Risks/Do-next advice (~19s) → worker summarized; advisor pair survives history on the next call.
  - Real TUI under pyte: `/advis` shows the menu entry with hint, set confirmation renders, ⏺ Advisor tool row shows the full advice, `/exit` clean.
- New tests: 7 server-control tests (incl. restart regression — verified to fail against the pre-fix wiring — and the multi-session gate) + 5 TS adapter tests (dispatch shapes via `command.dispatch` and `slash.exec`, error paths, slash-menu presence) + dispatch-schema tolerance test.
- Full Python suite: 8183 passed / 4 pre-existing baseline failures (tests/parity, reproduced on clean main). TS: 132 passed across adjacent suites; 8 pre-existing failures + 1 flake on main, none in touched files. `tsc --noEmit` clean.
- Critic-reviewed: REVISE (2 findings: restart-blind store path — reproduced live; multi-session settings leak) → both fixed → **APPROVE** on re-review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)