### PR TITLE
feat(tui): /goal activation indicator — ◎ /goal active (14s) above the composer

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -277,10 +277,12 @@ class _AgentSession:
                 # turn. /goal resume re-arms deliberately. Deviation from
                 # CC (which keeps the goal active) — documented.
                 goal_paused = False
+                goal_snapshot = None
                 if self._goal_mgr is not None and self._goal_mgr.is_active():
                     try:
                         self._goal_mgr.pause(reason="interrupted (ESC)")
                         goal_paused = True
+                        goal_snapshot = self._goal_snapshot_locked()
                     except Exception:  # noqa: BLE001
                         logger.debug("[agent-server] goal pause on interrupt failed",
                                      exc_info=True)
@@ -302,6 +304,7 @@ class _AgentSession:
                     "message": ("⏸ Goal paused — turn interrupted. Use "
                                 "/goal resume to continue, or /goal clear to stop."),
                     "goal_active": False,
+                    "goal": goal_snapshot,
                 })
             return
         if subtype == "set_permission_mode":
@@ -1664,6 +1667,7 @@ class _AgentSession:
                                     snapshot_now.get("total_cost_usd", 0.0) or 0.0
                                 ),
                             )
+                        restored_snapshot = self._goal_snapshot_locked()
                     if restored is not None:
                         goal_notice = (
                             f"◎ Goal restored (counters reset): {restored.goal}\n"
@@ -1676,6 +1680,7 @@ class _AgentSession:
                             "session_id": self.session_id,
                             "message": goal_notice,
                             "goal_active": True,
+                            "goal": restored_snapshot,
                         })
                 except Exception:  # noqa: BLE001 — a bad goal record must not break resume
                     logger.debug("[agent-server] goal restore failed",
@@ -1964,6 +1969,27 @@ class _AgentSession:
             logger.debug("[agent-server] goal judge bind failed", exc_info=True)
         return self._goal_mgr
 
+    def _goal_snapshot_locked(self) -> dict[str, Any] | None:
+        """Compact goal state for the TUI's persistent indicator
+        (``◎ /goal active (14s)``). Call with ``_lock`` HELD — reads the
+        same state the worker's post-turn hook mutates.
+
+        Only active|paused states have an indicator; done/cleared return
+        None so the client hides it. ``created_at`` is epoch seconds — the
+        client owns the ticking elapsed display.
+        """
+        mgr = self._goal_mgr
+        state = mgr.state if mgr is not None else None
+        if state is None or state.status not in ("active", "paused"):
+            return None
+        return {
+            "status": state.status,
+            "goal": state.goal,
+            "created_at": state.created_at,
+            "turns_used": state.turns_used,
+            "max_turns": state.max_turns,
+        }
+
     def _goal_set_gate(self) -> str | None:
         """CC docs/en/goal §Requirements: /goal needs an accepted trust
         dialog and the hooks framework enabled — "the command tells you why
@@ -2020,11 +2046,14 @@ class _AgentSession:
                     baseline_tokens=self._usage_token_total(snapshot),
                     baseline_cost_usd=float(snapshot.get("total_cost_usd", 0.0) or 0.0),
                 )
+                goal_snapshot = self._goal_snapshot_locked()
             self._save_session()
             reply: dict[str, Any] = {
                 "ok": result.ok,
                 "text": result.text,
                 "active": result.active,
+                # Indicator feed — None means "no indicator" (cleared/done).
+                "goal": goal_snapshot,
             }
             if result.kickoff:
                 reply["notice"] = result.notice
@@ -2043,11 +2072,13 @@ class _AgentSession:
             mgr = self._goal_manager()
             with self._lock:
                 result = run_subgoal_command(mgr, str(arg or ""))
+                goal_snapshot = self._goal_snapshot_locked()
             self._save_session()
             reply: dict[str, Any] = {
                 "ok": result.ok,
                 "text": result.text,
                 "active": result.active,
+                "goal": goal_snapshot,
             }
             if not result.ok:
                 reply["error"] = result.text
@@ -2203,6 +2234,8 @@ class _AgentSession:
                     # hooks, no ultracode reminder, no memory recall, no
                     # stats-odometer tick — loop machinery, not a user prompt.
                     self._inbox.put({"__goal__": True, "content": continuation})
+                goal_active = bool(mgr.is_active())
+                goal_snapshot = self._goal_snapshot_locked()
             self._save_session()  # persist turns_used/verdict/achieved state
 
             message = decision.get("message") or ""
@@ -2212,7 +2245,8 @@ class _AgentSession:
                     "subtype": "goal_status",
                     "session_id": self.session_id,
                     "message": message,
-                    "goal_active": bool(mgr.is_active()),
+                    "goal_active": goal_active,
+                    "goal": goal_snapshot,
                 })
         except Exception:  # noqa: BLE001 — the goal loop must never kill the worker
             logger.debug("[agent-server] goal continuation hook failed",

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -171,6 +171,8 @@ class _AgentSession:
     # lazily by _goal_manager(); the worker's post-turn hook evaluates it and
     # enqueues continuation turns. Persisted in the session file for /resume.
     _goal_mgr: Any = None
+    # Monotonic goal-state capture counter (see _goal_snapshot_locked).
+    _goal_rev: int = 0
 
     # Worker + cross-thread coordination.
     _inbox: _queue.Queue = field(default_factory=_queue.Queue)
@@ -278,12 +280,16 @@ class _AgentSession:
                 # CC (which keeps the goal active) — documented.
                 goal_paused = False
                 goal_snapshot = None
+                goal_rev = 0
                 if self._goal_mgr is not None and self._goal_mgr.is_active():
                     try:
                         self._goal_mgr.pause(reason="interrupted (ESC)")
                         goal_paused = True
-                        goal_snapshot = self._goal_snapshot_locked()
+                        goal_snapshot, goal_rev = self._goal_snapshot_locked()
                     except Exception:  # noqa: BLE001
+                        # No event either — the indicator keeps showing
+                        # "active", which is then TRUE: an unpaused goal
+                        # resurrects the loop at the next completed turn.
                         logger.debug("[agent-server] goal pause on interrupt failed",
                                      exc_info=True)
             # Release any in-flight permission ask NOW so the worker unblocks
@@ -305,6 +311,7 @@ class _AgentSession:
                                 "/goal resume to continue, or /goal clear to stop."),
                     "goal_active": False,
                     "goal": goal_snapshot,
+                    "goal_rev": goal_rev,
                 })
             return
         if subtype == "set_permission_mode":
@@ -666,6 +673,12 @@ class _AgentSession:
                 # Fresh conversation, fresh odometer (token/cost totals are
                 # process-wide spend and deliberately survive /clear).
                 self._stats_turns = 0
+                # Indicator rider (critic R1): only a SUCCESSFUL clear may
+                # hide the client's goal indicator — a rejected /clear
+                # (active turn) reply carries no `goal` field and the
+                # client leaves the indicator alone.
+                with self._lock:
+                    goal_snapshot, goal_rev = self._goal_snapshot_locked()
                 self._reply(request_id, {
                     "ok": True,
                     "count": 0,
@@ -673,6 +686,8 @@ class _AgentSession:
                     # reply): turns reset with the conversation, spend stays.
                     "session_turns": 0,
                     "cost": _cost_snapshot(),
+                    "goal": goal_snapshot,
+                    "goal_rev": goal_rev,
                 })
             except Exception as exc:  # noqa: BLE001
                 self._reply(request_id, {"ok": False, "error": str(exc)})
@@ -1667,7 +1682,7 @@ class _AgentSession:
                                     snapshot_now.get("total_cost_usd", 0.0) or 0.0
                                 ),
                             )
-                        restored_snapshot = self._goal_snapshot_locked()
+                        restored_snapshot, restored_rev = self._goal_snapshot_locked()
                     if restored is not None:
                         goal_notice = (
                             f"◎ Goal restored (counters reset): {restored.goal}\n"
@@ -1681,6 +1696,7 @@ class _AgentSession:
                             "message": goal_notice,
                             "goal_active": True,
                             "goal": restored_snapshot,
+                            "goal_rev": restored_rev,
                         })
                 except Exception:  # noqa: BLE001 — a bad goal record must not break resume
                     logger.debug("[agent-server] goal restore failed",
@@ -1969,26 +1985,36 @@ class _AgentSession:
             logger.debug("[agent-server] goal judge bind failed", exc_info=True)
         return self._goal_mgr
 
-    def _goal_snapshot_locked(self) -> dict[str, Any] | None:
+    def _goal_snapshot_locked(self) -> tuple[dict[str, Any] | None, int]:
         """Compact goal state for the TUI's persistent indicator
         (``◎ /goal active (14s)``). Call with ``_lock`` HELD — reads the
         same state the worker's post-turn hook mutates.
 
-        Only active|paused states have an indicator; done/cleared return
-        None so the client hides it. ``created_at`` is epoch seconds — the
-        client owns the ticking elapsed display.
+        Returns ``(snapshot, rev)``. Only active|paused states have an
+        indicator; done/cleared return None so the client hides it.
+        ``created_at`` is epoch seconds — the client owns the ticking
+        elapsed display.
+
+        ``rev`` is a per-session monotonic capture counter (critic R2):
+        captures are serialized by ``_lock``, so rev order == state order —
+        but the wire is enqueue order (``_save_session`` file IO sits
+        between capture and emit, and the client's control-reply promise
+        resolution can reorder against same-chunk events). The client
+        applies a carrier only when its rev is newer, so a stale "active"
+        can never clobber a fresher paused/done/cleared.
         """
+        self._goal_rev += 1
         mgr = self._goal_mgr
         state = mgr.state if mgr is not None else None
         if state is None or state.status not in ("active", "paused"):
-            return None
+            return None, self._goal_rev
         return {
             "status": state.status,
             "goal": state.goal,
             "created_at": state.created_at,
             "turns_used": state.turns_used,
             "max_turns": state.max_turns,
-        }
+        }, self._goal_rev
 
     def _goal_set_gate(self) -> str | None:
         """CC docs/en/goal §Requirements: /goal needs an accepted trust
@@ -2046,7 +2072,7 @@ class _AgentSession:
                     baseline_tokens=self._usage_token_total(snapshot),
                     baseline_cost_usd=float(snapshot.get("total_cost_usd", 0.0) or 0.0),
                 )
