### PR TITLE
docs(eval): terminal-bench 2.1 run command

### DIFF
--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -35,9 +35,26 @@ ln -sfn ~/.docker/cli-plugins ~/.docker-nocreds/cli-plugins  # keep compose v2
 export DOCKER_CONFIG=~/.docker-nocreds
 ```
 
-## Evaluate ALL terminal-bench 2.0 tasks
+## Evaluate ALL terminal-bench 2.1 tasks
 
-From the repo root:
+Terminal-bench 2.1 ([harbor-framework/terminal-bench-2-1](https://github.com/harbor-framework/terminal-bench-2-1))
+is the verified iteration of 2.0 — same 89 tasks, 26 of them fixed for
+bugs, timeouts/resources, and reward-hacking robustness. It resolves from
+Harbor Hub under an org-qualified name (no `@version`). From the repo root:
+
+```bash
+PYTHONPATH=$PWD/eval/harbor harbor run \
+  --dataset terminal-bench/terminal-bench-2-1 \
+  --agent clawcodex_agent:Clawcodex \
+  --model deepseek/deepseek-v4-flash \
+  --jobs-dir eval/harbor/jobs \
+  --n-concurrent 4
+```
+
+NOTE: hub datasets namespace task names — filters must match the full
+name: `-i 'terminal-bench/fix-git'` (or use a glob: `-i '*fix-git*'`).
+
+## Evaluate ALL terminal-bench 2.0 tasks
 
 ```bash
 PYTHONPATH=$PWD/eval/harbor harbor run \
@@ -56,7 +73,8 @@ aggregate accuracy; each trial dir has the agent's stream-json log under
 
 ```bash
 # A subset of tasks (repeatable glob filter) — good for smoke tests
-  -i fix-git -i openssl-selfsigned-cert
+  -i fix-git -i openssl-selfsigned-cert          # terminal-bench@2.0
+  -i 'terminal-bench/fix-git'                    # hub datasets (2.1)
 
 # First N tasks only
   --n-tasks 5


### PR DESCRIPTION
## Summary
- Documents evaluating clawcodex on [terminal-bench 2.1](https://github.com/harbor-framework/terminal-bench-2-1) — the verified iteration of 2.0 (same 89 tasks, 26 fixed for bugs, timeouts/resources, and reward-hacking robustness).
- No adapter changes needed: `eval/harbor/clawcodex_agent.py` is dataset-agnostic. 2.1 resolves from **Harbor Hub** as `--dataset terminal-bench/terminal-bench-2-1` (org-qualified, no `@version`), and hub datasets namespace task names — include filters need `-i 'terminal-bench/<task>'` (or a glob). Both facts now documented.

## Command
```bash
PYTHONPATH=$PWD/eval/harbor harbor run \
  --dataset terminal-bench/terminal-bench-2-1 \
  --agent clawcodex_agent:Clawcodex \
  --model deepseek/deepseek-v4-flash \
  --jobs-dir eval/harbor/jobs \
  --n-concurrent 4
```

## Test plan
- [x] `harbor datasets download 'terminal-bench/terminal-bench-2-1' --cache` — 89/89 tasks
- [x] Live smoke with deepseek/deepseek-v4-flash: `terminal-bench/fix-git` + `terminal-bench/openssl-selfsigned-cert`, 2 trials, 0 infra errors (both scored 0.0 — verified as genuine model misses on hash-exact/stdout-exact checks; the agents ran 19/14 turns to natural completion)
- [x] `terminal-bench/fix-git` with `-k 2`: **pass@2 = 1.0** (rewards 1.0 + 0.0, mean 0.5) — 2.1 wiring demonstrably scores both outcomes
- [x] Confirmed the smoke tasks are content-identical between 2.0 and 2.1 (same cache digest), so the mixed rewards reflect model variance, not dataset drift

🤖 Generated with [Claude Code](https://claude.com/claude-code)