### PR TITLE
chore(release): prepare PyPI publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,55 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Verify release tag matches package version
+        if: github.event_name == 'release'
+        shell: bash
+        run: |
+          version=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          test "${GITHUB_REF_NAME}" = "v${version}"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          python -m twine check --strict dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: python-distributions
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/clawcodex/
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: python-distributions
+          path: dist/
+
+      - name: Publish distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-07-16
+
+### Added
+
+- Added the `/eco` token-compression mode for reducing verbose Bash tool
+  output while preserving actionable information.
+- Added Anthropic Claude Opus 4.8 and Claude Fable 5 model configurations.
+
 ### Changed
 
 - Session history and transcripts (`sessions/`, `transcripts/`) now honor
@@ -17,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `~/.clawcodex/transcripts` if you want them to carry over. The
   `# Environment` system-prompt hint now points at the resolved root so the
   model finds session history in either configuration.
+- Updated OpenAI and prompt-toolkit dependency minimums to the versions used
+  by the current implementation.
+
+### Fixed
+
+- Corrected MiniMax pricing tiers and model modalities.
+- Prevented Anthropic OAuth identity migration from rewriting paths under
+  `.clawcodex`.
+- Restored Claude Code-compatible formatting for thrown tool errors.
 
 ## [1.1.0] - 2026-07-12
 
@@ -302,4 +319,7 @@ The focus was on building a solid foundation with clean architecture, comprehens
 
 ---
 
+[Unreleased]: https://github.com/agentforce314/clawcodex/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/agentforce314/clawcodex/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/agentforce314/clawcodex/compare/v1.0.0...v1.1.0
 [0.1.0]: https://github.com/agentforce314/clawcodex/releases/tag/v0.1.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include README.md
 include LICENSE
-include CLAUDE.md
-include MVP_PLAN.md
 recursive-include src *.py
 recursive-include src *.json
+prune tests

--- a/README.md
+++ b/README.md
@@ -491,6 +491,18 @@ Use `clawcodex config` to check connection status and
 ### Install
 
 ```bash
+# Install the latest release from PyPI (recommended)
+pipx install clawcodex
+# Or: uv tool install clawcodex
+# Or, inside an activated virtual environment: pip install clawcodex
+
+# Run the CLI
+clawcodex --help
+```
+
+For development from a source checkout:
+
+```bash
 git clone https://github.com/agentforce314/clawcodex.git
 cd clawcodex
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,34 +1,36 @@
 [build-system]
-requires = ["setuptools>=68.0", "wheel"]
+requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawcodex"
-version = "1.1.0"
+version = "1.2.0"
 description = "A production-oriented Python rebuild of Claude Code — real architecture, reliable CLI agent"
 readme = "README.md"
-license = {text = "MIT"}
+license = "MIT"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 authors = [
-    {name = "Claw Codex Team", email = "team@example.com"}
+    {name = "Claw Codex Team"}
 ]
 keywords = ["claude", "cli", "ai", "llm", "anthropic", "openai", "glm"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 dependencies = [
-    "anthropic",
-    "openai",
-    "python-dotenv",
-    "rich",
-    "prompt-toolkit",
+    "anthropic>=0.116.0",
+    "openai>=1.109.1",
+    "python-dotenv>=1.2.2",
+    "rich>=13.9.4",
+    "prompt-toolkit>=3.0.52",
     "tiktoken>=0.7.0",
     "textual>=0.79",
     # YAML frontmatter parser (SKILL.md, agent files, output styles).
@@ -70,7 +72,7 @@ dependencies = [
     # Terminal display-width measurement for the bridge status renderer.
     "wcwidth>=0.2",
     # ``typing.Self`` backport for Python 3.10 (added to stdlib in 3.11).
-    "typing_extensions>=4.0; python_version < '3.11'",
+    "typing_extensions>=4.16.0; python_version < '3.11'",
 ]
 
 [project.optional-dependencies]

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,11 @@
 """Claw Codex - Claude Code Python Implementation."""
 
-__version__ = "1.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("clawcodex")
+except PackageNotFoundError:  # Running directly from an unpackaged checkout.
+    __version__ = "1.2.0"
 __author__ = "Claw Codex Team"
 
 from .config import load_config, get_provider_config

--- a/tests/bridge/test_bridge_main.py
+++ b/tests/bridge/test_bridge_main.py
@@ -795,6 +795,10 @@ async def test_run_loop_respects_capacity() -> None:
 
     assert len(spawner.spawns) == 1  # capacity 1; second not yet spawned
 
+    # A real child exits after SIGTERM during shutdown. Mirror that behavior
+    # in the fake so this capacity test does not wait the production 30-second
+    # shutdown grace period (the forced-shutdown path is tested separately).
+    spawner.handles[0].complete('interrupted')
     cancel.set()
     await task
 


### PR DESCRIPTION
## Summary

- prepare version 1.2.0 metadata and changelog
- add clean sdist/wheel packaging and PyPI install docs
- add a Trusted Publishing GitHub Actions workflow
- derive the CLI version from installed package metadata

## Validation

- `python -m build`
- `python -m twine check --strict dist/*`
- isolated wheel install: `clawcodex --version` reports 1.2.0
- 47 focused CLI/version/release tests pass
- broader `pytest tests/ -q`: 2,466 passed + 17 subtests before an existing async hang; no failures observed before interruption
