### PR TITLE
feat(tui): port upstream TypeScript implementation's /logo command — startup logo color schemes

### DIFF
--- a/src/command_system/logo_command.py
+++ b/src/command_system/logo_command.py
@@ -2,14 +2,16 @@
 
 Port of ``typescript/src/commands/logo/`` (``logo.tsx`` + ``index.ts``). Picks the
 startup-banner color palette and persists it to the global config ``logoColor`` key;
-the two startup banners (REPL + TUI) resolve and render it on next launch.
+the Ink TUI banner (``ui-tui/src/banner.ts``) resolves and renders it — live on
+selection, and again at every startup via its synchronous config read.
 
-Coexistence: **fall-through** (the ``/export`` pattern, NOT the ``/theme``/``/effort``/
-``/model`` inversion). There is **no TUI dialog** for ``/logo`` (it is not in the TUI's
-``LOCAL_BUILTINS``/``open_dialog`` map), so the dispatch falls through and this
-``InteractiveCommand`` serves every surface via the ``UIHost`` port — TUI
-(``TextualUIHost.select``), REPL (``ReplUIHost.select``), SDK (``NullUIHost`` → clean
-error), and the help/aggregator listings.
+Coexistence: the interactive Ink TUI **shadows** ``/logo`` with its own local
+command + picker overlay (``ui-tui/src/app/slash/commands/session.ts`` →
+``logoPicker.tsx``), which persists through the agent-server ``set_logo_color``
+control. This ``InteractiveCommand`` therefore serves the non-TUI surfaces via the
+``UIHost`` port — headless/SDK (``NullUIHost`` → clean error) and the
+help/aggregator listings. (Its original REPL/Textual consumers were deleted in the
+UI consolidation, PR #566.)
 
 Faithfulness to TS (``logo.tsx``):
   * ``call(onDone, _context)`` **ignores args** — the picker is the only path; no

--- a/src/config.py
+++ b/src/config.py
@@ -512,9 +512,10 @@ def set_logo_color(name: str) -> None:
     """Persist the startup logo color palette to the global config.
 
     Mirrors TS ``/logo`` (``saveGlobalConfig(c => ({...c, logoColor: chosen}))``). A
-    top-level config key (like :func:`set_theme`), read via
-    ``load_config().get("logoColor")`` by the startup banners — NOT a nested settings
-    field.
+    top-level config key (like :func:`set_theme`) — NOT a nested settings field.
+    Read by the Ink TUI banner (synchronously at startup via
+    ``ui-tui/src/lib/logoPalettes.ts::readLogoColorSync``) and echoed in the
+    agent-server's ``get_settings`` reply.
     """
     _get_default_manager().set_global("logoColor", name)
 

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -398,6 +398,9 @@ class _AgentSession:
         if subtype == "set_output_style":
             self._do_set_output_style(request_id, inner.get("style"))
             return
+        if subtype == "set_logo_color":
+            self._do_set_logo_color(request_id, inner.get("name"))
+            return
         if subtype == "knowledge":
             self._do_knowledge(request_id, inner.get("action"))
             return
@@ -466,6 +469,8 @@ class _AgentSession:
                 # OS-1 W3 — the /output-style no-arg display.
                 "output_style": getattr(self.tool_context, "output_style_name", None) or "default",
                 "available_output_styles": self._available_output_styles(),
+                # /logo — the persisted startup-logo palette (None = default).
+                "logo_color": _current_logo_color(),
             })
             return
         if subtype == "get_context_usage":
@@ -1454,6 +1459,33 @@ class _AgentSession:
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] knowledge failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _do_set_logo_color(self, request_id: object, name: object) -> None:
+        """Persist the startup-logo palette (the TUI's /logo — openclaude's
+        ``saveGlobalConfig(c => ({...c, logoColor: chosen}))``). A pure global
+        config write with no agent/system-prompt impact, so unlike
+        ``set_output_style`` there is no idle-only gate."""
+        from src.utils.logo_palettes import LOGO_PALETTE_NAMES, is_logo_palette_name
+
+        if not is_logo_palette_name(name):
+            self._reply(
+                request_id,
+                {
+                    "ok": False,
+                    "error": f"invalid palette (valid: {', '.join(LOGO_PALETTE_NAMES)})",
+                    "available_palettes": LOGO_PALETTE_NAMES,
+                },
+            )
+            return
+        try:
+            from src.config import set_logo_color
+
+            set_logo_color(str(name))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] set_logo_color failed")
+            self._reply(request_id, {"ok": False, "error": f"failed to persist: {exc}"})
+            return
+        self._reply(request_id, {"ok": True, "logo_color": name})
 
     def _do_set_output_style(self, request_id: object, style: object) -> None:
         """Switch the output style mid-session (the original's /output-style).
@@ -3947,6 +3979,20 @@ def _dispatch_app_state(sess: "_AgentSession", **changes: Any) -> None:
         store.set_state(lambda prev: replace_state(prev, **changes))
     except Exception:  # noqa: BLE001
         logger.debug("[agent-server] app-state dispatch failed", exc_info=True)
+
+
+def _current_logo_color() -> str | None:
+    """The persisted /logo palette name, or None for the default/unset (the
+    ``get_settings`` rider; the TUI's startup read is its own synchronous
+    config.json read — see ui-tui/src/lib/logoPalettes.ts)."""
+    try:
+        from src.config import load_config
+        from src.utils.logo_palettes import is_logo_palette_name
+
+        value = load_config().get("logoColor")
+        return value if is_logo_palette_name(value) else None
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def _current_mode(tool_context: Any, default: str) -> str:

--- a/src/utils/logo_palettes.py
+++ b/src/utils/logo_palettes.py
@@ -1,20 +1,20 @@
 """Color palettes for the startup banner logo.
 
 Port of ``typescript/src/components/StartupScreen.palettes.ts``. Selected via the
-``/logo`` command, persisted in the global config ``logoColor`` key, and applied by
-the two startup banners (``src/repl/core.py::_print_startup_header`` and
-``src/tui/widgets/header.py::StartupHeader._render_banner``).
+``/logo`` command, persisted in the global config ``logoColor`` key (written by
+:func:`src.config.set_logo_color` — the ``set_logo_color`` agent-server control).
 
