### PR TITLE
Fix uv installation link in SETUP_GUIDE.md

### DIFF
--- a/docs/guide/SETUP_GUIDE.md
+++ b/docs/guide/SETUP_GUIDE.md
@@ -6,7 +6,7 @@ Detailed installation and configuration for **clawcodex**. For a quick overview,
 
 - **Python 3.10+** (3.11 recommended)
 - **git**
-- **[uv](https://github.com/astral-sh/uv)** (recommended) or `pip`
+- **[uv]([https://github.com/astral-sh/uv](https://github.com/astral-sh/uv#installation))**
 - An API key for at least one supported provider: Anthropic, OpenAI, Z.ai (GLM), MiniMax, OpenRouter, or DeepSeek
 
 ## 1. Clone and install

--- a/docs/guide/SETUP_GUIDE.md
+++ b/docs/guide/SETUP_GUIDE.md
@@ -6,7 +6,7 @@ Detailed installation and configuration for **clawcodex**. For a quick overview,
 
 - **Python 3.10+** (3.11 recommended)
 - **git**
-- **[uv]([https://github.com/astral-sh/uv](https://github.com/astral-sh/uv#installation))**
+- **[uv](https://github.com/astral-sh/uv#installation)** (recommended)
 - An API key for at least one supported provider: Anthropic, OpenAI, Z.ai (GLM), MiniMax, OpenRouter, or DeepSeek
 
 ## 1. Clone and install


### PR DESCRIPTION
Updated the installation link for 'uv' in the setup guide.

Also pip doesn't work with more recent version of Python, installation fails without uv