### PR TITLE
fix(anthropic): OAuth identity rewrite corrupted .clawcodex paths into ~/.Claude Code

### DIFF
--- a/src/providers/anthropic_provider.py
+++ b/src/providers/anthropic_provider.py
@@ -309,7 +309,21 @@ class AnthropicProvider(BaseProvider):
 
         prefix = "You are Claude Code, Anthropic's official CLI for Claude."
         def clean(text: str) -> str:
-            return re.sub(r"claw[ -]?codex", "Claude Code", text, flags=re.IGNORECASE)
+            # Disguise standalone brand mentions only. A match inside a
+            # machine-readable token must survive verbatim: path segments
+            # (~/.clawcodex/sessions, /etc/clawcodex), env vars
+            # ($CLAWCODEX_CONFIG_DIR), module/file names (clawcodex_dirs),
+            # and domains (clawcodex.app). Rewriting those made the system
+            # prompt name literal nonexistent paths — ~/.Claude Code/… —
+            # which the model then obediently searched (the "guessed" wrong
+            # paths #706 set out to fix were in fact produced here, after
+            # prompt assembly).
+            return re.sub(
+                r"(?<![\w.$/\\-])claw[ -]?codex(?![\w-])(?!\.\w)",
+                "Claude Code",
+                text,
+                flags=re.IGNORECASE,
+            )
         if isinstance(system, str):
             system = prefix + "\n\n" + clean(system)
         elif isinstance(system, list):

--- a/tests/test_anthropic_subscription.py
+++ b/tests/test_anthropic_subscription.py
@@ -112,6 +112,53 @@ def test_provider_uses_bearer_oauth_and_adapts_tools(monkeypatch) -> None:
     assert result.usage["billing_mode"] == "subscription"
 
 
+def test_identity_rewrite_preserves_paths_env_vars_and_domains(monkeypatch) -> None:
+    """The OAuth identity disguise must not corrupt machine-readable tokens.
+
+    Regression for the `.Claude Code` misdirection: rewriting `clawcodex`
+    inside paths turned the #706/#707 prompt lines (and the auto-memory
+    section) into literal nonexistent locations — `~/.Claude Code/sessions`
+    — which the model then searched verbatim.
+    """
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    with patch.object(auth, "get_valid_credentials", return_value=_credentials()), \
+         patch("src.providers.anthropic_provider.anthropic.Anthropic"):
+        provider = AnthropicProvider(api_key="")
+
+    system_blocks = [
+        {"type": "text", "text": (
+            "- clawcodex data directory: /Users/u/.clawcodex — sessions live in "
+            "the sessions/ subdirectory, or under $CLAWCODEX_CONFIG_DIR."
+        )},
+        {"type": "text", "text": (
+            "You have a persistent, file-based memory system at "
+            "`/Users/u/.clawcodex/projects/-Users-u-proj/memory/`.\n"
+            'Grep with pattern="x" path="/Users/u/.clawcodex/sessions/" glob="*.json"\n'
+            "Managed policy lives in /etc/clawcodex; see clawcodex_dirs.py and "
+            "https://clawcodex.app/install.sh. Run clawcodex to start. clawcodex, "
+            "the tool, saves hooks in .clawcodex/settings.json."
+        )},
+    ]
+    _, _, system = provider._prepare_subscription_request([], None, system_blocks)
+
+    assert system[0]["text"].startswith("You are Claude Code")
+    text = "\n".join(b["text"] for b in system[1:])
+    # Machine-readable tokens survive verbatim.
+    assert "/Users/u/.clawcodex — sessions" in text
+    assert "/Users/u/.clawcodex/projects/-Users-u-proj/memory/" in text
+    assert '/Users/u/.clawcodex/sessions/' in text
+    assert "$CLAWCODEX_CONFIG_DIR" in text
+    assert "/etc/clawcodex" in text
+    assert "clawcodex_dirs.py" in text
+    assert "clawcodex.app" in text
+    assert ".clawcodex/settings.json" in text
+    # Nothing is rewritten INTO a bogus path.
+    assert ".Claude Code" not in text
+    # Standalone brand mentions are still disguised.
+    assert "Claude Code data directory:" in text
+    assert "Run Claude Code to start. Claude Code, the tool," in text
+
+
 def test_subscription_usage_is_not_priced_as_api_billing() -> None:
     from src.cost_tracker import record_api_usage
     with patch("src.cost_tracker.add_to_total_cost_state"), \


### PR DESCRIPTION
## Root cause of the errors #706 / #707 didn't fully fix

The trace that motivated those PRs — the model searching `/Users/…/.Claude Code/projects/<slug>/memory` and `/Users/…/.Claude Code/sessions` — was **not model guessing**. On Claude-subscription OAuth logins, `AnthropicProvider._prepare_subscription_request()` runs

```python
re.sub(r"claw[ -]?codex", "Claude Code", text, flags=re.IGNORECASE)
```

over every system block at request time. That rewrites **filesystem paths too**: `~/.clawcodex/sessions/` → `~/.Claude Code/sessions/`. So the corrected paths #706/#707 added (and the auto-memory section) reached the model already corrupted — the prompt *authoritatively named nonexistent locations*, and the model obediently searched them. Reproduced byte-for-byte: running the shipped `clean()` over the real assembled prompt produces exactly the paths from the failure trace.

This only bites subscription logins (`api_key` empty + `anthropic-oauth.json` present), which is why prompt-assembly-level reproductions looked correct — the corruption happens in the provider layer, after assembly. It also explains #706's original "pure guessing" misdiagnosis.

## Fix

Constrain the disguise to standalone brand mentions. Matches that are part of a machine-readable token survive verbatim:

- path segments: `~/.clawcodex/…`, `/etc/clawcodex`, `.clawcodex/settings.json`
- env vars: `$CLAWCODEX_CONFIG_DIR` / `CLAWCODEX_CONFIG_DIR`
- module/file names: `clawcodex_dirs.py`
- domains: `clawcodex.app`

Standalone prose (`clawcodex data directory:`, `run clawcodex.`, `clawcodex, the tool`) is still rewritten, and the official `You are Claude Code…` prefix block is unchanged, so the OAuth-endpoint conventions are preserved.

```python
re.sub(r"(?<![\w.$/\\-])claw[ -]?codex(?![\w-])(?!\.\w)", "Claude Code", text, flags=re.IGNORECASE)
```

## Tests

- New `test_identity_rewrite_preserves_paths_env_vars_and_domains` — real-world strings from the assembled prompt (memory path, sessions Grep line, #706 data-dir line, env var, domain, prose); asserts paths survive, `.Claude Code` never appears, prose is still disguised, prefix block stays first.
- Existing `test_provider_uses_bearer_oauth_and_adapts_tools` (asserts `ClawCodex` prose is disguised) still passes.
- 71 green across `test_anthropic_subscription` / `test_prompt_assembly` / `test_live_base_system_prompt` / `test_clawcodex_dirs`; 72 green across `test_model_system` / `test_openai_subscription` (that path passes `instructions` through untouched — no analogous bug).
- End-to-end: assembled the live clawsphere prompt, ran it through the fixed `_prepare_subscription_request` — memory/sessions/data-dir paths intact, no `.Claude Code`, brand prose disguised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)