### PR TITLE
feat(worktree): --worktree/-w session isolation — parallel sessions in isolated git worktrees (backend + ui-tui)

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -36,6 +36,18 @@ def main():
 
     import os
 
+    # Worktree env hygiene — MUST run before anything snapshots the
+    # environment (prefetch spawns, run_pre_action, tui_launcher child env),
+    # and before the subcommand sieve so the ``tui`` path is covered too.
+    # A clawcodex spawned from INSIDE a --worktree session (e.g. by the
+    # agent's Bash tool) inherits the parent's CLAWCODEX_WORKTREE_* vars;
+    # without the strip its TUI would adopt the OUTER session's worktree and
+    # its clean-exit path would delete it out from under the parent. Only the
+    # launcher that creates a worktree may advertise one (see
+    # src/utils/worktree_session.py module docstring).
+    from src.utils.worktree_session import strip_worktree_env
+    strip_worktree_env()
+
     # OpenClaude default: experimental API betas off unless the user opts in
     # (mirrors typescript/src/entrypoints/cli.tsx:44 — tool search
     # defer_loading / global cache scope / context management need internal
@@ -181,6 +193,16 @@ def main():
     if not _gate_folder_trust():
         return 1
 
+    # --worktree: create/resume AFTER the trust gate (the gate runs against
+    # the ORIGINAL cwd — user consents to the repo before we mutate
+    # .claude/worktrees/; nothing re-checks trust against the worktree path,
+    # the backend has no trust gate of its own). The worktree becomes the
+    # session's workspace; the TUI + agent-server child run inside it and the
+    # env block carries the session for the exit-time keep/remove flow.
+    worktree_session = _maybe_create_worktree(args)
+    if worktree_session is _WORKTREE_FAILED:
+        return 1
+
     profile_checkpoint("phase4_dispatch")
     from src.entrypoints.tui_launcher import launch_ink_tui
 
@@ -189,7 +211,43 @@ def main():
         model=args.model,
         permission_mode=args._resolved_permission_mode,
         is_bypass_available=args._resolved_is_bypass_available,
+        workspace=(worktree_session.worktree_path if worktree_session else None),
+        worktree=worktree_session,
     )
+
+
+#: Sentinel: worktree creation was requested and failed (error already
+#: printed) — distinct from None (no --worktree flag).
+_WORKTREE_FAILED = object()
+
+
+def _maybe_create_worktree(args):
+    """Create/resume the session worktree when ``--worktree`` was passed.
+
+    Returns the :class:`WorktreeSession`, ``None`` when the flag is absent, or
+    :data:`_WORKTREE_FAILED` after printing the error (mirrors TS setup.ts:
+    red stderr + exit 1).
+    """
+    option = getattr(args, "worktree", None)
+    if option is None:
+        return None
+
+    from src.utils.worktree_session import (
+        WorktreeError,
+        create_session_from_cli_option,
+    )
+
+    try:
+        session = create_session_from_cli_option(option)
+    except WorktreeError as exc:
+        print(f"Error creating worktree: {exc}", file=sys.stderr)
+        return _WORKTREE_FAILED
+    print(
+        f"Using worktree {session.worktree_name} at {session.worktree_path} "
+        f"(branch {session.worktree_branch})",
+        file=sys.stderr,
+    )
+    return session
 
 
 def _gate_folder_trust() -> bool:
@@ -323,6 +381,22 @@ Examples:
     parser.add_argument('prompt', nargs='?', help='Prompt to send in non-interactive mode')
     parser.add_argument('--version', action='store_true', help='Show version information')
     parser.add_argument('--config', action='store_true', help='Show current configuration')
+    # Optional-value flag, mirroring TS `-w, --worktree [name]`
+    # (typescript/src/main.tsx:3804). Bare `-w` → True → a name is generated.
+    # Known commander/argparse ambiguity, same as TS: `-w <bareword>` consumes
+    # the word, so a headless prompt should come via -p or --worktree=NAME.
+    parser.add_argument(
+        '-w', '--worktree',
+        nargs='?', const=True, default=None, metavar='NAME',
+        help=(
+            'Run this session in an isolated git worktree at '
+            '.claude/worktrees/NAME (created or resumed; a name is generated '
+            'when omitted). NAME may also be a PR reference (#123 or a GitHub '
+            'PR URL). At exit you choose to keep or remove it; parallel '
+            'sessions with different names never touch each other\'s files. '
+            'Prefer --worktree=NAME when combining with a positional prompt.'
+        ),
+    )
 
     # ---- Interactive UI ----
     #
@@ -537,6 +611,15 @@ def _run_print_mode(args) -> int:
         print("error: --fallback-model must differ from --model", file=sys.stderr)
         return 2
 
+    # --worktree in print mode: run headless inside the worktree and KEEP it
+    # (TS print mode has no exit dialog and leaves the worktree in place; the
+    # stderr note is a deliberate small improvement so scripts can find it).
+    worktree_session = _maybe_create_worktree(args)
+    if worktree_session is _WORKTREE_FAILED:
+        return 1
+    if worktree_session is not None:
+        os.chdir(worktree_session.worktree_path)
+
     options = HeadlessOptions(
         prompt=args.prompt,
         output_format=args.output_format,
@@ -553,7 +636,15 @@ def _run_print_mode(args) -> int:
         include_partial_messages=bool(args.include_partial_messages),
         verbose=bool(args.verbose),
     )
-    return run_headless(options)
+    try:
+        return run_headless(options)
+    finally:
+        if worktree_session is not None:
+            print(
+                f"Worktree kept at {worktree_session.worktree_path} "
+                f"(branch {worktree_session.worktree_branch})",
+                file=sys.stderr,
+            )
 
 
 def _split_csv(value: str | None) -> list[str]:

--- a/src/entrypoints/tui_launcher.py
+++ b/src/entrypoints/tui_launcher.py
@@ -15,7 +15,8 @@ Usage::
     clawcodex tui [--provider P] [--model M] [--permission-mode MODE]
                   [--dangerously-skip-permissions]
                   [--allow-dangerously-skip-permissions]
-                  [--workspace DIR] [--tui-dir DIR] [--print-connect]
+                  [--workspace DIR] [--worktree [NAME]] [--tui-dir DIR]
+                  [--print-connect]
 
 ``--print-connect`` instead runs the agent-server directly and prints its
 ``cc://`` URL + token, then waits (for attaching the reference client or
@@ -65,6 +66,13 @@ def run_tui_launcher(argv: list[str]) -> int:
     )
     parser.add_argument("--workspace", default=None,
                         help="Workspace root the agent operates in (default: cwd).")
+    parser.add_argument(
+        "-w", "--worktree",
+        nargs="?", const=True, default=None, metavar="NAME",
+        help="Run this session in an isolated git worktree at "
+             ".claude/worktrees/NAME (created or resumed; a name is generated "
+             "when omitted). NAME may also be a PR reference (#123 or PR URL).",
+    )
     parser.add_argument("--tui-dir", default=None,
                         help="Path to the ui-tui client (default: auto-detect).")
     parser.add_argument("--print-connect", action="store_true",
@@ -106,9 +114,39 @@ def run_tui_launcher(argv: list[str]) -> int:
         dangerously or allow_dangerously or has_allow_bypass_permissions_mode()
     ) and not is_bypass_permissions_mode_disabled()
 
+    # --worktree: the trust gate already ran in cli.py::_run_tui_subcommand
+    # (against the original cwd) before this launcher was invoked. Create or
+    # resume the worktree relative to --workspace (or cwd) and make it the
+    # session's workspace.
+    worktree_session = None
+    if args.worktree is not None:
+        from src.utils.worktree_session import (
+            WorktreeError,
+            create_session_from_cli_option,
+        )
+
+        base_cwd = str(Path(args.workspace).resolve()) if args.workspace else None
+        try:
+            worktree_session = create_session_from_cli_option(args.worktree, cwd=base_cwd)
+        except WorktreeError as exc:
+            print(f"clawcodex tui: error creating worktree: {exc}", file=sys.stderr)
+            return 1
+        print(
+            f"Using worktree {worktree_session.worktree_name} at "
+            f"{worktree_session.worktree_path} "
+            f"(branch {worktree_session.worktree_branch})",
+            file=sys.stderr,
+        )
+        args.workspace = worktree_session.worktree_path
+
     if args.print_connect:
         args.permission_mode = mode
         args.is_bypass_available = is_bypass_available
+        if worktree_session is not None:
+            # run_agent_server_subcommand runs IN THIS process; exporting the
+            # session here is exactly how the server's worktree controls see
+            # it (same channel the spawned-child path uses).
+            os.environ.update(worktree_session.to_env())
         return _print_connect(args)
     return launch_ink_tui(
         provider=args.provider,
@@ -117,6 +155,7 @@ def run_tui_launcher(argv: list[str]) -> int:
         is_bypass_available=is_bypass_available,
         workspace=args.workspace,
         tui_dir=args.tui_dir,
+        worktree=worktree_session,
     )
 
 
@@ -128,6 +167,7 @@ def launch_ink_tui(
     is_bypass_available: bool = False,
     workspace: str | None = None,
     tui_dir: str | None = None,
+    worktree=None,
 ) -> int:
     """Launch the Ink TUI as the interactive UI (it spawns + owns the agent-server).
 
@@ -151,6 +191,7 @@ def launch_ink_tui(
         workspace=workspace,
         tui_dir=tui_dir,
         print_connect=False,
+        worktree_session=worktree,
     )
     try:
         return asyncio.run(_launch(args))
@@ -224,6 +265,13 @@ def _child_env(args) -> dict[str, str]:
     existing = env.get("PYTHONPATH", "")
     env["PYTHONPATH"] = str(_REPO_ROOT) + (os.pathsep + existing if existing else "")
     env["CLAWCODEX_AGENT_SERVER_CMD"] = " ".join(_agent_server_cmd(args))
+    # --worktree session block: read by the Ink TUI (banner + exit keep/remove
+    # gating, validated against OWNER_PID/ppid) and inherited by the
+    # agent-server child (exit-time git ops). cli.py stripped any INHERITED
+    # block at entry, so this is only ever the worktree THIS launcher created.
+    worktree = getattr(args, "worktree_session", None)
+    if worktree is not None:
+        env.update(worktree.to_env())
     return env
 
 

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -32,6 +32,10 @@ client → server (``send_to_agent``)::
     {type:'control_request', request_id, request:{subtype:'set_model', model, provider?}}
                                              # replies {ok, model, warning?} | {ok:false, error}
     {type:'control_request', request_id, request:{subtype:'get_settings'|'get_context_usage'}}
+    {type:'control_request', request_id, request:{subtype:'worktree_status'}}
+                                             # {ok, active, name?, path?, branch?, git_ok?, dirty_files?, commits?}
+    {type:'control_request', request_id, request:{subtype:'worktree_exit', action:'keep'|'remove'}}
+                                             # {ok, message} | {ok:false, error}; client uses a LONG timeout
 
 Concurrency model
 -----------------
@@ -173,6 +177,9 @@ class _AgentSession:
     _goal_mgr: Any = None
     # Monotonic goal-state capture counter (see _goal_snapshot_locked).
     _goal_rev: int = 0
+    # --worktree exit already serviced (keep or remove) — a second
+    # worktree_exit is refused so the client can't double-remove.
+    _worktree_done: bool = False
 
     # Worker + cross-thread coordination.
     _inbox: _queue.Queue = field(default_factory=_queue.Queue)
@@ -638,6 +645,12 @@ class _AgentSession:
             return
         if subtype == "advisor":
             self._do_advisor_command(request_id, inner.get("arg"))
+            return
+        if subtype == "worktree_status":
+            await self._do_worktree_status(request_id)
+            return
+        if subtype == "worktree_exit":
+            await self._do_worktree_exit(request_id, inner.get("action"))
             return
         if subtype == "clear":
             # Reset the conversation so /clear actually starts a fresh context
@@ -2114,6 +2127,101 @@ class _AgentSession:
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] subgoal command failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _worktree_env_session(self):
+        """The --worktree session advertised by the launcher, if any.
+
+        Read from ``CLAWCODEX_WORKTREE_*`` (set by src/cli.py / tui_launcher
+        for the worktree THIS process tree was launched into; cli.py strips
+        any inherited block at entry, so nested sessions never see one).
+        Gated on ``single_session``: the env block is process-wide, so on the
+        multi-session --http transport it must not be visible — any WS client
+        could otherwise remove a worktree it doesn't own.
+        """
+        if not self.config.single_session or self._worktree_done:
+            return None
+        from src.utils.worktree_session import WorktreeSession
+
+        return WorktreeSession.from_env()
+
+    async def _do_worktree_status(self, request_id: object) -> None:
+        """Exit-time snapshot for the client's keep/remove decision.
+
+        ``git_ok: False`` means the counts are placeholders, not measurements
+        — the client must fail closed (treat as has-changes, render no
+        numbers, never silent-remove).
+        """
+        ws = self._worktree_env_session()
+        if ws is None:
+            self._reply(request_id, {"ok": True, "active": False})
+            return
+
+        from src.utils.worktree_session import worktree_changes
+
+        changes = await asyncio.to_thread(worktree_changes, ws)
+        self._reply(request_id, {
+            "ok": True,
+            "active": True,
+            "name": ws.worktree_name,
+            "path": ws.worktree_path,
+            "branch": ws.worktree_branch,
+            "original_cwd": ws.original_cwd,
+            "git_ok": changes.git_ok,
+            "dirty_files": changes.dirty_files,
+            "commits": changes.commits,
+        })
+
+    async def _do_worktree_exit(self, request_id: object, action: object) -> None:
+        """Perform the exit-time keep/remove the client chose.
+
+        The client is about to terminate this process either way; ``remove``
+        chdirs to the original cwd first so the dying process doesn't hold
+        its cwd inside the directory being deleted. Runs in a thread — a
+        ``git worktree remove --force`` of a large tree can take minutes and
+        must not block the control loop (the client uses a long RPC timeout
+        for exactly this call).
+        """
+        ws = self._worktree_env_session()
+        if ws is None:
+            self._reply(request_id, {"ok": False, "error": "no active worktree session"})
+            return
+        if action == "keep":
+            from src.utils.worktree_session import keep_message
+
+            self._worktree_done = True
+            self._reply(request_id, {"ok": True, "message": keep_message(ws)})
+            return
+        if action != "remove":
+            self._reply(request_id, {
+                "ok": False,
+                "error": f"invalid worktree_exit action: {action!r} (keep | remove)",
+            })
+            return
+
+        from src.utils.worktree_session import (
+            cleanup_worktree,
+            removal_message,
+            worktree_changes,
+        )
+
+        def _remove() -> dict:
+            import os
+
+            # Measure BEFORE removal — the message reports what was discarded.
+            changes = worktree_changes(ws)
+            try:
+                os.chdir(ws.original_cwd)
+            except OSError:
+                pass  # removal runs with explicit cwd=repo_root regardless
+            ok, error = cleanup_worktree(ws)
+            if not ok:
+                return {"ok": False, "error": error}
+            return {"ok": True, "message": removal_message(ws, changes)}
+
+        result = await asyncio.to_thread(_remove)
+        if result.get("ok"):
+            self._worktree_done = True
+        self._reply(request_id, result)
 
     def _do_advisor_command(self, request_id: object, arg: object) -> None:
         """Control handler for /advisor — configure the reviewer model.

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -2198,6 +2198,21 @@ class _AgentSession:
             })
             return
 