-Imports only ``rich`` + stdlib (NO Textual) so the REPL banner can import it. The
-palette ROLES (gradient / accent / cream / dim / border) are mapped onto Python's
-mascot+table+Panel banner (which differs from TS's gradient ASCII logo) via
-:func:`banner_palette` + :func:`mascot_gradient_text`.
+The rendering consumer is the Ink TUI banner: ``ui-tui/src/lib/logoPalettes.ts``
+carries the SAME verbatim palette table (keep the two in sync) and
+``ui-tui/src/banner.ts`` paints the wordmark/mascot rows from it. The old Rich
+REPL / Textual TUI banners that this module originally styled were deleted in the
+UI consolidation (PR #566), and their ``banner_palette`` / ``mascot_gradient_text``
+helpers went with them; this module now only keeps the palette table + validators
+for the ``/logo`` command and the server control.
 """
 from __future__ import annotations
 
 from dataclasses import dataclass
-
-from rich.text import Text
 
 RGB = tuple[int, int, int]
 
@@ -113,58 +113,6 @@ def resolve_logo_palette(name: str | None) -> LogoPalette:
     return LOGO_PALETTES[DEFAULT_LOGO_PALETTE]
 
 
-def rgb_hex(rgb: RGB) -> str:
-    """``(r,g,b)`` → ``"#rrggbb"`` (Rich truecolor style)."""
-    r, g, b = rgb
-    return f"#{r:02x}{g:02x}{b:02x}"
-
-
-@dataclass(frozen=True)
-class BannerStyles:
-    """Resolved Rich style strings for the banner elements. ``bold`` weight is
-    preserved where the original hardcoded styles were bold (so ``/logo`` changes
-    only hue, not weight)."""
-
-    border: str  # Panel border_style (current "bright_black" — not bold)
-    title: str  # Panel title (current "bold bright_cyan")
-    accent: str  # version row (current "bold white"/"bold cyan")
-    value: str  # table values (current "bold magenta"/"green"/"blue")
-    label: str  # label column (current "bright_black" — not bold)
-    dim: str  # footer / subtitle (current "dim" — not bold)
-
-
-def banner_palette(name: str | None) -> BannerStyles:
-    """Resolve ``name`` → the banner style strings. Never raises (unknown/None →
-    default ``sunset``)."""
-    p = resolve_logo_palette(name)
-    return BannerStyles(
-        border=rgb_hex(p.border),
-        title=f"bold {rgb_hex(p.accent)}",
-        accent=f"bold {rgb_hex(p.accent)}",
-        value=f"bold {rgb_hex(p.cream)}",
-        label=rgb_hex(p.dim),
-        dim=rgb_hex(p.dim),
-    )
-
-
-def mascot_gradient_text(name: str | None, mascot_lines: list[str]) -> Text:
-    """Build the mascot as a Rich ``Text`` with a vertical gradient: each line gets a
-    gradient stop sampled across the palette (bold, matching the original
-    ``bold orange3``). Never raises."""
-    palette = resolve_logo_palette(name)
-    gradient = palette.gradient
-    n = len(mascot_lines)
-    text = Text(no_wrap=True)
-    for i, line in enumerate(mascot_lines):
-        if n <= 1:
-            stop = gradient[0]
-        else:
-            stop = gradient[round(i * (len(gradient) - 1) / (n - 1))]
-        suffix = "\n" if i < n - 1 else ""
-        text.append(line + suffix, style=f"bold {rgb_hex(stop)}")
-    return text
-
-
 __all__ = [
     "RGB",
     "LogoPalette",
@@ -174,8 +122,4 @@ __all__ = [
     "LOGO_PALETTE_LABELS",
     "is_logo_palette_name",
     "resolve_logo_palette",
-    "rgb_hex",
-    "BannerStyles",
-    "banner_palette",
-    "mascot_gradient_text",
 ]

--- a/tests/server/test_agent_server_e2e.py
+++ b/tests/server/test_agent_server_e2e.py
@@ -627,6 +627,53 @@ async def test_control_set_output_style(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_control_set_logo_color(tmp_path):
+    """set_logo_color validates the palette, persists it to the global config
+    (the /logo picker's write path), and get_settings echoes it back."""
+    from src.tool_system.registry import ToolRegistry
+
+    with contextlib.ExitStack() as stack:
+        for p in _patches(_TextProvider, ToolRegistry([])):
+            stack.enter_context(p)
+        spawn = make_spawn_agent(AgentServerConfig(permission_mode="default"))
+        handle = await spawn("ds_test", str(tmp_path), None)
+        gen = handle.messages_from_agent()
+        try:
+            init = await asyncio.wait_for(gen.__anext__(), timeout=5)
+            assert init["subtype"] == "init"
+
+            async def _reply_for(rid, req):
+                await handle.send_to_agent({"type": "control_request", "request_id": rid, "request": req})
+                for _ in range(12):
+                    msg = await asyncio.wait_for(gen.__anext__(), timeout=5)
+                    if msg.get("type") == "control_response" and msg["response"].get("request_id") == rid:
+                        return msg["response"]["response"]
+                raise AssertionError(f"no reply for {rid}")
+
+            ok = await _reply_for("l1", {"subtype": "set_logo_color", "name": "forest"})
+            assert ok["ok"] is True and ok["logo_color"] == "forest"
+
+            # Persisted where the TUI's startup read (and the original's
+            # getGlobalConfig) looks: the global config's top-level logoColor.
+            from src.config import load_config
+
+            assert load_config().get("logoColor") == "forest"
+
+            settings = await _reply_for("l2", {"subtype": "get_settings"})
+            assert settings["logo_color"] == "forest"
+
+            bad = await _reply_for("l3", {"subtype": "set_logo_color", "name": "lava"})
+            assert bad["ok"] is False and "invalid palette" in bad["error"]
+            assert "forest" in bad["available_palettes"]
+            # A rejected name must not clobber the persisted choice.
+            assert load_config().get("logoColor") == "forest"
+        finally:
+            await handle.shutdown()
+            with contextlib.suppress(Exception):
+                await gen.aclose()
+
+
+@pytest.mark.asyncio
 async def test_control_set_model(tmp_path):
     """set_model round-trips {ok, model}: the TUI's /model needs the resulting
     model echoed back (a bare ack reads as failure), refusal on cross-provider

--- a/tests/test_logo_palettes.py
+++ b/tests/test_logo_palettes.py
@@ -1,7 +1,11 @@
 """Tests for the logo color-palette module (Phase 8).
 
-Guards the direct data port of ``StartupScreen.palettes.ts`` and the banner-style
-helpers (``banner_palette``, ``mascot_gradient_text``, ``rgb_hex``).
+Guards the direct data port of ``StartupScreen.palettes.ts``. The Rich
+banner-style helpers this file also covered (``banner_palette``,
+``mascot_gradient_text``, ``rgb_hex``) were deleted along with their REPL/Textual
+consumers (UI consolidation, PR #566) — the rendering twin now lives in
+``ui-tui/src/lib/logoPalettes.ts`` + ``ui-tui/src/banner.ts`` with its own
+vitest coverage (``logoPalettes.test.ts``).
 """
 from __future__ import annotations
 
@@ -10,11 +14,8 @@ from src.utils.logo_palettes import (
     LOGO_PALETTE_LABELS,
     LOGO_PALETTE_NAMES,
     LOGO_PALETTES,
-    banner_palette,
     is_logo_palette_name,
-    mascot_gradient_text,
     resolve_logo_palette,
-    rgb_hex,
 )
 
 
@@ -58,43 +59,3 @@ def test_resolve_logo_palette_falls_back_to_default():
     assert resolve_logo_palette("ocean") is LOGO_PALETTES["ocean"]
     assert resolve_logo_palette("bogus") is LOGO_PALETTES["sunset"]
     assert resolve_logo_palette(None) is LOGO_PALETTES["sunset"]
-
-
-def test_rgb_hex():
-    assert rgb_hex((255, 180, 100)) == "#ffb464"
-    assert rgb_hex((0, 0, 0)) == "#000000"
-    assert rgb_hex((100, 80, 65)) == "#645041"
-
-
-def test_banner_palette_styles():
-    st = banner_palette("ocean")
-    p = LOGO_PALETTES["ocean"]
-    assert st.border == rgb_hex(p.border)  # not bold (Panel border)
-    assert st.title == f"bold {rgb_hex(p.accent)}"
-    assert st.accent == f"bold {rgb_hex(p.accent)}"
-    assert st.value == f"bold {rgb_hex(p.cream)}"  # bold preserved
-    assert st.label == rgb_hex(p.dim)  # not bold
-    assert st.dim == rgb_hex(p.dim)
-
-
-def test_banner_palette_default_on_unset():
-    assert banner_palette(None) == banner_palette("sunset")
-    assert banner_palette("bogus") == banner_palette("sunset")
-
-
-def test_mascot_gradient_text_per_line():
-    lines = ["a", "b", "c", "d"]  # the 4-line mascot shape
-    text = mascot_gradient_text("sunset", lines)
-    assert text.plain == "a\nb\nc\nd"
-    grad = LOGO_PALETTES["sunset"].gradient
-    # 4 lines sample stops [0, 2, 3, 5].
-    expected = [grad[0], grad[2], grad[3], grad[5]]
-    styles = [span.style for span in text.spans]
-    assert styles == [f"bold {rgb_hex(s)}" for s in expected]
-
-
-def test_mascot_gradient_text_single_line_guard():
-    # N<=1 must not divide-by-zero.
-    text = mascot_gradient_text("forest", ["only"])
-    assert text.plain == "only"
-    assert text.spans[0].style == f"bold {rgb_hex(LOGO_PALETTES['forest'].gradient[0])}"

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -301,6 +301,21 @@ describe('GatewayClient NDJSON adapter', () => {
     await expect(p).resolves.toEqual({ ok: false })
   })
 
+  it('routes config.set logoColor to the set_logo_color control and echoes the value', async () => {
+    // /logo persistence: the round-trip matters — a not-ready backend must
+    // surface as ok:false (the command prints "this session only"), never a
+    // silent false success.
+    const p = gw.request('config.set', { key: 'logoColor', value: 'forest' })
+    await replyToControl('set_logo_color', { logo_color: 'forest', ok: true })
+    await expect(p).resolves.toEqual({ ok: true, value: 'forest' })
+  })
+
+  it('reflects a set_logo_color rejection as ok:false', async () => {
+    const p = gw.request('config.set', { key: 'logoColor', value: 'lava' })
+    await replyToControl('set_logo_color', { error: 'invalid palette', ok: false })
+    await expect(p).resolves.toEqual({ ok: false })
+  })
+
   // ── config.set model (the /model picker + typed /model) ───────────────────
 
   it('parses the picker model grammar and answers with the switched value', async () => {

--- a/ui-tui/src/__tests__/logoCommand.test.ts
+++ b/ui-tui/src/__tests__/logoCommand.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getOverlayState, resetOverlayState } from '../app/overlayStore.js'
+import { findSlashCommand } from '../app/slash/registry.js'
+import type { SlashRunCtx } from '../app/slash/types.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
+
+/** Minimal SlashRunCtx for the /logo command: transcript + gateway.rpc +
+ *  the guarded() wrappers createSlashHandler builds per invocation. */
+const makeCtx = (rpcResult: unknown) => {
+  const sys = vi.fn()
+  const rpc = vi.fn().mockResolvedValue(rpcResult)
+
+  const ctx = {
+    gateway: { rpc },
+    guarded:
+      <T>(fn: (r: T) => void) =>
+      (r: null | T) => {
+        if (r) {
+          fn(r)
+        }
+      },
+    guardedErr: vi.fn(),
+    transcript: { sys }
+  } as unknown as SlashRunCtx
+
+  return { ctx, rpc, sys }
+}
+
+const logoCmd = findSlashCommand('logo')!
+
+describe('/logo TUI-local command', () => {
+  beforeEach(() => {
+    resetOverlayState()
+    resetUiState()
+    // The store seeds logoPalette from the developer's real config at module
+    // init — pin it for determinism.
+    patchUiState({ logoPalette: '' })
+  })
+
+  it('is registered with the palette grammar', () => {
+    expect(logoCmd).toBeDefined()
+    expect(logoCmd.argumentHint).toBe('[sunset|forest|ocean|monochrome]')
+  })
+
+  it('bare /logo opens the picker overlay (the original local-jsx LogoPicker)', () => {
+    const { ctx, rpc } = makeCtx({ ok: true })
+    logoCmd.run('', ctx, '/logo')
+
+    expect(getOverlayState().logoPicker).toBe(true)
+    expect(rpc).not.toHaveBeenCalled()
+  })
+
+  it('/logo <name> persists via config.set logoColor and confirms next-launch visibility', async () => {
+    const { ctx, rpc, sys } = makeCtx({ ok: true, value: 'forest' })
+    logoCmd.run('forest', ctx, '/logo forest')
+
+    expect(rpc).toHaveBeenCalledWith('config.set', { key: 'logoColor', value: 'forest' })
+
+    // TS-verbatim confirmation: the intro banner is a committed transcript
+    // row the renderer never re-emits, so like the original the change is
+    // next-launch-only. (The screen repaint is covered by the live pyte e2e's
+    // relaunch phase, not by this store-level test.)
+    await vi.waitFor(() => expect(sys).toHaveBeenCalledWith('Startup logo set to Forest green. Visible on next launch.'))
+    // Patched on success so the picker's "· current" marker tracks what was
+    // actually persisted.
+    expect(getUiState().logoPalette).toBe('forest')
+  })
+
+  it('reports failure without claiming success when the backend could not persist', async () => {
+    const { ctx, sys } = makeCtx({ ok: false })
+    logoCmd.run('ocean', ctx, '/logo ocean')
+
+    await vi.waitFor(() =>
+      expect(sys).toHaveBeenCalledWith('Could not persist the startup logo (backend not ready) — try again shortly.')
+    )
+    // Not persisted → the picker's current marker must not move.
+    expect(getUiState().logoPalette).toBe('')
+  })
+
+  it('rejects unknown palettes with usage and touches nothing', () => {
+    const { ctx, rpc, sys } = makeCtx({ ok: true })
+    logoCmd.run('lava', ctx, '/logo lava')
+
+    expect(sys).toHaveBeenCalledWith('usage: /logo [sunset|forest|ocean|monochrome]')
+    expect(getUiState().logoPalette).toBe('')
+    expect(getOverlayState().logoPicker).toBe(false)
+    expect(rpc).not.toHaveBeenCalled()
+  })
+})

--- a/ui-tui/src/__tests__/logoPalettes.test.ts
+++ b/ui-tui/src/__tests__/logoPalettes.test.ts
@@ -1,0 +1,158 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { lobster, logo, wordmarkGradient } from '../banner.js'
+import {
+  DEFAULT_LOGO_PALETTE,
+  gradientStopForRow,
+  isLogoPaletteName,
+  LOGO_PALETTE_LABELS,
+  LOGO_PALETTE_NAMES,
+  LOGO_PALETTES,
+  readLogoColorSync,
+  rgbStr
+} from '../lib/logoPalettes.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const C = DEFAULT_THEME.color
+
+// The shipped brand ramp (banner.ts LOGO_SUNSET) — the default look that unset
+// AND explicit "sunset" must both keep.
+const BRAND_TOP = 'rgb(245,166,120)'
+
+describe('logo palette table (StartupScreen.palettes.ts parity)', () => {
+  it('carries the four openclaude palettes with six gradient stops each', () => {
+    expect(LOGO_PALETTE_NAMES).toEqual(['sunset', 'forest', 'ocean', 'monochrome'])
+
+    for (const name of LOGO_PALETTE_NAMES) {
+      expect(LOGO_PALETTES[name].gradient).toHaveLength(6)
+    }
+
+    expect(DEFAULT_LOGO_PALETTE).toBe('sunset')
+    expect(LOGO_PALETTE_LABELS.sunset).toBe('Sunset (default)')
+    expect(LOGO_PALETTE_LABELS.forest).toBe('Forest green')
+    expect(LOGO_PALETTE_LABELS.ocean).toBe('Ocean blue')
+    expect(LOGO_PALETTE_LABELS.monochrome).toBe('Monochrome')
+  })
+
+  it('spot-checks verbatim TS gradient values', () => {
+    expect(LOGO_PALETTES.sunset.gradient[0]).toEqual([255, 180, 100])
+    expect(LOGO_PALETTES.forest.gradient[5]).toEqual([25, 80, 45])
+    expect(LOGO_PALETTES.ocean.gradient[2]).toEqual([80, 150, 220])
+    expect(LOGO_PALETTES.monochrome.gradient[3]).toEqual([125, 125, 125])
+  })
+
+  it('validates palette names', () => {
+    expect(isLogoPaletteName('ocean')).toBe(true)
+    expect(isLogoPaletteName('lava')).toBe(false)
+    expect(isLogoPaletteName('')).toBe(false)
+    expect(isLogoPaletteName(undefined)).toBe(false)
+    // hasOwnProperty guard: prototype keys must not validate.
+    expect(isLogoPaletteName('constructor')).toBe(false)
+  })
+})
+
+describe('gradientStopForRow', () => {
+  const stops = LOGO_PALETTES.ocean.gradient
+
+  it('maps a 6-row block onto 6 stops one-to-one', () => {
+    for (let i = 0; i < 6; i++) {
+      expect(gradientStopForRow(stops, i, 6)).toEqual(stops[i])
+    }
+  })
+
+  it('samples ends for other row counts and degenerate inputs', () => {
+    expect(gradientStopForRow(stops, 0, 3)).toEqual(stops[0])
+    expect(gradientStopForRow(stops, 2, 3)).toEqual(stops[5])
+    expect(gradientStopForRow(stops, 0, 1)).toEqual(stops[0])
+  })
+})
+
+describe('banner painting with /logo palettes', () => {
+  it('keeps the shipped brand ramp for unset and explicit sunset', () => {
+    expect(wordmarkGradient(undefined)[0]).toBe(BRAND_TOP)
+    expect(wordmarkGradient('')[0]).toBe(BRAND_TOP)
+    expect(wordmarkGradient('sunset')[0]).toBe(BRAND_TOP)
+    expect(wordmarkGradient('not-a-palette')[0]).toBe(BRAND_TOP)
+
+    const rows = logo(C, undefined, 'sunset')
+    expect(rows[0]![0]).toBe(BRAND_TOP)
+  })
+
+  it('paints wordmark rows from a non-default palette gradient', () => {
+    const rows = logo(C, undefined, 'ocean')
+    expect(rows).toHaveLength(6)
+    rows.forEach((row, i) => expect(row[0]).toBe(rgbStr(LOGO_PALETTES.ocean.gradient[i]!)))
+  })
+
+  it('paints lobster rows from a non-default palette, keeps theme colors otherwise', () => {
+    const themed = lobster(C, undefined, undefined)
+    const sunset = lobster(C, undefined, 'sunset')
+    expect(sunset).toEqual(themed)
+
+    const forest = lobster(C, undefined, 'forest')
+    expect(forest).toHaveLength(6)
+    forest.forEach((row, i) =>
+      expect(row[0]).toBe(rgbStr(gradientStopForRow(LOGO_PALETTES.forest.gradient, i, 6)))
+    )
+  })
+
+  it('lets a skin banner override win over the palette', () => {
+    const rows = logo(C, '[#ff0000]X[/]', 'ocean')
+    expect(rows).toEqual([['#ff0000', 'X']])
+
+    const hero = lobster(C, '[#00ff00]Y[/]', 'ocean')
+    expect(hero).toEqual([['#00ff00', 'Y']])
+  })
+})
+
+describe('readLogoColorSync', () => {
+  const prevHome = process.env.CLAWCODEX_HOME
+  let dir = ''
+
+  afterEach(() => {
+    if (prevHome === undefined) {
+      delete process.env.CLAWCODEX_HOME
+    } else {
+      process.env.CLAWCODEX_HOME = prevHome
+    }
+
+    if (dir) {
+      rmSync(dir, { force: true, recursive: true })
+      dir = ''
+    }
+  })
+
+  const home = (config?: string) => {
+    dir = mkdtempSync(join(tmpdir(), 'clawcodex-logo-'))
+    mkdirSync(dir, { recursive: true })
+
+    if (config !== undefined) {
+      writeFileSync(join(dir, 'config.json'), config)
+    }
+
+    process.env.CLAWCODEX_HOME = dir
+  }
+
+  it('reads a valid persisted palette name', () => {
+    home(JSON.stringify({ logoColor: 'forest' }))
+    expect(readLogoColorSync()).toBe('forest')
+  })
+
+  it("returns '' for unset, invalid, malformed, and missing config", () => {
+    home(JSON.stringify({ default_provider: 'anthropic' }))
+    expect(readLogoColorSync()).toBe('')
+
+    home(JSON.stringify({ logoColor: 'lava' }))
+    expect(readLogoColorSync()).toBe('')
+
+    home('{not json')
+    expect(readLogoColorSync()).toBe('')
+
+    home(undefined)
+    expect(readLogoColorSync()).toBe('')
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -139,6 +139,7 @@ export interface OverlayState {
   billing: BillingOverlayState | null
   clarify: ClarifyReq | null
   confirm: ConfirmReq | null
+  logoPicker: boolean
   modelPicker: boolean
   pager: null | PagerState
   petPicker: boolean
@@ -176,6 +177,8 @@ export interface UiState {
   info: null | SessionInfo
   liveSessionCount: number
   inlineDiffs: boolean
+  /** Persisted /logo palette name ('' = default sunset brand look). */
+  logoPalette: string
   mouseTracking: MouseTrackingMode
   notice: Notice | null
   pasteCollapseLines: number
@@ -401,6 +404,7 @@ export interface AppLayoutActions {
   closeLiveSession: (id: string) => Promise<null | SessionCloseResponse>
   newLiveSession: () => void
   newPromptSession: (prompt: string, modelArg?: string) => void
+  onLogoSelect: (value: string) => void
   onModelSelect: (value: string) => void
   resumeById: (id: string) => void
   setStickyPrompt: (value: string) => void
@@ -463,6 +467,7 @@ export interface AppOverlaysProps {
   onClarifyAnswer: (value: string) => void
   onActiveSessionSelect: (sessionId: string) => void
   onActiveSessionClose: (sessionId: string) => Promise<null | SessionCloseResponse>
+  onLogoSelect: (value: string) => void
   onModelSelect: (value: string) => void
   onNewLiveSession: () => void
   onNewPromptSession: (prompt: string, modelArg?: string) => void

--- a/ui-tui/src/app/overlayStore.ts
+++ b/ui-tui/src/app/overlayStore.ts
@@ -9,6 +9,7 @@ const buildOverlayState = (): OverlayState => ({
   billing: null,
   clarify: null,
   confirm: null,
+  logoPicker: false,
   modelPicker: false,
   pager: null,
   petPicker: false,
@@ -30,6 +31,7 @@ export const $isBlocked = computed(
     billing,
     clarify,
     confirm,
+    logoPicker,
     modelPicker,
     pager,
     petPicker,
@@ -46,6 +48,7 @@ export const $isBlocked = computed(
       billing ||
       clarify ||
       confirm ||
+      logoPicker ||
       modelPicker ||
       pager ||
       petPicker ||
@@ -79,6 +82,7 @@ export const resetFlowOverlays = () =>
     ...buildOverlayState(),
     agents: $overlayState.get().agents,
     agentsInitialHistoryIndex: $overlayState.get().agentsInitialHistoryIndex,
+    logoPicker: $overlayState.get().logoPicker,
     modelPicker: $overlayState.get().modelPicker,
     petPicker: $overlayState.get().petPicker,
     pluginsHub: $overlayState.get().pluginsHub,

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -11,6 +11,7 @@ import type {
   SlashExecResponse,
   VoiceToggleResponse
 } from '../../../gatewayTypes.js'
+import { isLogoPaletteName, LOGO_PALETTE_LABELS, LOGO_PALETTE_NAMES } from '../../../lib/logoPalettes.js'
 import { formatVoiceRecordKey, parseVoiceRecordKey } from '../../../lib/platform.js'
 import { fmtK } from '../../../lib/text.js'
 import type { PanelSection } from '../../../types.js'
@@ -375,6 +376,48 @@ export const sessionCommands: SlashCommand[] = [
           ctx.guarded<SlashExecResponse>(r => {
             const body = r.output || '/pet: no output'
             ctx.transcript.sys(r.warning ? `warning: ${r.warning}\n${body}` : body)
+          })
+        )
+        .catch(ctx.guardedErr)
+    }
+  },
+
+  {
+    argumentHint: `[${LOGO_PALETTE_NAMES.join('|')}]`,
+    help: 'change the startup logo color scheme',
+    name: 'logo',
+    usage: `/logo [${LOGO_PALETTE_NAMES.join('|')}]`,
+    // Port of openclaude's /logo (commands/logo/). Bare /logo opens the picker
+    // overlay (the original's local-jsx LogoPicker); /logo <name> applies —
+    // that arg path is the /model-picker pattern (the overlay re-enters
+    // "/logo <name>" so the result lands in the transcript), a documented
+    // divergence from the TS command, which is picker-only. Next-launch-only,
+    // like the original: the intro banner is a committed transcript row and
+    // the renderer never re-emits committed rows, so the already-painted
+    // wordmark cannot reliably repaint mid-session. logoPalette is patched on
+    // success anyway — it keeps the picker's "· current" marker truthful.
+    run: (arg, ctx) => {
+      const name = arg.trim().toLowerCase()
+
+      if (!name) {
+        return patchOverlayState({ logoPicker: true })
+      }
+
+      if (!isLogoPaletteName(name)) {
+        return ctx.transcript.sys(`usage: /logo [${LOGO_PALETTE_NAMES.join('|')}]`)
+      }
+
+      ctx.gateway
+        .rpc<ConfigSetResponse>('config.set', { key: 'logoColor', value: name })
+        .then(
+          ctx.guarded<ConfigSetResponse>(r => {
+            if (!r.value) {
+              return ctx.transcript.sys('Could not persist the startup logo (backend not ready) — try again shortly.')
+            }
+
+            patchUiState({ logoPalette: name })
+            // TS-verbatim (logo.tsx onDone).
+            ctx.transcript.sys(`Startup logo set to ${LOGO_PALETTE_LABELS[name]}. Visible on next launch.`)
           })
         )
         .catch(ctx.guardedErr)

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -2,6 +2,7 @@ import { atom, computed } from 'nanostores'
 
 import { MOUSE_TRACKING } from '../config/env.js'
 import { ZERO } from '../domain/usage.js'
+import { readLogoColorSync } from '../lib/logoPalettes.js'
 import { ZERO_SESSION_STATS } from '../lib/sessionStats.js'
 import { DEFAULT_THEME } from '../theme.js'
 
@@ -19,6 +20,9 @@ const buildUiState = (): UiState => ({
   info: null,
   liveSessionCount: 0,
   inlineDiffs: true,
+  // Seeded synchronously from ~/.clawcodex/config.json so the banner's first
+  // paint is already in the chosen palette (the backend isn't up yet).
+  logoPalette: readLogoColorSync(),
   mouseTracking: MOUSE_TRACKING,
   notice: null,
   pasteCollapseLines: 5,
@@ -39,6 +43,7 @@ export const $uiState = atom<UiState>(buildUiState())
 
 export const $uiTheme = computed($uiState, state => state.theme)
 export const $uiSessionId = computed($uiState, state => state.sid)
+export const $uiLogoPalette = computed($uiState, state => state.logoPalette)
 
 export const getUiState = () => $uiState.get()
 

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -170,6 +170,10 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return patchOverlayState({ petPicker: false })
     }
 
+    if (overlay.logoPicker) {
+      return patchOverlayState({ logoPicker: false })
+    }
+
     if (overlay.billing) {
       return patchOverlayState({ billing: null })
     }

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -1067,6 +1067,11 @@ export function useMainApp(gw: GatewayClient) {
     slashRef.current(`/model ${value}`)
   }, [])
 
+  const onLogoSelect = useCallback((value: string) => {
+    patchOverlayState({ logoPicker: false })
+    slashRef.current(`/logo ${value}`)
+  }, [])
+
   const closeLiveSession = useCallback(
     async (id: string) => {
       patchUiState({ status: 'closing session…' })
@@ -1169,6 +1174,7 @@ export function useMainApp(gw: GatewayClient) {
       clearSelection,
       newLiveSession: () => session.newLiveSession(),
       newPromptSession,
+      onLogoSelect,
       onModelSelect,
       // Resuming a cold session from the overlay CLOSES the current one, so it
       // must respect the busy guard just like the `/resume` slash path.
@@ -1191,6 +1197,7 @@ export function useMainApp(gw: GatewayClient) {
       clearSelection,
       closeLiveSession,
       newPromptSession,
+      onLogoSelect,
       onModelSelect,
       session
     ]

--- a/ui-tui/src/banner.ts
+++ b/ui-tui/src/banner.ts
@@ -1,3 +1,11 @@
+import {
+  DEFAULT_LOGO_PALETTE,
+  gradientStopForRow,
+  isLogoPaletteName,
+  LOGO_PALETTES,
+  type LogoPaletteName,
+  rgbStr
+} from './lib/logoPalettes.js'
 import type { ThemeColors } from './theme.js'
 
 const RICH_RE = /\[(?:bold\s+)?(?:dim\s+)?(#(?:[0-9a-fA-F]{3,8}))\]([\s\S]*?)(\[\/\])/g
@@ -73,6 +81,7 @@ const LOGO_SUNSET = [
   'rgb(193,102,77)',
   'rgb(178,90,70)'
 ] as const
+
 // Claws/arms in accent, body in primary, tail in accent — both are the brand
 // terracotta, so the whole mascot reads lobster-red.
 const LOBSTER_GRADIENT = [1, 1, 0, 0, 0, 1] as const
@@ -86,11 +95,52 @@ const colorize = (art: string[], gradient: readonly number[], c: ThemeColors): L
 export const LOGO_WIDTH = Math.max(...LOGO_ART.map(line => line.length))
 export const LOBSTER_WIDTH = Math.max(...LOBSTER_ART.map(line => line.length))
 
-export const logo = (c: ThemeColors, customLogo?: string): Line[] =>
-  customLogo ? parseRichMarkup(customLogo) : LOGO_ART.map((text, i) => [LOGO_SUNSET[i] ?? c.primary, text])
+// /logo palette → banner painting (applied at the banner's startup paint; the
+// intro row is committed to scrollback, so a mid-session /logo shows on the
+// NEXT launch, matching the original). The unset default AND an explicit
+// "sunset" both keep the shipped look (brand LOGO_SUNSET wordmark,
+// theme-colored lobster): "Sunset (default)" IS clawcodex's default scheme,
+// and picking it must return exactly to it. Only a non-default palette
+// changes the paint — wordmark rows one gradient stop each, lobster rows
+// sampled from the same gradient so the mascot doesn't clash
+// terracotta-on-ocean. Skin overrides (customLogo / customHero) win over the
+// palette: a skin is a full rebrand, /logo recolors the default logo.
+const nonDefaultPalette = (logoColor?: string): LogoPaletteName | null =>
+  logoColor && logoColor !== DEFAULT_LOGO_PALETTE && isLogoPaletteName(logoColor) ? logoColor : null
 
-export const lobster = (c: ThemeColors, customHero?: string): Line[] =>
-  customHero ? parseRichMarkup(customHero) : colorize(LOBSTER_ART, LOBSTER_GRADIENT, c)
+/** The 6 wordmark row colors the banner will actually use for `logoColor` —
+ *  also drives the /logo picker swatches so previews stay truthful. */
+export const wordmarkGradient = (logoColor?: string): string[] => {
+  const name = nonDefaultPalette(logoColor)
+
+  return name ? LOGO_PALETTES[name].gradient.map(rgbStr) : [...LOGO_SUNSET]
+}
+
+export const logo = (c: ThemeColors, customLogo?: string, logoColor?: string): Line[] => {
+  if (customLogo) {
+    return parseRichMarkup(customLogo)
+  }
+
+  const grad = wordmarkGradient(logoColor)
+
+  return LOGO_ART.map((text, i) => [grad[i] ?? c.primary, text])
+}
+
+export const lobster = (c: ThemeColors, customHero?: string, logoColor?: string): Line[] => {
+  if (customHero) {
+    return parseRichMarkup(customHero)
+  }
+
+  const name = nonDefaultPalette(logoColor)
+
+  if (name) {
+    const stops = LOGO_PALETTES[name].gradient
+
+    return LOBSTER_ART.map((text, i) => [rgbStr(gradientStopForRow(stops, i, LOBSTER_ART.length)), text])
+  }
+
+  return colorize(LOBSTER_ART, LOBSTER_GRADIENT, c)
+}
 
 export const artWidth = (lines: Line[]) => lines.reduce((m, [, t]) => Math.max(m, t.length), 0)
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -123,11 +123,12 @@ const TranscriptPane = memo(function TranscriptPane({
 
               {row.msg.kind === 'intro' ? (
                 <Box flexDirection="column" paddingTop={1}>
-                  <Banner maxWidth={Math.max(1, composer.cols - 2)} t={ui.theme} />
+                  <Banner logoPalette={ui.logoPalette} maxWidth={Math.max(1, composer.cols - 2)} t={ui.theme} />
 
                   {row.msg.info && (
                     <SessionPanel
                       info={row.msg.info}
+                      logoPalette={ui.logoPalette}
                       maxWidth={Math.max(1, composer.cols - 2)}
                       sid={ui.sid}
                       t={ui.theme}
@@ -299,6 +300,7 @@ const ComposerPane = memo(function ComposerPane({
           completions={composer.completions}
           onActiveSessionClose={actions.closeLiveSession}
           onActiveSessionSelect={actions.activateLiveSession}
+          onLogoSelect={actions.onLogoSelect}
           onModelSelect={actions.onModelSelect}
           onNewLiveSession={actions.newLiveSession}
           onNewPromptSession={actions.newPromptSession}

--- a/ui-tui/src/components/appOverlays.tsx
+++ b/ui-tui/src/components/appOverlays.tsx
@@ -5,11 +5,12 @@ import { useGateway } from '../app/gatewayContext.js'
 import type { AppOverlaysProps } from '../app/interfaces.js'
 import { $overlayState, patchOverlayState } from '../app/overlayStore.js'
 import { argumentHintFor } from '../app/slash/argumentHints.js'
-import { $uiSessionId, $uiTheme } from '../app/uiStore.js'
+import { $uiLogoPalette, $uiSessionId, $uiTheme } from '../app/uiStore.js'
 
 import { ActiveSessionSwitcher } from './activeSessionSwitcher.js'
 import { FloatBox } from './appChrome.js'
 import { BillingOverlay } from './billingOverlay.js'
+import { LogoPicker } from './logoPicker.js'
 import { MaskedPrompt } from './maskedPrompt.js'
 import { ModelPicker } from './modelPicker.js'
 import { OverlayHint } from './overlayControls.js'
@@ -127,6 +128,7 @@ export function FloatingOverlays({
   completions,
   onActiveSessionSelect,
   onActiveSessionClose,
+  onLogoSelect,
   onModelSelect,
   onNewLiveSession,
   onNewPromptSession,
@@ -139,6 +141,7 @@ export function FloatingOverlays({
   | 'completions'
   | 'onActiveSessionSelect'
   | 'onActiveSessionClose'
+  | 'onLogoSelect'
   | 'onModelSelect'
   | 'onNewLiveSession'
   | 'onNewPromptSession'
@@ -149,8 +152,10 @@ export function FloatingOverlays({
   const overlay = useStore($overlayState)
   const sid = useStore($uiSessionId)
   const theme = useStore($uiTheme)
+  const logoPalette = useStore($uiLogoPalette)
 
   const hasAny =
+    overlay.logoPicker ||
     overlay.modelPicker ||
     overlay.pager ||
     overlay.petPicker ||
@@ -195,6 +200,17 @@ export function FloatingOverlays({
             onCancel={() => patchOverlayState({ modelPicker: false })}
             onSelect={onModelSelect}
             sessionId={sid}
+            t={theme}
+          />
+        </FloatBox>
+      )}
+
+      {overlay.logoPicker && (
+        <FloatBox color={theme.color.border}>
+          <LogoPicker
+            current={logoPalette}
+            onClose={() => patchOverlayState({ logoPicker: false })}
+            onSelect={onLogoSelect}
             t={theme}
           />
         </FloatBox>

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -84,7 +84,7 @@ function CompactBanner({ cols, t }: { cols: number; t: Theme }) {
   )
 }
 
-export function Banner({ maxWidth, t }: { maxWidth?: number; t: Theme }) {
+export function Banner({ logoPalette, maxWidth, t }: { logoPalette?: string; maxWidth?: number; t: Theme }) {
   const term = useStdout().stdout?.columns ?? 80
   const cols = Math.max(1, Math.min(term, maxWidth ?? term))
 
@@ -92,7 +92,7 @@ export function Banner({ maxWidth, t }: { maxWidth?: number; t: Theme }) {
     return null
   }
 
-  const logoLines = logo(t.color, t.bannerLogo || undefined)
+  const logoLines = logo(t.color, t.bannerLogo || undefined, logoPalette)
   const logoW = t.bannerLogo ? artWidth(logoLines) : LOGO_WIDTH
 
   if (cols >= logoW + 2) {
@@ -159,10 +159,10 @@ function CollapseToggle({
 const SKILLS_MAX = 8
 const TOOLSETS_MAX = 8
 
-export function SessionPanel({ info, maxWidth, sid, t }: SessionPanelProps) {
+export function SessionPanel({ info, logoPalette, maxWidth, sid, t }: SessionPanelProps) {
   const term = useStdout().stdout?.columns ?? 100
   const cols = Math.max(20, Math.min(term, maxWidth ?? term))
-  const heroLines = lobster(t.color, t.bannerHero || undefined)
+  const heroLines = lobster(t.color, t.bannerHero || undefined, logoPalette)
   const leftW = Math.min((artWidth(heroLines) || LOBSTER_WIDTH) + 4, Math.floor(cols * 0.4))
   const wide = cols >= 90 && leftW + 40 < cols
   const w = Math.max(20, wide ? cols - leftW - 14 : cols - 12)
@@ -478,6 +478,7 @@ interface PanelProps {
 
 interface SessionPanelProps {
   info: SessionInfo
+  logoPalette?: string
   maxWidth?: number
   sid?: string | null
   t: Theme

--- a/ui-tui/src/components/logoPicker.tsx
+++ b/ui-tui/src/components/logoPicker.tsx
@@ -1,0 +1,88 @@
+import { Box, Text, useInput } from '@clawcodex/ink'
+import { useState } from 'react'
+
+import { wordmarkGradient } from '../banner.js'
+import {
+  DEFAULT_LOGO_PALETTE,
+  isLogoPaletteName,
+  LOGO_PALETTE_LABELS,
+  LOGO_PALETTE_NAMES,
+  type LogoPaletteName
+} from '../lib/logoPalettes.js'
+import type { Theme } from '../theme.js'
+
+import { OverlayHint } from './overlayControls.js'
+
+/**
+ * Interactive /logo picker overlay — port of openclaude's `LogoPicker`
+ * (`components/LogoPicker.tsx`). Each option carries a six-block preview
+ * swatch (one ▇ per gradient stop, the original's `previewSwatch`); the
+ * swatch colors come from `wordmarkGradient` so the preview is exactly what
+ * the banner will paint on the next launch. Enter hands the chosen name to
+ * `onSelect` (the app re-enters `/logo <name>`, the /model picker pattern);
+ * Esc cancels.
+ */
+export function LogoPicker({ current, onClose, onSelect, t }: LogoPickerProps) {
+  const initial = isLogoPaletteName(current) ? current : DEFAULT_LOGO_PALETTE
+  const [idx, setIdx] = useState(Math.max(0, LOGO_PALETTE_NAMES.indexOf(initial)))
+
+  useInput((_input, key) => {
+    if (key.escape) {
+      return onClose()
+    }
+
+    if (key.upArrow) {
+      return setIdx(i => Math.max(0, i - 1))
+    }
+
+    if (key.downArrow) {
+      return setIdx(i => Math.min(LOGO_PALETTE_NAMES.length - 1, i + 1))
+    }
+
+    if (key.return) {
+      const name = LOGO_PALETTE_NAMES[idx]
+
+      return name ? onSelect(name) : undefined
+    }
+  })
+
+  return (
+    <Box flexDirection="column">
+      <Text bold color={t.color.accent}>
+        Choose the startup logo color scheme
+      </Text>
+
+      {LOGO_PALETTE_NAMES.map((name, i) => {
+        const at = i === idx
+
+        return (
+          <Text key={name} wrap="truncate-end">
+            <Text bold={at} color={at ? t.color.accent : t.color.muted}>
+              {at ? '▸ ' : '  '}
+            </Text>
+            {wordmarkGradient(name).map((color, s) => (
+              <Text color={color} key={s}>
+                ▇
+              </Text>
+            ))}
+            <Text bold={at} color={at ? t.color.accent : t.color.text} inverse={at}>
+              {'  '}
+              {LOGO_PALETTE_LABELS[name]}
+            </Text>
+            {name === initial && <Text color={t.color.muted}> · current</Text>}
+          </Text>
+        )
+      })}
+
+      <OverlayHint t={t}>↑/↓ select · Enter apply · Esc cancel</OverlayHint>
+    </Box>
+  )
+}
+
+interface LogoPickerProps {
+  /** The active palette name ('' = default sunset). */
+  current: string
+  onClose: () => void
+  onSelect: (name: LogoPaletteName) => void
+  t: Theme
+}

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -266,6 +266,7 @@ const SLASHES: ReadonlyArray<{ desc: string; hint?: string; name: string }> = [
   { desc: 'Clear the conversation', name: '/clear' },
   { desc: 'Switch the model', name: '/model' },
   { desc: 'Set the output style', hint: '[<name>]', name: '/output-style' },
+  { desc: 'Change the startup logo color scheme', name: '/logo' },
   { desc: 'Set the permission mode', hint: '[default|plan|acceptEdits|dontAsk|bypassPermissions]', name: '/mode' },
   { desc: 'Compact the conversation to save context', name: '/compact' },
   { desc: 'Show context-window usage', name: '/context' },
@@ -536,6 +537,14 @@ export class GatewayClient extends EventEmitter {
         }
 
         if (key === 'model') {return this.setModel(String(value ?? '')) as Promise<T>}
+
+        if (key === 'logoColor') {
+          return this.controlQuery('set_logo_color', { name: value }).then(r => {
+            const ok = (r as any)?.ok === true
+
+            return (ok ? { ok: true, value: String(value ?? '') } : { ok: false }) as T
+          })
+        }
 
         if (key === 'effort' || key === 'reasoning') {this.sendControl('set_effort', { effort: value })}
         else if (key === 'provider') {this.sendControl('set_provider', { provider: value })}

--- a/ui-tui/src/lib/logoPalettes.ts
+++ b/ui-tui/src/lib/logoPalettes.ts
@@ -1,0 +1,139 @@
+import { readFileSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/**
+ * Color palettes for the startup banner logo, selected via /logo.
+ *
+ * Port of openclaude's `components/StartupScreen.palettes.ts` (values verbatim;
+ * the Python twin is `src/utils/logo_palettes.py`). The chosen name persists in
+ * the global config's top-level `logoColor` key (~/.clawcodex/config.json) —
+ * written by the backend's `set_logo_color` control, read synchronously at TUI
+ * startup by `readLogoColorSync` so the banner paints correctly on first render
+ * (the original reads `getGlobalConfig().logoColor` the same way).
+ */
+
+export type RGB = readonly [number, number, number]
+
+export interface LogoPalette {
+  /** Gradient stops painted top→bottom across the ASCII logo rows. */
+  gradient: readonly RGB[]
+  /** Highlight color (unused by the TUI banner today; kept for parity). */
+  accent: RGB
+  /** Soft body text color (unused by the TUI banner today; kept for parity). */
+  cream: RGB
+  /** Dim color (unused by the TUI banner today; kept for parity). */
+  dim: RGB
+  /** Border color (unused by the TUI banner today; kept for parity). */
+  border: RGB
+}
+
+export const LOGO_PALETTES = {
+  sunset: {
+    gradient: [
+      [255, 180, 100],
+      [240, 140, 80],
+      [217, 119, 87],
+      [193, 95, 60],
+      [160, 75, 55],
+      [130, 60, 50]
+    ],
+    accent: [240, 148, 100],
+    cream: [220, 195, 170],
+    dim: [120, 100, 82],
+    border: [100, 80, 65]
+  },
+  forest: {
+    gradient: [
+      [180, 240, 170],
+      [130, 215, 130],
+      [85, 180, 95],
+      [55, 145, 75],
+      [40, 110, 60],
+      [25, 80, 45]
+    ],
+    accent: [120, 200, 120],
+    cream: [200, 220, 190],
+    dim: [90, 120, 90],
+    border: [70, 95, 70]
+  },
+  ocean: {
+    gradient: [
+      [170, 220, 255],
+      [125, 185, 240],
+      [80, 150, 220],
+      [55, 115, 190],
+      [40, 85, 150],
+      [25, 55, 110]
+    ],
+    accent: [110, 180, 230],
+    cream: [195, 215, 235],
+    dim: [90, 115, 145],
+    border: [70, 90, 115]
+  },
+  monochrome: {
+    gradient: [
+      [225, 225, 225],
+      [195, 195, 195],
+      [160, 160, 160],
+      [125, 125, 125],
+      [95, 95, 95],
+      [70, 70, 70]
+    ],
+    accent: [200, 200, 200],
+    cream: [210, 210, 210],
+    dim: [120, 120, 120],
+    border: [95, 95, 95]
+  }
+} as const satisfies Record<string, LogoPalette>
+
+export type LogoPaletteName = keyof typeof LOGO_PALETTES
+
+export const LOGO_PALETTE_NAMES = Object.keys(LOGO_PALETTES) as LogoPaletteName[]
+
+export const DEFAULT_LOGO_PALETTE: LogoPaletteName = 'sunset'
+
+export const LOGO_PALETTE_LABELS: Record<LogoPaletteName, string> = {
+  sunset: 'Sunset (default)',
+  forest: 'Forest green',
+  ocean: 'Ocean blue',
+  monochrome: 'Monochrome'
+}
+
+export function isLogoPaletteName(value: unknown): value is LogoPaletteName {
+  return typeof value === 'string' && Object.prototype.hasOwnProperty.call(LOGO_PALETTES, value)
+}
+
+/** `(r,g,b)` → the `rgb(r,g,b)` string ink's `<Text color>` accepts. */
+export const rgbStr = ([r, g, b]: RGB): string => `rgb(${r},${g},${b})`
+
+/**
+ * The gradient stop for row `i` of an `n`-row art block: stops are sampled
+ * evenly top→bottom (round-to-nearest), so a 6-row block over 6 stops maps
+ * one stop per row. Mirrors the deleted Rich banner's `mascot_gradient_text`.
+ */
+export function gradientStopForRow(stops: readonly RGB[], i: number, n: number): RGB {
+  if (n <= 1 || stops.length === 1) {
+    return stops[0]!
+  }
+
+  return stops[Math.round((i * (stops.length - 1)) / (n - 1))]!
+}
+
+/**
+ * The persisted `logoColor` palette name, or `''` when unset/invalid/unreadable.
+ * Synchronous on purpose: the banner is the first transcript row and must paint
+ * correctly before the backend is up (~20s cold start), exactly like the
+ * original's `getGlobalConfig()` read. `CLAWCODEX_HOME` matches lib/history.ts.
+ */
+export function readLogoColorSync(): '' | LogoPaletteName {
+  try {
+    const dir = process.env.CLAWCODEX_HOME ?? join(homedir(), '.clawcodex')
+    const parsed: unknown = JSON.parse(readFileSync(join(dir, 'config.json'), 'utf8'))
+    const value = (parsed as { logoColor?: unknown }).logoColor
+
+    return isLogoPaletteName(value) ? value : ''
+  } catch {
+    return ''
+  }
+}


### PR DESCRIPTION
Port of upstream TypeScript implementation's `/logo` slash command (`typescript/src/commands/logo/` + `LogoPicker.tsx` + `StartupScreen.palettes.ts`) to the current Ink TUI.

## What it does
- **Bare `/logo`** opens a picker overlay with the four palettes (Sunset (default) / Forest green / Ocean blue / Monochrome), each previewed with the original's six-block gradient swatch (`▇` per stop) and a `· current` marker; ↑/↓ + Enter applies, Esc cancels.
- **`/logo <name>`** applies directly (the /model-picker pattern — the overlay re-enters this path so the result lands in the transcript).
- Selection persists global-config `logoColor` via a new agent-server `set_logo_color` control and confirms with the TS-verbatim **"Startup logo set to X. Visible on next launch."** — the intro banner is a committed transcript row the renderer never re-emits, so like the original the palette applies at the next startup paint.
- At startup the TUI seeds the palette from a **synchronous** `~/.clawcodex/config.json` read (parity with the original's `getGlobalConfig()`), so the banner paints correctly ~20s before the backend is ready.
- Non-default palettes paint the wordmark one gradient stop per row and sample the lobster mascot rows from the same gradient; **unset and explicit `sunset` keep the exact shipped brand look**; skin `banner_logo`/`banner_hero` overrides still win.

## Backend
- `agent_server.py`: `set_logo_color` control (validates via `is_logo_palette_name`, persists via `config.set_logo_color`, replies `ok`/`error`+`available_palettes`; no idle-gate — pure config write) and a `logo_color` rider on `get_settings`.
- Pruned the dead Rich-banner helpers in `src/utils/logo_palettes.py` (their REPL/Textual consumers were deleted in the UI consolidation, PR #566) and repointed stale docstrings; the Python `LogoCommand` stays for headless/SDK surfaces (shadowed by the TUI-local command).

## Testing
- vitest: palette-table parity, banner painting (default-look preservation, palette rows, skin precedence), `readLogoColorSync`, `/logo` command dispatch/persist/failure paths, `config.set logoColor` adapter round-trip. Full ui-tui suite failure set identical to main baseline.
- pytest: `set_logo_color` control e2e (validate → persist → `get_settings` echo → invalid rejected without clobbering). Full suite green vs baseline (8161 passed).
- Live pyte e2e (isolated $HOME): default sunset paint → `/logo forest` confirmation + persisted config → picker current-marker + Esc → **relaunch paints forest before backend ready**. Two consecutive full passes.
- Critic-reviewed: one REVISE round (caught the original "live repaint" claim being unreliable — the renderer doesn't re-emit committed rows; fixed to next-launch-only TS semantics), then APPROVE with independent re-verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)