-                goal_snapshot = self._goal_snapshot_locked()
+                goal_snapshot, goal_rev = self._goal_snapshot_locked()
             self._save_session()
             reply: dict[str, Any] = {
                 "ok": result.ok,
@@ -2054,6 +2080,7 @@ class _AgentSession:
                 "active": result.active,
                 # Indicator feed — None means "no indicator" (cleared/done).
                 "goal": goal_snapshot,
+                "goal_rev": goal_rev,
             }
             if result.kickoff:
                 reply["notice"] = result.notice
@@ -2072,13 +2099,14 @@ class _AgentSession:
             mgr = self._goal_manager()
             with self._lock:
                 result = run_subgoal_command(mgr, str(arg or ""))
-                goal_snapshot = self._goal_snapshot_locked()
+                goal_snapshot, goal_rev = self._goal_snapshot_locked()
             self._save_session()
             reply: dict[str, Any] = {
                 "ok": result.ok,
                 "text": result.text,
                 "active": result.active,
                 "goal": goal_snapshot,
+                "goal_rev": goal_rev,
             }
             if not result.ok:
                 reply["error"] = result.text
@@ -2235,7 +2263,7 @@ class _AgentSession:
                     # stats-odometer tick — loop machinery, not a user prompt.
                     self._inbox.put({"__goal__": True, "content": continuation})
                 goal_active = bool(mgr.is_active())
-                goal_snapshot = self._goal_snapshot_locked()
+                goal_snapshot, goal_rev = self._goal_snapshot_locked()
             self._save_session()  # persist turns_used/verdict/achieved state
 
             message = decision.get("message") or ""
@@ -2247,6 +2275,7 @@ class _AgentSession:
                     "message": message,
                     "goal_active": goal_active,
                     "goal": goal_snapshot,
+                    "goal_rev": goal_rev,
                 })
         except Exception:  # noqa: BLE001 — the goal loop must never kill the worker
             logger.debug("[agent-server] goal continuation hook failed",

--- a/tests/server/test_goal_control.py
+++ b/tests/server/test_goal_control.py
@@ -519,6 +519,48 @@ class TestGoalSnapshotFeed(unittest.TestCase):
         _control(sess, "interrupt")
         event = _goal_events(emitted)[-1]
         self.assertEqual(event["goal"]["status"], "paused")
+        self.assertGreater(event["goal_rev"], 0)
+
+    def test_goal_rev_is_monotonic_across_carriers(self) -> None:
+        """Capture order == rev order (critic R2): the client uses rev to
+        drop carriers the wire delivered out of capture order."""
+        sess, emitted = _make_session()
+        with patch.object(_AgentSession, "_goal_set_gate", return_value=None):
+            _control(sess, "goal", arg="ship it")
+        rev_set = _last_reply(emitted)["goal_rev"]
+        _control(sess, "goal", arg="pause")
+        rev_pause = _last_reply(emitted)["goal_rev"]
+        _control(sess, "goal", arg="clear")
+        rev_clear = _last_reply(emitted)["goal_rev"]
+        self.assertLess(rev_set, rev_pause)
+        self.assertLess(rev_pause, rev_clear)
+
+    def test_clear_control_reply_carries_goal_rider(self) -> None:
+        """A SUCCESSFUL /clear tells the client to hide the indicator via
+        the reply rider (goal=None + rev), same channel as every other
+        carrier."""
+        sess, emitted = _make_session()
+        _set_goal(sess)
+        sess.session.conversation.clear = MagicMock()
+        with patch("src.server.agent_server._cost_snapshot", return_value={}):
+            _control(sess, "clear")
+        reply = _last_reply(emitted)
+        self.assertTrue(reply["ok"])
+        self.assertIn("goal", reply)
+        self.assertIsNone(reply["goal"])
+        self.assertGreater(reply["goal_rev"], 0)
+
+    def test_rejected_clear_reply_has_no_goal_rider(self) -> None:
+        """A /clear refused mid-turn must NOT carry the rider — the goal is
+        still armed and the client indicator must stay up (critic R1)."""
+        sess, emitted = _make_session()
+        _set_goal(sess)
+        sess._current_abort = MagicMock()  # simulate a running turn
+        _control(sess, "clear")
+        reply = _last_reply(emitted)
+        self.assertFalse(reply["ok"])
+        self.assertNotIn("goal", reply)
+        self.assertTrue(sess._goal_mgr.is_active())
 
     def test_continue_event_carries_snapshot_with_turn_odometer(self) -> None:
         sess, emitted = _make_session()

--- a/tests/server/test_goal_control.py
+++ b/tests/server/test_goal_control.py
@@ -472,6 +472,104 @@ class TestGoalPersistence(unittest.TestCase):
                 )
 
 