+        # Idle-only, like every destructive control (clear/resume/rewind/…):
+        # the turn runs on the worker thread while this handler runs on the
+        # main loop, so without the guard a mid-turn exit could `git worktree
+        # remove --force` the directory out from under live tool calls
+        # (critic: worktree_exit was the only file-deleting control missing
+        # it). The client degrades the refusal to keep-and-exit.
+        with self._lock:
+            active = self._current_abort is not None
+        if active:
+            self._reply(request_id, {
+                "ok": False,
+                "error": "cannot remove the worktree during an active turn",
+            })
+            return
+
         from src.utils.worktree_session import (
             cleanup_worktree,
             removal_message,

--- a/src/utils/worktree_session.py
+++ b/src/utils/worktree_session.py
@@ -42,6 +42,7 @@ import random
 import re
 import shutil
 import subprocess
+import time
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -616,7 +617,32 @@ def cleanup_worktree(session: WorktreeSession) -> tuple[bool, str]:
 
     Branch deletion is best-effort (TS parity): a failure there is logged but
     doesn't fail the removal.
+
+    Defense-in-depth: re-assert the launcher's injective slug→(path, branch)
+    mapping at the point of destruction. The session normally round-trips
+    through the env channel the launcher itself wrote, but a split/forged env
+    block (real worktree path + ``branch=main``) would otherwise turn the
+    best-effort ``branch -D`` into deleting an arbitrary branch. (``git
+    worktree remove`` already refuses paths that aren't registered worktrees;
+    this closes the branch half.)
     """
+    if not session.worktree_branch.startswith("worktree-"):
+        return False, (
+            f"refusing to clean up: branch {session.worktree_branch!r} is not "
+            "a worktree-* session branch"
+        )
+    expected_root = os.path.abspath(worktrees_dir(session.repo_root))
+    actual_path = os.path.abspath(session.worktree_path)
+    try:
+        inside = os.path.commonpath([expected_root, actual_path]) == expected_root
+    except ValueError:  # different drives (Windows) — definitely outside
+        inside = False
+    if not inside:
+        return False, (
+            f"refusing to clean up: {session.worktree_path} is outside "
+            f"{expected_root}"
+        )
+
     _, remove_err, remove_rc = _git(
         ["worktree", "remove", "--force", session.worktree_path],
         cwd=session.repo_root, timeout=600.0,
@@ -624,6 +650,9 @@ def cleanup_worktree(session: WorktreeSession) -> tuple[bool, str]:
     if remove_rc != 0:
         return False, remove_err.strip() or "git worktree remove failed"
 
+    # Brief settle before branch -D (TS parity, worktree.ts:930 sleep(100)) —
+    # lets git release worktree locks on slower filesystems/Windows.
+    time.sleep(0.1)
     _, branch_err, branch_rc = _git(
         ["branch", "-D", session.worktree_branch], cwd=session.repo_root
     )

--- a/src/utils/worktree_session.py
+++ b/src/utils/worktree_session.py
@@ -1,0 +1,667 @@
+"""Session-scoped git worktrees — the ``--worktree`` / ``-w`` feature.
+
+Port of ``typescript/src/utils/worktree.ts`` (the *session* subset used by
+``setup.ts`` and ``WorktreeExitDialog.tsx``): create-or-resume an isolated
+worktree at ``<repoRoot>/.claude/worktrees/<slug>`` on branch
+``worktree-<slug>``, run the whole session inside it, and at exit either keep
+it or remove it (directory + branch).
+
+Relationship to the other worktree helpers in this repo — do NOT merge them:
+``src/utils/git.py::create_worktree/remove_worktree`` (used by
+``src/workflow/worktree.py``) and ``src/bridge/worktree.py`` are throwaway
+agent-isolation primitives (``-b``/``--detach``, no base resolution, no
+resume, no post-creation setup). This module is the session-lifecycle port
+with resume semantics, base-branch resolution, ``.worktreeinclude`` support
+and keep/remove bookkeeping.
+
+Process topology: the CLI launcher (``src/cli.py`` / ``tui_launcher``) creates
+the worktree BEFORE spawning the Ink TUI, and advertises it to the child
+processes via ``CLAWCODEX_WORKTREE_*`` env vars (see :class:`WorktreeSession`).
+The agent-server reads the same vars to service the exit-time ``worktree_status``
+/ ``worktree_exit`` control requests. ``src/cli.py::main`` strips any INHERITED
+``CLAWCODEX_WORKTREE_*`` at entry so a nested clawcodex launched from inside a
+worktree (e.g. by the agent's Bash tool) can never adopt — and delete — the
+outer session's worktree.
+
+Security note on canonical-root resolution: TS validates ``.git`` gitfile /
+commondir backpointers itself (typescript/src/utils/git.ts:126-158) because it
+parses those files in-process. We shell out to ``git rev-parse`` instead —
+git FOLLOWS pointer files but does not enforce TS's backpointer/ancestry
+policy, so a crafted ``.git`` file could still resolve ``--git-common-dir``
+into another repo, landing worktree creation and the settings.local.json copy
+there. Accepted residual risk: the folder-trust gate has already run on the
+launch directory, and the impact is local-integrity-only. Revisit if a
+backend-side trust gate ever lands.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import random
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+MAX_WORKTREE_SLUG_LENGTH = 64
+_VALID_SLUG_SEGMENT = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+WORKTREES_SUBDIR = os.path.join(".claude", "worktrees")
+
+#: Env channel launcher → (Ink TUI, agent-server). Keep in sync with
+#: ``ui-tui/src/lib/worktree.ts``.
+ENV_NAME = "CLAWCODEX_WORKTREE_NAME"
+ENV_PATH = "CLAWCODEX_WORKTREE_PATH"
+ENV_BRANCH = "CLAWCODEX_WORKTREE_BRANCH"
+ENV_ORIGINAL_CWD = "CLAWCODEX_WORKTREE_ORIGINAL_CWD"
+ENV_REPO_ROOT = "CLAWCODEX_WORKTREE_REPO_ROOT"
+ENV_OWNER_PID = "CLAWCODEX_WORKTREE_OWNER_PID"
+ENV_PREFIX = "CLAWCODEX_WORKTREE_"
+
+# Prevent git/SSH from prompting for credentials (which would hang the CLI):
+# GIT_TERMINAL_PROMPT=0 stops git opening /dev/tty; empty GIT_ASKPASS disables
+# askpass GUIs; stdin is DEVNULL on every call below. Mirrors GIT_NO_PROMPT_ENV
+# in the TS reference.
+_GIT_NO_PROMPT_ENV = {"GIT_TERMINAL_PROMPT": "0", "GIT_ASKPASS": ""}
+
+# Slug words for unnamed sessions. Deviation from TS (setup.ts uses
+# getPlanSlug()'s adjective-verb-noun word slug with plan-file-collision
+# retry): ours is adj-noun-<4 base36> retried against worktree-path existence
+# — the actual collision domain here.
+_SLUG_ADJECTIVES = (
+    "swift", "bright", "calm", "keen", "bold", "quiet", "amber", "coral",
+    "misty", "nimble", "lucid", "mellow", "brisk", "sunny", "vivid", "wry",
+)
+_SLUG_NOUNS = (
+    "fox", "owl", "elm", "oak", "ray", "wren", "fern", "reef",
+    "dune", "cove", "peak", "glen", "pine", "brook", "cliff", "vale",
+)
+_SLUG_SUFFIX_ALPHABET = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+
+class WorktreeError(Exception):
+    """A worktree operation failed; ``str(exc)`` is user-presentable."""
+
+
+@dataclass
+class WorktreeSession:
+    """A live ``--worktree`` session, serializable over the env channel."""
+
+    worktree_name: str
+    worktree_path: str
+    worktree_branch: str
+    original_cwd: str
+    repo_root: str
+
+    def to_env(self) -> dict[str, str]:
+        """Env vars advertising this session to child processes.
+
+        ``OWNER_PID`` is the CALLING process — only the launcher that created
+        the worktree ever calls this, and the Ink TUI validates its ppid
+        against it so a stale/leaked env block is ignored.
+        """
+        return {
+            ENV_NAME: self.worktree_name,
+            ENV_PATH: self.worktree_path,
+            ENV_BRANCH: self.worktree_branch,
+            ENV_ORIGINAL_CWD: self.original_cwd,
+            ENV_REPO_ROOT: self.repo_root,
+            ENV_OWNER_PID: str(os.getpid()),
+        }
+
+    @classmethod
+    def from_env(cls, environ: dict[str, str] | os._Environ | None = None) -> "WorktreeSession | None":
+        env = os.environ if environ is None else environ
+        values = {key: env.get(key, "") for key in (ENV_NAME, ENV_PATH, ENV_BRANCH,
+                                                    ENV_ORIGINAL_CWD, ENV_REPO_ROOT)}
+        if not all(values.values()):
+            return None
+        return cls(
+            worktree_name=values[ENV_NAME],
+            worktree_path=values[ENV_PATH],
+            worktree_branch=values[ENV_BRANCH],
+            original_cwd=values[ENV_ORIGINAL_CWD],
+            repo_root=values[ENV_REPO_ROOT],
+        )
+
+
+@dataclass
+class WorktreeChanges:
+    """What would be lost if the worktree were removed right now.
+
+    ``git_ok=False`` means a git command failed — callers MUST fail closed:
+    treat as has-changes, never silent-remove, and render no counts (they are
+    zeroed placeholders, not measurements).
+    """
+
+    git_ok: bool
+    dirty_files: int
+    commits: int
+
+    @property
+    def is_clean(self) -> bool:
+        return self.git_ok and self.dirty_files == 0 and self.commits == 0
+
+
+@dataclass
+class _CreateResult:
+    worktree_path: str
+    worktree_branch: str
+    existed: bool
+    base_branch: str | None = None
+
+
+def _git(
+    args: list[str],
+    cwd: str,
+    timeout: float = 60.0,
+    no_prompt: bool = False,
+) -> tuple[str, str, int]:
+    """Run ``git <args>`` in ``cwd``; (stdout, stderr, rc). Never raises."""
+    env = None
+    if no_prompt:
+        env = {**os.environ, **_GIT_NO_PROMPT_ENV}
+    try:
+        result = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            cwd=cwd,
+            timeout=timeout,
+            stdin=subprocess.DEVNULL,
+            env=env,
+        )
+        return result.stdout.strip(), result.stderr.strip(), result.returncode
+    except subprocess.TimeoutExpired:
+        return "", f"git {' '.join(args[:2])} timed out after {timeout:.0f}s", -1
+    except FileNotFoundError:
+        return "", "git not found on PATH", -1
+    except OSError as exc:
+        return "", str(exc), -1
+
+
+def validate_worktree_slug(slug: str) -> None:
+    """Reject slugs that could escape ``.claude/worktrees/`` (TS parity).
+
+    The slug is joined into the worktrees dir with ``os.path.join``, which
+    normalizes ``..`` segments and discards the prefix for absolute paths —
+    so both must be rejected up front. Forward slashes are allowed for
+    nesting (``user/feature``); each segment is validated independently.
+    Raises :class:`WorktreeError` (callers surface the message verbatim).
+    """
+    if len(slug) > MAX_WORKTREE_SLUG_LENGTH:
+        raise WorktreeError(
+            f"Invalid worktree name: must be {MAX_WORKTREE_SLUG_LENGTH} "
+            f"characters or fewer (got {len(slug)})"
+        )
+    for segment in slug.split("/"):
+        if segment in (".", ".."):
+            raise WorktreeError(
+                f'Invalid worktree name "{slug}": must not contain "." or ".." path segments'
+            )
+        if not _VALID_SLUG_SEGMENT.match(segment):
+            raise WorktreeError(
+                f'Invalid worktree name "{slug}": each "/"-separated segment must be '
+                "non-empty and contain only letters, digits, dots, underscores, and dashes"
+            )
+
+
+def flatten_slug(slug: str) -> str:
+    """``user/feature`` → ``user+feature`` for both branch name and dir name.
+
+    Nesting is unsafe in both places: git refs D/F-conflict
+    (``worktree-user`` file vs ``worktree-user/feature`` dir) and a nested
+    worktree dir lives INSIDE the parent worktree, so removing the parent
+    deletes the child. ``+`` is valid in branch names and paths but not in
+    the slug allowlist, so the mapping is injective (TS parity).
+    """
+    return slug.replace("/", "+")
+
+
+def worktree_branch_name(slug: str) -> str:
+    return f"worktree-{flatten_slug(slug)}"
+
+
+def worktrees_dir(repo_root: str) -> str:
+    return os.path.join(repo_root, WORKTREES_SUBDIR)
+
+
+def worktree_path_for(repo_root: str, slug: str) -> str:
+    return os.path.join(worktrees_dir(repo_root), flatten_slug(slug))
+
+
+def parse_pr_reference(text: str) -> int | None:
+    """``#123`` or a GitHub-style ``…/pull/123`` URL → 123, else None.
+
+    The ``/pull/N`` path shape is GitHub-specific (GitLab uses
+    ``/-/merge_requests/N``, Bitbucket ``/pull-requests/N``), so matching any
+    host is safe (TS parity, incl. GHE hosts).
+    """
+    url_match = re.match(
+        r"^https?://[^/]+/[^/]+/[^/]+/pull/(\d+)/?(?:[?#].*)?$", text, re.IGNORECASE
+    )
+    if url_match:
+        return int(url_match.group(1))
+    hash_match = re.match(r"^#(\d+)$", text)
+    if hash_match:
+        return int(hash_match.group(1))
+    return None
+
+
+def generate_worktree_slug(repo_root: str, max_tries: int = 10) -> str:
+    """Random ``adj-noun-xxxx`` slug whose worktree path doesn't exist yet."""
+    slug = ""
+    for _ in range(max_tries):
+        suffix = "".join(random.choices(_SLUG_SUFFIX_ALPHABET, k=4))
+        slug = f"{random.choice(_SLUG_ADJECTIVES)}-{random.choice(_SLUG_NOUNS)}-{suffix}"
+        if not os.path.exists(worktree_path_for(repo_root, slug)):
+            return slug
+    return slug
+
+
+def find_canonical_git_root(cwd: str) -> str | None:
+    """The MAIN repository root, resolving through linked worktrees.
+
+    ``--git-common-dir`` from inside a linked worktree is ``<main>/.git`` —
+    its parent is the main root. When the common dir is NOT named ``.git``
+    (submodules resolve to ``<super>/.git/modules/<name>``; unusual layouts),
+    fall back to the worktree's own toplevel rather than fabricating a root.
+    See the module docstring for why TS's gitfile backpointer validation is
+    deliberately not replicated here.
+    """
+    out, _, rc = _git(["rev-parse", "--path-format=absolute", "--git-common-dir"], cwd=cwd)
+    if rc == 0 and out:
+        common = Path(out)
+        if common.name == ".git":
+            return str(common.parent)
+    top, _, rc = _git(["rev-parse", "--show-toplevel"], cwd=cwd)
+    return top or None if rc == 0 else None
+
+
+def is_git_repository(cwd: str) -> bool:
+    _, _, rc = _git(["rev-parse", "--is-inside-work-tree"], cwd=cwd)
+    return rc == 0
+
+
+def build_rev_parse_failure_message(base_branch: str, stderr: str, exit_code: int) -> str:
+    """Human-readable message for base-branch resolution failures (TS parity)."""
+    detail = stderr.strip() or f"exit code {exit_code}"
+    hint = (
+        " (HEAD has no resolvable commit — make at least one commit, or check "
+        "whether git is installed and on PATH)"
+        if base_branch == "HEAD"
+        else ""
+    )
+    return f'Failed to resolve base branch "{base_branch}": {detail}{hint}'
+
+
+def _read_resumable_worktree(worktree_path: str) -> bool:
+    """True iff ``worktree_path`` is an existing LINKED worktree we can resume.
+
+    The gate requires ``<path>/.git`` to exist as a FILE (a linked worktree's
+    gitfile pointer) before trusting ``rev-parse``: inside an orphaned plain
+    directory, ``git -C <path> rev-parse HEAD`` walks UP and reports the main
+    repo's HEAD — "resuming" into an unisolated subdirectory of the main tree.
+    Mirrors TS ``readWorktreeHeadSha`` reading the gitfile directly.
+    """
+    gitfile = Path(worktree_path) / ".git"
+    if not gitfile.is_file():
+        return False
+    _, _, rc = _git(["rev-parse", "--verify", "HEAD"], cwd=worktree_path)
+    return rc == 0
+
+
+def _get_or_create_worktree(
+    repo_root: str, slug: str, pr_number: int | None = None
+) -> _CreateResult:
+    """Create the worktree for ``slug``, or resume it if it already exists."""
+    worktree_path = worktree_path_for(repo_root, slug)
+    branch = worktree_branch_name(slug)
+
+    if _read_resumable_worktree(worktree_path):
+        return _CreateResult(worktree_path=worktree_path, worktree_branch=branch, existed=True)
+
+    os.makedirs(worktrees_dir(repo_root), exist_ok=True)
+
+    # ── base resolution (TS order) ──
+    base_branch: str
+    if pr_number is not None:
+        _, fetch_err, fetch_rc = _git(
+            ["fetch", "origin", f"pull/{pr_number}/head"],
+            cwd=repo_root, timeout=300.0, no_prompt=True,
+        )
+        if fetch_rc != 0:
+            raise WorktreeError(
+                f"Failed to fetch PR #{pr_number}: "
+                + (fetch_err.strip() or 'PR may not exist or the repository may not have a remote named "origin"')
+            )
+        base_branch = "FETCH_HEAD"
+    else:
+        from src.utils.git import get_default_branch
+
+        default_branch = get_default_branch(repo_root)
+        origin_ref = f"origin/{default_branch}"
+        _, _, local_rc = _git(
+            ["rev-parse", "--verify", "--quiet", f"refs/remotes/origin/{default_branch}"],
+            cwd=repo_root,
+        )
+        if local_rc == 0:
+            # origin/<branch> already known locally: skip the fetch. A slightly
+            # stale base is fine — the user can pull inside the worktree.
+            base_branch = origin_ref
+        else:
+            _, _, fetch_rc = _git(
+                ["fetch", "origin", default_branch],
+                cwd=repo_root, timeout=300.0, no_prompt=True,
+            )
+            base_branch = origin_ref if fetch_rc == 0 else "HEAD"
+
+    _, sha_err, sha_rc = _git(["rev-parse", base_branch], cwd=repo_root)
+    if sha_rc != 0:
+        raise WorktreeError(build_rev_parse_failure_message(base_branch, sha_err, sha_rc))
+
+    # -B (not -b): reset an orphan branch left behind by a removed worktree
+    # dir instead of failing (TS parity).
+    _, add_err, add_rc = _git(
+        ["worktree", "add", "-B", branch, worktree_path, base_branch],
+        cwd=repo_root, timeout=600.0,
+    )
+    if add_rc != 0:
+        message = f"Failed to create worktree: {add_err.strip()}"
+        if os.path.exists(worktree_path):
+            # Never auto-delete a directory we don't understand (e.g. a
+            # half-removed worktree after a kill): fail loud with a hint.
+            message += (
+                f"\nA non-worktree directory already exists at {worktree_path}. "
+                'Run "git worktree prune" and remove the directory if it is a '
+                "leftover, then retry."
+            )
+        raise WorktreeError(message)
+
+    return _CreateResult(
+        worktree_path=worktree_path, worktree_branch=branch,
+        existed=False, base_branch=base_branch,
+    )
+
+
+def _copy_local_settings(repo_root: str, worktree_path: str) -> None:
+    """Propagate local settings (permission grants, hook config the worktree
+    session needs) — best-effort, TS parity.
+
+    Two tiers, both copied when present: clawcodex's own project tier
+    (``.clawcodex/settings.local.json`` — permission rules; namespaced away
+    from the real Claude Code harness, see src/permissions/settings_paths.py)
+    and the harness-compatible ``.claude/settings.local.json`` (read for
+    hooks; the tier TS itself copies).
+    """
+    from src.permissions.settings_paths import local_settings_path
+
+    sources = [
+        local_settings_path(repo_root),
+        os.path.join(repo_root, ".claude", "settings.local.json"),
+    ]
+    for source in sources:
+        rel = os.path.relpath(source, repo_root)
+        dest = os.path.join(worktree_path, rel)
+        try:
+            if os.path.isfile(source):
+                os.makedirs(os.path.dirname(dest), exist_ok=True)
+                shutil.copyfile(source, dest)
+        except OSError as exc:
+            logger.warning("[worktree] failed to copy %s: %s", rel, exc)
+
+
+def _configure_hooks_path(repo_root: str, worktree_path: str) -> None:
+    """Point the shared repo config at the main repo's hooks dir so relative
+    ``.husky``-style hooks keep working from inside the worktree (TS parity,
+    minus the config-read memoization)."""
+    for candidate in (os.path.join(repo_root, ".husky"),
+                      os.path.join(repo_root, ".git", "hooks")):
+        if os.path.isdir(candidate):
+            _, err, rc = _git(["config", "core.hooksPath", candidate], cwd=worktree_path)
+            if rc != 0:
+                logger.warning("[worktree] failed to configure hooks path: %s", err)
+            return
+
+
+def copy_worktree_include_files(repo_root: str, worktree_path: str) -> list[str]:
+    """Copy gitignored files matched by ``.worktreeinclude`` into the worktree.
+
+    Only files that are BOTH matched by a ``.worktreeinclude`` pattern
+    (.gitignore syntax, via ``pathspec``) AND gitignored are copied — e.g.
+    ``.env`` files a fresh checkout lacks. Uses ``git ls-files … --directory``
+    so fully-ignored dirs (node_modules/…) collapse to one entry, expanding a
+    collapsed dir only when a pattern explicitly targets inside it (TS parity).
+    """
+    include_file = os.path.join(repo_root, ".worktreeinclude")
+    try:
+        with open(include_file, encoding="utf-8") as fh:
+            include_content = fh.read()
+    except OSError:
+        return []
+
+    patterns = [
+        line.strip() for line in include_content.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    if not patterns:
+        return []
+
+    import pathspec
+
+    try:
+        # GitIgnoreSpec = .gitignore semantics — the same contract as the
+        # `ignore` npm library the TS reference matches with.
+        spec = pathspec.GitIgnoreSpec.from_lines(patterns)
+    except Exception as exc:  # noqa: BLE001 — malformed user patterns
+        logger.warning("[worktree] invalid .worktreeinclude patterns: %s", exc)
+        return []
+
+    listed, _, rc = _git(
+        ["ls-files", "--others", "--ignored", "--exclude-standard", "--directory"],
+        cwd=repo_root, timeout=300.0,
+    )
+    if rc != 0 or not listed:
+        return []
+
+    entries = [entry for entry in listed.splitlines() if entry]
+    collapsed_dirs = [entry for entry in entries if entry.endswith("/")]
+    files = [entry for entry in entries if not entry.endswith("/") and spec.match_file(entry)]
+
+    def _should_expand(directory: str) -> bool:
+        for pattern in patterns:
+            normalized = pattern[1:] if pattern.startswith("/") else pattern
+            if normalized.startswith(directory):
+                return True
+            glob_match = re.search(r"[*?\[]", normalized)
+            if glob_match and glob_match.start() > 0:
+                literal_prefix = normalized[: glob_match.start()]
+                if directory.startswith(literal_prefix):
+                    return True
+        return spec.match_file(directory.rstrip("/"))
+
+    dirs_to_expand = [d for d in collapsed_dirs if _should_expand(d)]
+    if dirs_to_expand:
+        expanded, _, rc = _git(
+            ["ls-files", "--others", "--ignored", "--exclude-standard", "--", *dirs_to_expand],
+            cwd=repo_root, timeout=300.0,
+        )
+        if rc == 0 and expanded:
+            files.extend(f for f in expanded.splitlines() if f and spec.match_file(f))
+
+    copied: list[str] = []
+    for relative in files:
+        src = os.path.join(repo_root, relative)
+        dest = os.path.join(worktree_path, relative)
+        try:
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            shutil.copyfile(src, dest)
+            copied.append(relative)
+        except OSError as exc:
+            logger.warning("[worktree] failed to copy %s: %s", relative, exc)
+    if copied:
+        logger.info("[worktree] copied %d files from .worktreeinclude", len(copied))
+    return copied
+
+
+def _post_creation_setup(repo_root: str, worktree_path: str) -> None:
+    _copy_local_settings(repo_root, worktree_path)
+    _configure_hooks_path(repo_root, worktree_path)
+    copy_worktree_include_files(repo_root, worktree_path)
+
+
+def create_worktree_for_session(
+    slug: str | None,
+    cwd: str | None = None,
+    pr_number: int | None = None,
+) -> WorktreeSession:
+    """Create or resume the session worktree; raises :class:`WorktreeError`.
+
+    ``slug=None`` generates a random name. A PR-based session should pass
+    both the ``pr-<n>`` slug and ``pr_number`` (see the CLI wiring).
+    """
+    original_cwd = os.path.abspath(cwd or os.getcwd())
+
+    if not is_git_repository(original_cwd):
+        raise WorktreeError(
+            f"Can only use --worktree in a git repository, but {original_cwd} "
+            "is not a git repository. (WorktreeCreate hooks for other VCS "
+            "systems are not supported in clawcodex yet.)"
+        )
+
+    repo_root = find_canonical_git_root(original_cwd)
+    if not repo_root:
+        raise WorktreeError("Could not determine the main git repository root.")
+
+    if slug is None:
+        slug = generate_worktree_slug(repo_root)
+    validate_worktree_slug(slug)
+
+    result = _get_or_create_worktree(repo_root, slug, pr_number=pr_number)
+    if result.existed:
+        logger.info("[worktree] resuming existing worktree at %s", result.worktree_path)
+    else:
+        logger.info(
+            "[worktree] created %s on branch %s (base %s)",
+            result.worktree_path, result.worktree_branch, result.base_branch,
+        )
+        _post_creation_setup(repo_root, result.worktree_path)
+
+    return WorktreeSession(
+        worktree_name=slug,
+        worktree_path=result.worktree_path,
+        worktree_branch=result.worktree_branch,
+        original_cwd=original_cwd,
+        repo_root=repo_root,
+    )
+
+
+def create_session_from_cli_option(
+    option: bool | str, cwd: str | None = None
+) -> WorktreeSession:
+    """CLI adapter: ``--worktree`` (bare → ``True``) or ``--worktree NAME``.
+
+    ``NAME`` may be a PR reference (``#123`` or a GitHub-style PR URL) —
+    those become slug ``pr-<n>`` based on ``pull/<n>/head`` (TS parity).
+    """
+    slug: str | None = None
+    pr_number: int | None = None
+    if isinstance(option, str):
+        pr_number = parse_pr_reference(option)
+        slug = f"pr-{pr_number}" if pr_number is not None else option
+    return create_worktree_for_session(slug, cwd=cwd, pr_number=pr_number)
+
+
+def worktree_changes(session: WorktreeSession) -> WorktreeChanges:
+    """Measure what removal would lose. Fail-closed on any git failure.
+
+    ``commits`` counts commits reachable from HEAD but from no SURVIVING ref:
+    the worktree's own branch is excluded (cleanup is about to ``branch -D``
+    it), every other local branch and all remotes count as safe keepers.
+    Deviation from TS's ``base..HEAD`` (which under-counts on resumed
+    worktrees — the resumed base is HEAD-at-resume — letting the silent-remove
+    path discard committed unmerged work): the lost-set is safer and also
+    avoids TS's false warning on merged-back work. The exclude pattern MUST be
+    the branch's short name — ``refs/heads/<branch>`` silently fails to match
+    ``--branches`` (patterns match after prefix-stripping), which would zero
+    the count and flip the failure into silent data loss.
+    """
+    status_out, _, status_rc = _git(["status", "--porcelain"], cwd=session.worktree_path)
+    if status_rc != 0:
+        return WorktreeChanges(git_ok=False, dirty_files=0, commits=0)
+    dirty_files = len([line for line in status_out.splitlines() if line.strip()])
+
+    count_out, _, count_rc = _git(
+        ["rev-list", "--count", "HEAD", "--not",
+         f"--exclude={session.worktree_branch}", "--branches", "--remotes"],
+        cwd=session.worktree_path,
+    )
+    try:
+        commits = int(count_out)
+    except ValueError:
+        count_rc = -1
+        commits = 0
+    if count_rc != 0:
+        return WorktreeChanges(git_ok=False, dirty_files=dirty_files, commits=0)
+
+    return WorktreeChanges(git_ok=True, dirty_files=dirty_files, commits=commits)
+
+
+def cleanup_worktree(session: WorktreeSession) -> tuple[bool, str]:
+    """Remove the worktree directory and its branch. Returns ``(ok, error)``.
+
+    Branch deletion is best-effort (TS parity): a failure there is logged but
+    doesn't fail the removal.
+    """
+    _, remove_err, remove_rc = _git(
+        ["worktree", "remove", "--force", session.worktree_path],
+        cwd=session.repo_root, timeout=600.0,
+    )
+    if remove_rc != 0:
+        return False, remove_err.strip() or "git worktree remove failed"
+
+    _, branch_err, branch_rc = _git(
+        ["branch", "-D", session.worktree_branch], cwd=session.repo_root
+    )
+    if branch_rc != 0:
+        logger.warning("[worktree] could not delete branch %s: %s",
+                       session.worktree_branch, branch_err)
+    return True, ""
+
+
+def keep_message(session: WorktreeSession) -> str:
+    return (
+        f"Worktree kept. Your work is saved at {session.worktree_path} "
+        f"on branch {session.worktree_branch}"
+    )
+
+
+def removal_message(session: WorktreeSession, changes: WorktreeChanges) -> str:
+    """TS WorktreeExitDialog wording matrix for the removal result."""
+    commits, dirty = changes.commits, changes.dirty_files
+    if not changes.git_ok:
+        return "Worktree removed."
+    if commits > 0 and dirty > 0:
+        noun = "commit" if commits == 1 else "commits"
+        return f"Worktree removed. {commits} {noun} and uncommitted changes were discarded."
+    if commits > 0:
+        noun = "commit" if commits == 1 else "commits"
+        verb = "was" if commits == 1 else "were"
+        return (f"Worktree removed. {commits} {noun} on "
+                f"{session.worktree_branch} {verb} discarded.")
+    if dirty > 0:
+        return "Worktree removed. Uncommitted changes were discarded."
+    return "Worktree removed (no changes)"
+
+
+def strip_worktree_env(environ: os._Environ | dict[str, str] | None = None) -> None:
+    """Delete every inherited ``CLAWCODEX_WORKTREE_*`` var (nested-session
+    hygiene — see module docstring). Call at CLI entry, before anything
+    snapshots the environment."""
+    env = os.environ if environ is None else environ
+    for key in [k for k in env if k.startswith(ENV_PREFIX)]:
+        del env[key]

--- a/tests/entrypoints/test_worktree_cli_wiring.py
+++ b/tests/entrypoints/test_worktree_cli_wiring.py
@@ -1,0 +1,171 @@
+"""--worktree CLI wiring: parser shapes, nested-env hygiene at cli entry,
+launcher env plumbing, and the headless keep-note path."""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.cli import _build_parser, _maybe_create_worktree, _WORKTREE_FAILED
+from src.entrypoints.tui_launcher import _child_env
+from src.utils.worktree_session import ENV_OWNER_PID, ENV_PATH, WorktreeSession
+
+
+# ── parser ───────────────────────────────────────────────────────────────────
+
+def test_parser_bare_flag_means_generate_name():
+    args = _build_parser().parse_args(["-w", "-p", "hi"])
+    assert args.worktree is True
+    assert args.prompt == "hi"
+
+
+def test_parser_flag_with_name_and_eq_form():
+    assert _build_parser().parse_args(["--worktree", "fix-auth"]).worktree == "fix-auth"
+    assert _build_parser().parse_args(["--worktree=fix-auth"]).worktree == "fix-auth"
+    assert _build_parser().parse_args(["-w", "#123", "-p"]).worktree == "#123"
+
+
+def test_parser_default_is_off():
+    assert _build_parser().parse_args([]).worktree is None
+
+
+# ── _maybe_create_worktree ───────────────────────────────────────────────────
+
+def test_maybe_create_returns_none_without_flag():
+    assert _maybe_create_worktree(SimpleNamespace(worktree=None)) is None
+
+
+def test_maybe_create_reports_failure_outside_git_repo(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    result = _maybe_create_worktree(SimpleNamespace(worktree=True))
+    assert result is _WORKTREE_FAILED
+    err = capsys.readouterr().err
+    assert "Error creating worktree" in err
+    assert "git repository" in err
+
+
+# ── env hygiene (critic B1: nested sessions must never adopt the outer one) ──
+
+def test_cli_main_strips_inherited_worktree_env():
+    from src.cli import main
+
+    inherited = {
+        ENV_PATH: "/outer/.claude/worktrees/x",
+        "CLAWCODEX_WORKTREE_NAME": "x",
+        "CLAWCODEX_WORKTREE_BRANCH": "worktree-x",
+        "CLAWCODEX_WORKTREE_ORIGINAL_CWD": "/outer",
+        "CLAWCODEX_WORKTREE_REPO_ROOT": "/outer",
+        ENV_OWNER_PID: "12345",
+    }
+    with patch.dict(os.environ, inherited):
+        # --version is the cheapest full pass through main()'s entry block.
+        with patch("sys.argv", ["clawcodex", "--version"]):
+            main()
+        for key in inherited:
+            assert key not in os.environ, f"{key} leaked through cli entry"
+
+
+# ── launcher env plumbing ────────────────────────────────────────────────────
+
+def _launcher_args(worktree: WorktreeSession | None) -> SimpleNamespace:
+    return SimpleNamespace(
+        provider=None, model=None, permission_mode="default",
+        is_bypass_available=False, worktree_session=worktree,
+    )
+
+
+def test_child_env_carries_worktree_block_with_owner_pid():
+    session = WorktreeSession(
+        worktree_name="feat", worktree_path="/r/.claude/worktrees/feat",
+        worktree_branch="worktree-feat", original_cwd="/r", repo_root="/r",
+    )
+    env = _child_env(_launcher_args(session))
+    assert env[ENV_PATH] == "/r/.claude/worktrees/feat"
+    assert env["CLAWCODEX_WORKTREE_NAME"] == "feat"
+    assert env["CLAWCODEX_WORKTREE_BRANCH"] == "worktree-feat"
+    assert env["CLAWCODEX_WORKTREE_ORIGINAL_CWD"] == "/r"
+    assert env["CLAWCODEX_WORKTREE_REPO_ROOT"] == "/r"
+    assert env[ENV_OWNER_PID] == str(os.getpid())
+
+
+def test_child_env_has_no_worktree_block_without_session():
+    env = _child_env(_launcher_args(None))
+    assert not any(k.startswith("CLAWCODEX_WORKTREE_") for k in env)
+
+
+# ── headless keep note ───────────────────────────────────────────────────────
+
+def _headless_args(**overrides):
+    base = dict(
+        prompt="hi", output_format="text", input_format="text",
+        include_partial_messages=False, max_turns=1, model=None,
+        fallback_model=None, provider=None, allowed_tools=None,
+        disallowed_tools=None, verbose=False,
+        dangerously_skip_permissions=False,
+        _resolved_permission_mode="default",
+        _resolved_is_bypass_available=False,
+        worktree=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_print_mode_chdirs_into_worktree_and_prints_keep_note(tmp_path, monkeypatch, capsys):
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git_env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+               "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True, env=git_env)
+    (repo / "f.txt").write_text("x")
+    subprocess.run(["git", "add", "f.txt"], cwd=repo, check=True, env=git_env)
+    subprocess.run(["git", "commit", "-q", "-m", "i"], cwd=repo, check=True, env=git_env)
+    monkeypatch.chdir(repo)
+
+    from src import cli
+
+    seen = {}
+
+    def fake_run_headless(options):
+        seen["cwd"] = os.getcwd()
+        return 0
+
+    with patch("src.entrypoints.headless.run_headless", fake_run_headless):
+        rc = cli._run_print_mode(_headless_args(worktree="headless-wt"))
+
+    assert rc == 0
+    expected_wt = str(repo / ".claude" / "worktrees" / "headless-wt")
+    assert os.path.realpath(seen["cwd"]) == os.path.realpath(expected_wt)
+    err = capsys.readouterr().err
+    assert "Worktree kept at" in err
+    assert "headless-wt" in err
+    assert os.path.isdir(expected_wt)  # headless always keeps
+
+
+def test_print_mode_keep_note_survives_run_errors(tmp_path, monkeypatch, capsys):
+    import subprocess
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    git_env = {**os.environ, "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+               "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"}
+    subprocess.run(["git", "init", "-q", "-b", "main"], cwd=repo, check=True, env=git_env)
+    (repo / "f.txt").write_text("x")
+    subprocess.run(["git", "add", "f.txt"], cwd=repo, check=True, env=git_env)
+    subprocess.run(["git", "commit", "-q", "-m", "i"], cwd=repo, check=True, env=git_env)
+    monkeypatch.chdir(repo)
+
+    from src import cli
+
+    def exploding_run_headless(options):
+        raise RuntimeError("boom")
+
+    with patch("src.entrypoints.headless.run_headless", exploding_run_headless):
+        try:
+            cli._run_print_mode(_headless_args(worktree="errpath"))
+        except RuntimeError:
+            pass
+
+    assert "Worktree kept at" in capsys.readouterr().err

--- a/tests/server/test_worktree_controls.py
+++ b/tests/server/test_worktree_controls.py
@@ -1,0 +1,204 @@
+"""Agent-server ``worktree_status`` / ``worktree_exit`` controls (--worktree).
+
+The env block (``CLAWCODEX_WORKTREE_*``) is the channel the launcher uses to
+advertise the session; the controls are gated on ``single_session`` (stdio
+transport) so a multi-session --http server can never expose one client's
+worktree to another.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.server.agent_server import AgentServerConfig, _AgentSession
+from src.utils.worktree_session import create_worktree_for_session
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True,
+        env={**os.environ,
+             "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture(autouse=True)
+def _restore_cwd():
+    """worktree_exit's remove path os.chdir()s (so the dying backend doesn't
+    hold its cwd inside the removed dir) — in tests the process lives on and
+    the target is a pytest tmp dir that gets cleaned up, so restore."""
+    before = os.getcwd()
+    try:
+        yield
+    finally:
+        os.chdir(before)
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    (root / "README.md").write_text("hi\n")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "-q", "-m", "initial")
+    return root
+
+
+def _make_session(single_session: bool = True) -> tuple[_AgentSession, list[dict]]:
+    emitted: list[dict] = []
+    sess = _AgentSession(
+        session_id="wt-sess", cwd="/tmp",
+        config=AgentServerConfig(single_session=single_session),
+        loop=MagicMock(), out_queue=MagicMock(),
+    )
+    sess._emit = lambda env: emitted.append(env)  # type: ignore[method-assign]
+    return sess, emitted
+
+
+def _control(sess: _AgentSession, subtype: str, **params) -> None:
+    asyncio.run(sess._handle_control_request({
+        "type": "control_request",
+        "request_id": "req-1",
+        "request": {"subtype": subtype, **params},
+    }))
+
+
+def _last_reply(emitted: list[dict]) -> dict:
+    for env in reversed(emitted):
+        if env.get("type") == "control_response":
+            return env["response"]["response"]
+    raise AssertionError(f"no control_response in {emitted!r}")
+
+
+def _env_for(repo: Path, name: str) -> dict[str, str]:
+    session = create_worktree_for_session(name, cwd=str(repo))
+    return session.to_env()
+
+
+def test_status_reports_inactive_without_env():
+    sess, emitted = _make_session()
+    clean_env = {k: v for k, v in os.environ.items()
+                 if not k.startswith("CLAWCODEX_WORKTREE_")}
+    with patch.dict(os.environ, clean_env, clear=True):
+        _control(sess, "worktree_status")
+    reply = _last_reply(emitted)
+    assert reply == {"ok": True, "active": False}
+
+
+def test_status_reports_counts_for_active_worktree(repo):
+    env = _env_for(repo, "status-wt")
+    wt_path = env["CLAWCODEX_WORKTREE_PATH"]
+    (Path(wt_path) / "dirty.txt").write_text("x")
+
+    sess, emitted = _make_session()
+    with patch.dict(os.environ, env):
+        _control(sess, "worktree_status")
+    reply = _last_reply(emitted)
+    assert reply["ok"] is True
+    assert reply["active"] is True
+    assert reply["name"] == "status-wt"
+    assert reply["branch"] == "worktree-status-wt"
+    assert reply["path"] == wt_path
+    assert reply["git_ok"] is True
+    assert reply["dirty_files"] == 1
+    assert reply["commits"] == 0
+
+
+def test_controls_are_gated_off_multi_session_transports(repo):
+    # Process-wide env on --http would let ANY WS client remove a worktree it
+    # doesn't own; the gate reports inactive / refuses.
+    env = _env_for(repo, "http-wt")
+    sess, emitted = _make_session(single_session=False)
+    with patch.dict(os.environ, env):
+        _control(sess, "worktree_status")
+        status = _last_reply(emitted)
+        _control(sess, "worktree_exit", action="remove")
+        exit_reply = _last_reply(emitted)
+    assert status == {"ok": True, "active": False}
+    assert exit_reply["ok"] is False
+    assert os.path.isdir(env["CLAWCODEX_WORKTREE_PATH"])  # untouched
+
+
+def test_exit_keep_replies_message_and_marks_done(repo):
+    env = _env_for(repo, "keeper")
+    sess, emitted = _make_session()
+    with patch.dict(os.environ, env):
+        _control(sess, "worktree_exit", action="keep")
+        keep = _last_reply(emitted)
+        _control(sess, "worktree_exit", action="keep")
+        second = _last_reply(emitted)
+        _control(sess, "worktree_status")
+        status = _last_reply(emitted)
+    assert keep["ok"] is True
+    assert "Worktree kept" in keep["message"]
+    assert env["CLAWCODEX_WORKTREE_PATH"] in keep["message"]
+    assert os.path.isdir(env["CLAWCODEX_WORKTREE_PATH"])
+    # done-latch: the flow is one-shot per session
+    assert second["ok"] is False
+    assert status == {"ok": True, "active": False}
+
+
+def test_exit_remove_deletes_worktree_and_reports_no_changes(repo):
+    env = _env_for(repo, "removee")
+    sess, emitted = _make_session()
+    with patch.dict(os.environ, env):
+        _control(sess, "worktree_exit", action="remove")
+    reply = _last_reply(emitted)
+    assert reply["ok"] is True
+    assert reply["message"] == "Worktree removed (no changes)"
+    assert not os.path.exists(env["CLAWCODEX_WORKTREE_PATH"])
+    assert _git(repo, "branch", "--list", "worktree-removee") == ""
+
+
+def test_exit_remove_reports_discarded_work(repo):
+    env = _env_for(repo, "discard")
+    wt = Path(env["CLAWCODEX_WORKTREE_PATH"])
+    (wt / "new.txt").write_text("x")
+    _git(wt, "add", "new.txt")
+    _git(wt, "commit", "-q", "-m", "wip")
+    (wt / "extra.txt").write_text("y")
+
+    sess, emitted = _make_session()
+    with patch.dict(os.environ, env):
+        _control(sess, "worktree_exit", action="remove")
+    reply = _last_reply(emitted)
+    assert reply["ok"] is True
+    assert reply["message"] == (
+        "Worktree removed. 1 commit and uncommitted changes were discarded."
+    )
+    assert not os.path.exists(str(wt))
+
+
+def test_exit_remove_failure_reports_error_and_stays_active(repo):
+    env = _env_for(repo, "stubborn")
+    env["CLAWCODEX_WORKTREE_PATH"] = "/nonexistent/nowhere"
+    sess, emitted = _make_session()
+    with patch.dict(os.environ, env):
+        _control(sess, "worktree_exit", action="remove")
+        failed = _last_reply(emitted)
+        _control(sess, "worktree_status")
+        status = _last_reply(emitted)
+    assert failed["ok"] is False
+    assert failed["error"]
+    # NOT latched done — the client may retry or fall back to keep.
+    assert status["active"] is True
+
+
+def test_exit_invalid_action_is_rejected(repo):
+    env = _env_for(repo, "badaction")
+    sess, emitted = _make_session()
+    with patch.dict(os.environ, env):
+        _control(sess, "worktree_exit", action="explode")
+    reply = _last_reply(emitted)
+    assert reply["ok"] is False
+    assert "explode" in reply["error"]
+    assert os.path.isdir(env["CLAWCODEX_WORKTREE_PATH"])

--- a/tests/server/test_worktree_controls.py
+++ b/tests/server/test_worktree_controls.py
@@ -202,3 +202,47 @@ def test_exit_invalid_action_is_rejected(repo):
     assert reply["ok"] is False
     assert "explode" in reply["error"]
     assert os.path.isdir(env["CLAWCODEX_WORKTREE_PATH"])
+
+
+def test_exit_remove_is_refused_during_an_active_turn(repo):
+    """Idle-only, like every destructive control (critic MAJOR): the turn
+    runs on the worker thread while controls run on the main loop — removal
+    mid-turn would delete the directory out from under live tool calls."""
+    from src.utils.abort_controller import AbortController
+
+    env = _env_for(repo, "busy-wt")
+    sess, emitted = _make_session()
+    sess._current_abort = AbortController()
+    with patch.dict(os.environ, env):
+        _control(sess, "worktree_exit", action="remove")
+        refused = _last_reply(emitted)
+        # keep stays allowed mid-turn — it deletes nothing.
+        _control(sess, "worktree_exit", action="keep")
+        kept = _last_reply(emitted)
+    assert refused["ok"] is False
+    assert "active turn" in refused["error"]
+    assert os.path.isdir(env["CLAWCODEX_WORKTREE_PATH"])  # untouched
+    assert kept["ok"] is True
+
+
+def test_exit_remove_refuses_forged_branch_or_foreign_path(repo):
+    """Defense-in-depth (critic): a split env block must not turn the
+    best-effort `branch -D` into deleting an arbitrary branch, nor point
+    removal outside .claude/worktrees/."""
+    env = _env_for(repo, "forged")
+    sess, emitted = _make_session()
+    with patch.dict(os.environ, {**env, "CLAWCODEX_WORKTREE_BRANCH": "main"}):
+        _control(sess, "worktree_exit", action="remove")
+    forged_branch = _last_reply(emitted)
+    assert forged_branch["ok"] is False
+    assert "worktree-" in forged_branch["error"]
+    assert _git(repo, "branch", "--list", "main").strip() != ""  # main survives
+
+    outside = repo.parent / "outside-dir"
+    outside.mkdir(exist_ok=True)
+    with patch.dict(os.environ, {**env, "CLAWCODEX_WORKTREE_PATH": str(outside)}):
+        _control(sess, "worktree_exit", action="remove")
+    foreign_path = _last_reply(emitted)
+    assert foreign_path["ok"] is False
+    assert "outside" in foreign_path["error"]
+    assert outside.is_dir()  # untouched

--- a/tests/utils/test_worktree_session.py
+++ b/tests/utils/test_worktree_session.py
@@ -1,0 +1,419 @@
+"""Unit tests for src/utils/worktree_session.py (the --worktree feature core).
+
+Temp-repo tests drive real git — creation, fast-resume, orphan-dir rejection,
+the lost-commit matrix (critic-mandated: the --exclude short-name form), and
+cleanup. No network: repos are remote-less unless a test adds a local remote.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src.utils.worktree_session import (
+    ENV_OWNER_PID,
+    ENV_PATH,
+    ENV_PREFIX,
+    WorktreeError,
+    WorktreeSession,
+    cleanup_worktree,
+    create_session_from_cli_option,
+    create_worktree_for_session,
+    find_canonical_git_root,
+    flatten_slug,
+    generate_worktree_slug,
+    keep_message,
+    parse_pr_reference,
+    removal_message,
+    strip_worktree_env,
+    validate_worktree_slug,
+    worktree_branch_name,
+    worktree_changes,
+    worktree_path_for,
+    worktrees_dir,
+)
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True, check=True,
+        env={**os.environ,
+             "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+             "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t"},
+    )
+    return result.stdout.strip()
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    """A remote-less repo with one initial commit (empty repos fail base
+    resolution by design — HEAD is unresolvable)."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(root, "init", "-q", "-b", "main")
+    (root / "README.md").write_text("hello\n")
+    _git(root, "add", "README.md")
+    _git(root, "commit", "-q", "-m", "initial")
+    return root
+
+
+# ── slug validation ──────────────────────────────────────────────────────────
+
+def test_validate_slug_accepts_ts_allowlist():
+    for slug in ("feature", "user/feature", "a.b_c-d", "pr-123", "A" * 64):
+        validate_worktree_slug(slug)
+
+
+@pytest.mark.parametrize("slug", [
+    "../escape", "..", ".", "a/../b", "/abs", "a//b", "a/", "/",
+    "spaces bad", "semi;colon", "a" * 65, "back\\slash", "tilde~",
+])
+def test_validate_slug_rejects_escapes_and_bad_chars(slug):
+    with pytest.raises(WorktreeError):
+        validate_worktree_slug(slug)
+
+
+def test_flatten_slug_is_injective_over_allowed_alphabet():
+    # '+' is not in the slug allowlist, so '/'→'+' cannot collide with a
+    # literal slug (TS parity rationale).
+    assert flatten_slug("user/feature") == "user+feature"
+    assert worktree_branch_name("user/feature") == "worktree-user+feature"
+    with pytest.raises(WorktreeError):
+        validate_worktree_slug("user+feature")
+
+
+def test_paths_flatten_nested_slugs(repo):
+    path = worktree_path_for(str(repo), "user/feature")
+    assert path == str(repo / ".claude" / "worktrees" / "user+feature")
+    assert worktrees_dir(str(repo)) == str(repo / ".claude" / "worktrees")
+
+
+# ── PR references ────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("text,expected", [
+    ("#123", 123),
+    ("https://github.com/owner/repo/pull/45", 45),
+    ("https://github.com/owner/repo/pull/45/", 45),
+    ("https://github.com/owner/repo/pull/45?tab=files", 45),
+    ("https://ghe.example.com/o/r/pull/7#discussion", 7),
+    ("http://github.com/o/r/pull/9", 9),
+    ("123", None),
+    ("#12a", None),
+    ("https://gitlab.com/o/r/-/merge_requests/3", None),
+    ("pull/45", None),
+])
+def test_parse_pr_reference(text, expected):
+    assert parse_pr_reference(text) == expected
+
+
+# ── env round-trip + hygiene ─────────────────────────────────────────────────
+
+def test_env_round_trip_and_owner_pid():
+    session = WorktreeSession(
+        worktree_name="x", worktree_path="/r/.claude/worktrees/x",
+        worktree_branch="worktree-x", original_cwd="/r", repo_root="/r",
+    )
+    env = session.to_env()
+    assert env[ENV_OWNER_PID] == str(os.getpid())
+    assert WorktreeSession.from_env(env) == session
+
+
+def test_from_env_requires_every_var():
+    env = WorktreeSession(
+        worktree_name="x", worktree_path="/p", worktree_branch="b",
+        original_cwd="/r", repo_root="/r",
+    ).to_env()
+    for key in list(env):
+        if key == ENV_OWNER_PID:
+            continue  # owner pid is a client-side (TUI) gate, not required here
+        partial = {k: v for k, v in env.items() if k != key}
+        assert WorktreeSession.from_env(partial) is None
+
+
+def test_strip_worktree_env_removes_inherited_block():
+    # Nested-session hygiene: a clawcodex spawned inside a --worktree session
+    # inherits the block; cli.main strips it so the nested TUI can never adopt
+    # (and clean-exit-delete) the outer session's worktree.
+    env = {ENV_PATH: "/outer", f"{ENV_PREFIX}NAME": "outer", "OTHER": "keep"}
+    strip_worktree_env(env)
+    assert env == {"OTHER": "keep"}
+
+
+# ── creation / resume ────────────────────────────────────────────────────────
+
+def test_create_worktree_for_session_creates_dir_and_branch(repo):
+    session = create_worktree_for_session("feat-x", cwd=str(repo))
+    assert session.worktree_path == str(repo / ".claude" / "worktrees" / "feat-x")
+    assert session.worktree_branch == "worktree-feat-x"
+    assert session.repo_root == str(repo)
+    assert (Path(session.worktree_path) / ".git").is_file()
+    assert (Path(session.worktree_path) / "README.md").read_text() == "hello\n"
+    assert "worktree-feat-x" in _git(repo, "branch", "--list", "worktree-feat-x")
+
+
+def test_create_from_subdirectory_lands_in_repo_root(repo):
+    sub = repo / "src"
+    sub.mkdir()
+    session = create_worktree_for_session("from-sub", cwd=str(sub))
+    assert session.repo_root == str(repo)
+    assert session.worktree_path.startswith(str(repo / ".claude"))
+    assert session.original_cwd == str(sub)
+
+
+def test_resume_existing_worktree_preserves_work(repo):
+    first = create_worktree_for_session("keeper", cwd=str(repo))
+    marker = Path(first.worktree_path) / "wip.txt"
+    marker.write_text("in progress\n")
+
+    second = create_worktree_for_session("keeper", cwd=str(repo))
+    assert second.worktree_path == first.worktree_path
+    assert marker.read_text() == "in progress\n"  # resume, not recreate
+
+
+def test_creating_inside_a_worktree_resolves_to_main_repo(repo):
+    outer = create_worktree_for_session("outer", cwd=str(repo))
+    inner = create_worktree_for_session("inner", cwd=outer.worktree_path)
+    # Lands in the MAIN repo's .claude/worktrees, not nested inside `outer`.
+    assert inner.worktree_path == str(repo / ".claude" / "worktrees" / "inner")
+
+
+def test_orphaned_plain_dir_is_rejected_not_adopted(repo):
+    """Critic B2: a plain directory at the worktree path must NOT fast-resume
+    (bare rev-parse walks up and reports the MAIN repo's HEAD) and must NOT be
+    auto-deleted — creation fails loud with a prune hint."""
+    orphan = repo / ".claude" / "worktrees" / "orphan"
+    orphan.mkdir(parents=True)
+    (orphan / "leftover.txt").write_text("precious\n")
+
+    with pytest.raises(WorktreeError) as excinfo:
+        create_worktree_for_session("orphan", cwd=str(repo))
+    assert "git worktree prune" in str(excinfo.value)
+    assert (orphan / "leftover.txt").read_text() == "precious\n"  # untouched
+
+
+def test_dash_b_resets_orphan_branch(repo):
+    """A leftover branch without a worktree dir is reset by `-B` (TS parity)."""
+    _git(repo, "branch", "worktree-ghost")
+    session = create_worktree_for_session("ghost", cwd=str(repo))
+    assert (Path(session.worktree_path) / ".git").is_file()
+
+
+def test_base_falls_back_to_head_without_origin(repo):
+    """Remote-less repo: base resolution ends at HEAD (no fetch, no crash)."""
+    session = create_worktree_for_session("no-origin", cwd=str(repo))
+    wt_head = _git(Path(session.worktree_path), "rev-parse", "HEAD")
+    assert wt_head == _git(repo, "rev-parse", "HEAD")
+
+
+def test_not_a_git_repo_raises_clean_error(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    with pytest.raises(WorktreeError) as excinfo:
+        create_worktree_for_session("x", cwd=str(plain))
+    assert "git repository" in str(excinfo.value)
+
+
+def test_generated_slug_is_valid_and_fresh(repo):
+    slug = generate_worktree_slug(str(repo))
+    validate_worktree_slug(slug)
+    assert not os.path.exists(worktree_path_for(str(repo), slug))
+
+
+def test_cli_option_true_generates_name_and_pr_ref_maps_to_slug(repo, monkeypatch):
+    monkeypatch.chdir(repo)
+    session = create_session_from_cli_option(True)
+    assert session.worktree_name  # generated
+    # PR refs would fetch pull/<n>/head — no remote here, so expect the
+    # fetch-failure error, proving the option routed into PR mode.
+    with pytest.raises(WorktreeError) as excinfo:
+        create_session_from_cli_option("#12345")
+    assert "PR #12345" in str(excinfo.value)
+
+
+# ── canonical root ───────────────────────────────────────────────────────────
+
+def test_find_canonical_git_root(repo):
+    assert find_canonical_git_root(str(repo)) == str(repo)
+    sub = repo / "deep" / "er"
+    sub.mkdir(parents=True)
+    assert find_canonical_git_root(str(sub)) == str(repo)
+    session = create_worktree_for_session("rooty", cwd=str(repo))
+    assert find_canonical_git_root(session.worktree_path) == str(repo)
+    assert find_canonical_git_root("/") is None
+
+
+# ── change measurement (the lost-commit matrix, critic B4) ───────────────────
+
+def test_changes_clean_worktree_is_clean_in_remote_less_repo(repo):
+    session = create_worktree_for_session("clean", cwd=str(repo))
+    changes = worktree_changes(session)
+    assert changes.git_ok is True
+    assert (changes.dirty_files, changes.commits) == (0, 0)
+    assert changes.is_clean
+
+
+def test_changes_counts_dirty_files(repo):
+    session = create_worktree_for_session("dirty", cwd=str(repo))
+    (Path(session.worktree_path) / "a.txt").write_text("a")
+    (Path(session.worktree_path) / "b.txt").write_text("b")
+    changes = worktree_changes(session)
+    assert changes.dirty_files == 2
+    assert changes.commits == 0
+    assert not changes.is_clean
+
+
+def test_changes_counts_unmerged_commit_as_lost(repo):
+    """The critical case that catches a wrong --exclude pattern form: a
+    worktree-only commit must count as 1 (refs/heads/<branch> as the exclude
+    pattern silently matches nothing and reads 0 → silent data loss)."""
+    session = create_worktree_for_session("unmerged", cwd=str(repo))
+    wt = Path(session.worktree_path)
+    (wt / "new.txt").write_text("x")
+    _git(wt, "add", "new.txt")
+    _git(wt, "commit", "-q", "-m", "wip")
+    changes = worktree_changes(session)
+    assert changes.commits == 1
+    assert not changes.is_clean
+
+
+def test_changes_merged_back_commit_is_not_lost(repo):
+    """Better than TS: work merged into main no longer warns on remove."""
+    session = create_worktree_for_session("merged", cwd=str(repo))
+    wt = Path(session.worktree_path)
+    (wt / "done.txt").write_text("x")
+    _git(wt, "add", "done.txt")
+    _git(wt, "commit", "-q", "-m", "done")
+    _git(repo, "merge", "-q", session.worktree_branch)
+    changes = worktree_changes(session)
+    assert (changes.dirty_files, changes.commits) == (0, 0)
+    assert changes.is_clean
+
+
+def test_changes_resumed_worktree_still_counts_prior_commit(repo):
+    """Critic M1: TS's base..HEAD counts 0 after a resume (base is
+    HEAD-at-resume) and silently discards the prior session's commit; the
+    lost-set count keeps protecting it."""
+    first = create_worktree_for_session("resumed", cwd=str(repo))
+    wt = Path(first.worktree_path)
+    (wt / "s1.txt").write_text("x")
+    _git(wt, "add", "s1.txt")
+    _git(wt, "commit", "-q", "-m", "session-1 work")
+
+    second = create_worktree_for_session("resumed", cwd=str(repo))  # resume
+    changes = worktree_changes(second)
+    assert changes.commits == 1
+    assert not changes.is_clean
+
+
+def test_changes_fails_closed_when_git_fails():
+    ghost = WorktreeSession(
+        worktree_name="gone", worktree_path="/nonexistent/worktree",
+        worktree_branch="worktree-gone", original_cwd="/", repo_root="/",
+    )
+    changes = worktree_changes(ghost)
+    assert changes.git_ok is False
+    assert not changes.is_clean
+
+
+# ── cleanup ──────────────────────────────────────────────────────────────────
+
+def test_cleanup_removes_dir_and_branch(repo):
+    session = create_worktree_for_session("byebye", cwd=str(repo))
+    ok, error = cleanup_worktree(session)
+    assert ok, error
+    assert not os.path.exists(session.worktree_path)
+    assert _git(repo, "branch", "--list", "worktree-byebye") == ""
+
+
+def test_cleanup_reports_failure(repo):
+    session = create_worktree_for_session("failing", cwd=str(repo))
+    broken = WorktreeSession(
+        worktree_name="failing", worktree_path="/nonexistent/nowhere",
+        worktree_branch=session.worktree_branch,
+        original_cwd=session.original_cwd, repo_root=session.repo_root,
+    )
+    ok, error = cleanup_worktree(broken)
+    assert not ok
+    assert error
+
+
+# ── post-creation setup ──────────────────────────────────────────────────────
+
+def test_settings_local_json_is_copied_for_both_tiers(repo):
+    # clawcodex's own project tier + the harness-compatible .claude tier
+    # (hooks) — both propagate so the worktree session behaves like the
+    # original checkout.
+    for dirname in (".clawcodex", ".claude"):
+        d = repo / dirname
+        d.mkdir(exist_ok=True)
+        (d / "settings.local.json").write_text('{"permissions": {}}')
+    session = create_worktree_for_session("settings", cwd=str(repo))
+    for dirname in (".clawcodex", ".claude"):
+        copied = Path(session.worktree_path) / dirname / "settings.local.json"
+        assert copied.read_text() == '{"permissions": {}}'
+
+
+def test_worktreeinclude_copies_matched_gitignored_files(repo):
+    (repo / ".gitignore").write_text(".env\nbuild/\n")
+    (repo / ".worktreeinclude").write_text("# secrets\n.env\n")
+    (repo / ".env").write_text("SECRET=1\n")
+    build = repo / "build"
+    build.mkdir()
+    (build / "out.bin").write_text("binary")
+    _git(repo, "add", ".gitignore", ".worktreeinclude")
+    _git(repo, "commit", "-q", "-m", "ignore rules")
+
+    session = create_worktree_for_session("env-carry", cwd=str(repo))
+    wt = Path(session.worktree_path)
+    assert (wt / ".env").read_text() == "SECRET=1\n"          # matched → copied
+    assert not (wt / "build" / "out.bin").exists()             # ignored, unmatched
+
+
+def test_worktreeinclude_expands_collapsed_dir_for_targeted_pattern(repo):
+    (repo / ".gitignore").write_text("config/\n")
+    (repo / ".worktreeinclude").write_text("config/secrets/api.key\n")
+    secrets = repo / "config" / "secrets"
+    secrets.mkdir(parents=True)
+    (secrets / "api.key").write_text("k")
+    (repo / "config" / "other.txt").write_text("no")
+    _git(repo, "add", ".gitignore", ".worktreeinclude")
+    _git(repo, "commit", "-q", "-m", "rules")
+
+    session = create_worktree_for_session("collapsed", cwd=str(repo))
+    wt = Path(session.worktree_path)
+    assert (wt / "config" / "secrets" / "api.key").read_text() == "k"
+    assert not (wt / "config" / "other.txt").exists()
+
+
+# ── messages ─────────────────────────────────────────────────────────────────
+
+def test_message_wording_matrix(repo):
+    session = WorktreeSession(
+        worktree_name="m", worktree_path="/p", worktree_branch="worktree-m",
+        original_cwd="/r", repo_root="/r",
+    )
+    from src.utils.worktree_session import WorktreeChanges
+
+    assert keep_message(session) == (
+        "Worktree kept. Your work is saved at /p on branch worktree-m"
+    )
+    ok = lambda d, c: WorktreeChanges(git_ok=True, dirty_files=d, commits=c)  # noqa: E731
+    assert removal_message(session, ok(0, 0)) == "Worktree removed (no changes)"
+    assert removal_message(session, ok(2, 0)) == (
+        "Worktree removed. Uncommitted changes were discarded."
+    )
+    assert removal_message(session, ok(0, 1)) == (
+        "Worktree removed. 1 commit on worktree-m was discarded."
+    )
+    assert removal_message(session, ok(0, 3)) == (
+        "Worktree removed. 3 commits on worktree-m were discarded."
+    )
+    assert removal_message(session, ok(2, 3)) == (
+        "Worktree removed. 3 commits and uncommitted changes were discarded."
+    )
+    assert removal_message(
+        session, WorktreeChanges(git_ok=False, dirty_files=0, commits=0)
+    ) == "Worktree removed."

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -97,8 +97,10 @@ describe('createSlashHandler', () => {
   it('exits locally for /quit', () => {
     const ctx = buildCtx()
 
+    // requestExit (not die): /quit routes through the --worktree keep/remove
+    // flow when one is active; requestExit itself dies for plain sessions.
     expect(createSlashHandler(ctx)('/quit')).toBe(true)
-    expect(ctx.session.die).toHaveBeenCalledTimes(1)
+    expect(ctx.session.requestExit).toHaveBeenCalledTimes(1)
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
   })
 
@@ -107,6 +109,7 @@ describe('createSlashHandler', () => {
     const ctx = buildCtx()
 
     expect(createSlashHandler(ctx)('/exit')).toBe(true)
+    expect(ctx.session.requestExit).not.toHaveBeenCalled()
     expect(ctx.session.die).not.toHaveBeenCalled()
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
     expect(ctx.transcript.sys).toHaveBeenCalledWith(DASHBOARD_EXIT_DISABLED_MESSAGE)
@@ -117,7 +120,7 @@ describe('createSlashHandler', () => {
     const ctx = buildCtx()
 
     expect(createSlashHandler(ctx)('/quit')).toBe(true)
-    expect(ctx.session.die).toHaveBeenCalledTimes(1)
+    expect(ctx.session.requestExit).toHaveBeenCalledTimes(1)
   })
 
   it('handles /update locally and exits with code 42 via dieWithCode', () => {
@@ -984,6 +987,7 @@ const buildSession = () => ({
   guardBusySessionSwitch: vi.fn(() => false),
   newLiveSession: vi.fn(),
   newSession: vi.fn(),
+  requestExit: vi.fn(),
   resetVisibleHistory: vi.fn(),
   resumeById: vi.fn(),
   setSessionStartedAt: vi.fn()

--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -59,21 +59,23 @@ describe('shouldAllowIdleHotkeyExit', () => {
 
 describe('handleIdleHotkeyExit', () => {
   it('exits in normal terminals', () => {
-    const actions = { die: vi.fn(), sys: vi.fn() }
+    // requestExit (not die): the exit must route through the --worktree
+    // keep/remove flow when one is active — same path as /exit.
+    const actions = { requestExit: vi.fn(), sys: vi.fn() }
 
     handleIdleHotkeyExit(actions, false)
 
-    expect(actions.die).toHaveBeenCalledTimes(1)
+    expect(actions.requestExit).toHaveBeenCalledTimes(1)
     expect(actions.sys).not.toHaveBeenCalled()
   })
 
   it('asks the dashboard for a fresh chat instead of leaving a ghost session', () => {
-    const actions = { die: vi.fn(), sys: vi.fn() }
+    const actions = { requestExit: vi.fn(), sys: vi.fn() }
     const requestDashboardNewSession = vi.fn()
 
     handleIdleHotkeyExit(actions, true, requestDashboardNewSession)
 
-    expect(actions.die).not.toHaveBeenCalled()
+    expect(actions.requestExit).not.toHaveBeenCalled()
     expect(requestDashboardNewSession).toHaveBeenCalledTimes(1)
     expect(actions.sys).toHaveBeenCalledWith('starting a fresh dashboard chat...')
   })

--- a/ui-tui/src/__tests__/worktree.test.ts
+++ b/ui-tui/src/__tests__/worktree.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseWorktreeSession, planWorktreeExit } from '../lib/worktree.js'
+
+const OWNER_PID = 4242
+
+const fullEnv = (overrides: Record<string, string | undefined> = {}) => ({
+  CLAWCODEX_WORKTREE_BRANCH: 'worktree-fix-auth',
+  CLAWCODEX_WORKTREE_NAME: 'fix-auth',
+  CLAWCODEX_WORKTREE_ORIGINAL_CWD: '/repo',
+  CLAWCODEX_WORKTREE_OWNER_PID: String(OWNER_PID),
+  CLAWCODEX_WORKTREE_PATH: '/repo/.claude/worktrees/fix-auth',
+  CLAWCODEX_WORKTREE_REPO_ROOT: '/repo',
+  ...overrides
+})
+
+describe('parseWorktreeSession', () => {
+  it('parses a complete env block when ppid matches the owner', () => {
+    expect(parseWorktreeSession(fullEnv(), OWNER_PID)).toEqual({
+      branch: 'worktree-fix-auth',
+      name: 'fix-auth',
+      originalCwd: '/repo',
+      path: '/repo/.claude/worktrees/fix-auth',
+      repoRoot: '/repo'
+    })
+  })
+
+  it('returns null when any var is missing', () => {
+    for (const key of [
+      'CLAWCODEX_WORKTREE_NAME',
+      'CLAWCODEX_WORKTREE_PATH',
+      'CLAWCODEX_WORKTREE_BRANCH',
+      'CLAWCODEX_WORKTREE_ORIGINAL_CWD',
+      'CLAWCODEX_WORKTREE_REPO_ROOT'
+    ]) {
+      expect(parseWorktreeSession(fullEnv({ [key]: undefined }), OWNER_PID)).toBeNull()
+    }
+  })
+
+  it('rejects a stale/leaked env block via the OWNER_PID ppid gate', () => {
+    // A dev-mode `node dist/entry.js` inside someone else's worktree session
+    // inherits the vars but is NOT a child of that launcher — it must not
+    // adopt (and at clean exit delete) a worktree it doesn't own.
+    expect(parseWorktreeSession(fullEnv(), OWNER_PID + 1)).toBeNull()
+    expect(parseWorktreeSession(fullEnv({ CLAWCODEX_WORKTREE_OWNER_PID: undefined }), OWNER_PID)).toBeNull()
+    expect(parseWorktreeSession(fullEnv({ CLAWCODEX_WORKTREE_OWNER_PID: 'nope' }), OWNER_PID)).toBeNull()
+    expect(parseWorktreeSession(fullEnv({ CLAWCODEX_WORKTREE_OWNER_PID: '0' }), 0)).toBeNull()
+  })
+})
+
+describe('planWorktreeExit', () => {
+  const BR = 'worktree-fix-auth'
+
+  it('silently removes an untouched worktree (TS WorktreeExitDialog parity)', () => {
+    expect(planWorktreeExit({ active: true, commits: 0, dirty_files: 0, git_ok: true, ok: true }, BR)).toEqual({
+      kind: 'silent-remove'
+    })
+  })
+
+  it('asks with both counts when dirty files and commits exist', () => {
+    const plan = planWorktreeExit({ active: true, commits: 2, dirty_files: 3, git_ok: true, ok: true }, BR)
+
+    expect(plan.kind).toBe('dialog')
+
+    if (plan.kind === 'dialog') {
+      expect(plan.removeIsDanger).toBe(true)
+      expect(plan.subtitle).toBe(
+        `You have 3 uncommitted files and 2 commits on ${BR}. All will be lost if you remove.`
+      )
+    }
+  })
+
+  it('uses singular wording for one file / one commit', () => {
+    const files = planWorktreeExit({ active: true, commits: 0, dirty_files: 1, git_ok: true, ok: true }, BR)
+    const commits = planWorktreeExit({ active: true, commits: 1, dirty_files: 0, git_ok: true, ok: true }, BR)
+
+    expect(files).toEqual({
+      kind: 'dialog',
+      removeIsDanger: true,
+      subtitle: 'You have 1 uncommitted file. These will be lost if you remove the worktree.'
+    })
+    expect(commits).toEqual({
+      kind: 'dialog',
+      removeIsDanger: true,
+      subtitle: `You have 1 commit on ${BR}. The branch will be deleted if you remove the worktree.`
+    })
+  })
+
+  it('fails closed on git_ok:false — dialog with generic subtitle, no fabricated counts', () => {
+    const plan = planWorktreeExit(
+      { active: true, commits: 7, dirty_files: 9, git_ok: false, ok: true },
+      BR
+    )
+
+    expect(plan.kind).toBe('dialog')
+
+    if (plan.kind === 'dialog') {
+      expect(plan.subtitle).not.toMatch(/[79]/)
+      expect(plan.subtitle).toContain('Could not inspect the worktree')
+    }
+  })
+
+  it('never silent-removes when counts are missing but git_ok is false', () => {
+    expect(planWorktreeExit({ active: true, git_ok: false, ok: true }, BR).kind).toBe('dialog')
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -20,7 +20,8 @@ import type {
   SessionInfo,
   SlashCatalog,
   SudoReq,
-  Usage
+  Usage,
+  WorktreeExitReq
 } from '../types.js'
 
 export interface StateSetter<T> {
@@ -146,6 +147,7 @@ export interface OverlayState {
   sessions: boolean
   skillsHub: boolean
   sudo: null | SudoReq
+  worktreeExit: null | WorktreeExitReq
 }
 
 export interface PagerState {
@@ -267,6 +269,9 @@ export interface InputHandlerActions {
   dispatchSubmission: (full: string) => void
   guardBusySessionSwitch: (what?: string) => boolean
   newSession: (msg?: string, title?: string) => void
+  /** Orderly exit: runs the --worktree keep/remove flow when one is active,
+   *  otherwise (or on a second call while one is in flight) dies directly. */
+  requestExit: () => void
   sys: (text: string) => void
 }
 
@@ -364,6 +369,8 @@ export interface SlashHandlerContext {
     guardBusySessionSwitch: (what?: string) => boolean
     newLiveSession: (msg?: string, title?: string) => void
     newSession: (msg?: string, title?: string) => void
+    /** /exit path: worktree keep/remove flow when active, else die(). */
+    requestExit: () => void
     resetVisibleHistory: (info?: null | SessionInfo) => void
     resumeById: (id: string) => void
     setSessionStartedAt: StateSetter<number>

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -16,7 +16,8 @@ const buildOverlayState = (): OverlayState => ({
   secret: null,
   sessions: false,
   skillsHub: false,
-  sudo: null
+  sudo: null,
+  worktreeExit: null
 })
 
 export const $overlayState = atom<OverlayState>(buildOverlayState())
@@ -36,7 +37,8 @@ export const $isBlocked = computed(
     secret,
     sessions,
     skillsHub,
-    sudo
+    sudo,
+    worktreeExit
   }) =>
     Boolean(
       agents ||
@@ -51,7 +53,8 @@ export const $isBlocked = computed(
       secret ||
       sessions ||
       skillsHub ||
-      sudo
+      sudo ||
+      worktreeExit
     )
 )
 
@@ -80,5 +83,9 @@ export const resetFlowOverlays = () =>
     petPicker: $overlayState.get().petPicker,
     pluginsHub: $overlayState.get().pluginsHub,
     sessions: $overlayState.get().sessions,
-    skillsHub: $overlayState.get().skillsHub
+    skillsHub: $overlayState.get().skillsHub,
+    // Deliberately preserved: the exit keep/remove dialog is an explicit user
+    // flow, not turn-scoped — a background turn completing while it is up
+    // must not wipe it (that would strand requestExit's in-flight guard).
+    worktreeExit: $overlayState.get().worktreeExit
   })

--- a/ui-tui/src/app/slash/commands/core.ts
+++ b/ui-tui/src/app/slash/commands/core.ts
@@ -135,7 +135,9 @@ export const coreCommands: SlashCommand[] = [
         return
       }
 
-      ctx.session.die()
+      // Routes through the --worktree keep/remove flow when one is active;
+      // a plain session dies immediately.
+      ctx.session.requestExit()
     }
   },
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -27,7 +27,7 @@ const DASHBOARD_NEW_SESSION_MESSAGE = 'starting a fresh dashboard chat...'
 export const shouldAllowIdleHotkeyExit = (dashboardTuiMode = DASHBOARD_TUI_MODE) => !dashboardTuiMode
 
 export function handleIdleHotkeyExit(
-  actions: Pick<InputHandlerActions, 'die' | 'sys'>,
+  actions: Pick<InputHandlerActions, 'requestExit' | 'sys'>,
   dashboardTuiMode = DASHBOARD_TUI_MODE,
   requestDashboardNewSession?: () => void
 ) {
@@ -37,7 +37,9 @@ export function handleIdleHotkeyExit(
     return actions.sys(DASHBOARD_NEW_SESSION_MESSAGE)
   }
 
-  return actions.die()
+  // requestExit runs the --worktree keep/remove flow when one is active and
+  // dies directly otherwise — same routing as /exit.
+  return actions.requestExit()
 }
 
 /**

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -27,6 +27,12 @@ import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import { terminalParityHints } from '../lib/terminalParity.js'
 import { buildToolTrailLine, formatAbandonedClarify, sameToolTrailGroup, toolTrailLabel } from '../lib/text.js'
 import { estimatedMsgHeight, messageHeightKey } from '../lib/virtualHeights.js'
+import {
+  getWorktreeSession,
+  planWorktreeExit,
+  setWorktreeExitNote,
+  type WorktreeStatusResponse
+} from '../lib/worktree.js'
 import type { Msg, PanelSection, SlashCatalog } from '../types.js'
 
 import { createGatewayEventHandler } from './createGatewayEventHandler.js'
@@ -498,6 +504,108 @@ export function useMainApp(gw: GatewayClient) {
     [exit, gw]
   )
 
+  // ── --worktree exit flow ────────────────────────────────────────────────
+  // /exit and the idle hotkey exits route through here instead of die(): with
+  // a worktree session active, the TS reference's WorktreeExitDialog semantics
+  // apply — untouched worktree removed silently, otherwise a Keep(default)/
+  // Remove dialog; the git ops run in the backend (worktree.exit RPC, long
+  // deadline). dieWithCode (e.g. /update) bypasses this and keeps the
+  // worktree silently; signal/crash exits never reach it (worktree kept).
+  const exitFlightRef = useRef(false)
+
+  const requestExit = useCallback(() => {
+    const wt = getWorktreeSession()
+
+    // No worktree session — plain exit. In-flight flow — the second request
+    // is the escape hatch (backend may be wedged): die now, worktree kept.
+    if (!wt || exitFlightRef.current) {
+      return die()
+    }
+
+    exitFlightRef.current = true
+
+    const finish = (note: null | string) => {
+      if (note) {
+        setWorktreeExitNote(note)
+      }
+
+      die()
+    }
+
+    const keptNote = `Worktree kept at ${wt.path} (branch ${wt.branch})`
+
+    const perform = (action: 'keep' | 'remove') => {
+      patchOverlayState(prev =>
+        prev.worktreeExit
+          ? {
+              ...prev,
+              worktreeExit: { ...prev.worktreeExit, phase: action === 'keep' ? 'keeping' : 'removing' }
+            }
+          : prev
+      )
+      gw.request<Record<string, any>>('worktree.exit', { action })
+        .then(r => {
+          if (r && r.ok !== false) {
+            finish(typeof r.message === 'string' && r.message ? r.message : null)
+          } else {
+            const detail = typeof r?.error === 'string' && r.error ? ` (${r.error})` : ''
+
+            finish(`Worktree cleanup failed, exiting anyway${detail} — worktree kept at ${wt.path}`)
+          }
+        })
+        .catch(() => finish(`Worktree cleanup failed, exiting anyway — worktree kept at ${wt.path}`))
+    }
+
+    gw.request<WorktreeStatusResponse>('worktree.status', {})
+      .then(status => {
+        if (!status || status.ok === false || status.active === false) {
+          // Backend can't service the flow (dead, init_error, no session on
+          // its side) — keep the worktree, tell the user where it lives.
+          return finish(keptNote)
+        }
+
+        const plan = planWorktreeExit(status, wt.branch)
+
+        if (plan.kind === 'silent-remove') {
+          // TS parity: an untouched worktree is removed without asking. The
+          // overlay still mounts (phase 'removing') so slow removals show
+          // their interim state instead of a frozen UI.
+          patchOverlayState({
+            worktreeExit: {
+              branch: wt.branch,
+              onCancel: () => {},
+              onChoose: () => {},
+              onForceQuit: () => finish(keptNote),
+              path: wt.path,
+              phase: 'removing',
+              removeIsDanger: false,
+              subtitle: ''
+            }
+          })
+
+          return perform('remove')
+        }
+
+        patchOverlayState({
+          worktreeExit: {
+            branch: wt.branch,
+            onCancel: () => {
+              // Esc — abort the exit entirely, back to the session (TS parity).
+              exitFlightRef.current = false
+              patchOverlayState({ worktreeExit: null })
+            },
+            onChoose: perform,
+            onForceQuit: () => finish(keptNote),
+            path: wt.path,
+            phase: 'asking',
+            removeIsDanger: plan.removeIsDanger,
+            subtitle: plan.subtitle
+          }
+        })
+      })
+      .catch(() => finish(keptNote))
+  }, [die, gw])
+
   const session = useSessionLifecycle({
     colsRef,
     composerActions,
@@ -730,6 +838,7 @@ export function useMainApp(gw: GatewayClient) {
       dispatchSubmission,
       guardBusySessionSwitch: session.guardBusySessionSwitch,
       newSession: session.newSession,
+      requestExit,
       sys
     },
     composer: { actions: composerActions, refs: composerRefs, state: composerState },
@@ -868,6 +977,7 @@ export function useMainApp(gw: GatewayClient) {
           guardBusySessionSwitch: session.guardBusySessionSwitch,
           newLiveSession: session.newLiveSession,
           newSession: session.newSession,
+          requestExit,
           resetVisibleHistory: session.resetVisibleHistory,
           resumeById: session.resumeById,
           setSessionStartedAt
@@ -888,6 +998,7 @@ export function useMainApp(gw: GatewayClient) {
       page,
       panel,
       paste,
+      requestExit,
       selection,
       send,
       session,

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -548,9 +548,18 @@ export function useMainApp(gw: GatewayClient) {
           if (r && r.ok !== false) {
             finish(typeof r.message === 'string' && r.message ? r.message : null)
           } else {
-            const detail = typeof r?.error === 'string' && r.error ? ` (${r.error})` : ''
+            const error = typeof r?.error === 'string' ? r.error : ''
 
-            finish(`Worktree cleanup failed, exiting anyway${detail} — worktree kept at ${wt.path}`)
+            // The backend refuses removal while a turn is running (idle-only,
+            // like every destructive control) — that's a normal keep, not a
+            // failure.
+            if (error.includes('active turn')) {
+              finish(`${keptNote} (a turn was still running)`)
+            } else {
+              const detail = error ? ` (${error})` : ''
+
+              finish(`Worktree cleanup failed, exiting anyway${detail} — worktree kept at ${wt.path}`)
+            }
           }
         })
         .catch(() => finish(`Worktree cleanup failed, exiting anyway — worktree kept at ${wt.path}`))

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -17,6 +17,7 @@ import { PetPicker } from './petPicker.js'
 import { PluginsHub } from './pluginsHub.js'
 import { ApprovalPrompt, ClarifyPrompt, ConfirmPrompt } from './prompts.js'
 import { SkillsHub } from './skillsHub.js'
+import { WorktreeExitPrompt } from './worktreeExitPrompt.js'
 
 const COMPLETION_WINDOW = 16
 
@@ -29,6 +30,16 @@ export function PromptZone({
 }: Pick<AppOverlaysProps, 'cols' | 'onApprovalChoice' | 'onClarifyAnswer' | 'onSecretSubmit' | 'onSudoSubmit'>) {
   const overlay = useStore($overlayState)
   const theme = useStore($uiTheme)
+
+  // The exit flow outranks everything: the user has already asked to leave,
+  // and the dialog's Esc explicitly returns to the session.
+  if (overlay.worktreeExit) {
+    return (
+      <Box flexDirection="column" flexShrink={0} paddingX={1} paddingY={1}>
+        <WorktreeExitPrompt req={overlay.worktreeExit} t={theme} />
+      </Box>
+    )
+  }
 
   if (overlay.approval) {
     return (

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -4,6 +4,7 @@ import unicodeSpinners from 'unicode-animations'
 
 import { artWidth, lobster, LOBSTER_WIDTH, logo, LOGO_WIDTH } from '../banner.js'
 import { flat } from '../lib/text.js'
+import { getWorktreeSession } from '../lib/worktree.js'
 import type { Theme } from '../theme.js'
 import type { PanelSection, SessionInfo } from '../types.js'
 
@@ -174,6 +175,10 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
   const [systemOpen, setSystemOpen] = useState(false)
   const [mcpOpen, setMcpOpen] = useState(false)
 
+  // --worktree session (env-advertised by the launcher) — shown under cwd so
+  // parallel sessions are visually distinguishable at a glance.
+  const worktree = getWorktreeSession()
+
   const truncLine = (pfx: string, items: string[]) => {
     let line = ''
     let shown = 0
@@ -298,6 +303,12 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
             {info.cwd || process.cwd()}
           </Text>
 
+          {worktree && (
+            <Text color={t.color.muted} wrap="truncate-end">
+              worktree <Text color={t.color.accent}>{worktree.name}</Text> · {worktree.branch}
+            </Text>
+          )}
+
           {sid && (
             <Text>
               <Text color={t.color.sessionLabel}>Session: </Text>
@@ -327,6 +338,11 @@ export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
             <Text color={t.color.muted} wrap="truncate-end">
               {info.cwd || process.cwd()}
             </Text>
+            {worktree && (
+              <Text color={t.color.muted} wrap="truncate-end">
+                worktree <Text color={t.color.accent}>{worktree.name}</Text> · {worktree.branch}
+              </Text>
+            )}
             {sid && (
               <Text wrap="truncate-end">
                 <Text color={t.color.sessionLabel}>Session: </Text>

--- a/ui-tui/src/components/worktreeExitPrompt.tsx
+++ b/ui-tui/src/components/worktreeExitPrompt.tsx
@@ -64,7 +64,7 @@ export function WorktreeExitPrompt({ req, t }: WorktreeExitPromptProps) {
     return (
       <Box borderColor={t.color.border} borderStyle="double" flexDirection="column" paddingX={1}>
         <Text color={t.color.warn}>{req.phase === 'keeping' ? 'Keeping worktree…' : 'Removing worktree…'}</Text>
-        <Text color={t.color.muted}>Ctrl+C to quit without waiting (worktree left in place)</Text>
+        <Text color={t.color.muted}>Ctrl+C to quit without waiting (the worktree may be left in a partial state)</Text>
       </Box>
     )
   }

--- a/ui-tui/src/components/worktreeExitPrompt.tsx
+++ b/ui-tui/src/components/worktreeExitPrompt.tsx
@@ -1,0 +1,115 @@
+/**
+ * Exit-time keep/remove dialog for a --worktree session — the TS reference's
+ * WorktreeExitDialog (options, default-to-keep, Esc-cancels-exit, interim
+ * keeping/removing state) on the clawcodex prompt-overlay chassis
+ * (ConfirmPrompt's select styling).
+ */
+import { Box, Text, useInput } from '@clawcodex/ink'
+import { useState } from 'react'
+
+import type { Theme } from '../theme.js'
+import type { WorktreeExitReq } from '../types.js'
+
+interface WorktreeExitPromptProps {
+  req: WorktreeExitReq
+  t: Theme
+}
+
+export function WorktreeExitPrompt({ req, t }: WorktreeExitPromptProps) {
+  // 0 = keep (default focus, TS parity), 1 = remove.
+  const [sel, setSel] = useState(0)
+
+  const busy = req.phase !== 'asking'
+
+  useInput((ch, key) => {
+    const lower = ch.toLowerCase()
+
+    if (busy) {
+      // A hung `git worktree remove` would otherwise lock the UI for the full
+      // RPC deadline (10 min) with no escape — Ctrl+C/Ctrl+D dies immediately
+      // (worktree left in place, the safe direction).
+      if (key.ctrl && (lower === 'c' || lower === 'd')) {
+        req.onForceQuit()
+      }
+
+      return
+    }
+
+    if (key.escape || (key.ctrl && lower === 'c')) {
+      return req.onCancel()
+    }
+
+    if (lower === 'k') {
+      return req.onChoose('keep')
+    }
+
+    if (lower === 'r') {
+      return req.onChoose('remove')
+    }
+
+    if (key.upArrow) {
+      setSel(0)
+    }
+
+    if (key.downArrow) {
+      setSel(1)
+    }
+
+    if (key.return) {
+      req.onChoose(sel === 0 ? 'keep' : 'remove')
+    }
+  })
+
+  if (busy) {
+    return (
+      <Box borderColor={t.color.border} borderStyle="double" flexDirection="column" paddingX={1}>
+        <Text color={t.color.warn}>{req.phase === 'keeping' ? 'Keeping worktree…' : 'Removing worktree…'}</Text>
+        <Text color={t.color.muted}>Ctrl+C to quit without waiting (worktree left in place)</Text>
+      </Box>
+    )
+  }
+
+  const accent = req.removeIsDanger ? t.color.warn : t.color.accent
+
+  const rows = [
+    { color: t.color.text, desc: `Stays at ${req.path}`, label: 'Keep worktree' },
+    {
+      color: req.removeIsDanger ? t.color.error : t.color.text,
+      desc: req.removeIsDanger ? 'All changes and commits will be lost.' : 'Clean up the worktree directory.',
+      label: 'Remove worktree'
+    }
+  ]
+
+  return (
+    <Box borderColor={accent} borderStyle="double" flexDirection="column" paddingX={1}>
+      <Text bold color={accent}>
+        ? Exiting worktree session
+      </Text>
+
+      <Box paddingLeft={1}>
+        <Text color={t.color.text} wrap="wrap">
+          {req.subtitle}
+        </Text>
+      </Box>
+
+      <Text />
+
+      {rows.map((row, i) => (
+        <Box flexDirection="column" key={row.label}>
+          <Text>
+            <Text color={sel === i ? accent : t.color.muted}>{sel === i ? '▸ ' : '  '}</Text>
+            <Text bold={sel === i} color={sel === i ? row.color : t.color.muted}>
+              {row.label}
+            </Text>
+          </Text>
+          <Text color={t.color.muted} wrap="truncate-end">
+            {'    '}
+            {row.desc}
+          </Text>
+        </Box>
+      ))}
+
+      <Text color={t.color.muted}>↑/↓ select · Enter confirm · K/R quick · Esc back to session</Text>
+    </Box>
+  )
+}

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -14,6 +14,7 @@ import { type MemorySnapshot, startMemoryMonitor } from './lib/memoryMonitor.js'
 import { openExternalUrl } from './lib/openExternalUrl.js'
 import { recordParentLifecycle } from './lib/parentLog.js'
 import { resetTerminalModes } from './lib/terminalModes.js'
+import { registerWorktreeNoteOnExit } from './lib/worktree.js'
 
 if (!process.stdin.isTTY) {
   console.log('clawcodex-tui: no TTY')
@@ -51,6 +52,11 @@ resetTerminalModes()
 process.on('exit', () => {
   resetTerminalModes(process.stdout, FULLSCREEN)
 })
+
+// --worktree keep/remove result under the final frame. Registered AFTER the
+// reset backstop (sane terminal) and BEFORE the cost summary so it reads as
+// the session's closing status line.
+registerWorktreeNoteOnExit()
 
 // Session cost summary under the final frame — the original's useCostSummary
 // process-exit hook (costHook.ts:12). Registered AFTER the reset backstop

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -28,6 +28,13 @@ import type { SessionInfo } from './types.js'
 const STARTUP_TIMEOUT_MS = 30_000
 const MAX_LOG_LINES = 500
 const RPC_TIMEOUT_MS = 5_000
+
+/** Worktree exit RPCs get a LONG deadline: `git worktree remove --force` on a
+ *  node_modules-scale tree can far exceed the default 5 s — a timeout there
+ *  would misreport "cleanup failed" and SIGTERM the backend mid-removal,
+ *  leaving a half-deleted directory. The prompt shows an interim
+ *  "Removing worktree…" state while this runs. */
+const WORKTREE_RPC_TIMEOUT_MS = 600_000
 // clawcodex app version shown in the banner ("clawcodex v{version}"). Keep in
 // sync with the installer (install.sh INSTALLER_VERSION).
 const CLAWCODEX_VERSION = '1.0.0'
@@ -607,6 +614,19 @@ export class GatewayClient extends EventEmitter {
         this.sendControl('interrupt', {})
 
         return Promise.resolve({ ok: true } as T)
+
+      // ── --worktree exit flow (long deadline: removal can take minutes) ───
+      case 'worktree.exit':
+        return this.controlQuery(
+          'worktree_exit',
+          { action: String(p.action ?? '') },
+          WORKTREE_RPC_TIMEOUT_MS
+        ).then(r => (r ?? { error: 'no response from backend', ok: false }) as T)
+
+      case 'worktree.status':
+        return this.controlQuery('worktree_status', {}, WORKTREE_RPC_TIMEOUT_MS).then(
+          r => (r ?? { error: 'no response from backend', ok: false }) as T
+        )
       // ── skills hub + /skills subcommands ─────────────────────────────────
       case 'skills.manage': {
         const action = String(p.action ?? 'list')
@@ -817,7 +837,11 @@ export class GatewayClient extends EventEmitter {
   }
 
   // ── event plumbing ───────────────────────────────────────────────────────
-  private controlQuery(subtype: string, params: Record<string, unknown>): Promise<unknown> {
+  private controlQuery(
+    subtype: string,
+    params: Record<string, unknown>,
+    timeoutMs: number = RPC_TIMEOUT_MS
+  ): Promise<unknown> {
     const requestId = `q${++this.reqId}`
 
     return new Promise(resolve => {
@@ -828,7 +852,7 @@ export class GatewayClient extends EventEmitter {
           this.pending.delete(requestId)
           resolve(null)
         }
-      }, RPC_TIMEOUT_MS)
+      }, timeoutMs)
     })
   }
 

--- a/ui-tui/src/lib/worktree.ts
+++ b/ui-tui/src/lib/worktree.ts
@@ -1,0 +1,142 @@
+/**
+ * Session worktree (--worktree) client support.
+ *
+ * The Python launcher creates/resumes the worktree BEFORE spawning this TUI
+ * and advertises it via CLAWCODEX_WORKTREE_* env vars (the same block the
+ * agent-server child inherits to service the exit-time git ops). Keep the
+ * var names in sync with src/utils/worktree_session.py.
+ *
+ * Ownership gate: the launcher stamps CLAWCODEX_WORKTREE_OWNER_PID with its
+ * own pid, and this TUI is spawned as its DIRECT child — so a session is only
+ * honored when process.ppid matches. A dev-mode `node dist/entry.js` run
+ * inside someone else's worktree session (stale/leaked env) fails the gate
+ * and behaves like a plain session instead of adopting — and potentially
+ * deleting — a worktree it doesn't own.
+ */
+
+export interface WorktreeSessionInfo {
+  branch: string
+  name: string
+  originalCwd: string
+  path: string
+  repoRoot: string
+}
+
+/** Backend `worktree_status` reply (src/server/agent_server.py). */
+export interface WorktreeStatusResponse {
+  active?: boolean
+  branch?: string
+  commits?: number
+  dirty_files?: number
+  /** false → counts are placeholders; fail closed (dialog, generic subtitle). */
+  git_ok?: boolean
+  name?: string
+  ok?: boolean
+  original_cwd?: string
+  path?: string
+}
+
+/** Pure parser — exported for tests; getWorktreeSession() feeds it process env. */
+export function parseWorktreeSession(
+  env: Record<string, string | undefined>,
+  ppid: number
+): null | WorktreeSessionInfo {
+  const name = env.CLAWCODEX_WORKTREE_NAME
+  const path = env.CLAWCODEX_WORKTREE_PATH
+  const branch = env.CLAWCODEX_WORKTREE_BRANCH
+  const originalCwd = env.CLAWCODEX_WORKTREE_ORIGINAL_CWD
+  const repoRoot = env.CLAWCODEX_WORKTREE_REPO_ROOT
+
+  if (!name || !path || !branch || !originalCwd || !repoRoot) {
+    return null
+  }
+
+  const ownerPid = Number(env.CLAWCODEX_WORKTREE_OWNER_PID ?? '')
+
+  if (!Number.isInteger(ownerPid) || ownerPid <= 0 || ownerPid !== ppid) {
+    return null
+  }
+
+  return { branch, name, originalCwd, path, repoRoot }
+}
+
+let cached: null | undefined | WorktreeSessionInfo
+
+/** The worktree session this TUI runs inside, or null. Memoized (env is fixed). */
+export function getWorktreeSession(): null | WorktreeSessionInfo {
+  if (cached === undefined) {
+    cached = parseWorktreeSession(process.env, process.ppid)
+  }
+
+  return cached
+}
+
+/** Test hook: reset the memo so parseWorktreeSession runs again. */
+export function resetWorktreeSessionCacheForTesting(): void {
+  cached = undefined
+}
+
+export type WorktreeExitPlan =
+  | { kind: 'dialog'; removeIsDanger: boolean; subtitle: string }
+  | { kind: 'silent-remove' }
+
+/**
+ * Decide the exit flow from a `worktree_status` reply — the TS reference's
+ * WorktreeExitDialog effect: clean (0 dirty, 0 lost commits, git healthy) →
+ * remove silently; anything else → ask, with the reference's subtitle matrix.
+ * `git_ok: false` fails closed: generic subtitle, no fabricated counts.
+ */
+export function planWorktreeExit(status: WorktreeStatusResponse, branch: string): WorktreeExitPlan {
+  const gitOk = status.git_ok !== false
+  const dirty = gitOk ? (status.dirty_files ?? 0) : 0
+  const commits = gitOk ? (status.commits ?? 0) : 0
+
+  if (gitOk && dirty === 0 && commits === 0) {
+    return { kind: 'silent-remove' }
+  }
+
+  let subtitle: string
+
+  if (!gitOk) {
+    subtitle =
+      'Could not inspect the worktree (git failed). Keep it to be safe, or remove it if you are sure.'
+  } else if (dirty > 0 && commits > 0) {
+    subtitle =
+      `You have ${dirty} uncommitted ${dirty === 1 ? 'file' : 'files'} and ` +
+      `${commits} ${commits === 1 ? 'commit' : 'commits'} on ${branch}. All will be lost if you remove.`
+  } else if (dirty > 0) {
+    subtitle = `You have ${dirty} uncommitted ${dirty === 1 ? 'file' : 'files'}. These will be lost if you remove the worktree.`
+  } else {
+    subtitle = `You have ${commits} ${commits === 1 ? 'commit' : 'commits'} on ${branch}. The branch will be deleted if you remove the worktree.`
+  }
+
+  return { kind: 'dialog', removeIsDanger: true, subtitle }
+}
+
+// ── exit note ────────────────────────────────────────────────────────────────
+// The keep/remove result prints AFTER Ink unmounts (same pattern as the cost
+// summary): stash it here, and a process 'exit' hook writes it synchronously.
+
+let exitNote: null | string = null
+
+export function setWorktreeExitNote(note: string): void {
+  exitNote = note
+}
+
+export function getWorktreeExitNoteForTesting(): null | string {
+  return exitNote
+}
+
+/**
+ * Print the keep/remove result under the final frame. Register AFTER
+ * entry.tsx's terminal-mode reset backstop (exit listeners run in order) so
+ * the note lands on a sane terminal, and BEFORE the cost summary so it reads
+ * as the session's closing status line.
+ */
+export function registerWorktreeNoteOnExit(): void {
+  process.on('exit', () => {
+    if (exitNote) {
+      process.stdout.write(`\n${exitNote}\n`)
+    }
+  })
+}

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -127,6 +127,24 @@ export interface ClarifyReq {
   requestId: string
 }
 
+/** Exit-time keep/remove dialog for a --worktree session (the TS reference's
+ *  WorktreeExitDialog). `phase` flips to keeping/removing while the backend
+ *  RPC runs — removal of a large tree can take a while. */
+export interface WorktreeExitReq {
+  branch: string
+  /** Esc — abort the exit and return to the session. */
+  onCancel: () => void
+  onChoose: (action: 'keep' | 'remove') => void
+  /** Ctrl+C/Ctrl+D during the busy phase — die now without waiting for the
+   *  backend RPC (worktree left in place). Escape hatch for a hung git. */
+  onForceQuit: () => void
+  path: string
+  phase: 'asking' | 'keeping' | 'removing'
+  /** Remove is rendered as destructive when changes would be lost. */
+  removeIsDanger: boolean
+  subtitle: string
+}
+
 export interface Msg {
   // Structured Edit/Write patch for kind:'diff' segments — rendered by
   // DiffView (line numbers, word diff, ColorDiff). Text-only diff segments


### PR DESCRIPTION
Port of upstream TypeScript implementation's `--worktree` session feature (typescript/src/utils/worktree.ts + setup.ts + WorktreeExitDialog.tsx): run each coding session in an isolated git worktree so multiple parallel sessions on the same repo never stomp each other's files.

## What you get

```
clawcodex --worktree            # generated name, e.g. calm-reef-x3k2
clawcodex -w fix-auth           # named (created or resumed)
clawcodex tui --worktree=NAME   # explicit subcommand form
clawcodex -p "…" -w             # headless: runs inside the worktree, keeps it
```

- Worktree at `<repoRoot>/.claude/worktrees/<name>` on branch `worktree-<name>`, based on `origin/<default-branch>` when available (local ref → fetch → `HEAD` fallback); PR refs (`-w '#123'` / PR URL) base on `pull/<n>/head` as `pr-<n>`.
- Same name = resume (fast path gated on the worktree's `.git` file so an orphaned plain dir is never silently adopted — or deleted).
- Banner shows `worktree <name> · <branch>` under the cwd (wide + narrow layouts).
- Exit (`/exit`, Ctrl+C/Ctrl+D idle): untouched worktree is removed silently ("Worktree removed (no changes)"); otherwise a Keep(default)/Remove dialog with the reference's subtitle wording; Esc returns to the session. Result note prints under the final frame next to the cost summary.
- Post-creation setup: `settings.local.json` propagated (both `.clawcodex/` and `.claude/` tiers), `core.hooksPath` pinned to the main repo when `.husky`/`.git/hooks` exists, `.worktreeinclude`-matched gitignored files copied (pathspec/gitignore semantics incl. the collapsed-dir expansion optimization).

## Architecture

The Python CLI parent creates/resumes the worktree **before** spawning the Ink TUI (exactly where TS's `setup.ts` does it) and hands the worktree path down as the workspace — TUI and agent-server child simply live inside it. Session metadata travels via `CLAWCODEX_WORKTREE_*` env; the exit flow is TUI-driven (`requestExit` → `worktree_status`/`worktree_exit` agent-server controls) with the git ops in the Python backend.

## Safety properties (critic-mandated, all tested)

- **Nested-session hygiene**: `cli.py` strips inherited `CLAWCODEX_WORKTREE_*` at entry, and the TUI honors the block only when `CLAWCODEX_WORKTREE_OWNER_PID == ppid` — a clawcodex spawned by the agent's Bash tool inside a worktree can never adopt (and clean-exit-delete) the outer session's worktree.
- **Lost-commit counting**: `git rev-list --count HEAD --not --exclude=<branch> --branches --remotes` — commits unreachable from any *surviving* ref. Deliberate deviation from TS's `base..HEAD`, which on a *resumed* worktree counts prior-session commits as zero and lets the silent-remove path `branch -D` committed unmerged work; the lost-set is strictly safer and also stops warning about merged-back work. (The exclude must be the branch *short name*: the `refs/heads/…` form silently matches nothing.)
- **Fail-closed status**: any git failure → `git_ok:false` → dialog with a generic subtitle, no fabricated counts, never silent-remove.
- **Long-op safety**: worktree RPCs ride a 600 s deadline (not the 5 s default) with an interim "Removing worktree…" state, so a big removal isn't misreported and the backend isn't SIGTERM'd mid-`git worktree remove`; Ctrl+C during the busy phase force-quits without waiting (worktree left in place).
- **Transport gate**: the controls only serve `single_session` (stdio) transports — on multi-session `--http` the process-wide env must not let one WS client remove another's worktree.
- **Idle-only removal**: `worktree_exit remove` refuses during an active turn (mirroring `clear`/`resume`/`rewind`/`compact`) — the turn runs on the worker thread while controls run on the main loop, so a mid-turn exit could otherwise delete the directory out from under live tool calls; the TUI renders the refusal as a normal keep. `keep` stays allowed mid-turn.
- **Destruction invariants**: `cleanup_worktree` re-asserts the launcher's slug mapping at the point of destruction (branch must be `worktree-*`, path must be under `.claude/worktrees/`), so a split/forged env block can't aim `branch -D` at an arbitrary branch; `git worktree remove` itself already refuses unregistered paths.
- **Exit reentrancy**: in-flight guard; a second exit request force-dies (worktree kept) if the backend is wedged.

## Deferred (not load-bearing for the core feature)

`--tmux` (incl. iTerm2 -CC), WorktreeCreate/WorktreeRemove hook delegation (hook *type* exists in Python, no executor wiring), `worktree.sparsePaths`/`symlinkDirectories` settings, EnterWorktree/ExitWorktree in-session tools, worktree restore on `--resume`, stale ephemeral-worktree sweep. Slug generation is `adj-noun-xxxx` with path-existence retry (vs TS's plan-slug reuse) — better matched to the collision domain. `tui --print-connect --worktree` runs on the http transport where the exit controls are gated off, so its worktree persists (keep) — intended for that debug path.

## Tests

- `tests/utils/test_worktree_session.py` (52): slug validation matrix, flatten injectivity, PR refs, env round-trip + strip, create/resume/orphan-rejection/`-B` reset, canonical root (subdir + from-inside-worktree), the lost-commit matrix (remote-less clean→0, unmerged→1, merged-back→0, resumed→1, fail-closed), cleanup, settings copy both tiers, `.worktreeinclude` incl. collapsed-dir expansion, message wording matrix.
- `tests/server/test_worktree_controls.py` (8): status/exit round-trips in a temp repo, single_session gate, done-latch, failure paths.
- `tests/entrypoints/test_worktree_cli_wiring.py` (10): parser shapes, nested-env strip through `main()`, `_child_env` block + OWNER_PID, headless chdir + keep note (incl. error path).
- ui-tui `worktree.test.ts` (8): env parsing + ppid gate, `planWorktreeExit` matrix + fail-closed rendering; exit-path tests updated to the `requestExit` contract.
- Suites: full pytest at baseline (only pre-existing failures, verified against main); ui-tui vitest at baseline (9 pre-existing); `tsc --noEmit` clean; eslint clean.
- **Live pyte e2e (real TUI + real backend + real provider), all pass**: (A) clean → silent remove, dir+branch gone; (B) dirty → dialog with correct subtitle → Keep default → work survives; (C) resume shows prior work → Esc cancels exit → Remove → discard wording → gone; (D) **two concurrent sessions** in different worktrees, file isolation verified, both silently removed. Plus a live headless `-p -w` run (created → ran turn inside → kept with note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
