### PR TITLE
fix(tests): repair the 6 pre-existing suite failures (4 parity + 2 env)

### DIFF
--- a/src/reference_data/ts_tool_properties.json
+++ b/src/reference_data/ts_tool_properties.json
@@ -41,7 +41,11 @@
     "WebFetch": {"is_read_only": true, "is_concurrency_safe": true},
     "WebSearch": {"is_read_only": true, "is_concurrency_safe": true},
     "Write": {"is_read_only": false, "is_concurrency_safe": false},
-    "Agent": {"is_read_only": false, "_is_read_only_note": "ch07 round-4: TS AgentTool.isReadOnly()=true, but the port keeps false — sub-agents run Edit/Write so Agent is not read-only in effect (concurrency-safety != read-only); no live is_read_only consumer exists.", "is_concurrency_safe": true, "is_destructive": true}
+    "Agent": {"is_read_only": false, "_is_read_only_note": "ch07 round-4: TS AgentTool.isReadOnly()=true, but the port keeps false — sub-agents run Edit/Write so Agent is not read-only in effect (concurrency-safety != read-only); no live is_read_only consumer exists.", "is_concurrency_safe": true, "is_destructive": true},
+    "advisor": {"is_read_only": true, "is_concurrency_safe": true, "_note": "clawcodex-only client-side dispatch tool (src/tool_system/tools/advisor.py), not a TS core tool — it only reads conversation state and forwards it to the reviewer model, so read-only/concurrency-safe by design."},
+    "ExitPlanMode": {"is_read_only": false, "is_concurrency_safe": true, "_note": "TS ExitPlanModeV2Tool.ts:179-184 — isConcurrencySafe()=true, isReadOnly()=false ('Now writes to disk': edited plan text is written to the plan file)."},
+    "Monitor": {"is_read_only": false, "is_concurrency_safe": true, "_note": "TS MonitorTool.ts:54 — isConcurrencySafe()=true (fire-and-forget spawn); isReadOnly not overridden in TS, so the false default stands."},
+    "Workflow": {"is_read_only": true, "is_concurrency_safe": true, "_note": "TS WorkflowTool impl is not in the reference dump (only constants.ts; tools.ts:118-121 loads a bundled .js), so these are the port's documented design (workflow.py:200-201): spawned subagents carry their own permission checks, mirroring Agent's concurrency-safety."}
   },
   "required_tool_attributes": [
     "name",

--- a/tests/parity/test_e2e_edit_flow.py
+++ b/tests/parity/test_e2e_edit_flow.py
@@ -5,6 +5,7 @@ Tests the full tool dispatch pipeline for the Edit and Write tools.
 """
 from __future__ import annotations
 
+import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -151,15 +152,31 @@ class TestE2EWriteFlow(unittest.TestCase):
         self.assertTrue(target.exists())
 
     def test_write_outside_workspace_blocked(self) -> None:
-        """Write tool blocks writes outside workspace root."""
+        """Write tool blocks writes outside workspace root.
+
+        A bare ToolContext defaults to bypassPermissions, and — faithful to
+        TS ``shouldBypassPermissions`` (permissions.ts:1268-1281) — that mode
+        skips the working-directory allowlist entirely, so pin a gated mode.
+        In a gated mode the permission pipeline surfaces an *ask* before the
+        tool body runs (TS prompts for outside-cwd writes), so dispatch
+        yields an error result rather than raising; the containment gate
+        itself still hard-refuses the path.
+        """
+        self.ctx.permission_context.mode = "default"
+        target = Path(tempfile.gettempdir()) / f"outside_workspace_test_{os.getpid()}.txt"
+        target.unlink(missing_ok=True)  # stale leftover from a crashed run
+        self.addCleanup(lambda: target.unlink(missing_ok=True))
+        result = self.registry.dispatch(
+            ToolCall(name="Write", input={
+                "file_path": str(target),
+                "content": "bad\n",
+            }),
+            self.ctx,
+        )
+        self.assertTrue(result.is_error)
+        self.assertFalse(target.exists())  # nothing written
         with self.assertRaises(ToolPermissionError):
-            self.registry.dispatch(
-                ToolCall(name="Write", input={
-                    "file_path": "/tmp/outside_workspace_test.txt",
-                    "content": "bad\n",
-                }),
-                self.ctx,
-            )
+            self.ctx.ensure_allowed_path(str(target))
 
 
 class TestE2EPermissionDenyBlocks(unittest.TestCase):

--- a/tests/parity/test_e2e_file_read.py
+++ b/tests/parity/test_e2e_file_read.py
@@ -135,12 +135,27 @@ class TestE2EFileRead(unittest.TestCase):
         self.assertIn("Hello, world!", content)
 
     def test_read_outside_workspace_blocked(self) -> None:
-        """Read tool blocks reads outside workspace root."""
+        """Read tool blocks reads outside workspace root.
+
+        A bare ToolContext defaults to bypassPermissions, and — faithful to
+        TS ``shouldBypassPermissions`` (permissions.ts:1268-1281) — that mode
+        skips the working-directory allowlist entirely, so pin a gated mode.
+        In a gated mode the permission pipeline surfaces an *ask* before the
+        tool body runs (TS prompts for outside-cwd reads), so dispatch yields
+        an error result rather than raising; the containment gate itself
+        still hard-refuses the path.
+        """
+        self.ctx.permission_context.mode = "default"
+        result = self.registry.dispatch(
+            ToolCall(name="Read", input={"file_path": "/etc/passwd"}),
+            self.ctx,
+        )
+        self.assertTrue(result.is_error)
+        # "root:" is the first passwd entry on macOS and Linux; an error
+        # message legitimately mentioning a path or workspace *root* is fine.
+        self.assertNotIn("root:", str(result.output))  # no content leak
         with self.assertRaises(ToolPermissionError):
-            self.registry.dispatch(
-                ToolCall(name="Read", input={"file_path": "/etc/passwd"}),
-                self.ctx,
-            )
+            self.ctx.ensure_readable_path("/etc/passwd")
 
     def test_read_tool_is_concurrent_safe(self) -> None:
         """Read tool can be called concurrently."""

--- a/tests/test_mcp_config_full.py
+++ b/tests/test_mcp_config_full.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import tempfile
 import pytest
 from pathlib import Path
@@ -71,7 +72,9 @@ class TestVscodeDiscovery:
 
 class TestValidateServerConnectivity:
     def test_valid_command(self):
-        config = McpStdioServerConfig(command="python")
+        # sys.executable rather than "python": macOS/Linux boxes often ship
+        # only `python3`, and shutil.which accepts an absolute path.
+        config = McpStdioServerConfig(command=sys.executable)
         issues = validate_server_connectivity(config)
         assert issues == []
 

--- a/tests/test_mcp_doctor.py
+++ b/tests/test_mcp_doctor.py
@@ -1,3 +1,5 @@
+import sys
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -92,7 +94,10 @@ class TestDiagnosticReport:
 
 class TestValidateStdioConfig:
     def test_valid_command(self):
-        config = McpStdioServerConfig(command="python")
+        # sys.executable rather than "python": macOS/Linux boxes often ship
+        # only `python3`. An absolute path contains os.sep, so the doctor's
+        # PATH lookup (guarded by `os.sep not in command`) is skipped.
+        config = McpStdioServerConfig(command=sys.executable)
         warnings = _validate_stdio_config("test", config)
         assert warnings == []
 


### PR DESCRIPTION
Fixes the 6 pre-existing test failures reproducible on pristine `origin/main` (4 parity + 2 python-on-PATH env issues). All fixes are test-side / reference-data-side; no product code changes.

## 1. MCP env failures (2) — `python` not on PATH

`tests/test_mcp_config_full.py::TestValidateServerConnectivity::test_valid_command` and `tests/test_mcp_doctor.py::TestValidateStdioConfig::test_valid_command` hardcoded `command="python"`, which fails on machines that only ship `python3` (stock macOS/Homebrew). Both validators resolve via `shutil.which`, which accepts absolute paths, so the tests now use `sys.executable`.

## 2. Tool-property parity failures (2) — snapshot missing newer tools

`test_default_is_read_only_false` / `test_default_is_concurrency_safe_false` assert that every registered tool *not* listed in `tool_overrides` of `src/reference_data/ts_tool_properties.json` returns the default (false) properties. Four tools added since the snapshot was last touched deviate deliberately and were never listed:

| Tool | is_read_only | is_concurrency_safe | Source |
|------|--------------|---------------------|--------|
| `advisor` | true | true | clawcodex-only client-side dispatch tool; reads conversation state only (`advisor.py`) |
| `ExitPlanMode` | false | true | TS `ExitPlanModeV2Tool.ts:179-184` ("Now writes to disk") |
| `Monitor` | false | true | TS `MonitorTool.ts:54`; `isReadOnly` not overridden in TS |
| `Workflow` | true | true | TS impl not in the reference dump (bundled .js); port's documented design (`workflow.py:200-201`) |

Each entry carries a `_note` citation. `test_overridden_tools_match_snapshot` value-checks the new entries against the live tools and passes.

## 3. Outside-workspace containment tests (2) — obsolete assertion shape

`test_read_outside_workspace_blocked` / `test_write_outside_workspace_blocked` expected `registry.dispatch` to raise `ToolPermissionError`. Two (correct, TS-faithful) architecture changes made that impossible:

- A bare `ToolContext` defaults to `bypassPermissions`, and the path gates (`ensure_allowed_path` / `ensure_readable_path`) mirror TS `shouldBypassPermissions` (`permissions.ts:1268-1281`) — bypass mode skips the working-directory allowlist by design.
- In gated modes, `registry.dispatch` runs `has_permissions_to_use_tool` *before* the tool body; an outside-workspace path yields an **ask**, which surfaces as an `is_error` `ToolResult` (no handler in tests), so the body's containment gate never runs.

All production entry points construct `ToolContext` with explicit permission contexts (`agent_server.py`, `headless.py`, `mcp_serve.py`, `subagent_context.py`); the permissive default is a documented in-process convenience. No product regression — the tests were asserting an assertion shape the architecture no longer has.

The tests now pin `mode="default"` and assert the real protective contract:
- dispatch must **not** succeed — `is_error` result, no content leak (`root:` marker), no file written
- the containment gate itself still hard-raises `ToolPermissionError`

## Verification

- All 6 previously-failing tests pass; their 5 files pass in full (98 tests).
- Full suite: green (was 6 failed / 8362 passed on pristine main).
- Critic review: APPROVE (one optional comment-accuracy nit, applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
