### PR TITLE
docs(readme): add PyPI installation to translations

### DIFF
--- a/docs/i18n/README_AR.md
+++ b/docs/i18n/README_AR.md
@@ -151,15 +151,27 @@ clawcodex config       # عرض الإعدادات
 ### التثبيت
 
 ```bash
-git clone https://github.com/GPT-AGI/Claw-Codex.git
-cd Claw-Codex
+# التثبيت من PyPI (موصى به). اسم الحزمة هو clawcodex-cli،
+# بينما يبقى اسم الأمر المثبّت clawcodex.
+pipx install clawcodex-cli
+# أو: uv tool install clawcodex-cli
+# أو داخل بيئة افتراضية مفعّلة: pip install clawcodex-cli
+
+clawcodex --help
+```
+
+للتطوير من الشيفرة المصدرية:
+
+```bash
+git clone https://github.com/agentforce314/clawcodex.git
+cd clawcodex
 
 # إنشاء venv (يُوصى بـ uv)
 uv venv --python 3.11
 source .venv/bin/activate
 
-# التثبيت
-uv pip install -r requirements.txt
+# تثبيت الحزمة وأدوات التطوير
+uv pip install -e ".[dev]"
 ```
 
 يتم حفظ ملف التكوين في `~/.clawcodex/config.json`. مثال مبسّط:

--- a/docs/i18n/README_FR.md
+++ b/docs/i18n/README_FR.md
@@ -152,15 +152,27 @@ clawcodex config       # Voir les paramètres
 ### Installation
 
 ```bash
-git clone https://github.com/GPT-AGI/Claw-Codex.git
-cd Claw-Codex
+# Installer depuis PyPI (recommandé). Le paquet s'appelle clawcodex-cli,
+# mais la commande installée reste `clawcodex`.
+pipx install clawcodex-cli
+# Ou : uv tool install clawcodex-cli
+# Ou dans un environnement virtuel activé : pip install clawcodex-cli
+
+clawcodex --help
+```
+
+Pour contribuer depuis les sources :
+
+```bash
+git clone https://github.com/agentforce314/clawcodex.git
+cd clawcodex
 
 # Créer un venv (uv recommandé)
 uv venv --python 3.11
 source .venv/bin/activate
 
-# Installer
-uv pip install -r requirements.txt
+# Installer le paquet et les outils de développement
+uv pip install -e ".[dev]"
 ```
 
 Le fichier de configuration est enregistré dans `~/.clawcodex/config.json`. Exemple minimal :

--- a/docs/i18n/README_HI.md
+++ b/docs/i18n/README_HI.md
@@ -151,15 +151,27 @@ clawcodex config       # सेटिंग्स देखें
 ### इंस्टॉल करें
 
 ```bash
-git clone https://github.com/GPT-AGI/Claw-Codex.git
-cd Claw-Codex
+# PyPI से इंस्टॉल करें (अनुशंसित)। पैकेज का नाम clawcodex-cli है,
+# लेकिन इंस्टॉल होने वाला कमांड `clawcodex` ही रहता है।
+pipx install clawcodex-cli
+# या: uv tool install clawcodex-cli
+# या सक्रिय वर्चुअल एनवायरनमेंट में: pip install clawcodex-cli
+
+clawcodex --help
+```
+
+सोर्स से विकास करने के लिए:
+
+```bash
+git clone https://github.com/agentforce314/clawcodex.git
+cd clawcodex
 
 # venv बनाएं (uv अनुशंसित)
 uv venv --python 3.11
 source .venv/bin/activate
 
-# इंस्टॉल करें
-uv pip install -r requirements.txt
+# पैकेज और डेवलपमेंट टूल इंस्टॉल करें
+uv pip install -e ".[dev]"
 ```
 
 कॉन्फ़िगरेशन फ़ाइल `~/.clawcodex/config.json` में सहेजी जाती है। न्यूनतम उदाहरण:

