### PR TITLE
chore(release): publish as clawcodex-cli 1.2.1

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/project/clawcodex/
+      url: https://pypi.org/project/clawcodex-cli/
     permissions:
       id-token: write
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-07-16
+
+### Changed
+
+- The PyPI distribution is named `clawcodex-cli` because PyPI reserves
+  `clawcodex` as confusingly similar to the unrelated `claw-codex` project.
+  The installed executable remains `clawcodex`.
+
 ## [1.2.0] - 2026-07-16
 
 ### Added
@@ -319,7 +327,8 @@ The focus was on building a solid foundation with clean architecture, comprehens
 
 ---
 
-[Unreleased]: https://github.com/agentforce314/clawcodex/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/agentforce314/clawcodex/compare/v1.2.1...HEAD
+[1.2.1]: https://github.com/agentforce314/clawcodex/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/agentforce314/clawcodex/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/agentforce314/clawcodex/compare/v1.0.0...v1.1.0
 [0.1.0]: https://github.com/agentforce314/clawcodex/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -491,10 +491,11 @@ Use `clawcodex config` to check connection status and
 ### Install
 
 ```bash
-# Install the latest release from PyPI (recommended)
-pipx install clawcodex
-# Or: uv tool install clawcodex
-# Or, inside an activated virtual environment: pip install clawcodex
+# Install the latest release from PyPI (recommended). The distribution is
+# named clawcodex-cli; the installed command remains `clawcodex`.
+pipx install clawcodex-cli
+# Or: uv tool install clawcodex-cli
+# Or, inside an activated virtual environment: pip install clawcodex-cli
 
 # Run the CLI
 clawcodex --help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=77.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "clawcodex"
-version = "1.2.0"
+name = "clawcodex-cli"
+version = "1.2.1"
 description = "A production-oriented Python rebuild of Claude Code — real architecture, reliable CLI agent"
 readme = "README.md"
 license = "MIT"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,9 +3,9 @@
 from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = version("clawcodex")
+    __version__ = version("clawcodex-cli")
 except PackageNotFoundError:  # Running directly from an unpackaged checkout.
-    __version__ = "1.2.0"
+    __version__ = "1.2.1"
 __author__ = "Claw Codex Team"
 
 from .config import load_config, get_provider_config


### PR DESCRIPTION
## Summary

- rename the PyPI distribution to `clawcodex-cli` after PyPI rejected `clawcodex` as confusingly similar to the unrelated `claw-codex` project
- preserve the installed `clawcodex` command and `src` import package
- prepare v1.2.1 metadata, changelog, install instructions, and publishing URL

## Validation

- `python -m build`
- `python -m twine check --strict dist/*`
- clean wheel install reports `clawcodex-cli 1.2.1` and `clawcodex --version` reports 1.2.1
- 101 focused release, CLI, and bridge tests pass
