### PR TITLE
test: add effort=None to worktree-cli fake parsed-args

### DIFF
--- a/tests/entrypoints/test_worktree_cli_wiring.py
+++ b/tests/entrypoints/test_worktree_cli_wiring.py
@@ -100,7 +100,7 @@ def _headless_args(**overrides):
     base = dict(
         prompt="hi", output_format="text", input_format="text",
         include_partial_messages=False, max_turns=1, model=None,
-        fallback_model=None, provider=None, allowed_tools=None,
+        fallback_model=None, effort=None, provider=None, allowed_tools=None,
         disallowed_tools=None, verbose=False,
         dangerously_skip_permissions=False,
         _resolved_permission_mode="default",


### PR DESCRIPTION
Follow-up to #722: the `_headless_args` SimpleNamespace simulates parsed argparse output and needs the new `effort` attribute. Fixes the only 2 failures in the post-merge CI run (2 failed / 8609 passed → 10/10 locally in the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)