--- a/docs/i18n/README_PT.md
+++ b/docs/i18n/README_PT.md
@@ -152,15 +152,27 @@ clawcodex config       # Ver configurações
 ### Instalar
 
 ```bash
-git clone https://github.com/GPT-AGI/Claw-Codex.git
-cd Claw-Codex
+# Instalar pelo PyPI (recomendado). O pacote se chama clawcodex-cli,
+# mas o comando instalado continua sendo `clawcodex`.
+pipx install clawcodex-cli
+# Ou: uv tool install clawcodex-cli
+# Ou em um ambiente virtual ativado: pip install clawcodex-cli
+
+clawcodex --help
+```
+
+Para desenvolver a partir do código-fonte:
+
+```bash
+git clone https://github.com/agentforce314/clawcodex.git
+cd clawcodex
 
 # Criar venv (uv recomendado)
 uv venv --python 3.11
 source .venv/bin/activate
 
-# Instalar
-uv pip install -r requirements.txt
+# Instalar o pacote e as ferramentas de desenvolvimento
+uv pip install -e ".[dev]"
 ```
 
 O arquivo de configuração é salvo em `~/.clawcodex/config.json`. Exemplo mínimo:

--- a/docs/i18n/README_RU.md
+++ b/docs/i18n/README_RU.md
@@ -152,15 +152,27 @@ clawcodex config       # Просмотреть настройки
 ### Установка
 
 ```bash
-git clone https://github.com/GPT-AGI/Claw-Codex.git
-cd Claw-Codex
+# Установка из PyPI (рекомендуется). Пакет называется clawcodex-cli,
+# а установленная команда по-прежнему называется `clawcodex`.
+pipx install clawcodex-cli
+# Или: uv tool install clawcodex-cli
+# Или в активированном виртуальном окружении: pip install clawcodex-cli
+
+clawcodex --help
+```
+
+Для разработки из исходного кода:
+
+```bash
+git clone https://github.com/agentforce314/clawcodex.git
+cd clawcodex
 
 # Создать venv (рекомендуется uv)
 uv venv --python 3.11
 source .venv/bin/activate
 
-# Установить
-uv pip install -r requirements.txt
+# Установить пакет и инструменты разработки
+uv pip install -e ".[dev]"
 ```
 
 Файл конфигурации сохраняется в `~/.clawcodex/config.json`. Минимальный пример:

--- a/docs/i18n/README_ZH.md
+++ b/docs/i18n/README_ZH.md
@@ -27,14 +27,15 @@
 ## ⚡ 快速安装
 
 ```bash
-git clone https://github.com/agentforce314/clawcodex.git
-cd clawcodex
-python3 -m venv .venv && source .venv/bin/activate   # Python 3.10+
-pip install -r requirements.txt
+# 从 PyPI 安装（推荐）。发行包名是 clawcodex-cli，
+# 安装后的命令仍然是 clawcodex。
+pipx install clawcodex-cli
+# 或：uv tool install clawcodex-cli
+# 或在已激活的虚拟环境中：pip install clawcodex-cli
 
-python -m src.cli login   # 配置写入 ~/.clawcodex/config.json
+clawcodex login   # 配置写入 ~/.clawcodex/config.json
 
-python -m src.cli --dangerously-skip-permissions   # 启动 REPL
+clawcodex --dangerously-skip-permissions   # 启动 REPL
 ```
 
 配置文件保存在 `~/.clawcodex/config.json`。最小示例：
@@ -357,6 +358,18 @@ clawcodex --allow-dangerously-skip-permissions         # 允许之后通过 /per
 ## 🚀 快速开始
 
 ### 安装
+
+```bash
+# 从 PyPI 安装（推荐）。发行包名是 clawcodex-cli，
+# 安装后的命令仍然是 `clawcodex`。
+pipx install clawcodex-cli
+# 或：uv tool install clawcodex-cli
+# 或在已激活的虚拟环境中：pip install clawcodex-cli
+
+clawcodex --help
+```
+
+如需从源码开发：
 
 ```bash
 git clone https://github.com/agentforce314/clawcodex.git


### PR DESCRIPTION
## Summary

- add `pipx`, `uv tool`, and `pip` installation from the published `clawcodex-cli` PyPI distribution to all six translated READMEs
- clarify that the installed command remains `clawcodex`
- retain source-development instructions and correct their repository URL

The primary README already documents the same PyPI installation flow from the v1.2.1 release.

## Validation

- verified all seven user-facing READMEs mention `clawcodex-cli`
- verified every translated README includes `pipx install clawcodex-cli` and `clawcodex --help`
- `git diff --check`
