### PR TITLE
feat(tui): Tab accepts the composer's suggested query placeholder

### DIFF
--- a/ui-tui/src/__tests__/tabAcceptSuggestion.test.ts
+++ b/ui-tui/src/__tests__/tabAcceptSuggestion.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldAcceptPlaceholderSuggestion } from '../app/useInputHandlers.js'
+import { PLACEHOLDERS, suggestedQuery } from '../content/placeholders.js'
+
+describe('suggestedQuery — extract the tab-acceptable query from a placeholder', () => {
+  it('returns the quoted query verbatim', () => {
+    expect(suggestedQuery('Try "explain this codebase"')).toBe('explain this codebase')
+    expect(suggestedQuery('Try "fix the lint errors"')).toBe('fix the lint errors')
+  })
+
+  it('keeps trailing punctuation that is part of the query', () => {
+    expect(suggestedQuery('Try "how does the config loader work?"')).toBe('how does the config loader work?')
+  })
+
+  it('extracts a suggested slash command, ignoring prose after the quotes', () => {
+    expect(suggestedQuery('Try "/help" for commands')).toBe('/help')
+  })
+
+  it('takes the first quoted span when several appear', () => {
+    expect(suggestedQuery('Try "first" or "second"')).toBe('first')
+  })
+
+  it('turns an open-ended stub into a continuable sentence (ellipsis → trailing space)', () => {
+    expect(suggestedQuery('Try "write a test for…"')).toBe('write a test for ')
+    expect(suggestedQuery('Try "write a test for..."')).toBe('write a test for ')
+  })
+
+  it('returns null when the placeholder carries no quoted query', () => {
+    expect(suggestedQuery('Ask me anything…')).toBeNull()
+    expect(suggestedQuery('')).toBeNull()
+  })
+
+  it('returns null when the quotes hold nothing but an ellipsis', () => {
+    expect(suggestedQuery('Try "…"')).toBeNull()
+    expect(suggestedQuery('Try "..."')).toBeNull()
+  })
+
+  it('every shipped placeholder yields null or a clean non-empty query', () => {
+    const escape = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
+    for (const placeholder of PLACEHOLDERS) {
+      const query = suggestedQuery(placeholder)
+
+      if (query === null) {
+        continue
+      }
+
+      expect(query.length).toBeGreaterThan(0)
+      expect(query).not.toMatch(/(?:…|\.{3})$/)
+      // Round-trip: the extracted query must sit in the placeholder as a
+      // whole quoted span (optionally ellipsis-terminated). Bites when a
+      // nested quote silently truncates the extraction.
+      expect(placeholder).toMatch(new RegExp(`"${escape(query.trimEnd())}(?:…|\\.{3})?"`))
+    }
+  })
+
+  it('the shipped list still contains tab-acceptable suggestions', () => {
+    expect(PLACEHOLDERS.some(p => suggestedQuery(p) !== null)).toBe(true)
+  })
+})
+
+describe('shouldAcceptPlaceholderSuggestion — Tab accepts only what is visibly suggested', () => {
+  const visible = { busy: false, completionsLen: 0, conversationEmpty: true, input: '' }
+
+  it('accepts plain Tab while the placeholder suggestion is showing', () => {
+    expect(shouldAcceptPlaceholderSuggestion({ shift: false, tab: true }, visible)).toBe(true)
+  })
+
+  it('never fires for Shift+Tab — that cycles the permission mode', () => {
+    expect(shouldAcceptPlaceholderSuggestion({ shift: true, tab: true }, visible)).toBe(false)
+  })
+
+  it('never fires for non-Tab keys', () => {
+    expect(shouldAcceptPlaceholderSuggestion({ shift: false, tab: false }, visible)).toBe(false)
+  })
+
+  it('defers to an open completion menu', () => {
+    expect(shouldAcceptPlaceholderSuggestion({ shift: false, tab: true }, { ...visible, completionsLen: 2 })).toBe(
+      false
+    )
+  })
+
+  it('stays inert once the user typed something (placeholder is hidden)', () => {
+    expect(shouldAcceptPlaceholderSuggestion({ shift: false, tab: true }, { ...visible, input: 'h' })).toBe(false)
+  })
+
+  it('stays inert mid-conversation (placeholder is only shown on a fresh transcript)', () => {
+    expect(
+      shouldAcceptPlaceholderSuggestion({ shift: false, tab: true }, { ...visible, conversationEmpty: false })
+    ).toBe(false)
+  })
+
+  it('stays inert while a turn is running (placeholder is hidden when busy)', () => {
+    expect(shouldAcceptPlaceholderSuggestion({ shift: false, tab: true }, { ...visible, busy: true })).toBe(false)
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -287,6 +287,10 @@ export interface InputHandlerContext {
     refs: ComposerRefs
     state: ComposerState
   }
+  /** True while the transcript holds nothing but the intro — the state in
+   *  which appLayout shows the `Try "…"` placeholder, and the only state in
+   *  which Tab may accept its suggested query. */
+  conversationEmpty: boolean
   gateway: GatewayServices
   terminal: {
     hasSelection: boolean

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react'
 
 import { DASHBOARD_TUI_MODE } from '../config/env.js'
 import { TYPING_IDLE_MS } from '../config/timing.js'
+import { PLACEHOLDER, suggestedQuery } from '../content/placeholders.js'
 import type {
   ApprovalRespondResponse,
   SecretRespondResponse,
@@ -79,6 +80,22 @@ export function shouldFallThroughForScroll(key: {
   return false
 }
 
+/**
+ * Plain Tab accepts the composer placeholder's suggested query (`Try "…"`).
+ * True only while that suggestion is actually visible — fresh conversation,
+ * idle, empty input (appLayout gates the placeholder on the first two;
+ * TextInput hides it once the input has text) — and only for unmodified Tab
+ * with no completion menu open, so it can never shadow completion-accept or
+ * the Shift+Tab permission-mode cycle. Mirrors original CC's Tab fallback
+ * (useTypeahead.tsx handleKeyDown: tab / no shift / no suggestions / empty
+ * input → insert the prompt suggestion).
+ */
+export const shouldAcceptPlaceholderSuggestion = (
+  key: { shift: boolean; tab: boolean },
+  state: { busy: boolean; completionsLen: number; conversationEmpty: boolean; input: string }
+): boolean =>
+  key.tab && !key.shift && !state.completionsLen && !state.input && state.conversationEmpty && !state.busy
+
 export function applyVoiceRecordResponse(
   response: null | VoiceRecordResponse,
   starting: boolean,
@@ -100,7 +117,7 @@ export function applyVoiceRecordResponse(
 }
 
 export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
-  const { actions, composer, gateway, terminal, voice, wheelStep } = ctx
+  const { actions, composer, conversationEmpty, gateway, terminal, voice, wheelStep } = ctx
   const { actions: cActions, refs: cRefs, state: cState } = composer
 
   const overlay = useStore($overlayState)
@@ -657,6 +674,26 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
             : row.text
 
         cActions.setInput(cState.input.slice(0, cState.compReplace) + text)
+      }
+
+      return
+    }
+
+    if (
+      shouldAcceptPlaceholderSuggestion(key, {
+        busy: live.busy,
+        completionsLen: cState.completions.length,
+        conversationEmpty,
+        input: cState.input
+      })
+    ) {
+      const query = suggestedQuery(PLACEHOLDER)
+
+      // 'Ask me anything…' carries no query — Tab stays inert. On accept the
+      // external value change snaps TextInput's cursor to the end, and a
+      // suggested `/command` pops its completion menu exactly as if typed.
+      if (query) {
+        cActions.setInput(query)
       }
 
       return

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -851,6 +851,7 @@ export function useMainApp(gw: GatewayClient) {
       sys
     },
     composer: { actions: composerActions, refs: composerRefs, state: composerState },
+    conversationEmpty: empty,
     gateway,
     terminal: { hasSelection, scrollRef, scrollWithSelection, selection, stdout },
     voice: {

--- a/ui-tui/src/content/placeholders.ts
+++ b/ui-tui/src/content/placeholders.ts
@@ -11,3 +11,32 @@ export const PLACEHOLDERS = [
 ]
 
 export const PLACEHOLDER = pick(PLACEHOLDERS)
+
+/**
+ * The tab-acceptable query inside a composer placeholder: `Try "explain this
+ * codebase"` suggests the query `explain this codebase`; a placeholder with no
+ * quoted span ('Ask me anything…') suggests nothing. An open-ended stub
+ * (`Try "write a test for…"`) drops the ellipsis and keeps one trailing space
+ * so the accepted text reads as a sentence the user finishes typing.
+ *
+ * Original CC accepts its prompt suggestion the same way — plain Tab on an
+ * empty input inserts the suggestion text (useTypeahead.tsx handleKeyDown);
+ * there the suggestion state already holds the bare query, while ours is
+ * embedded in the `Try "…"` placeholder string, hence this extraction.
+ */
+export function suggestedQuery(placeholder: string): null | string {
+  const quoted = /"([^"]+)"/.exec(placeholder)?.[1]
+
+  if (!quoted) {
+    return null
+  }
+
+  const openEnded = /(?:…|\.{3})$/.test(quoted)
+  const query = quoted.replace(/(?:…|\.{3})$/, '').trimEnd()
+
+  if (!query) {
+    return null
+  }
+
+  return openEnded ? `${query} ` : query
+}


### PR DESCRIPTION
## Summary
The composer's dim placeholder on a fresh idle session (`Try "explain this codebase"`, `Try "/help" for commands`, …) is a system suggestion of a query — but there was no way to take it. Plain **Tab** now accepts it: the suggested query is inserted into the input with the cursor at the end.

- `Try "explain this codebase"` → inserts `explain this codebase`
- `Try "write a test for…"` → inserts `write a test for ` (ellipsis dropped, trailing space kept so the sentence is continuable)
- `Try "/help" for commands` → inserts `/help` and pops the slash completion menu exactly as if typed
- `Ask me anything…` carries no query → Tab stays inert

Mirrors original CC's Tab fallback (`typescript/src/hooks/useTypeahead.tsx` handleKeyDown: tab / no shift / no suggestions / empty input → accept the prompt suggestion); there the suggestion state holds the bare query, ours is embedded in the `Try "…"` placeholder string, hence the extraction helper.

## Gating
`shouldAcceptPlaceholderSuggestion` mirrors the placeholder-visibility condition exactly (conversation empty + idle + empty input, threaded as `InputHandlerContext.conversationEmpty` from the same flag appLayout renders from), plus no-completions and no-shift — so Tab can never insert what isn't displayed and never shadows completion-accept or the Shift+Tab permission-mode cycle.

## Verification
- 16 unit tests (extraction incl. round-trip invariant over the shipped list; all six predicate gates); `tsc --noEmit` and eslint clean
- Full ui-tui vitest: zero new failures (8 pre-existing environmental failures proven identical on clean main via stash/run/pop; 1 known full-suite-load flake)
- Live pyte e2e in a real PTY against the dev backend: all three placeholder families pass (plain query, ellipsis stub, `/help` + menu), incl. second-Tab-inert; PTY-resize repaint used to defeat cell-diff renderer artifacts in pyte
- Critic subagent: APPROVE · Codex adversarial review: approve, no material findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)