### PR TITLE
fix: bump src.__version__ to 1.0.0 (stale at 0.6.0)

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,6 @@
 """Claw Codex - Claude Code Python Implementation."""
 
-__version__ = "0.6.0"
+__version__ = "1.0.0"
 __author__ = "Claw Codex Team"
 
 from .config import load_config, get_provider_config


### PR DESCRIPTION
`src/__init__.py`'s `__version__` feeds `clawcodex --version`, `doctor`, `/release-notes`, and `mcp serve`, but was left at **0.6.0** by both the v0.7.0 and v1.0.0 release bumps (which only touched pyproject / install.sh / the TUI banner). Align it with the released version.

The v1.0.0 tag will be moved to the merge commit so the tagged release reports the right version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)