+# ── indicator snapshot feed (TUI "◎ /goal active (14s)" line) ──────────
+
+
+class TestGoalSnapshotFeed(unittest.TestCase):
+    """Every goal-state carrier (control replies + goal_status events) must
+    ship the compact snapshot the TUI indicator renders from — with
+    ``created_at`` so the client owns a correct ticking elapsed display."""
+
+    def test_set_reply_carries_active_snapshot(self) -> None:
+        sess, emitted = _make_session()
+        with patch.object(_AgentSession, "_goal_set_gate", return_value=None):
+            _control(sess, "goal", arg="ship the feature")
+        snap = _last_reply(emitted)["goal"]
+        self.assertEqual(snap["status"], "active")
+        self.assertEqual(snap["goal"], "ship the feature")
+        self.assertGreater(snap["created_at"], 0)
+        self.assertEqual(snap["turns_used"], 0)
+        self.assertGreater(snap["max_turns"], 0)
+
+    def test_clear_reply_carries_none(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess)
+        _control(sess, "goal", arg="clear")
+        reply = _last_reply(emitted)
+        self.assertIn("goal", reply)
+        self.assertIsNone(reply["goal"])
+
+    def test_pause_and_status_replies_carry_paused_snapshot(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess)
+        _control(sess, "goal", arg="pause")
+        self.assertEqual(_last_reply(emitted)["goal"]["status"], "paused")
+        _control(sess, "goal", arg="")
+        self.assertEqual(_last_reply(emitted)["goal"]["status"], "paused")
+
+    def test_subgoal_reply_carries_snapshot(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess)
+        _control(sess, "subgoal", arg="also update docs")
+        self.assertEqual(_last_reply(emitted)["goal"]["status"], "active")
+
+    def test_interrupt_pause_event_carries_paused_snapshot(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess)
+        _control(sess, "interrupt")
+        event = _goal_events(emitted)[-1]
+        self.assertEqual(event["goal"]["status"], "paused")
+
+    def test_continue_event_carries_snapshot_with_turn_odometer(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess, judge=_judge_returning(
+            '{"verdict": "continue", "reason": "tests still red"}'
+        ))
+        sess._maybe_continue_goal({"subtype": "success", "response_text": "wip"})
+        event = _goal_events(emitted)[-1]
+        self.assertEqual(event["goal"]["status"], "active")
+        self.assertEqual(event["goal"]["turns_used"], 1)
+
+    def test_done_event_carries_none_snapshot(self) -> None:
+        sess, emitted = _make_session()
+        _set_goal(sess, judge=_judge_returning(
+            '{"verdict": "done", "reason": "all pass"}'
+        ))
+        sess._maybe_continue_goal({"subtype": "success", "response_text": "ok"})
+        event = _goal_events(emitted)[-1]
+        self.assertIn("goal", event)
+        self.assertIsNone(event["goal"])
+
+    def test_restore_event_carries_active_snapshot(self) -> None:
+        import src.server.agent_server as srv
+
+        with __import__("tempfile").TemporaryDirectory() as td:
+            tmp = __import__("pathlib").Path(td)
+            with patch.object(srv, "_sessions_dir", return_value=tmp):
+                sess, _ = _make_session()
+                from src.agent.conversation import Conversation
+
+                conv = Conversation()
+                conv.add_user_message("kick")
+                sess.session = SimpleNamespace(conversation=conv)
+                sess._save_session = _AgentSession._save_session.__get__(sess)
+                _set_goal(sess, "finish the port")
+                sess._save_session()
+
+                sess2, emitted2 = _make_session()
+                sess2.session = SimpleNamespace(conversation=Conversation())
+                sess2._save_session = lambda: None  # type: ignore[method-assign]
+                asyncio.run(sess2._handle_control_request({
+                    "type": "control_request",
+                    "request_id": "r9",
+                    "request": {"subtype": "resume", "session_id": "goal-sess"},
+                }))
+                event = _goal_events(emitted2)[-1]
+                self.assertEqual(event["goal"]["status"], "active")
+                self.assertEqual(event["goal"]["goal"], "finish the port")
+                self.assertGreater(event["goal"]["created_at"], 0)
+
+
 class TestUsageTokenTotal(unittest.TestCase):
     def test_sums_model_usage(self) -> None:
         snap = {"model_usage": {

--- a/ui-tui/src/__tests__/goalCommand.test.ts
+++ b/ui-tui/src/__tests__/goalCommand.test.ts
@@ -159,6 +159,97 @@ describe('/goal gateway adapter', () => {
     expect(ev.payload.text).toContain('Continuing toward goal')
   })
 
+  it('SET reply snapshot publishes a goal.state event for the indicator', async () => {
+    const p = gw.request('command.dispatch', { arg: 'ship the feature', name: 'goal' })
+    await replyToLastControl({
+      active: true,
+      goal: { created_at: 1_751_800_000, goal: 'ship the feature', max_turns: 20, status: 'active', turns_used: 0 },
+      kickoff: 'ship the feature',
+      notice: '◎ Goal set (20-turn budget): ship the feature',
+      ok: true,
+      text: '◎ Goal set (20-turn budget): ship the feature'
+    })
+    await p
+
+    const ev = events.find(e => e.type === 'goal.state')
+
+    expect(ev).toBeTruthy()
+    expect(ev.payload.goal).toMatchObject({ created_at: 1_751_800_000, status: 'active' })
+  })
+
+  it('clear reply with a null snapshot publishes goal.state null', async () => {
+    const p = gw.request('command.dispatch', { arg: 'clear', name: 'goal' })
+    await replyToLastControl({ active: false, goal: null, ok: true, text: '✓ Goal cleared.' })
+    await p
+
+    const ev = events.find(e => e.type === 'goal.state')
+
+    expect(ev).toBeTruthy()
+    expect(ev.payload.goal).toBeNull()
+  })
+
+  it('a reply without the snapshot field (older backend) publishes nothing', async () => {
+    const p = gw.request('command.dispatch', { arg: 'status', name: 'goal' })
+    await replyToLastControl({ active: true, ok: true, text: '◎ Goal (active): x' })
+    await p
+
+    expect(events.find(e => e.type === 'goal.state')).toBeUndefined()
+  })
+
+  it('goal_status events refresh the indicator from their snapshot', async () => {
+    proc.line({
+      goal: { created_at: 1_751_800_000, goal: 'x', max_turns: 20, status: 'paused', turns_used: 3 },
+      goal_active: false,
+      message: '⏸ Goal paused — turn interrupted.',
+      session_id: 's1',
+      subtype: 'goal_status',
+      type: 'system'
+    })
+    await flush()
+
+    const ev = events.find(e => e.type === 'goal.state')
+
+    expect(ev).toBeTruthy()
+    expect(ev.payload.goal).toMatchObject({ status: 'paused', turns_used: 3 })
+  })
+
+  it('legacy goal_status without a snapshot clears only on goal_active=false', async () => {
+    proc.line({
+      goal_active: true,
+      message: '↻ Continuing toward goal (1/20): wip',
+      session_id: 's1',
+      subtype: 'goal_status',
+      type: 'system'
+    })
+    await flush()
+    expect(events.find(e => e.type === 'goal.state')).toBeUndefined()
+
+    proc.line({
+      goal_active: false,
+      message: '✓ Goal achieved: all pass',
+      session_id: 's1',
+      subtype: 'goal_status',
+      type: 'system'
+    })
+    await flush()
+
+    const ev = events.find(e => e.type === 'goal.state')
+
+    expect(ev).toBeTruthy()
+    expect(ev.payload.goal).toBeNull()
+  })
+
+  it('/clear drops the indicator (backend /clear removes the goal)', async () => {
+    const p = gw.request('command.dispatch', { arg: '', name: 'clear' })
+    await replyToLastControl({ ok: true })
+    await p
+
+    const ev = events.find(e => e.type === 'goal.state')
+
+    expect(ev).toBeTruthy()
+    expect(ev.payload.goal).toBeNull()
+  })
+
   it('/goal and /subgoal are in the slash catalog', async () => {
     proc.line({
       cwd: '/ws', model: 'm', protocol_version: '0.1.0', session_id: 's1',

--- a/ui-tui/src/__tests__/goalCommand.test.ts
+++ b/ui-tui/src/__tests__/goalCommand.test.ts
@@ -164,6 +164,7 @@ describe('/goal gateway adapter', () => {
     await replyToLastControl({
       active: true,
       goal: { created_at: 1_751_800_000, goal: 'ship the feature', max_turns: 20, status: 'active', turns_used: 0 },
+      goal_rev: 3,
       kickoff: 'ship the feature',
       notice: '◎ Goal set (20-turn budget): ship the feature',
       ok: true,
@@ -175,6 +176,7 @@ describe('/goal gateway adapter', () => {
 
     expect(ev).toBeTruthy()
     expect(ev.payload.goal).toMatchObject({ created_at: 1_751_800_000, status: 'active' })
+    expect(ev.payload.rev).toBe(3)
   })
 
   it('clear reply with a null snapshot publishes goal.state null', async () => {
@@ -239,15 +241,37 @@ describe('/goal gateway adapter', () => {
     expect(ev.payload.goal).toBeNull()
   })
 
-  it('/clear drops the indicator (backend /clear removes the goal)', async () => {
+  it('/clear drops the indicator (legacy success reply without the rider)', async () => {
     const p = gw.request('command.dispatch', { arg: '', name: 'clear' })
     await replyToLastControl({ ok: true })
+    const d: any = await p
+
+    const ev = events.find(e => e.type === 'goal.state')
+
+    expect(ev).toBeTruthy()
+    expect(ev.payload.goal).toBeNull()
+    expect(d.output).toContain('cleared')
+  })
+
+  it('/clear success routes the new goal rider (with rev) through', async () => {
+    const p = gw.request('command.dispatch', { arg: '', name: 'clear' })
+    await replyToLastControl({ cost: {}, goal: null, goal_rev: 9, ok: true, session_turns: 0 })
     await p
 
     const ev = events.find(e => e.type === 'goal.state')
 
     expect(ev).toBeTruthy()
     expect(ev.payload.goal).toBeNull()
+    expect(ev.payload.rev).toBe(9)
+  })
+
+  it('a REJECTED /clear (active turn) leaves the indicator alone', async () => {
+    const p = gw.request('command.dispatch', { arg: '', name: 'clear' })
+    await replyToLastControl({ error: 'cannot clear during an active turn', ok: false })
+    const d: any = await p
+
+    expect(events.find(e => e.type === 'goal.state')).toBeUndefined()
+    expect(d.output).toContain('cannot clear during an active turn')
   })
 
   it('/goal and /subgoal are in the slash catalog', async () => {

--- a/ui-tui/src/__tests__/goalIndicator.test.ts
+++ b/ui-tui/src/__tests__/goalIndicator.test.ts
@@ -1,0 +1,129 @@
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@clawcodex/ink'
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.hoisted(() => {
+  process.env.FORCE_COLOR = '3'
+  process.env.COLORTERM = 'truecolor'
+  delete process.env.NO_COLOR
+})
+
+import { $goalState, applyGoalSnapshot, resetGoalState } from '../app/goalStore.js'
+import { GoalIndicator } from '../components/goalIndicator.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const renderToString = (element: React.ReactElement): string => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 100, isTTY: false, rows: 30 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(element, {
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return output
+}
+
+const render = () => renderToString(React.createElement(GoalIndicator, { t: DEFAULT_THEME }))
+
+describe('goalStore.applyGoalSnapshot', () => {
+  afterEach(() => resetGoalState())
+
+  it('maps a wire snapshot (epoch seconds) to indicator state (epoch ms)', () => {
+    applyGoalSnapshot({ created_at: 1_751_800_000, goal: 'ship it', max_turns: 20, status: 'active', turns_used: 3 })
+
+    expect($goalState.get()).toEqual({
+      goal: 'ship it',
+      maxTurns: 20,
+      startedAt: 1_751_800_000_000,
+      status: 'active',
+      turnsUsed: 3
+    })
+  })
+
+  it('hides on null / unknown status / non-object garbage', () => {
+    applyGoalSnapshot({ created_at: 1, goal: 'x', status: 'active' })
+    applyGoalSnapshot(null)
+    expect($goalState.get()).toBeNull()
+
+    applyGoalSnapshot({ goal: 'x', status: 'done' })
+    expect($goalState.get()).toBeNull()
+
+    applyGoalSnapshot('garbage' as never)
+    expect($goalState.get()).toBeNull()
+  })
+
+  it('falls back to Date.now when created_at is missing or junk', () => {
+    const before = Date.now()
+    applyGoalSnapshot({ goal: 'x', status: 'active' })
+
+    const state = $goalState.get()
+
+    expect(state?.startedAt).toBeGreaterThanOrEqual(before)
+    expect(state?.startedAt).toBeLessThanOrEqual(Date.now())
+  })
+})
+
+describe('GoalIndicator', () => {
+  afterEach(() => {
+    resetGoalState()
+    vi.useRealTimers()
+  })
+
+  it('renders nothing without a goal', () => {
+    resetGoalState()
+    expect(stripAnsi(render()).trim()).toBe('')
+  })
+
+  it('shows the ticking elapsed badge for an active goal', () => {
+    applyGoalSnapshot({ created_at: (Date.now() - 14_000) / 1000, goal: 'ship it', max_turns: 20, status: 'active', turns_used: 0 })
+
+    const plain = stripAnsi(render())
+
+    expect(plain).toContain('◎ /goal active (14s)')
+    // pre-judge (turn 0): no odometer
+    expect(plain).not.toContain('turn')
+  })
+
+  it('adds the turn odometer once the judge has evaluated turns', () => {
+    applyGoalSnapshot({ created_at: (Date.now() - 62_000) / 1000, goal: 'ship it', max_turns: 20, status: 'active', turns_used: 3 })
+
+    expect(stripAnsi(render())).toContain('◎ /goal active (1m 2s · turn 3/20)')
+  })
+
+  it('renders in the permission lavender (the reference chrome color)', () => {
+    applyGoalSnapshot({ created_at: Date.now() / 1000, goal: 'x', status: 'active' })
+
+    // DEFAULT_THEME permission = rgb(177,185,249)
+    expect(render()).toContain('177;185;249')
+  })
+
+  it('clamps a future created_at (clock skew) to 0s instead of going negative', () => {
+    applyGoalSnapshot({ created_at: (Date.now() + 60_000) / 1000, goal: 'x', status: 'active' })
+
+    expect(stripAnsi(render())).toContain('◎ /goal active (0s)')
+  })
+
+  it('shows the muted paused badge with the resume hint', () => {
+    applyGoalSnapshot({ created_at: Date.now() / 1000, goal: 'x', status: 'paused' })
+
+    expect(stripAnsi(render())).toContain('⏸ /goal paused · /goal resume')
+  })
+})

--- a/ui-tui/src/__tests__/goalIndicator.test.ts
+++ b/ui-tui/src/__tests__/goalIndicator.test.ts
@@ -50,7 +50,6 @@ describe('goalStore.applyGoalSnapshot', () => {
     applyGoalSnapshot({ created_at: 1_751_800_000, goal: 'ship it', max_turns: 20, status: 'active', turns_used: 3 })
 
     expect($goalState.get()).toEqual({
-      goal: 'ship it',
       maxTurns: 20,
       startedAt: 1_751_800_000_000,
       status: 'active',
@@ -78,6 +77,39 @@ describe('goalStore.applyGoalSnapshot', () => {
 
     expect(state?.startedAt).toBeGreaterThanOrEqual(before)
     expect(state?.startedAt).toBeLessThanOrEqual(Date.now())
+  })
+
+  it('drops carriers whose rev is at or below the last applied one', () => {
+    // Fresh state at rev 5 (say, /goal pause reply)…
+    applyGoalSnapshot({ created_at: 1, goal: 'x', status: 'paused' }, 5)
+    // …then a STALE active carrier captured earlier but delivered later
+    // (worker post-turn event racing the control reply) must be ignored.
+    applyGoalSnapshot({ created_at: 1, goal: 'x', status: 'active' }, 4)
+    expect($goalState.get()?.status).toBe('paused')
+
+    applyGoalSnapshot({ created_at: 1, goal: 'x', status: 'active' }, 5)
+    expect($goalState.get()?.status).toBe('paused')
+
+    // A stale null (old "done" event) must not hide a newer active state.
+    applyGoalSnapshot(null, 3)
+    expect($goalState.get()?.status).toBe('paused')
+
+    // Newer rev applies.
+    applyGoalSnapshot({ created_at: 1, goal: 'x', status: 'active' }, 6)
+    expect($goalState.get()?.status).toBe('active')
+  })
+
+  it('rev-less carriers (legacy backend) apply unconditionally', () => {
+    applyGoalSnapshot({ created_at: 1, goal: 'x', status: 'active' }, 7)
+    applyGoalSnapshot(null)
+    expect($goalState.get()).toBeNull()
+  })
+
+  it('resetGoalState clears the rev watermark (fresh backend restarts at 1)', () => {
+    applyGoalSnapshot({ created_at: 1, goal: 'x', status: 'active' }, 50)
+    resetGoalState()
+    applyGoalSnapshot({ created_at: 1, goal: 'x', status: 'active' }, 1)
+    expect($goalState.get()?.status).toBe('active')
   })
 })
 
@@ -125,5 +157,40 @@ describe('GoalIndicator', () => {
     applyGoalSnapshot({ created_at: Date.now() / 1000, goal: 'x', status: 'paused' })
 
     expect(stripAnsi(render())).toContain('⏸ /goal paused · /goal resume')
+  })
+
+  it('ticks the elapsed display once per second while mounted', async () => {
+    vi.useFakeTimers()
+    applyGoalSnapshot({ created_at: (Date.now() - 14_000) / 1000, goal: 'x', status: 'active' })
+
+    const stdout = new PassThrough()
+    const stdin = new PassThrough()
+    const stderr = new PassThrough()
+    let output = ''
+
+    Object.assign(stdout, { columns: 100, isTTY: false, rows: 30 })
+    Object.assign(stdin, { isTTY: false })
+    Object.assign(stderr, { isTTY: false })
+    stdout.on('data', chunk => {
+      output += chunk.toString()
+    })
+
+    const instance = renderSync(React.createElement(GoalIndicator, { t: DEFAULT_THEME }), {
+      patchConsole: false,
+      stderr: stderr as unknown as NodeJS.WriteStream,
+      stdin: stdin as unknown as NodeJS.ReadStream,
+      stdout: stdout as unknown as NodeJS.WriteStream
+    })
+
+    try {
+      expect(stripAnsi(output)).toContain('(14s)')
+
+      await vi.advanceTimersByTimeAsync(2_100)
+
+      expect(stripAnsi(output)).toContain('(16s)')
+    } finally {
+      instance.unmount()
+      instance.cleanup()
+    }
   })
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -21,6 +21,7 @@ import { fromSkin } from '../theme.js'
 import type { Msg, SubagentProgress, SubagentStatus } from '../types.js'
 
 import { applyDelegationStatus, getDelegationState } from './delegationStore.js'
+import { applyGoalSnapshot, resetGoalState } from './goalStore.js'
 import type { GatewayEventHandlerContext } from './interfaces.js'
 import { getOverlayState, patchOverlayState } from './overlayStore.js'
 import { flashPet } from './petFlashStore.js'
@@ -332,6 +333,11 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
     if (skin) {
       applySkin(skin)
     }
+
+    // A (re)started backend has no goal until it says otherwise — a resume
+    // with an active goal re-arms via its goal_status event moments later.
+    // Prevents a stale "◎ /goal active" surviving a crash-respawn.
+    resetGoalState()
 
     // Kick off the config fetch once the gateway is actually ready. If handler
     // construction does this during React render, a startup transport error can
@@ -1002,6 +1008,12 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         return
 
+      case 'goal.state':
+        // /goal indicator feed (goal/subgoal replies, goal_status events,
+        // /clear). The payload is the whole truth — null hides the line.
+        applyGoalSnapshot(ev.payload?.goal ?? null)
+
+        return
       case 'error':
         turnController.recordError()
         flashPet('failed')

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1009,9 +1009,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
 
       case 'goal.state':
-        // /goal indicator feed (goal/subgoal replies, goal_status events,
-        // /clear). The payload is the whole truth — null hides the line.
-        applyGoalSnapshot(ev.payload?.goal ?? null)
+        // /goal indicator feed (goal/subgoal/clear replies, goal_status
+        // events). The payload is the whole truth — null hides the line;
+        // the store drops carriers whose rev is older than one applied.
+        applyGoalSnapshot(ev.payload?.goal ?? null, ev.payload?.rev)
 
         return
       case 'error':

--- a/ui-tui/src/app/goalStore.ts
+++ b/ui-tui/src/app/goalStore.ts
@@ -1,0 +1,45 @@
+import { atom } from 'nanostores'
+
+import type { GoalSnapshot } from '../gatewayTypes.js'
+
+// /goal indicator state — feeds the persistent right-aligned
+// "◎ /goal active (14s)" line above the composer (GoalIndicator). The
+// backend is the single source of truth: every /goal-/subgoal reply and
+// every goal_status event carries a snapshot (or null), folded in here.
+
+export interface GoalIndicatorState {
+  goal: string
+  maxTurns: number
+  /** Epoch ms the goal was set (backend created_at) — elapsed ticks off it. */
+  startedAt: number
+  status: 'active' | 'paused'
+  turnsUsed: number
+}
+
+export const $goalState = atom<GoalIndicatorState | null>(null)
+
+export const getGoalState = () => $goalState.get()
+
+export const resetGoalState = () => $goalState.set(null)
+
+/** Fold a wire snapshot into the store. Anything but a well-formed
+ *  active|paused snapshot hides the indicator. */
+export const applyGoalSnapshot = (snap: GoalSnapshot | null | undefined) => {
+  if (!snap || typeof snap !== 'object' || (snap.status !== 'active' && snap.status !== 'paused')) {
+    $goalState.set(null)
+
+    return
+  }
+
+  // created_at is epoch SECONDS (python time.time()); missing/garbage falls
+  // back to "now" so the timer still runs instead of showing a 56-year gap.
+  const createdS = typeof snap.created_at === 'number' && snap.created_at > 0 ? snap.created_at : null
+
+  $goalState.set({
+    goal: String(snap.goal ?? ''),
+    maxTurns: Math.max(0, Math.trunc(Number(snap.max_turns ?? 0) || 0)),
+    startedAt: createdS === null ? Date.now() : Math.round(createdS * 1000),
+    status: snap.status,
+    turnsUsed: Math.max(0, Math.trunc(Number(snap.turns_used ?? 0) || 0))
+  })
+}

--- a/ui-tui/src/app/goalStore.ts
+++ b/ui-tui/src/app/goalStore.ts
@@ -4,11 +4,12 @@ import type { GoalSnapshot } from '../gatewayTypes.js'
 
 // /goal indicator state — feeds the persistent right-aligned
 // "◎ /goal active (14s)" line above the composer (GoalIndicator). The
-// backend is the single source of truth: every /goal-/subgoal reply and
-// every goal_status event carries a snapshot (or null), folded in here.
+// backend is the single source of truth: every /goal, /subgoal and /clear
+// reply and every goal_status event carries a snapshot (or null), folded in
+// here. (The goal TEXT stays wire-only — the indicator never renders it;
+// /goal status is the reading surface.)
 
 export interface GoalIndicatorState {
-  goal: string
   maxTurns: number
   /** Epoch ms the goal was set (backend created_at) — elapsed ticks off it. */
   startedAt: number
@@ -18,13 +19,34 @@ export interface GoalIndicatorState {
 
 export const $goalState = atom<GoalIndicatorState | null>(null)
 
+// Highest backend capture-rev applied so far. Wire order is enqueue order,
+// not capture order (and control-reply promises resolve after same-chunk
+// events), so a stale "active" carrier can arrive AFTER the pause/clear
+// that superseded it — without this guard it would stick forever, because
+// paused/done goals emit no further events. Rev-less carriers (legacy
+// backend) apply unconditionally; legacy and revved backends never mix
+// within a session.
+let lastRev = 0
+
 export const getGoalState = () => $goalState.get()
 
-export const resetGoalState = () => $goalState.set(null)
+export const resetGoalState = () => {
+  lastRev = 0
+  $goalState.set(null)
+}
 
 /** Fold a wire snapshot into the store. Anything but a well-formed
- *  active|paused snapshot hides the indicator. */
-export const applyGoalSnapshot = (snap: GoalSnapshot | null | undefined) => {
+ *  active|paused snapshot hides the indicator; carriers with a rev at or
+ *  below one already applied are dropped as stale. */
+export const applyGoalSnapshot = (snap: GoalSnapshot | null | undefined, rev?: number) => {
+  if (typeof rev === 'number') {
+    if (rev <= lastRev) {
+      return
+    }
+
+    lastRev = rev
+  }
+
   if (!snap || typeof snap !== 'object' || (snap.status !== 'active' && snap.status !== 'paused')) {
     $goalState.set(null)
 
@@ -36,7 +58,6 @@ export const applyGoalSnapshot = (snap: GoalSnapshot | null | undefined) => {
   const createdS = typeof snap.created_at === 'number' && snap.created_at > 0 ? snap.created_at : null
 
   $goalState.set({
-    goal: String(snap.goal ?? ''),
     maxTurns: Math.max(0, Math.trunc(Number(snap.max_turns ?? 0) || 0)),
     startedAt: createdS === null ? Date.now() : Math.round(createdS * 1000),
     status: snap.status,

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -27,6 +27,7 @@ import { Banner, Panel, SessionPanel } from './branding.js'
 import { BusyLine } from './busyLine.js'
 import { ComposerFooter } from './composerFooter.js'
 import { FpsOverlay } from './fpsOverlay.js'
+import { GoalIndicator } from './goalIndicator.js'
 import { HelpHint } from './helpHint.js'
 import { MessageLine } from './messageLine.js'
 import { PetKitty, PetSprite } from './petSprite.js'
@@ -278,6 +279,8 @@ const ComposerPane = memo(function ComposerPane({
       )}
 
       <LiveTodoPanel />
+
+      <GoalIndicator t={ui.theme} />
 
       <Box
         borderBottom

--- a/ui-tui/src/components/goalIndicator.tsx
+++ b/ui-tui/src/components/goalIndicator.tsx
@@ -1,0 +1,65 @@
+/**
+ * GoalIndicator — the persistent "a /goal is driving this session" badge,
+ * right-aligned directly above the composer (reference: Claude Code's
+ * `◎ /goal active (14s)` chrome line):
+ *
+ *   ◎ /goal active (14s)                ← permission lavender, elapsed ticks 1s
+ *   ◎ /goal active (3m 2s · turn 3/20)  ← turn odometer once the judge has run
+ *   ⏸ /goal paused · /goal resume       ← muted (budget/ESC/user pause)
+ *
+ * Unlike BusyLine it renders while idle too: the loop's judge window (turn
+ * ended, evaluator deciding) is exactly when the user needs the reassurance
+ * that the goal is still armed. Elapsed comes off the backend's created_at,
+ * so pause→resume keeps the original clock and a restore starts a fresh one.
+ */
+import { Box, Text } from '@clawcodex/ink'
+import { useStore } from '@nanostores/react'
+import { memo, useEffect, useState } from 'react'
+
+import { $goalState } from '../app/goalStore.js'
+import { fmtDuration } from '../domain/messages.js'
+import type { Theme } from '../theme.js'
+
+export const GoalIndicator = memo(function GoalIndicator({ t }: { t: Theme }) {
+  const goal = useStore($goalState)
+  const [now, setNow] = useState(() => Date.now())
+
+  const active = goal?.status === 'active'
+
+  useEffect(() => {
+    if (!active) {
+      return
+    }
+
+    setNow(Date.now()) // repaint immediately on (re)activation, then tick
+    const clock = setInterval(() => setNow(Date.now()), 1000)
+
+    return () => clearInterval(clock)
+  }, [active])
+
+  if (!goal) {
+    return null
+  }
+
+  if (goal.status === 'paused') {
+    return (
+      <Box justifyContent="flex-end">
+        <Text color={t.color.muted} dim>
+          ⏸ /goal paused · /goal resume
+        </Text>
+      </Box>
+    )
+  }
+
+  const elapsed = fmtDuration(Math.max(0, now - goal.startedAt))
+  const turns = goal.turnsUsed > 0 && goal.maxTurns > 0 ? ` · turn ${goal.turnsUsed}/${goal.maxTurns}` : ''
+
+  return (
+    <Box justifyContent="flex-end">
+      <Text color={t.color.permission}>
+        ◎ /goal active ({elapsed}
+        {turns})
+      </Text>
+    </Box>
+  )
+})

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -21,7 +21,7 @@ import { readdirSync } from 'node:fs'
 import { resolve as pathResolve } from 'node:path'
 import { createInterface } from 'node:readline'
 
-import type { CostSnapshot, GatewayEvent, PatchHunk, StructuredDiffPayload } from './gatewayTypes.js'
+import type { CostSnapshot, GatewayEvent, GoalSnapshot, PatchHunk, StructuredDiffPayload } from './gatewayTypes.js'
 import { formatTotalCost, setLastCostSnapshot } from './lib/costSummary.js'
 import type { SessionInfo } from './types.js'
 
@@ -856,9 +856,13 @@ export class GatewayClient extends EventEmitter {
       case 'clear': {
         const r = await this.controlQuery('clear', {})
         this.publishSessionStats(r)
+        // Backend /clear also removes any active goal (CC docs/en/goal
+        // §Clear a goal) — drop the indicator with it.
+        this.publish({ payload: { goal: null }, type: 'goal.state' })
 
         return out('Conversation cleared.')
       }
+
       case 'compact': {
         const r = (await this.controlQuery('compact', { instructions: arg ?? null })) as any
 
@@ -949,6 +953,7 @@ export class GatewayClient extends EventEmitter {
             : `Output style: ${current}.`
         )
       }
+
       case 'provider': {
         const r = (await this.controlQuery('set_provider', { provider: arg })) as any
 
@@ -1012,6 +1017,8 @@ export class GatewayClient extends EventEmitter {
 
         if (!r || Object.keys(r).length === 0) {return out('goal: backend not ready')}
 
+        this.publishGoalState(r)
+
         if (r.ok && typeof r.kickoff === 'string' && r.kickoff) {
           return { message: r.kickoff, notice: typeof r.notice === 'string' ? r.notice : undefined, type: 'send' }
         }
@@ -1023,6 +1030,8 @@ export class GatewayClient extends EventEmitter {
         const r = (await this.controlQuery('subgoal', { arg: arg ?? '' })) as any
 
         if (!r || Object.keys(r).length === 0) {return out('subgoal: backend not ready')}
+
+        this.publishGoalState(r)
 
         return out(String(r.text ?? r.error ?? 'subgoal: no response'))
       }
@@ -1289,6 +1298,15 @@ export class GatewayClient extends EventEmitter {
             payload: { kind: 'goal', text: String(msg.message ?? '') },
             type: 'status.update'
           })
+
+          // Indicator refresh: every loop transition (continue/done/paused/
+          // restored) rides here. Backends without the snapshot field only
+          // clear on an explicit goal_active=false — never invent state.
+          if ('goal' in msg) {
+            this.publishGoalState(msg)
+          } else if (msg.goal_active === false) {
+            this.publish({ payload: { goal: null }, type: 'goal.state' })
+          }
         }
 
         break
@@ -1455,6 +1473,21 @@ export class GatewayClient extends EventEmitter {
 
     if (this.subscribed) {this.emit('event', ev)}
     else {this.buffered.push(ev)}
+  }
+
+  /** /goal indicator refresh from any carrier with a `goal` snapshot field
+   *  (goal/subgoal replies, goal_status events). A carrier WITHOUT the field
+   *  (older backend) is a no-op — never invent or drop state on silence. */
+  private publishGoalState(carrier: unknown): void {
+    const c = carrier as { goal?: unknown } | null
+
+    if (!c || typeof c !== 'object' || !('goal' in c)) {
+      return
+    }
+
+    const goal = c.goal && typeof c.goal === 'object' ? (c.goal as GoalSnapshot) : null
+
+    this.publish({ payload: { goal }, type: 'goal.state' })
   }
 
   /** Stats-line refresh from a clear/resume reply's rider (session_turns +

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -854,11 +854,25 @@ export class GatewayClient extends EventEmitter {
       }
 
       case 'clear': {
-        const r = await this.controlQuery('clear', {})
+        const r = (await this.controlQuery('clear', {})) as any
+
+        // The clear control is idle-only — a rejected /clear (active turn)
+        // must NOT hide the goal indicator or claim success (critic R1).
+        if (!r || r.ok === false) {
+          return out(`clear: ${r?.error ?? 'backend not ready'}`)
+        }
+
         this.publishSessionStats(r)
+
         // Backend /clear also removes any active goal (CC docs/en/goal
-        // §Clear a goal) — drop the indicator with it.
-        this.publish({ payload: { goal: null }, type: 'goal.state' })
+        // §Clear a goal). New backends say so via the reply's goal rider;
+        // a legacy success reply without the field falls back to an
+        // explicit hide — the goal IS gone backend-side either way.
+        if ('goal' in r) {
+          this.publishGoalState(r)
+        } else {
+          this.publish({ payload: { goal: null }, type: 'goal.state' })
+        }
 
         return out('Conversation cleared.')
       }
@@ -1476,10 +1490,11 @@ export class GatewayClient extends EventEmitter {
   }
 
   /** /goal indicator refresh from any carrier with a `goal` snapshot field
-   *  (goal/subgoal replies, goal_status events). A carrier WITHOUT the field
-   *  (older backend) is a no-op — never invent or drop state on silence. */
+   *  (goal/subgoal/clear replies, goal_status events). A carrier WITHOUT the
+   *  field (older backend) is a no-op — never invent or drop state on
+   *  silence. `goal_rev` rides along so the store can drop stale carriers. */
   private publishGoalState(carrier: unknown): void {
-    const c = carrier as { goal?: unknown } | null
+    const c = carrier as { goal?: unknown; goal_rev?: unknown; session_id?: unknown } | null
 
     if (!c || typeof c !== 'object' || !('goal' in c)) {
       return
@@ -1487,7 +1502,11 @@ export class GatewayClient extends EventEmitter {
 
     const goal = c.goal && typeof c.goal === 'object' ? (c.goal as GoalSnapshot) : null
 
-    this.publish({ payload: { goal }, type: 'goal.state' })
+    this.publish({
+      payload: { goal, rev: typeof c.goal_rev === 'number' ? c.goal_rev : undefined },
+      session_id: typeof c.session_id === 'string' ? c.session_id : undefined,
+      type: 'goal.state'
+    })
   }
 
   /** Stats-line refresh from a clear/resume reply's rider (session_turns +

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -665,6 +665,21 @@ export interface SpawnTreeLoadResponse {
   subagents?: unknown[]
 }
 
+// ── /goal indicator ──────────────────────────────────────────────────
+
+/** Wire shape of the backend's goal snapshot (agent_server
+ *  ``_goal_snapshot_locked``): rides /goal + /subgoal control replies and
+ *  every ``goal_status`` system event. Only active|paused goals are sent —
+ *  done/cleared arrive as null. */
+export interface GoalSnapshot {
+  /** Epoch SECONDS when the goal was set (python time.time()). */
+  created_at?: number
+  goal?: string
+  max_turns?: number
+  status?: string
+  turns_used?: number
+}
+
 export type GatewayEvent =
   | { payload?: { skin?: GatewaySkin }; session_id?: string; type: 'gateway.ready' }
   | { payload?: GatewaySkin; session_id?: string; type: 'skin.changed' }
@@ -779,4 +794,7 @@ export type GatewayEvent =
   /** Out-of-band stats-line refresh: /clear and /resume replies carry the
    *  odometer + totals so the line is right before any turn completes. */
   | { payload: { cost?: CostSnapshot; session_turns?: number }; session_id?: string; type: 'session.stats' }
+  /** /goal indicator refresh — the latest snapshot (null hides it). Fired
+   *  from /goal and /subgoal replies, goal_status events, and /clear. */
+  | { payload: { goal: GoalSnapshot | null }; session_id?: string; type: 'goal.state' }
   | { payload?: { message?: string }; session_id?: string; type: 'error' }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -795,6 +795,9 @@ export type GatewayEvent =
    *  odometer + totals so the line is right before any turn completes. */
   | { payload: { cost?: CostSnapshot; session_turns?: number }; session_id?: string; type: 'session.stats' }
   /** /goal indicator refresh — the latest snapshot (null hides it). Fired
-   *  from /goal and /subgoal replies, goal_status events, and /clear. */
-  | { payload: { goal: GoalSnapshot | null }; session_id?: string; type: 'goal.state' }
+   *  from /goal, /subgoal and /clear replies plus goal_status events. `rev`
+   *  is the backend's monotonic capture counter: the store ignores carriers
+   *  older than what it already applied (wire/promise order can invert
+   *  capture order); rev-less carriers (legacy backend) apply as-is. */
+  | { payload: { goal: GoalSnapshot | null; rev?: number }; session_id?: string; type: 'goal.state' }
   | { payload?: { message?: string }; session_id?: string; type: 'error' }


### PR DESCRIPTION
## What

A persistent, right-aligned chrome line directly above the composer whenever a `/goal` completion-condition loop is armed — matching the Claude Code reference UX:

```
 ✻ cogitating…
                                                    ◎ /goal active (2s)
 ────────────────────────────────────────────────────────────────────
 ❯
 ────────────────────────────────────────────────────────────────────
   esc to interrupt
```

- `◎ /goal active (14s)` — permission lavender `rgb(177,185,249)`, elapsed ticks every second off the backend's `created_at` (pause→resume keeps the original clock; restore starts fresh)
- `◎ /goal active (3m 2s · turn 3/20)` — turn odometer appears once the judge has evaluated turns
- `⏸ /goal paused · /goal resume` — muted badge on ESC auto-pause, budget exhaustion, judge parse-failure pause, or `/goal pause`
- Renders while idle too: the judge window (turn ended, evaluator deciding) is exactly when the reassurance matters

## How

**Backend** (`agent_server.py`): `_goal_snapshot_locked()` returns a compact `{status, goal, created_at, turns_used, max_turns}` snapshot + a per-session monotonic `goal_rev` capture counter, both under `_lock`. Rides all six carriers: `/goal`, `/subgoal`, `/clear` control replies and the three `goal_status` emission sites (ESC auto-pause, resume restore, post-turn verdict). `None` = hide.

**TUI**: new `goal.state` GatewayEvent → `goalStore` (nanostores, rev watermark drops stale carriers since wire/promise order can invert capture order — a stale "active" would otherwise stick forever) → `GoalIndicator` mounted above the composer. Store resets on `gateway.ready` (crash-respawn) and re-arms from the resume restore event.

**Critic loop** (2 rounds → APPROVE): R1 — a rejected `/clear` (idle-only control, i.e. the runaway-loop case) no longer hides the indicator or claims success; successful clears carry the rider. R2 — the `goal_rev` ordering guard. Also: legacy backends without the snapshot field only clear on explicit `goal_active=false`; the client never invents state.

## Testing

- 14 new backend tests (`tests/server/test_goal_control.py`, 40 pass; 104 with `tests/goals`) — snapshot fields on every carrier, rev monotonicity, rejected-`/clear` has no rider, restore event
- 15 new TUI tests across `goalIndicator.test.ts` + `goalCommand.test.ts` (28 pass) — store mapping (s→ms, garbage, skew clamp, rev watermark incl. stale-null), component render (color, odometer, paused badge, fake-timer 1s tick), adapter (`goal.state` publication rules incl. legacy matrix and `/clear` gating)
- Full suites at pre-existing baselines (TUI: same 8 stable + 1 flaky, all verified identical on clean main; Python: 8192 passed, 6 pre-existing env failures verified identical on clean main)
- Live pyte PTY e2e vs the real deepseek backend, run twice (pre- and post-revision): **ALL PASS** — set → right-aligned ticking indicator during the kickoff turn → ESC-interrupt flips to paused badge → resume continues elapsed (3s→10s) → clear removes it → `/exit`

## Follow-up (pre-existing, surfaced by the indicator)

`/resume` onto a session with no saved goal leaves a prior in-memory goal armed (`_do_resume` only touches the manager when the file has a goal record). The indicator now truthfully shows it; fixing belongs in a resume-semantics change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)