### PR TITLE
feat(vscode): port upstream TypeScript implementation VS Code extension onto the agent-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@ env/
 # IDE
 .idea/
 .vscode/
+# ...but the VS Code extension ships its own extension-host launch config
+!vscode-extension/clawcodex-vscode/.vscode/
 *.swp
 *.swo
 *~

--- a/src/providers/_stream_abort.py
+++ b/src/providers/_stream_abort.py
@@ -47,29 +47,23 @@ __all__ = ["StreamAbortGuard"]
 
 
 def _close_response_safely(stream: Any) -> None:
-    """Best-effort close of ``stream.response`` — never raises.
+    """Best-effort force-close of ``stream.response`` — never raises.
 
     Both the Anthropic SDK (``client.messages.stream``'s
     ``MessageStream``) and the OpenAI SDK (``Stream`` from
     ``client.chat.completions.create(stream=True)``) expose the
-    underlying httpx ``Response`` as ``stream.response``. Close is
-    idempotent on httpx (``if not self.is_closed`` guard), so a
-    double-close (e.g., listener fires AND the post-loop path also
+    underlying httpx ``Response`` as ``stream.response``. Delegates to
+    :func:`src.utils.stream_watchdog.force_close_response`, which
+    shuts the underlying socket down BEFORE closing — a bare
+    ``response.close()`` from the abort thread does not wake a
+    consumer parked in ``ssl.read()``, so the interrupt would stop
+    the chunks yet leave the turn hung. Shutdown+close is idempotent,
+    so a double-close (listener fires AND the post-loop path also
     closes) is harmless.
-
-    Failures in the listener thread must not propagate — the close is
-    purely defensive; the next-chunk read will eventually fail by
-    other means (timeout, server-side disconnect) even if the close
-    is a no-op.
     """
-    try:
-        response = getattr(stream, "response", None)
-        if response is not None:
-            close = getattr(response, "close", None)
-            if callable(close):
-                close()
-    except Exception:
-        pass
+    from src.utils.stream_watchdog import force_close_response
+
+    force_close_response(stream)
 
 
 class StreamAbortGuard:

--- a/src/utils/stream_watchdog.py
+++ b/src/utils/stream_watchdog.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import logging
 import os
+import socket as _socket
 import threading
 from typing import Any, Callable
 
@@ -40,7 +41,56 @@ __all__ = [
     "StreamIdleTimeout",
     "stream_idle_timeout_seconds",
     "StreamWatchdog",
+    "force_close_response",
 ]
+
+
+def force_close_response(stream: Any) -> None:
+    """Force a peer thread blocked on ``stream``'s next-chunk read to unwind.
+
+    ``response.close()`` alone is NOT enough: closing an httpx response
+    from another thread while the consumer is parked inside
+    ``ssl.read()``/``recv()`` does not wake the blocked syscall — the fd
+    stays referenced by the in-flight read, so the consumer hangs until
+    the server happens to drop the connection (observed live: an
+    agent-server ``interrupt`` during an Anthropic stream stopped the
+    deltas but the worker never raised, and even this watchdog's own
+    timeout close could not rescue it; faulthandler showed the consumer
+    in ``ssl.py:read`` minutes later). ``socket.shutdown(SHUT_RDWR)`` is
+    the documented cross-thread way to interrupt a blocked read: the
+    recv returns immediately and the SDK raises in the consumer thread.
+
+    The raw socket rides httpcore's response extensions
+    (``extensions["network_stream"].get_extra_info("socket")``) on both
+    the Anthropic and OpenAI SDK responses (httpx under both). Shutdown
+    first (wakes the reader), then ``close()`` (releases the
+    connection). Both steps are best-effort and idempotent; this helper
+    never raises — it runs on abort-listener and timer threads where an
+    exception would be lost anyway.
+    """
+    try:
+        response = getattr(stream, "response", None)
+        if response is None:
+            return
+        try:
+            extensions = getattr(response, "extensions", None) or {}
+            network_stream = extensions.get("network_stream")
+            sock = (
+                network_stream.get_extra_info("socket")
+                if network_stream is not None
+                else None
+            )
+            if sock is not None:
+                sock.shutdown(_socket.SHUT_RDWR)
+        except Exception:
+            # Already shut down / not a real socket / transport without
+            # the extension — fall through to the plain close.
+            pass
+        close = getattr(response, "close", None)
+        if callable(close):
+            close()
+    except Exception:
+        pass
 
 
 DEFAULT_STREAM_IDLE_TIMEOUT_S = 90.0
@@ -222,12 +272,7 @@ class StreamWatchdog:
             stream = self._stream
         # Close the response OUTSIDE the lock — close() may block on
         # network I/O and we shouldn't hold the lock during that.
-        try:
-            response = getattr(stream, "response", None)
-            if response is not None:
-                close = getattr(response, "close", None)
-                if callable(close):
-                    close()
-        except Exception:
-            # Best-effort: never let the close propagate out of the timer.
-            pass
+        # force_close_response shuts the socket down first so the
+        # consumer's blocked read actually returns (a bare close does
+        # not wake it — see the helper's docstring).
+        force_close_response(stream)

--- a/tests/test_stream_watchdog.py
+++ b/tests/test_stream_watchdog.py
@@ -179,5 +179,118 @@ class TestWatchdogIntegrationWithProvider(unittest.TestCase):
         fake_response.close.assert_called()
 
 
+class TestForceCloseResponse(unittest.TestCase):
+    """``force_close_response`` — the shutdown-then-close contract.
+
+    A bare ``response.close()`` from another thread does NOT wake a
+    consumer blocked in ``recv``/``ssl.read`` (observed live: agent-server
+    ``interrupt`` mid-Anthropic-stream stopped the deltas but the worker
+    thread never unwound). The fix shuts the underlying socket down
+    first — ``shutdown(SHUT_RDWR)`` is the documented cross-thread way
+    to interrupt a blocked read.
+    """
+
+    def test_shuts_socket_down_before_closing(self):
+        from src.utils.stream_watchdog import force_close_response
+        import socket as socket_mod
+
+        calls = []
+        sock = MagicMock()
+        sock.shutdown.side_effect = lambda how: calls.append(("shutdown", how))
+        network_stream = MagicMock()
+        network_stream.get_extra_info.return_value = sock
+        response = MagicMock()
+        response.extensions = {"network_stream": network_stream}
+        response.close.side_effect = lambda: calls.append(("close", None))
+        stream = MagicMock()
+        stream.response = response
+
+        force_close_response(stream)
+
+        network_stream.get_extra_info.assert_called_once_with("socket")
+        self.assertEqual(
+            calls,
+            [("shutdown", socket_mod.SHUT_RDWR), ("close", None)],
+        )
+
+    def test_close_still_runs_without_the_network_stream_extension(self):
+        from src.utils.stream_watchdog import force_close_response
+
+        response = MagicMock()
+        response.extensions = {}
+        stream = MagicMock()
+        stream.response = response
+
+        force_close_response(stream)
+
+        response.close.assert_called_once()
+
+    def test_shutdown_failure_does_not_block_the_close(self):
+        from src.utils.stream_watchdog import force_close_response
+
+        sock = MagicMock()
+        sock.shutdown.side_effect = OSError("already shut down")
+        network_stream = MagicMock()
+        network_stream.get_extra_info.return_value = sock
+        response = MagicMock()
+        response.extensions = {"network_stream": network_stream}
+        stream = MagicMock()
+        stream.response = response
+
+        force_close_response(stream)  # must not raise
+
+        response.close.assert_called_once()
+
+    def test_never_raises_without_a_response(self):
+        from src.utils.stream_watchdog import force_close_response
+
+        force_close_response(MagicMock(response=None))
+        force_close_response(object())  # no .response attribute at all
+
+    def test_unblocks_a_reader_parked_on_a_real_socket(self):
+        """The live-hang regression: a thread blocked in ``recv`` on a real
+        socket must unwind promptly once ``force_close_response`` runs.
+
+        Uses a plain TCP pair (the syscall semantics that caused the hang
+        are at the socket layer; TLS only wraps them) and an httpcore-shaped
+        stub exposing the socket via ``extensions['network_stream']``.
+        """
+        import socket as socket_mod
+
+        from src.utils.stream_watchdog import force_close_response
+
+        server, client = socket_mod.socketpair()
+        self.addCleanup(server.close)
+        self.addCleanup(client.close)
+
+        unwound = threading.Event()
+
+        def blocked_reader():
+            try:
+                client.recv(65536)  # server never sends — blocks
+            except Exception:
+                pass
+            unwound.set()
+
+        reader = threading.Thread(target=blocked_reader, daemon=True)
+        reader.start()
+        time.sleep(0.1)  # let the reader park inside recv
+        self.assertFalse(unwound.is_set(), "reader must be blocked before the close")
+
+        network_stream = MagicMock()
+        network_stream.get_extra_info.return_value = client
+        response = MagicMock()
+        response.extensions = {"network_stream": network_stream}
+        stream = MagicMock()
+        stream.response = response
+
+        force_close_response(stream)
+
+        self.assertTrue(
+            unwound.wait(timeout=2.0),
+            "shutdown(SHUT_RDWR) must wake the blocked recv",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/vscode-extension/clawcodex-vscode/.vscode/launch.json
+++ b/vscode-extension/clawcodex-vscode/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"]
+    }
+  ]
+}

--- a/vscode-extension/clawcodex-vscode/PORT_NOTES.md
+++ b/vscode-extension/clawcodex-vscode/PORT_NOTES.md
@@ -1,0 +1,122 @@
+# Port notes: openclaude-vscode → clawcodex-vscode
+
+This extension is a port of openclaude's `vscode-extension/openclaude-vscode` (the
+in-repo reference under `typescript/`, not shipped with clawcodex) onto the clawcodex
+backend. The module layout, webview UI, launch-target resolution, and test structure
+follow the reference; the wire protocol and provider integration are clawcodex-native.
+This file records every deliberate divergence.
+
+## 1. Chat backend: `agent-server --stdio`, not `--print` stream-json
+
+The reference spawns `openclaude --print --input-format=stream-json
+--output-format=stream-json --include-partial-messages`. clawcodex has that flag surface
+too (`clawcodex -p ...`), but its headless mode **auto-denies** interactive permission
+asks and emits a reduced event set (no `control_request`, no per-turn `result`, no
+thinking deltas). The functional equivalent of what the reference consumes is the
+clawcodex **agent-server** — the same backend the bundled Ink TUI uses:
+
+```
+clawcodex agent-server --stdio --workspace <cwd> --permission-mode <mode>
+                       [--provider <p>] [--model <m>]
+```
+
+It speaks the same SDK wire family the reference extension was built for: `system/init`,
+`assistant`/`user` message envelopes, `stream_event` `content_block_delta`
+(`text_delta` | `thinking_delta`), `control_request` subtype `can_use_tool` for
+permissions, and a per-turn terminal `result`.
+
+## 2. Client→server RPCs (new vs the reference)
+
+In the reference, `control_response` only ever flowed client→server (permission replies).
+The agent-server also uses the reverse direction: the client may send
+`control_request {request_id, request: {subtype}}` and the server answers with
+`control_response {response: {request_id, response}}`. `ProcessManager.sendControlRequest`
+correlates replies by `request_id` (pending-RPC map with timeout); matched replies are
+consumed, everything else flows to the chat handler. Used for:
+
+- `interrupt` — **abort**. Fire-and-forget (no reply); the server emits
+  `result/cancelled`. The reference sent SIGINT, which here would kill the whole server
+  and its session state.
+- `resume {session_id}` — session resume after spawn. There is no `--resume` spawn flag;
+  the webview restores the transcript from disk while this control reloads the
+  server-side conversation. A `{ok:false, error}` reply surfaces as an error banner.
+- `list_sessions` — available (used opportunistically); the primary session list is
+  disk-based so Resume works before any server is running.
+
+## 3. Permission replies
+
+`allow-session` persists rules by echoing the request's `suggestions` back as
+`chosen_updates` — the reference's `updatedPermissions` field is ignored by this server.
+The permission card renders the server's extra fields: `warning` (destructive-command
+caution), `session_label` (exact grant wording, rendered as "Yes, …"), and `plan`
+(ExitPlanMode approval body). All are escaped before entering the DOM.
+
+## 4. Sessions on disk
+
+`~/.clawcodex/sessions/<id>.json` (flat JSON: `session_id`, `updated_at` in epoch
+**seconds**, `preview`, `name` (nullable), `message_count`, `model`, `cwd`,
+`conversation.messages`) replaces the reference's `~/.openclaude/projects/<dir>/*.jsonl`.
+`$CLAWCODEX_CONFIG_DIR` is honored; there is **no `~/.claude` fallback** — clawcodex
+never shares state with a Claude Code install. The workspace filter realpaths both sides
+(the server stores resolved paths; VS Code hands out unresolved ones — think `/var` vs
+`/private/var`); if the workspace itself can't be resolved the list degrades to
+show-all rather than an empty resume picker. The scan parses every session file (server
+parity with `_list_saved_sessions`) and caps only the OUTPUT — with a flat store, an
+input-side cap could push all of the current workspace's sessions out of the scanned
+window whenever other projects were touched more recently, silently emptying Resume.
+`listSessions` runs async off the UI thread, so the full scan is affordable.
+
+## 5. Provider integration replaces the Azure/Foundry subsystem
+
+openclaude selects providers via env injection (`CLAUDE_CODE_USE_OPENAI`, `OPENAI_*`,
+Azure wizard + SecretStorage). clawcodex providers live in `~/.clawcodex/config.json`
+(`default_provider`, `providers.<name>`) with env-var key fallback, and are selected via
+`--provider`/`--model`. Accordingly:
+
+- Removed: the four Azure commands, `azure.*` settings, SecretStorage key,
+  `useOpenAIShim`, and all terminal env injection.
+- Added: `clawcodex.provider` / `clawcodex.model` settings (chat spawn flags), the
+  `Open Provider Config` command, and config-based provider detection for the Control
+  Center (`setting` / `config` / `env` / `unknown` sources). The extension reads the
+  config; it never writes it (credential setup belongs to the CLI).
+- The workspace "profile" concept maps to `<workspace>/.clawcodex/settings.json`
+  (project settings): same Found/Missing/Invalid/Unreadable states, watcher, and open
+  action, without openclaude's profile-name allowlist.
+
+## 6. Streaming-state derivation
+
+The agent-server emits only `content_block_delta` stream events — no
+`message_start`/`content_block_start`. Streaming state (status-bar spinner, typing
+indicator) flips on the first delta or tool activity of a turn; the thinking block shows
+on the first `thinking_delta` and hides when text starts or the turn ends.
+
+## 7. stderr policy
+
+The agent-server reserves stdout for JSON frames and logs diagnostics to stderr. Instead
+of forwarding every line as an error (reference behavior), only lines matching
+`/error|traceback|exception|fatal|critical/i` surface — substring on purpose, so
+`ValueError:`-style lines match.
+
+## 8. New Chat cold start
+
+"New chat" keeps the reference's kill+respawn architecture, so each fresh chat pays the
+agent-server cold start (provider + tool registry + MCP build) before the first token.
+Safe: user messages sent before init queue server-side. The server's `clear` control
+could keep the process warm; not adopted, to keep the reference lifecycle.
+
+## 9. Smaller notes
+
+- `permissionMode` gains `auto` (a real clawcodex mode). `dontAsk` exists server-side
+  but is deliberately not exposed in the settings enum.
+- `system` subtypes beyond `init`/`status` (e.g. goal status carriers) are ignored —
+  they are TUI concerns.
+- `result.session_id` updates the tracked session id every turn, so a crash-restart
+  resumes the file the server was actually writing.
+- The reference's `--continue` (continue most recent) has no agent-server equivalent
+  and was dropped; Resume Session covers the workflow.
+- The reference's `rate_limit` and `tool_progress` webview cases were dropped — the
+  agent-server does not emit those message types.
+- Tests run under plain `node --test` with a local functional `vscode` stub
+  (`test/register-vscode-stub.js`) instead of bun's `mock.module` + openclaude's shared
+  env mutex. Requires **Node ≥21** (the test-runner glob); the extension itself runs on
+  the VS Code host's Node.

--- a/vscode-extension/clawcodex-vscode/README.md
+++ b/vscode-extension/clawcodex-vscode/README.md
@@ -1,0 +1,80 @@
+# Clawcodex VS Code Extension
+
+A practical VS Code companion for clawcodex with a project-aware **Control Center**,
+predictable terminal launch behavior, and a **Chat** panel backed by the clawcodex
+agent-server — streaming responses, tool activity, thinking indicators, and interactive
+permission prompts included.
+
+## Features
+
+- **Chat in the Activity Bar (and as an editor panel)**:
+  - spawns `clawcodex agent-server --stdio` per session and speaks its NDJSON protocol
+  - streaming text and thinking deltas, tool-use cards with inputs/outputs, per-turn
+    usage stats
+  - **interactive permission prompts** (Allow / Deny / "Yes, allow …" persistent grants),
+    including plan-mode approval with the plan body
+  - session history: list, search, and resume saved sessions from `~/.clawcodex/sessions`
+  - abort generation via the server's graceful `interrupt` control
+- **Real Control Center status**:
+  - whether the configured `clawcodex` command is installed
+  - the launch command being used and the launch cwd that will be used for terminals
+  - the current workspace folder and whether `.clawcodex/settings.json` exists in it
+  - a conservative provider summary derived from `~/.clawcodex/config.json` and known
+    provider env keys — `unknown` is shown instead of guessing
+- **Project-aware launch behavior**:
+  - `Launch Clawcodex` launches from the active editor's workspace when possible
+  - falls back to the first workspace folder when needed
+  - avoids launching from an arbitrary default cwd when a project is open
+- **Built-in dark theme**: `Clawcodex Terminal Black`
+
+## Requirements
+
+- VS Code `1.95+`
+- `clawcodex` available on your PATH:
+
+  ```bash
+  curl -fsSL https://clawcodex.app/install.sh | bash
+  ```
+
+## Commands
+
+- `Clawcodex: Open Control Center`
+- `Clawcodex: Launch in Terminal` / `Clawcodex: Launch in Workspace Root`
+- `Clawcodex: New Chat` / `Clawcodex: Open Chat Panel` (`Ctrl/Cmd+Shift+L`)
+- `Clawcodex: Resume Session` / `Clawcodex: Abort Generation`
+- `Clawcodex: Open Project Settings` (workspace `.clawcodex/settings.json`)
+- `Clawcodex: Open Provider Config` (`~/.clawcodex/config.json`)
+- `Clawcodex: Open Repository` / `Clawcodex: Open Setup Guide`
+
+## Settings
+
+- `clawcodex.launchCommand` (default: `clawcodex`) — terminal launch command; its first
+  word is also the executable used to spawn the chat backend
+- `clawcodex.terminalName` (default: `Clawcodex`)
+- `clawcodex.permissionMode` (default: `acceptEdits`) — `default` | `acceptEdits` |
+  `plan` | `bypassPermissions` | `auto`, passed to the agent-server
+- `clawcodex.provider` / `clawcodex.model` — chat-session overrides; empty uses
+  `~/.clawcodex/config.json` defaults
+
+Provider credentials are configured by clawcodex itself (`clawcodex` → `/login`, or edit
+`~/.clawcodex/config.json`). The extension reads that config for status display but never
+writes it.
+
+## Development
+
+From this folder:
+
+```bash
+npm run test    # node --test with a local vscode stub (Node 21+)
+npm run lint    # syntax-check every shipped source file
+npm run e2e     # live protocol test against a real `clawcodex agent-server` (see script)
+```
+
+To package (optional):
+
+```bash
+npm run package
+```
+
+See `PORT_NOTES.md` for how this extension maps onto the clawcodex backend and where it
+deliberately diverges from the openclaude reference extension it was ported from.

--- a/vscode-extension/clawcodex-vscode/media/clawcodex.svg
+++ b/vscode-extension/clawcodex-vscode/media/clawcodex.svg
@@ -1,0 +1,6 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="128" height="128" rx="20" fill="#050505"/>
+  <rect x="16" y="20" width="96" height="88" rx="10" fill="#0a0908" stroke="#645041"/>
+  <path d="M32 48L46 60L32 72" stroke="#f09464" stroke-width="8" stroke-linecap="round" stroke-linejoin="round"/>
+  <rect x="56" y="68" width="38" height="8" rx="4" fill="#e8b86b"/>
+</svg>

--- a/vscode-extension/clawcodex-vscode/package.json
+++ b/vscode-extension/clawcodex-vscode/package.json
@@ -1,0 +1,194 @@
+{
+  "name": "clawcodex-vscode",
+  "displayName": "Clawcodex",
+  "description": "Practical VS Code companion for clawcodex with project-aware launch, Control Center, and chat backed by the clawcodex agent-server.",
+  "version": "0.1.0",
+  "publisher": "clawcodex",
+  "engines": {
+    "vscode": "^1.95.0"
+  },
+  "categories": [
+    "Themes",
+    "Other"
+  ],
+  "activationEvents": [
+    "onStartupFinished",
+    "onCommand:clawcodex.start",
+    "onCommand:clawcodex.startInWorkspaceRoot",
+    "onCommand:clawcodex.openDocs",
+    "onCommand:clawcodex.openSetupDocs",
+    "onCommand:clawcodex.openWorkspaceSettings",
+    "onCommand:clawcodex.openProviderConfig",
+    "onCommand:clawcodex.openControlCenter",
+    "onCommand:clawcodex.newChat",
+    "onCommand:clawcodex.openChat",
+    "onCommand:clawcodex.resumeSession",
+    "onCommand:clawcodex.abortChat",
+    "onView:clawcodex.controlCenter",
+    "onView:clawcodex.chat"
+  ],
+  "main": "./src/extension.js",
+  "files": [
+    "README.md",
+    "PORT_NOTES.md",
+    "media/**",
+    "src/extension.js",
+    "src/presentation.js",
+    "src/state.js",
+    "src/chat/**",
+    "themes/**"
+  ],
+  "contributes": {
+    "commands": [
+      {
+        "command": "clawcodex.start",
+        "title": "Clawcodex: Launch in Terminal",
+        "category": "Clawcodex"
+      },
+      {
+        "command": "clawcodex.startInWorkspaceRoot",
+        "title": "Clawcodex: Launch in Workspace Root",
+        "category": "Clawcodex"
+      },
+      {
+        "command": "clawcodex.openDocs",
+        "title": "Clawcodex: Open Repository",
+        "category": "Clawcodex"
+      },
+      {
+        "command": "clawcodex.openSetupDocs",
+        "title": "Clawcodex: Open Setup Guide",
+        "category": "Clawcodex"
+      },
+      {
+        "command": "clawcodex.openWorkspaceSettings",
+        "title": "Clawcodex: Open Project Settings",
+        "category": "Clawcodex"
+      },
+      {
+        "command": "clawcodex.openProviderConfig",
+        "title": "Clawcodex: Open Provider Config",
+        "category": "Clawcodex"
+      },
+      {
+        "command": "clawcodex.openControlCenter",
+        "title": "Clawcodex: Open Control Center",
+        "category": "Clawcodex"
+      },
+      {
+        "command": "clawcodex.newChat",
+        "title": "Clawcodex: New Chat",
+        "category": "Clawcodex"
+      },
+      {
+        "command": "clawcodex.openChat",
+        "title": "Clawcodex: Open Chat Panel",
+        "category": "Clawcodex"
+      },
+      {
+        "command": "clawcodex.resumeSession",
+        "title": "Clawcodex: Resume Session",
+        "category": "Clawcodex"
+      },
+      {
+        "command": "clawcodex.abortChat",
+        "title": "Clawcodex: Abort Generation",
+        "category": "Clawcodex"
+      }
+    ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "clawcodex",
+          "title": "Clawcodex",
+          "icon": "media/clawcodex.svg"
+        }
+      ]
+    },
+    "views": {
+      "clawcodex": [
+        {
+          "id": "clawcodex.chat",
+          "name": "Chat",
+          "type": "webview"
+        },
+        {
+          "id": "clawcodex.controlCenter",
+          "name": "Control Center",
+          "type": "webview"
+        }
+      ]
+    },
+    "keybindings": [
+      {
+        "command": "clawcodex.openChat",
+        "key": "ctrl+shift+l",
+        "mac": "cmd+shift+l"
+      }
+    ],
+    "configuration": {
+      "title": "Clawcodex",
+      "properties": {
+        "clawcodex.launchCommand": {
+          "type": "string",
+          "default": "clawcodex",
+          "description": "Command run in the integrated terminal when launching Clawcodex. The first word is also the executable used to spawn the chat backend (agent-server)."
+        },
+        "clawcodex.terminalName": {
+          "type": "string",
+          "default": "Clawcodex",
+          "description": "Integrated terminal tab name for Clawcodex sessions."
+        },
+        "clawcodex.permissionMode": {
+          "type": "string",
+          "default": "acceptEdits",
+          "enum": ["default", "acceptEdits", "plan", "bypassPermissions", "auto"],
+          "enumDescriptions": [
+            "Prompt for permission on each tool use (requires manual approval)",
+            "Auto-approve file edits, prompt for other operations (recommended)",
+            "Plan mode — research first, present a plan for approval before editing",
+            "Auto-approve all operations without prompting",
+            "Classifier decides per action whether to prompt"
+          ],
+          "description": "Permission mode for chat sessions (passed to `clawcodex agent-server --permission-mode`). Controls which tool operations are auto-approved."
+        },
+        "clawcodex.provider": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Provider name for chat sessions (passed as `--provider`). Empty uses the `default_provider` from `~/.clawcodex/config.json`."
+        },
+        "clawcodex.model": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Model override for chat sessions (passed as `--model`). Empty uses the provider's `default_model` from `~/.clawcodex/config.json`."
+        }
+      }
+    },
+    "themes": [
+      {
+        "label": "Clawcodex Terminal Black",
+        "uiTheme": "vs-dark",
+        "path": "./themes/Clawcodex-Terminal-Black.json"
+      }
+    ]
+  },
+  "scripts": {
+    "test": "node --require ./test/register-vscode-stub.js --test \"src/**/*.test.js\"",
+    "lint": "node scripts/lint.js",
+    "e2e": "node scripts/e2e-agent-server.mjs",
+    "package": "npx @vscode/vsce package --no-dependencies"
+  },
+  "keywords": [
+    "clawcodex",
+    "terminal",
+    "theme",
+    "cli",
+    "llm",
+    "agent"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/agentforce314/clawcodex"
+  },
+  "license": "MIT"
+}

--- a/vscode-extension/clawcodex-vscode/scripts/e2e-agent-server.mjs
+++ b/vscode-extension/clawcodex-vscode/scripts/e2e-agent-server.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+/**
+ * Live protocol e2e: drives the real `clawcodex agent-server --stdio` through
+ * the extension's ProcessManager and asserts the wire contract the chat
+ * depends on.
+ *
+ * Phases:
+ *   1. init        — system/init handshake arrives
+ *   2. rpc         — list_sessions control_request → correlated reply
+ *   3. turn        — live mini-turn: stream deltas → assistant → result   [live]
+ *   4. permission  — default-mode Write ask → control_request → deny → result [live]
+ *   5. interrupt   — abort mid-turn → result/cancelled                    [live]
+ *
+ * Usage:
+ *   node scripts/e2e-agent-server.mjs                  # full run (needs provider creds)
+ *   node scripts/e2e-agent-server.mjs --protocol-only  # phases 1-2 only (no LLM calls)
+ *
+ * Env:
+ *   CLAWCODEX_E2E_CMD    launcher override, e.g. "uv run python -m src.cli"
+ *                        (multi-word commands are wrapped in a shim script)
+ *   CLAWCODEX_E2E_MODEL  model override passed as --model
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+require(path.join(here, '..', 'test', 'register-vscode-stub.js'));
+const { ProcessManager } = require(path.join(here, '..', 'src', 'chat', 'processManager.js'));
+
+const PROTOCOL_ONLY = process.argv.includes('--protocol-only');
+const MODEL = process.env.CLAWCODEX_E2E_MODEL || null;
+
+const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'clawcodex-vscode-e2e-'));
+const cleanups = [() => fs.rmSync(tempRoot, { recursive: true, force: true })];
+
+function resolveCommand() {
+  const raw = (process.env.CLAWCODEX_E2E_CMD || 'clawcodex').trim();
+  const words = raw.split(/\s+/);
+  if (words.length === 1) return words[0];
+  // ProcessManager spawns a single executable; wrap multi-word launchers.
+  const shim = path.join(tempRoot, 'clawcodex-shim.sh');
+  fs.writeFileSync(shim, `#!/bin/sh\nexec ${raw} "$@"\n`);
+  fs.chmodSync(shim, 0o755);
+  return shim;
+}
+
+function makeSession({ permissionMode, workspace }) {
+  const pm = new ProcessManager({
+    command: resolveCommand(),
+    cwd: workspace,
+    permissionMode,
+    model: MODEL,
+  });
+
+  const state = {
+    pm,
+    events: [],
+    errors: [],
+    waiters: [],
+  };
+  pm.onMessage((msg) => {
+    state.events.push(msg);
+    for (const waiter of [...state.waiters]) {
+      if (waiter.predicate(msg)) {
+        state.waiters.splice(state.waiters.indexOf(waiter), 1);
+        clearTimeout(waiter.timer);
+        waiter.resolve(msg);
+      }
+    }
+  });
+  pm.onError((err) => state.errors.push(String(err.message || err)));
+  pm.start();
+  cleanups.push(() => pm.dispose());
+  return state;
+}
+
+function waitFor(state, label, predicate, timeoutMs) {
+  const already = state.events.find(predicate);
+  if (already) return Promise.resolve(already);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      const idx = state.waiters.findIndex(w => w.resolve === resolve);
+      if (idx >= 0) state.waiters.splice(idx, 1);
+      reject(new Error(`timeout waiting for ${label} after ${timeoutMs}ms; saw types: ${state.events.map(e => e.type + (e.subtype ? '/' + e.subtype : '')).join(', ') || '(none)'}${state.errors.length ? `; stderr: ${state.errors.slice(-3).join(' | ')}` : ''}`));
+    }, timeoutMs);
+    state.waiters.push({ predicate, resolve, timer });
+  });
+}
+
+let passed = 0;
+function ok(label, detail = '') {
+  passed += 1;
+  console.log(`  ✔ ${label}${detail ? ` — ${detail}` : ''}`);
+}
+
+async function main() {
+  const workspace = fs.mkdtempSync(path.join(tempRoot, 'ws-'));
+
+  console.log(`Phase 1+2: handshake + RPC (workspace ${workspace})`);
+  const proto = makeSession({ permissionMode: 'default', workspace });
+
+  const init = await waitFor(proto, 'system/init', m => m.type === 'system' && m.subtype === 'init', 120000);
+  if (!init.session_id) throw new Error('init carried no session_id');
+  ok('system/init received', `session ${init.session_id}, model ${init.model}, mode ${init.permission_mode}`);
+  if (init.permission_mode !== 'default') throw new Error(`expected permission_mode default, got ${init.permission_mode}`);
+  ok('permission_mode honored at spawn');
+
+  const sessions = await proto.pm.sendControlRequest('list_sessions', {}, { timeoutMs: 30000 });
+  if (!Array.isArray(sessions.sessions)) throw new Error(`list_sessions reply malformed: ${JSON.stringify(sessions).slice(0, 200)}`);
+  ok('list_sessions RPC round-trip', `${sessions.sessions.length} sessions`);
+
+  if (PROTOCOL_ONLY) {
+    proto.pm.dispose();
+    console.log(`\nPROTOCOL-ONLY PASS (${passed} checks)`);
+    return;
+  }
+
+  console.log('Phase 3: live mini-turn');
+  proto.pm.sendUserMessage('Reply with exactly the word OK and nothing else. Do not use any tools.');
+  const result1 = await waitFor(proto, 'result', m => m.type === 'result', 300000);
+  if (result1.subtype !== 'success') throw new Error(`turn ended ${result1.subtype}: ${result1.error || result1.result}`);
+  const sawDelta = proto.events.some(m => m.type === 'stream_event' && m.event?.type === 'content_block_delta');
+  const assistant = proto.events.find(m => m.type === 'assistant');
+  const text = assistant?.message?.content?.filter?.(b => b.type === 'text').map(b => b.text).join('') ?? '';
+  if (!assistant) throw new Error('no assistant envelope before result');
+  ok('live turn: deltas → assistant → result', `deltas=${sawDelta}, text=${JSON.stringify(text).slice(0, 40)}, usage=${JSON.stringify(result1.usage || {}).slice(0, 60)}`);
+
+  console.log('Phase 4: permission round-trip (deny a Write in default mode)');
+  proto.pm.sendUserMessage(
+    'Use the Write tool to create a file named e2e_perm_test.txt in the workspace root containing the word hello. If the permission is denied, stop and reply DENIED.',
+  );
+  const permReq = await waitFor(
+    proto,
+    'control_request/can_use_tool',
+    m => m.type === 'control_request' && m.request?.subtype === 'can_use_tool',
+    300000,
+  );
+  ok('control_request/can_use_tool received', `tool ${permReq.request.tool_name}, suggestions=${(permReq.request.suggestions || []).length}, label=${JSON.stringify(permReq.request.session_label)}`);
+  // Deny this and any retry asks for the rest of the turn.
+  const denyAll = (m) => {
+    if (m.type === 'control_request' && m.request?.subtype === 'can_use_tool') {
+      proto.pm.sendControlResponse(m.request_id, { behavior: 'deny', message: 'User denied permission' });
+    }
+    return false;
+  };
+  proto.waiters.push({ predicate: denyAll, resolve: () => {}, timer: setTimeout(() => {}, 0) });
+  proto.pm.sendControlResponse(permReq.request_id, { behavior: 'deny', message: 'User denied permission' });
+  const result2 = await waitFor(
+    proto,
+    'result after deny',
+    m => m.type === 'result' && proto.events.indexOf(m) > proto.events.indexOf(permReq),
+    300000,
+  );
+  if (fs.existsSync(path.join(workspace, 'e2e_perm_test.txt'))) {
+    throw new Error('denied Write still created the file');
+  }
+  ok('deny honored, turn completed', `result ${result2.subtype}, file not created`);
+
+  console.log('Phase 5: interrupt mid-turn');
+  proto.pm.sendUserMessage('Count from 1 to 500, one number per line. Do not use tools.');
+  await waitFor(
+    proto,
+    'first delta of the long turn',
+    m => m.type === 'stream_event' && m.event?.type === 'content_block_delta' && proto.events.indexOf(m) > proto.events.indexOf(result2),
+    300000,
+  );
+  proto.pm.abort();
+  const result3 = await waitFor(
+    proto,
+    'result/cancelled',
+    m => m.type === 'result' && proto.events.indexOf(m) > proto.events.indexOf(result2),
+    120000,
+  );
+  if (result3.subtype !== 'cancelled') throw new Error(`expected cancelled, got ${result3.subtype}`);
+  ok('interrupt → result/cancelled');
+
+  console.log('Phase 6: session usable after interrupt');
+  proto.pm.sendUserMessage('Reply with exactly the word STILL-ALIVE and nothing else. Do not use tools.');
+  const result4 = await waitFor(
+    proto,
+    'result after interrupt',
+    m => m.type === 'result' && proto.events.indexOf(m) > proto.events.indexOf(result3),
+    300000,
+  );
+  if (result4.subtype !== 'success') throw new Error(`post-interrupt turn ended ${result4.subtype}`);
+  ok('post-interrupt turn completed', `result ${result4.subtype}`);
+
+  proto.pm.dispose();
+  console.log(`\nE2E PASS (${passed} checks)`);
+}
+
+main()
+  .catch((err) => {
+    console.error(`\nE2E FAIL after ${passed} checks: ${err.message}`);
+    process.exitCode = 1;
+  })
+  .finally(() => {
+    for (const fn of cleanups.reverse()) {
+      try { fn(); } catch { /* best effort */ }
+    }
+  });

--- a/vscode-extension/clawcodex-vscode/scripts/lint.js
+++ b/vscode-extension/clawcodex-vscode/scripts/lint.js
@@ -1,0 +1,17 @@
+const { readdirSync } = require('node:fs');
+const { execFileSync } = require('node:child_process');
+const { join } = require('node:path');
+
+function check(dir) {
+  for (const f of readdirSync(dir, { withFileTypes: true })) {
+    if (f.isDirectory()) {
+      check(join(dir, f.name));
+    } else if (f.name.endsWith('.js') && !f.name.endsWith('.test.js')) {
+      execFileSync(process.execPath, ['--check', join(dir, f.name)], {
+        stdio: 'inherit',
+      });
+    }
+  }
+}
+
+check('./src');

--- a/vscode-extension/clawcodex-vscode/src/chat/chatProvider.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/chatProvider.js
@@ -1,0 +1,615 @@
+/**
+ * chatProvider — WebviewViewProvider (sidebar) and WebviewPanel manager
+ * (editor tab) that wire ProcessManager events to the chat UI.
+ */
+
+const vscode = require('vscode');
+const crypto = require('crypto');
+const { ProcessManager } = require('./processManager');
+const { buildPermissionControlResult } = require('./permissionResponse');
+const { toolDisplayName, toolIcon, parseToolInput } = require('./messageParser');
+const { renderChatHtml } = require('./chatRenderer');
+const {
+  isAssistantMessage, isStreamEvent, isResultMessage,
+  isPermissionRequest, isControlRequest, isSystemInit, isSystemStatus,
+  getTextContent, getToolUseBlocks,
+} = require('./protocol');
+
+async function openFileInEditor(filePath) {
+  try {
+    const uri = vscode.Uri.file(filePath);
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc, { preview: false });
+  } catch {
+    vscode.window.showWarningMessage(`Could not open file: ${filePath}`);
+  }
+}
+
+function getLaunchConfig() {
+  const cfg = vscode.workspace.getConfiguration('clawcodex');
+  const { getExecutableFromCommand } = require('../state');
+  const launchCommand = cfg.get('launchCommand', 'clawcodex');
+  const command = getExecutableFromCommand(launchCommand) || 'clawcodex';
+  const permissionMode = cfg.get('permissionMode', 'acceptEdits');
+  const provider = (cfg.get('provider', '') || '').trim() || null;
+  const model = (cfg.get('model', '') || '').trim() || null;
+  const folders = vscode.workspace.workspaceFolders;
+  const cwd = folders && folders.length > 0 ? folders[0].uri.fsPath : undefined;
+  return { command, cwd, env: {}, permissionMode, provider, model };
+}
+
+class ChatController {
+  constructor(sessionManager) {
+    this._sessionManager = sessionManager;
+    this._process = null;
+    this._webviews = new Set();
+    this._accumulatedText = '';
+    this._messages = [];
+    this._currentSessionId = null;
+    this._streaming = false;
+    this._thinkingTokens = 0;
+    this._thinkingStartTime = null;
+    this._thinkingVisible = false;
+    /** @type {Map<string, { input: Record<string, unknown>, suggestions: unknown[], toolUseId: string | null }>} */
+    this._pendingPermissions = new Map();
+
+    this._onDidChangeState = new vscode.EventEmitter();
+    this.onDidChangeState = this._onDidChangeState.event;
+  }
+
+  get sessionId() { return this._currentSessionId; }
+  get isStreaming() { return this._process && this._process.running; }
+  get sessionManager() { return this._sessionManager; }
+
+  registerWebview(webview) {
+    this._webviews.add(webview);
+    return { dispose: () => this._webviews.delete(webview) };
+  }
+
+  broadcast(msg) {
+    for (const wv of this._webviews) {
+      try { wv.postMessage(msg); } catch { /* webview might be disposed */ }
+    }
+  }
+
+  _broadcast(msg) {
+    this.broadcast(msg);
+  }
+
+  async startSession(opts = {}) {
+    this.stopSession();
+    this._accumulatedText = '';
+    // Only clear messages if this is a brand new session (not a resume)
+    if (!opts.sessionId) {
+      this._messages = [];
+    }
+    this._currentSessionId = opts.sessionId || null;
+
+    const { command, cwd, env, permissionMode, provider, model } = getLaunchConfig();
+
+    this._process = new ProcessManager({
+      command,
+      cwd,
+      env,
+      permissionMode,
+      provider,
+      model: opts.model || model,
+      extraArgs: opts.extraArgs || [],
+    });
+
+    this._readyResolve = null;
+    this._readyPromise = new Promise(resolve => { this._readyResolve = resolve; });
+
+    this._process.onMessage((msg) => {
+      if (msg.type === 'system' && this._readyResolve) {
+        this._readyResolve();
+        this._readyResolve = null;
+      }
+      this._handleMessage(msg);
+    });
+    this._process.onError((err) => {
+      this._broadcast({ type: 'error', message: err.message || String(err) });
+    });
+    this._process.onExit(({ code }) => {
+      // Flush any remaining streamed text
+      if (this._streaming && this._accumulatedText) {
+        this._broadcast({ type: 'stream_end', text: this._accumulatedText, usage: null, final: true });
+      } else if (this._streaming) {
+        this._broadcast({ type: 'stream_end', text: '', usage: null, final: true });
+      }
+      this._streaming = false;
+      this._accumulatedText = '';
+      this._broadcast({
+        type: 'connected',
+        message: code === 0 || code === null ? 'Ready' : `Process exited (code ${code})`,
+      });
+      this._onDidChangeState.fire('idle');
+    });
+
+    try {
+      this._process.start();
+      this._broadcast({ type: 'connected', message: 'Connected' });
+      this._onDidChangeState.fire('connected');
+    } catch (err) {
+      this._broadcast({ type: 'error', message: `Failed to start: ${err.message}` });
+      return;
+    }
+
+    // Resuming: the webview restore renders from disk; this control reloads
+    // the server-side conversation so the next turn continues the session.
+    if (opts.sessionId) {
+      await this._resumeOnServer(opts.sessionId);
+    }
+  }
+
+  async _resumeOnServer(sessionId) {
+    if (!this._process) return;
+    if (this._readyPromise) {
+      const grace = new Promise(resolve => setTimeout(resolve, 8000));
+      await Promise.race([this._readyPromise, grace]);
+      this._readyPromise = null;
+    }
+    try {
+      const reply = await this._process.sendControlRequest('resume', { session_id: sessionId });
+      if (reply && reply.ok === false) {
+        this._broadcast({
+          type: 'error',
+          message: `Resume failed: ${reply.error || 'unknown error'}`,
+        });
+      }
+    } catch (err) {
+      this._broadcast({ type: 'error', message: `Resume failed: ${err.message}` });
+    }
+  }
+
+  stopSession() {
+    if (this._process) {
+      this._process.dispose();
+      this._process = null;
+    }
+    this._streaming = false;
+    this._pendingPermissions.clear();
+  }
+
+  async sendMessage(text) {
+    // Keep the process alive for multi-turn — just send directly.
+    // The agent-server maintains full session state across turns.
+    // Only start a new process if none exists or it died.
+    if (!this._process || !this._process.running) {
+      await this.startSession({
+        sessionId: this._currentSessionId || undefined,
+      });
+    }
+    await this._doSend(text);
+  }
+
+  async _doSend(text) {
+    if (!this._process) return;
+    // On first message after process start, wait for the server init.
+    // Messages sent before init still queue server-side, so the grace
+    // timeout only bounds the wait, it cannot lose input.
+    if (this._readyPromise) {
+      const grace = new Promise(resolve => setTimeout(resolve, 8000));
+      await Promise.race([this._readyPromise, grace]);
+      this._readyPromise = null;
+    }
+    this._accumulatedText = '';
+    try {
+      this._process.sendUserMessage(text);
+      this._messages.push({ role: 'user', text });
+    } catch (err) {
+      this._broadcast({ type: 'error', message: err.message });
+    }
+  }
+
+  abort() {
+    if (this._process) {
+      this._process.abort();
+      // The server confirms with a result/cancelled message which finalizes
+      // the stream; this immediate echo just makes the UI feel responsive.
+      this._broadcast({ type: 'status', content: 'Interrupting...' });
+    }
+  }
+
+  async listServerSessions() {
+    if (!this._process || !this._process.running) return null;
+    try {
+      const reply = await this._process.sendControlRequest('list_sessions', {});
+      return Array.isArray(reply?.sessions) ? reply.sessions : [];
+    } catch {
+      return null;
+    }
+  }
+
+  sendPermissionResponse(requestId, action, toolUseId) {
+    if (!this._process) return;
+    const pending = this._pendingPermissions.get(requestId);
+    this._pendingPermissions.delete(requestId);
+    const result = buildPermissionControlResult(action, {
+      input: pending?.input,
+      toolUseId: toolUseId || pending?.toolUseId || null,
+      permissionSuggestions: pending?.suggestions,
+    });
+    try {
+      this._process.sendControlResponse(requestId, result);
+    } catch (err) {
+      this._broadcast({ type: 'error', message: err.message });
+    }
+  }
+
+  getMessages() { return this._messages; }
+
+  /**
+   * Mark the turn as streaming (status bar spinner + typing indicator).
+   * The agent-server wire has no message_start — the first activity of a
+   * turn (text/thinking delta, tool use) flips the state instead.
+   */
+  _ensureStreaming() {
+    if (this._streaming) return;
+    this._streaming = true;
+    this._broadcast({ type: 'stream_start' });
+    this._onDidChangeState.fire('streaming');
+  }
+
+  _handleMessage(msg) {
+    if (msg.session_id && !this._currentSessionId) {
+      this._currentSessionId = msg.session_id;
+    }
+
+    // System init — extract model and session info
+    if (isSystemInit(msg)) {
+      this._broadcast({
+        type: 'system_info',
+        model: msg.model || null,
+        sessionId: msg.session_id || null,
+      });
+      return;
+    }
+
+    // System status lines (info/error) from the server. Some status frames
+    // are data-only carriers (e.g. a mid-turn permission-mode push has no
+    // message) — don't blank the status pill for those.
+    if (isSystemStatus(msg)) {
+      if (msg.level === 'error') {
+        this._broadcast({ type: 'error', message: msg.message || 'Server error' });
+      } else if (typeof msg.message === 'string' && msg.message.trim()) {
+        this._broadcast({ type: 'status', content: msg.message });
+      }
+      return;
+    }
+
+    // Other system subtypes (goal_status, ...) are TUI concerns — ignore.
+    if (msg.type === 'system') {
+      return;
+    }
+
+    // Permission ask (control_request subtype can_use_tool)
+    if (isPermissionRequest(msg)) {
+      const req = msg.request || {};
+      const requestId = msg.request_id;
+      const toolInput =
+        req.input && typeof req.input === 'object' && !Array.isArray(req.input)
+          ? req.input
+          : {};
+      const suggestions = Array.isArray(req.suggestions) ? req.suggestions : [];
+      if (requestId) {
+        this._pendingPermissions.set(requestId, {
+          input: toolInput,
+          suggestions,
+          toolUseId: req.tool_use_id || null,
+        });
+      }
+      this._broadcast({
+        type: 'permission_request',
+        requestId,
+        toolName: req.tool_name || 'Unknown',
+        displayName: toolDisplayName(req.tool_name),
+        inputPreview: parseToolInput(req.input),
+        toolUseId: req.tool_use_id || null,
+        sessionLabel: typeof req.session_label === 'string' ? req.session_label : null,
+        warning: typeof req.warning === 'string' ? req.warning : null,
+        plan: typeof req.plan === 'string' ? req.plan : null,
+        hasSuggestions: suggestions.length > 0,
+      });
+      return;
+    }
+
+    // Non-permission inbound control_requests: nothing for a chat pane to do.
+    if (isControlRequest(msg)) {
+      return;
+    }
+
+    // Anthropic-style stream events (text/thinking deltas)
+    if (isStreamEvent(msg)) {
+      this._handleStreamEvent(msg);
+      return;
+    }
+
+    // Assistant message — mid-turn envelope; true completion comes from 'result'
+    if (isAssistantMessage(msg)) {
+      const inner = msg.message || msg;
+      const text = getTextContent(inner);
+      const toolBlocks = getToolUseBlocks(inner);
+      this._ensureStreaming();
+      this._hideThinking();
+      const toolUseVms = toolBlocks.map(tu => ({
+        id: tu.id,
+        name: tu.name,
+        displayName: toolDisplayName(tu.name),
+        icon: toolIcon(tu.name),
+        inputPreview: parseToolInput(tu.input),
+        input: tu.input,
+        status: 'running',
+      }));
+      this._messages.push({ role: 'assistant', text, toolUses: toolUseVms });
+
+      // Tool cards go out BEFORE the stream_end that finalizes the bubble,
+      // so text and its tool cards share one assistant bubble (the reference
+      // got the same grouping via content_block_start during streaming).
+      if (toolBlocks.length > 0) {
+        for (const vm of toolUseVms) {
+          this._broadcast({ type: 'tool_use', toolUse: vm });
+        }
+      }
+
+      // Finalize current text bubble but stay streaming — true completion
+      // is signaled by the 'result' message, not by the assistant message.
+      this._broadcast({ type: 'stream_end', text, usage: null, final: false });
+      this._accumulatedText = '';
+
+      if (toolBlocks.length > 0) {
+        this._broadcast({ type: 'status', content: 'Using tools...' });
+      }
+      return;
+    }
+
+    // User message with tool_result blocks — the tool output
+    if (msg.type === 'user' && msg.message) {
+      const content = msg.message.content;
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.type === 'tool_result' && block.tool_use_id) {
+            const resultText = typeof block.content === 'string'
+              ? block.content
+              : Array.isArray(block.content)
+                ? block.content.map(b => b.text || '').join('')
+                : '';
+            this._broadcast({
+              type: 'tool_result',
+              toolUseId: block.tool_use_id,
+              content: resultText.slice(0, 2000) || '(done)',
+              isError: block.is_error || false,
+            });
+          }
+        }
+        if (content.some(b => b && b.type === 'tool_result')) {
+          this._broadcast({ type: 'status', content: 'Thinking...' });
+        }
+      }
+      return;
+    }
+
+    // Per-turn result — the turn is complete. Go idle; the process stays
+    // alive for the next turn.
+    if (isResultMessage(msg)) {
+      // Track the LIVE session id: after a resume the server persists turns
+      // under its own (new) id, so a later crash-restart must resume that
+      // file, not the originally-picked one.
+      if (msg.session_id) {
+        this._currentSessionId = msg.session_id;
+      }
+      this._hideThinking();
+      const text = this._accumulatedText || '';
+      this._broadcast({ type: 'stream_end', text, usage: msg.usage || null, final: true });
+      if (msg.subtype === 'error') {
+        this._broadcast({ type: 'error', message: msg.error || msg.result || 'Turn failed' });
+      } else if (msg.subtype === 'cancelled') {
+        this._broadcast({ type: 'status', content: 'Interrupted' });
+      } else if (msg.num_turns !== undefined) {
+        this._broadcast({
+          type: 'status',
+          content: msg.num_turns > 1
+            ? 'Completed (' + msg.num_turns + ' turns)'
+            : 'Ready',
+        });
+      }
+      this._accumulatedText = '';
+      this._streaming = false;
+      this._onDidChangeState.fire('idle');
+      return;
+    }
+
+    // Everything else (agent_progress, task notifications, ...) is ignored.
+  }
+
+  _handleStreamEvent(msg) {
+    const event = msg.event;
+    if (!event || event.type !== 'content_block_delta' || !event.delta) return;
+
+    if (event.delta.type === 'text_delta' && event.delta.text) {
+      this._ensureStreaming();
+      this._hideThinking();
+      this._accumulatedText += event.delta.text;
+      this._broadcast({ type: 'stream_delta', text: this._accumulatedText });
+    } else if (event.delta.type === 'thinking_delta') {
+      this._ensureStreaming();
+      if (!this._thinkingVisible) {
+        this._thinkingVisible = true;
+        this._thinkingTokens = 0;
+        this._thinkingStartTime = Date.now();
+        this._broadcast({ type: 'thinking_start' });
+      }
+      this._thinkingTokens += (event.delta.thinking || '').length;
+      const elapsed = Math.round((Date.now() - (this._thinkingStartTime || Date.now())) / 1000);
+      this._broadcast({
+        type: 'thinking_delta',
+        tokens: this._thinkingTokens,
+        elapsed,
+      });
+    }
+  }
+
+  _hideThinking() {
+    if (this._thinkingVisible) {
+      this._thinkingVisible = false;
+      this._broadcast({ type: 'thinking_end' });
+    }
+  }
+
+  dispose() {
+    this.stopSession();
+    this._onDidChangeState.dispose();
+  }
+}
+
+function attachMessageHandler(webview, chatController, helpers) {
+  webview.onDidReceiveMessage(async (msg) => {
+    switch (msg.type) {
+      case 'send_message':
+        chatController.sendMessage(msg.text);
+        break;
+      case 'abort':
+        chatController.abort();
+        break;
+      case 'new_session':
+        chatController.stopSession();
+        chatController._currentSessionId = null;
+        chatController._messages = [];
+        webview.postMessage({ type: 'session_cleared' });
+        break;
+      case 'resume_session':
+        chatController.stopSession();
+        chatController._currentSessionId = null;
+        chatController._messages = [];
+        webview.postMessage({ type: 'session_cleared' });
+        await helpers.loadAndDisplaySession(webview, msg.sessionId);
+        await chatController.startSession({ sessionId: msg.sessionId });
+        break;
+      case 'permission_response':
+        chatController.sendPermissionResponse(msg.requestId, msg.action, msg.toolUseId);
+        break;
+      case 'copy_code':
+        if (msg.text) await vscode.env.clipboard.writeText(msg.text);
+        break;
+      case 'open_file':
+        if (msg.path) await openFileInEditor(msg.path);
+        break;
+      case 'request_sessions':
+        await helpers.sendSessionList(webview);
+        break;
+      case 'restore_request':
+        helpers.restoreMessages(webview);
+        break;
+      case 'webview_ready':
+        break;
+    }
+  });
+}
+
+function makeWebviewHelpers(chatController) {
+  return {
+    async sendSessionList(webview) {
+      if (!chatController.sessionManager) return;
+      try {
+        const sessions = await chatController.sessionManager.listSessions();
+        webview.postMessage({ type: 'session_list', sessions });
+      } catch {
+        webview.postMessage({ type: 'session_list', sessions: [] });
+      }
+    },
+    restoreMessages(webview) {
+      const messages = chatController.getMessages();
+      if (messages.length > 0) {
+        webview.postMessage({ type: 'restore_messages', messages });
+      }
+    },
+    async loadAndDisplaySession(webview, sessionId) {
+      if (!chatController.sessionManager) return;
+      try {
+        const messages = await chatController.sessionManager.loadSession(sessionId);
+        if (messages && messages.length > 0) {
+          chatController._messages = messages;
+          webview.postMessage({ type: 'restore_messages', messages });
+        }
+      } catch { /* session may not be loadable */ }
+    },
+  };
+}
+
+class ClawcodexChatViewProvider {
+  constructor(chatController) {
+    this._chatController = chatController;
+    this._webviewView = null;
+  }
+
+  resolveWebviewView(webviewView, _context, _token) {
+    this._webviewView = webviewView;
+    const webview = webviewView.webview;
+    webview.options = { enableScripts: true };
+
+    const registration = this._chatController.registerWebview(webview);
+    webviewView.onDidDispose(() => {
+      registration.dispose();
+      if (this._webviewView === webviewView) this._webviewView = null;
+    });
+
+    const nonce = crypto.randomBytes(16).toString('hex');
+    webview.html = renderChatHtml({ nonce, platform: process.platform });
+    attachMessageHandler(webview, this._chatController, makeWebviewHelpers(this._chatController));
+  }
+}
+
+class ClawcodexChatPanelManager {
+  constructor(chatController) {
+    this._chatController = chatController;
+    this._panel = null;
+  }
+
+  openPanel() {
+    if (this._panel) {
+      this._panel.reveal();
+      return;
+    }
+
+    this._panel = vscode.window.createWebviewPanel(
+      'clawcodex.chatPanel',
+      'Clawcodex Chat',
+      vscode.ViewColumn.Beside,
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+      },
+    );
+
+    const webview = this._panel.webview;
+    const registration = this._chatController.registerWebview(webview);
+
+    this._panel.onDidDispose(() => {
+      registration.dispose();
+      this._panel = null;
+    });
+
+    const nonce = crypto.randomBytes(16).toString('hex');
+    webview.html = renderChatHtml({ nonce, platform: process.platform });
+    attachMessageHandler(webview, this._chatController, makeWebviewHelpers(this._chatController));
+
+    const messages = this._chatController.getMessages();
+    if (messages.length > 0) {
+      webview.postMessage({ type: 'restore_messages', messages });
+    }
+  }
+
+  dispose() {
+    if (this._panel) {
+      this._panel.dispose();
+      this._panel = null;
+    }
+  }
+}
+
+module.exports = {
+  ChatController,
+  ClawcodexChatViewProvider,
+  ClawcodexChatPanelManager,
+  getLaunchConfig,
+};

--- a/vscode-extension/clawcodex-vscode/src/chat/chatProvider.test.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/chatProvider.test.js
@@ -1,0 +1,239 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// `vscode` resolves to test/vscode-stub.js via the --require preload; its
+// EventEmitter is functional, which these state-machine tests depend on.
+const { ChatController } = require('./chatProvider');
+
+function makeController() {
+  const controller = new ChatController(null);
+  const broadcasts = [];
+  controller.registerWebview({ postMessage: (m) => broadcasts.push(m) });
+  const states = [];
+  controller.onDidChangeState((s) => states.push(s));
+  return { controller, broadcasts, states };
+}
+
+const delta = (text) => ({
+  type: 'stream_event',
+  session_id: 's1',
+  event: { type: 'content_block_delta', delta: { type: 'text_delta', text } },
+});
+
+const thinking = (text) => ({
+  type: 'stream_event',
+  session_id: 's1',
+  event: { type: 'content_block_delta', delta: { type: 'thinking_delta', thinking: text } },
+});
+
+const result = (overrides = {}) => ({
+  type: 'result',
+  subtype: 'success',
+  session_id: 's1',
+  num_turns: 1,
+  result: '',
+  is_error: false,
+  ...overrides,
+});
+
+test('first text delta starts the stream once and accumulates; result finalizes and goes idle', () => {
+  const { controller, broadcasts, states } = makeController();
+
+  controller._handleMessage(delta('Hel'));
+  controller._handleMessage(delta('lo'));
+  controller._handleMessage(result({ usage: { input_tokens: 3, output_tokens: 4 } }));
+
+  const types = broadcasts.map(b => b.type);
+  assert.deepEqual(types.filter(t => t === 'stream_start'), ['stream_start'], 'stream_start fires exactly once');
+  const deltas = broadcasts.filter(b => b.type === 'stream_delta').map(b => b.text);
+  assert.deepEqual(deltas, ['Hel', 'Hello'], 'deltas accumulate');
+  const end = broadcasts.find(b => b.type === 'stream_end' && b.final);
+  assert.equal(end.text, 'Hello');
+  assert.deepEqual(end.usage, { input_tokens: 3, output_tokens: 4 });
+  assert.deepEqual(states, ['streaming', 'idle'], 'status-bar spinner engages on first delta, idles on result');
+  const status = broadcasts.filter(b => b.type === 'status').map(b => b.content);
+  assert.ok(status.includes('Ready'), `num_turns=1 → Ready (saw ${status})`);
+});
+
+test('thinking deltas show the thinking block and text hides it', () => {
+  const { controller, broadcasts } = makeController();
+
+  controller._handleMessage(thinking('hmm'));
+  controller._handleMessage(thinking('mmm'));
+  controller._handleMessage(delta('Answer'));
+  controller._handleMessage(result());
+
+  const types = broadcasts.map(b => b.type);
+  assert.deepEqual(types.filter(t => t === 'thinking_start'), ['thinking_start'], 'thinking_start fires once');
+  const thinkingEndIdx = types.indexOf('thinking_end');
+  const firstDeltaIdx = types.indexOf('stream_delta');
+  assert.ok(thinkingEndIdx >= 0 && thinkingEndIdx < firstDeltaIdx, 'thinking hides before text renders');
+  const meta = broadcasts.filter(b => b.type === 'thinking_delta');
+  assert.equal(meta[meta.length - 1].tokens, 6, 'token estimate accumulates thinking length');
+});
+
+test('thinking still open at turn end is closed by the result', () => {
+  const { controller, broadcasts } = makeController();
+
+  controller._handleMessage(thinking('all thinking, no text'));
+  controller._handleMessage(result());
+
+  const types = broadcasts.map(b => b.type);
+  assert.ok(types.indexOf('thinking_end') > types.indexOf('thinking_start'));
+  assert.ok(types.indexOf('thinking_end') < types.indexOf('stream_end'));
+});
+
+test('assistant envelope emits tool cards before the bubble-finalizing stream_end', () => {
+  const { controller, broadcasts } = makeController();
+
+  controller._handleMessage({
+    type: 'assistant',
+    session_id: 's1',
+    message: {
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'Editing now.' },
+        { type: 'tool_use', id: 'tu1', name: 'Edit', input: { file_path: '/a.py', old_string: 'x', new_string: 'y' } },
+      ],
+    },
+  });
+
+  const types = broadcasts.map(b => b.type);
+  const toolIdx = types.indexOf('tool_use');
+  const endIdx = types.indexOf('stream_end');
+  assert.ok(toolIdx >= 0 && toolIdx < endIdx, 'tool cards land in the same bubble as the text');
+  const tool = broadcasts[toolIdx].toolUse;
+  assert.equal(tool.id, 'tu1');
+  assert.equal(tool.displayName, 'Edit File');
+  assert.equal(tool.status, 'running');
+  const end = broadcasts[endIdx];
+  assert.equal(end.text, 'Editing now.');
+  assert.equal(end.final, false, 'assistant envelope is mid-turn; result finalizes');
+  assert.deepEqual(controller.getMessages().at(-1).toolUses.map(t => t.id), ['tu1']);
+});
+
+test('user tool_result envelope maps to tool_result broadcasts', () => {
+  const { controller, broadcasts } = makeController();
+
+  controller._handleMessage({
+    type: 'user',
+    session_id: 's1',
+    message: {
+      role: 'user',
+      content: [
+        { type: 'tool_result', tool_use_id: 'tu1', content: 'file edited', is_error: false },
+        { type: 'tool_result', tool_use_id: 'tu2', content: [{ type: 'text', text: 'boom' }], is_error: true },
+      ],
+    },
+  });
+
+  const results = broadcasts.filter(b => b.type === 'tool_result');
+  assert.deepEqual(results.map(r => [r.toolUseId, r.content, r.isError]), [
+    ['tu1', 'file edited', false],
+    ['tu2', 'boom', true],
+  ]);
+  assert.ok(broadcasts.some(b => b.type === 'status' && b.content === 'Thinking...'));
+});
+
+test('permission request broadcasts card fields and the reply echoes suggestions as chosen_updates', () => {
+  const { controller, broadcasts } = makeController();
+  const sent = [];
+  controller._process = { sendControlResponse: (id, res) => sent.push([id, res]) };
+
+  const suggestions = [{ type: 'setMode', mode: 'acceptEdits', destination: 'session' }];
+  controller._handleMessage({
+    type: 'control_request',
+    request_id: 'req-1',
+    request: {
+      subtype: 'can_use_tool',
+      tool_name: 'Write',
+      input: { file_path: '/x.txt', content: 'hi' },
+      tool_use_id: null,
+      suggestions,
+      session_label: 'allow all edits during this session',
+      warning: null,
+    },
+  });
+
+  const card = broadcasts.find(b => b.type === 'permission_request');
+  assert.equal(card.requestId, 'req-1');
+  assert.equal(card.displayName, 'Write File');
+  assert.equal(card.sessionLabel, 'allow all edits during this session');
+  assert.equal(card.hasSuggestions, true);
+  assert.equal(card.inputPreview, '/x.txt');
+
+  controller.sendPermissionResponse('req-1', 'allow-session', null);
+  assert.equal(sent.length, 1);
+  const [requestId, reply] = sent[0];
+  assert.equal(requestId, 'req-1');
+  assert.equal(reply.behavior, 'allow');
+  assert.deepEqual(reply.updatedInput, { file_path: '/x.txt', content: 'hi' });
+  assert.deepEqual(reply.chosen_updates, suggestions);
+});
+
+test('deny reply carries the deny behavior and clears the pending entry', () => {
+  const { controller } = makeController();
+  const sent = [];
+  controller._process = { sendControlResponse: (id, res) => sent.push([id, res]) };
+
+  controller._handleMessage({
+    type: 'control_request',
+    request_id: 'req-2',
+    request: { subtype: 'can_use_tool', tool_name: 'Bash', input: { command: 'rm -rf /tmp/x' }, suggestions: [] },
+  });
+  controller.sendPermissionResponse('req-2', 'deny', null);
+  controller.sendPermissionResponse('req-2', 'deny', null); // pending already consumed
+
+  assert.equal(sent[0][1].behavior, 'deny');
+  assert.equal(sent.length, 2, 'second reply still sends (server ignores unknown ids)');
+  assert.equal(controller._pendingPermissions.size, 0);
+});
+
+test('non-permission control_requests and unknown system subtypes are ignored', () => {
+  const { controller, broadcasts } = makeController();
+
+  controller._handleMessage({ type: 'control_request', request_id: 'r', request: { subtype: 'something_else' } });
+  controller._handleMessage({ type: 'system', subtype: 'goal_status', session_id: 's1', message: 'goal carrier' });
+  controller._handleMessage({ type: 'agent_progress', session_id: 's1' });
+
+  assert.deepEqual(broadcasts, []);
+});
+
+test('system init and status frames map to system_info / status / error', () => {
+  const { controller, broadcasts } = makeController();
+
+  controller._handleMessage({ type: 'system', subtype: 'init', session_id: 'ds_1', model: 'claude-opus-4-6', permission_mode: 'default' });
+  controller._handleMessage({ type: 'system', subtype: 'status', session_id: 'ds_1', level: 'info', message: 'saved' });
+  controller._handleMessage({ type: 'system', subtype: 'status', session_id: 'ds_1', level: 'info', permission_mode: 'acceptEdits' });
+  controller._handleMessage({ type: 'system', subtype: 'status', session_id: 'ds_1', level: 'error', message: 'provider down' });
+
+  assert.deepEqual(broadcasts.map(b => b.type), ['system_info', 'status', 'error']);
+  assert.equal(broadcasts[0].model, 'claude-opus-4-6');
+  assert.equal(broadcasts[0].sessionId, 'ds_1');
+  assert.equal(controller.sessionId, 'ds_1', 'first session_id is captured');
+  assert.equal(broadcasts[1].content, 'saved');
+  assert.equal(broadcasts[2].message, 'provider down');
+});
+
+test('result error and cancelled subtypes surface distinctly and reset streaming', () => {
+  const { controller, broadcasts, states } = makeController();
+
+  controller._handleMessage(delta('partial'));
+  controller._handleMessage(result({ subtype: 'error', is_error: true, error: 'boom' }));
+  assert.ok(broadcasts.some(b => b.type === 'error' && b.message === 'boom'));
+
+  broadcasts.length = 0;
+  controller._handleMessage(delta('again'));
+  controller._handleMessage(result({ subtype: 'cancelled', num_turns: 0 }));
+  assert.ok(broadcasts.some(b => b.type === 'status' && b.content === 'Interrupted'));
+  assert.deepEqual(states, ['streaming', 'idle', 'streaming', 'idle']);
+});
+
+test('result session_id tracks the LIVE server session across resumes', () => {
+  const { controller } = makeController();
+  controller._currentSessionId = 'old-picked-session';
+
+  controller._handleMessage(result({ session_id: 'new-live-session' }));
+
+  assert.equal(controller.sessionId, 'new-live-session');
+});

--- a/vscode-extension/clawcodex-vscode/src/chat/chatRenderer.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/chatRenderer.js
@@ -1,0 +1,1333 @@
+/**
+ * chatRenderer — produces the full self-contained HTML document for the chat
+ * webview.  All CSS and JS are inlined (no external bundles).
+ *
+ * The webview JS communicates with the extension host via postMessage.
+ * Incoming messages update the DOM incrementally so streaming feels fluid.
+ */
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function renderChatHtml({ nonce, platform }) {
+  const modKey = platform === 'darwin' ? 'Cmd' : 'Ctrl';
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy"
+        content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <style>
+    :root {
+      --oc-bg: #0a0908;
+      --oc-panel: #110d0c;
+      --oc-panel-strong: #17110f;
+      --oc-panel-soft: #1d1512;
+      --oc-border: #645041;
+      --oc-border-soft: rgba(220,195,170,0.14);
+      --oc-text: #f7efe5;
+      --oc-text-dim: #dcc3aa;
+      --oc-text-soft: #aa9078;
+      --oc-accent: #d77757;
+      --oc-accent-bright: #f09464;
+      --oc-accent-soft: rgba(240,148,100,0.18);
+      --oc-positive: #e8b86b;
+      --oc-warning: #f3c969;
+      --oc-critical: #ff8a6c;
+      --oc-focus: #ffd3a1;
+      --oc-user-bg: rgba(240,148,100,0.12);
+      --oc-user-border: rgba(240,148,100,0.28);
+      --oc-assistant-bg: rgba(255,255,255,0.03);
+      --oc-assistant-border: rgba(220,195,170,0.10);
+      --oc-code-bg: #1a1310;
+      --oc-code-border: rgba(220,195,170,0.12);
+      --oc-tool-bg: rgba(232,184,107,0.06);
+      --oc-tool-border: rgba(232,184,107,0.22);
+      --oc-perm-bg: rgba(255,138,108,0.08);
+      --oc-perm-border: rgba(255,138,108,0.35);
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; overflow: hidden; }
+    body {
+      font-family: var(--vscode-font-family, "Segoe UI", system-ui, sans-serif);
+      font-size: 13px;
+      color: var(--oc-text);
+      background: var(--oc-bg);
+      display: flex;
+      flex-direction: column;
+      position: relative;
+    }
+
+    /* ── Header ── */
+    .chat-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--oc-border-soft);
+      background: var(--oc-panel);
+      flex-shrink: 0;
+    }
+    .chat-header .brand {
+      font-weight: 700;
+      font-size: 14px;
+      color: var(--oc-text);
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .chat-header .brand-accent { color: var(--oc-accent-bright); }
+    .header-btn {
+      border: 1px solid var(--oc-border-soft);
+      border-radius: 6px;
+      background: rgba(255,255,255,0.04);
+      color: var(--oc-text-dim);
+      padding: 4px 8px;
+      font-size: 12px;
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .header-btn:hover { border-color: var(--oc-accent); color: var(--oc-text); }
+    .header-btn.danger { border-color: var(--oc-critical); color: var(--oc-critical); }
+    .header-btn.danger:hover { background: rgba(255,138,108,0.12); }
+    #abortBtn { display: none; }
+
+    /* ── Status bar ── */
+    .status-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 4px 12px;
+      font-size: 11px;
+      color: var(--oc-text-soft);
+      border-bottom: 1px solid var(--oc-border-soft);
+      background: var(--oc-panel);
+      flex-shrink: 0;
+    }
+    .status-bar .status-dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: var(--oc-text-soft);
+      flex-shrink: 0;
+    }
+    .status-bar .status-dot.connected { background: var(--oc-positive); }
+    .status-bar .status-dot.streaming { background: var(--oc-accent-bright); animation: pulse 1s infinite; }
+    .status-bar .status-dot.error { background: var(--oc-critical); }
+    @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
+    .status-text { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .status-usage { color: var(--oc-text-soft); }
+
+    /* ── Message list ── */
+    .messages {
+      flex: 1;
+      overflow-y: auto;
+      padding: 12px;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .messages::-webkit-scrollbar { width: 6px; }
+    .messages::-webkit-scrollbar-track { background: transparent; }
+    .messages::-webkit-scrollbar-thumb { background: rgba(220,195,170,0.18); border-radius: 3px; }
+
+    /* ── Welcome screen ── */
+    .welcome {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      flex: 1;
+      text-align: center;
+      padding: 32px 16px;
+      gap: 16px;
+    }
+    .welcome-title { font-size: 20px; font-weight: 700; color: var(--oc-text); }
+    .welcome-title .accent { color: var(--oc-accent-bright); }
+    .welcome-sub { font-size: 13px; color: var(--oc-text-dim); max-width: 36ch; }
+    .welcome-hint { font-size: 11px; color: var(--oc-text-soft); }
+    .welcome-hint kbd {
+      padding: 2px 6px;
+      border-radius: 4px;
+      border: 1px solid var(--oc-border-soft);
+      background: rgba(255,255,255,0.04);
+      font-family: inherit;
+      font-size: 11px;
+    }
+
+    /* ── User message ── */
+    .msg-user {
+      align-self: flex-end;
+      max-width: 85%;
+      padding: 10px 14px;
+      border-radius: 14px 14px 4px 14px;
+      background: var(--oc-user-bg);
+      border: 1px solid var(--oc-user-border);
+      word-break: break-word;
+      white-space: pre-wrap;
+    }
+
+    /* ── Assistant message ── */
+    .msg-assistant {
+      align-self: flex-start;
+      max-width: 95%;
+      padding: 10px 14px;
+      border-radius: 4px 14px 14px 14px;
+      background: var(--oc-assistant-bg);
+      border: 1px solid var(--oc-assistant-border);
+      word-break: break-word;
+    }
+    .msg-assistant .md-content { line-height: 1.55; }
+    .msg-assistant .md-content:empty { display: none; }
+    .msg-assistant .md-content p { margin-bottom: 8px; }
+    .msg-assistant .md-content p:last-child { margin-bottom: 0; }
+    .msg-assistant .md-content ul,
+    .msg-assistant .md-content ol { padding-left: 20px; margin-bottom: 8px; }
+    .msg-assistant .md-content li { margin-bottom: 4px; }
+    .msg-assistant .md-content h1,
+    .msg-assistant .md-content h2,
+    .msg-assistant .md-content h3 {
+      color: var(--oc-text);
+      margin: 12px 0 6px;
+      font-size: 14px;
+      font-weight: 700;
+    }
+    .msg-assistant .md-content h1 { font-size: 16px; }
+    .msg-assistant .md-content a { color: var(--oc-accent-bright); text-decoration: underline; }
+    .msg-assistant .md-content strong { color: var(--oc-text); font-weight: 700; }
+    .msg-assistant .md-content em { font-style: italic; color: var(--oc-text-dim); }
+    .msg-assistant .md-content blockquote {
+      border-left: 3px solid var(--oc-accent);
+      padding: 4px 12px;
+      margin: 8px 0;
+      color: var(--oc-text-dim);
+    }
+    .msg-assistant .md-content hr {
+      border: none;
+      border-top: 1px solid var(--oc-border-soft);
+      margin: 12px 0;
+    }
+
+    /* inline code */
+    .md-content code:not(.code-block code) {
+      padding: 1px 5px;
+      border-radius: 4px;
+      background: var(--oc-code-bg);
+      border: 1px solid var(--oc-code-border);
+      font-family: var(--vscode-editor-font-family, Consolas, monospace);
+      font-size: 12px;
+      color: var(--oc-accent-bright);
+    }
+
+    /* fenced code */
+    .code-wrapper {
+      position: relative;
+      margin: 8px 0;
+      border-radius: 8px;
+      border: 1px solid var(--oc-code-border);
+      background: var(--oc-code-bg);
+      overflow: hidden;
+    }
+    .code-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 4px 10px;
+      font-size: 11px;
+      color: var(--oc-text-soft);
+      border-bottom: 1px solid var(--oc-code-border);
+      background: rgba(255,255,255,0.02);
+    }
+    .code-copy-btn {
+      border: none;
+      background: transparent;
+      color: var(--oc-text-soft);
+      cursor: pointer;
+      font-size: 11px;
+      padding: 2px 6px;
+      border-radius: 4px;
+    }
+    .code-copy-btn:hover { background: rgba(255,255,255,0.08); color: var(--oc-text); }
+    .code-block {
+      display: block;
+      padding: 10px 12px;
+      overflow-x: auto;
+      font-family: var(--vscode-editor-font-family, Consolas, monospace);
+      font-size: 12px;
+      line-height: 1.5;
+      white-space: pre;
+      color: var(--oc-text-dim);
+    }
+    .code-block::-webkit-scrollbar { height: 4px; }
+    .code-block::-webkit-scrollbar-thumb { background: rgba(220,195,170,0.2); border-radius: 2px; }
+
+    /* keyword highlighting */
+    .hl-keyword { color: #c586c0; }
+    .hl-string { color: #ce9178; }
+    .hl-comment { color: #6a9955; font-style: italic; }
+    .hl-number { color: #b5cea8; }
+    .hl-func { color: #dcdcaa; }
+    .hl-type { color: #4ec9b0; }
+
+    /* ── Tool use card ── */
+    .tool-card {
+      margin: 8px 0;
+      border-radius: 8px;
+      border: 1px solid var(--oc-tool-border);
+      background: var(--oc-tool-bg);
+      overflow: hidden;
+    }
+    .tool-header {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 10px;
+      cursor: pointer;
+      user-select: none;
+    }
+    .tool-icon { font-size: 14px; flex-shrink: 0; }
+    .tool-name { font-weight: 600; font-size: 12px; color: var(--oc-text); flex: 1; }
+    .tool-status { font-size: 11px; color: var(--oc-text-soft); }
+    .tool-status.running { color: var(--oc-accent-bright); }
+    .tool-status.error { color: var(--oc-critical); }
+    .tool-status.complete { color: var(--oc-positive); }
+    .tool-chevron {
+      font-size: 10px;
+      color: var(--oc-text-soft);
+      transition: transform 150ms;
+    }
+    .tool-card.expanded .tool-chevron { transform: rotate(90deg); }
+    .tool-body {
+      display: none;
+      padding: 0 10px 10px;
+      font-size: 12px;
+      border-top: 1px solid var(--oc-tool-border);
+    }
+    .tool-card.expanded .tool-body { display: block; }
+    .tool-input-label,
+    .tool-output-label {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--oc-text-soft);
+      margin: 8px 0 4px;
+    }
+    .tool-input-content,
+    .tool-output-content {
+      padding: 6px 8px;
+      border-radius: 6px;
+      background: rgba(0,0,0,0.2);
+      font-family: var(--vscode-editor-font-family, Consolas, monospace);
+      font-size: 11px;
+      color: var(--oc-text-dim);
+      white-space: pre-wrap;
+      word-break: break-all;
+      max-height: 200px;
+      overflow-y: auto;
+    }
+    .tool-output-content.error { color: var(--oc-critical); }
+    .tool-path {
+      font-weight: 400;
+      color: var(--oc-text-soft);
+      font-size: 11px;
+      margin-left: 4px;
+    }
+    .file-link {
+      color: var(--oc-accent-bright);
+      cursor: pointer;
+      text-decoration: none;
+      border-bottom: 1px dotted var(--oc-accent);
+      transition: color 120ms, border-color 120ms;
+    }
+    .file-link:hover {
+      color: var(--oc-focus);
+      border-bottom-color: var(--oc-focus);
+    }
+    .tool-input-content.tool-diff-old {
+      border-left: 3px solid var(--oc-critical);
+      padding-left: 10px;
+      color: #ff9e8a;
+      text-decoration: line-through;
+      opacity: 0.7;
+    }
+    .tool-input-content.tool-diff-new {
+      border-left: 3px solid var(--oc-positive);
+      padding-left: 10px;
+      color: #c8e6a0;
+    }
+    .tool-diff-btn {
+      margin-top: 6px;
+      border: 1px solid var(--oc-accent);
+      border-radius: 6px;
+      background: rgba(240,148,100,0.08);
+      color: var(--oc-accent-bright);
+      padding: 4px 10px;
+      font-size: 11px;
+      cursor: pointer;
+    }
+    .tool-diff-btn:hover { background: rgba(240,148,100,0.16); }
+
+    /* ── Permission card ── */
+    .perm-card {
+      margin: 8px 0;
+      padding: 10px 12px;
+      border-radius: 8px;
+      border: 1px solid var(--oc-perm-border);
+      background: var(--oc-perm-bg);
+    }
+    .perm-title { font-weight: 700; font-size: 12px; color: var(--oc-critical); margin-bottom: 6px; }
+    .perm-desc { font-size: 12px; color: var(--oc-text-dim); margin-bottom: 8px; }
+    .perm-warning {
+      font-size: 12px;
+      color: var(--oc-warning);
+      margin-bottom: 8px;
+    }
+    .perm-input,
+    .perm-plan {
+      padding: 6px 8px;
+      margin-bottom: 8px;
+      border-radius: 6px;
+      background: rgba(0,0,0,0.2);
+      font-family: var(--vscode-editor-font-family, Consolas, monospace);
+      font-size: 11px;
+      color: var(--oc-text-dim);
+      white-space: pre-wrap;
+      max-height: 120px;
+      overflow-y: auto;
+    }
+    .perm-plan { max-height: 220px; }
+    .perm-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+    .perm-btn {
+      padding: 5px 12px;
+      border-radius: 6px;
+      font-size: 12px;
+      font-weight: 600;
+      cursor: pointer;
+      border: 1px solid;
+    }
+    .perm-btn.allow {
+      background: rgba(232,184,107,0.14);
+      border-color: var(--oc-positive);
+      color: var(--oc-positive);
+    }
+    .perm-btn.deny {
+      background: rgba(255,138,108,0.1);
+      border-color: var(--oc-critical);
+      color: var(--oc-critical);
+    }
+    .perm-btn.allow-session {
+      background: rgba(232,184,107,0.08);
+      border-color: rgba(232,184,107,0.4);
+      color: var(--oc-text-dim);
+    }
+    .perm-btn:hover { filter: brightness(1.15); }
+
+    /* ── Status pill ── */
+    .msg-status {
+      align-self: center;
+      font-size: 11px;
+      color: var(--oc-text-soft);
+      padding: 4px 12px;
+      border-radius: 999px;
+      border: 1px solid var(--oc-border-soft);
+      background: rgba(255,255,255,0.02);
+    }
+
+    /* ── Thinking block ── */
+    .thinking-block {
+      display: none;
+      align-self: flex-start;
+      padding: 10px 14px;
+      border-radius: 10px;
+      border: 1px solid rgba(200,160,255,0.25);
+      background: rgba(160,120,220,0.08);
+      margin: 4px 0;
+      gap: 6px;
+      flex-direction: column;
+    }
+    .thinking-block.visible { display: flex; }
+    .thinking-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+      color: #c4a0ff;
+      font-weight: 600;
+    }
+    .thinking-spinner {
+      width: 12px; height: 12px;
+      border: 2px solid rgba(200,160,255,0.3);
+      border-top-color: #c4a0ff;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    .thinking-meta {
+      font-size: 11px;
+      color: var(--oc-text-soft);
+    }
+
+    /* ── Typing indicator ── */
+    .typing-indicator {
+      display: none;
+      align-self: flex-start;
+      padding: 10px 14px;
+      gap: 4px;
+    }
+    .typing-indicator.visible { display: flex; }
+    .typing-dot {
+      width: 6px; height: 6px;
+      border-radius: 50%;
+      background: var(--oc-accent);
+      animation: typingBounce 1.2s infinite;
+    }
+    .typing-dot:nth-child(2) { animation-delay: 0.2s; }
+    .typing-dot:nth-child(3) { animation-delay: 0.4s; }
+    @keyframes typingBounce {
+      0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+      30% { transform: translateY(-4px); opacity: 1; }
+    }
+
+    /* ── Input area ── */
+    .input-area {
+      display: flex;
+      gap: 8px;
+      padding: 10px 12px;
+      border-top: 1px solid var(--oc-border-soft);
+      background: var(--oc-panel);
+      flex-shrink: 0;
+      align-items: flex-end;
+    }
+    .input-area textarea {
+      flex: 1;
+      min-height: 36px;
+      max-height: 160px;
+      padding: 8px 12px;
+      border: 1px solid var(--oc-border-soft);
+      border-radius: 10px;
+      background: rgba(255,255,255,0.04);
+      color: var(--oc-text);
+      font-family: inherit;
+      font-size: 13px;
+      resize: none;
+      outline: none;
+      line-height: 1.4;
+    }
+    .input-area textarea::placeholder { color: var(--oc-text-soft); }
+    .input-area textarea:focus { border-color: var(--oc-accent); }
+    .send-btn {
+      width: 36px;
+      height: 36px;
+      border-radius: 10px;
+      border: 1px solid var(--oc-accent);
+      background: linear-gradient(135deg, rgba(240,148,100,0.2), rgba(215,119,87,0.12));
+      color: var(--oc-accent-bright);
+      cursor: pointer;
+      font-size: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .send-btn:hover { background: rgba(240,148,100,0.25); }
+    .send-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    /* ── Session list overlay ── */
+    .session-overlay {
+      display: none;
+      position: absolute;
+      inset: 0;
+      z-index: 100;
+      background: rgba(5,5,5,0.92);
+      flex-direction: column;
+    }
+    .session-overlay.visible { display: flex; }
+    .session-overlay-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 10px 12px;
+      border-bottom: 1px solid var(--oc-border-soft);
+    }
+    .session-overlay-header h2 { font-size: 14px; font-weight: 700; flex: 1; }
+    .session-search {
+      margin: 8px 12px;
+      padding: 8px 10px;
+      border: 1px solid var(--oc-border-soft);
+      border-radius: 8px;
+      background: rgba(255,255,255,0.04);
+      color: var(--oc-text);
+      font-size: 13px;
+      outline: none;
+    }
+    .session-search:focus { border-color: var(--oc-accent); }
+    .session-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 8px 12px;
+    }
+    .session-group-label {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: var(--oc-text-soft);
+      padding: 8px 0 4px;
+    }
+    .session-item {
+      padding: 10px;
+      border-radius: 8px;
+      border: 1px solid transparent;
+      cursor: pointer;
+      margin-bottom: 4px;
+    }
+    .session-item:hover { background: rgba(255,255,255,0.04); border-color: var(--oc-border-soft); }
+    .session-item-title { font-weight: 600; font-size: 13px; color: var(--oc-text); margin-bottom: 2px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .session-item-preview { font-size: 11px; color: var(--oc-text-dim); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .session-item-time { font-size: 10px; color: var(--oc-text-soft); margin-top: 2px; }
+    .session-empty { text-align: center; padding: 32px; color: var(--oc-text-soft); }
+  </style>
+</head>
+<body>
+  <div class="chat-header">
+    <div class="brand">claw<span class="brand-accent">codex</span></div>
+    <button class="header-btn" id="historyBtn" title="Session history">History</button>
+    <button class="header-btn" id="newChatBtn" title="New chat">+ New</button>
+    <button class="header-btn danger" id="abortBtn" title="Abort generation">Stop</button>
+  </div>
+  <div class="status-bar">
+    <span class="status-dot" id="statusDot"></span>
+    <span class="status-text" id="statusText">Ready</span>
+    <span class="status-usage" id="statusUsage"></span>
+  </div>
+
+  <div class="messages" id="messages">
+    <div class="welcome" id="welcomeScreen">
+      <div class="welcome-title">claw<span class="accent">codex</span></div>
+      <div class="welcome-sub">Ask a question, request a code change, or start a new task.</div>
+      <div class="welcome-hint">Press <kbd>${escapeHtml(modKey)}+L</kbd> to focus input</div>
+    </div>
+  </div>
+
+  <div class="thinking-block" id="thinkingBlock">
+    <div class="thinking-header">
+      <div class="thinking-spinner"></div>
+      <span id="thinkingLabel">Thinking...</span>
+    </div>
+    <div class="thinking-meta" id="thinkingMeta"></div>
+  </div>
+
+  <div class="typing-indicator" id="typingIndicator">
+    <div class="typing-dot"></div>
+    <div class="typing-dot"></div>
+    <div class="typing-dot"></div>
+  </div>
+
+  <div class="input-area">
+    <textarea id="chatInput" placeholder="Message clawcodex..." rows="1"></textarea>
+    <button class="send-btn" id="sendBtn" title="Send message">&#x27A4;</button>
+  </div>
+
+  <!-- Session list overlay -->
+  <div class="session-overlay" id="sessionOverlay">
+    <div class="session-overlay-header">
+      <h2>Session History</h2>
+      <button class="header-btn" id="closeSessionsBtn">Close</button>
+    </div>
+    <input class="session-search" id="sessionSearch" type="text" placeholder="Search sessions..." />
+    <div class="session-list" id="sessionList">
+      <div class="session-empty">No sessions found</div>
+    </div>
+  </div>
+
+<script nonce="${nonce}">
+(function() {
+  const vscode = acquireVsCodeApi();
+
+  const messagesEl = document.getElementById('messages');
+  const welcomeEl = document.getElementById('welcomeScreen');
+  const inputEl = document.getElementById('chatInput');
+  const sendBtn = document.getElementById('sendBtn');
+  const abortBtn = document.getElementById('abortBtn');
+  const newChatBtn = document.getElementById('newChatBtn');
+  const historyBtn = document.getElementById('historyBtn');
+  const statusDot = document.getElementById('statusDot');
+  const statusText = document.getElementById('statusText');
+  const statusUsage = document.getElementById('statusUsage');
+  const typingIndicator = document.getElementById('typingIndicator');
+  const sessionOverlay = document.getElementById('sessionOverlay');
+  const closeSessionsBtn = document.getElementById('closeSessionsBtn');
+  const sessionSearch = document.getElementById('sessionSearch');
+  const sessionList = document.getElementById('sessionList');
+
+  let isStreaming = false;
+  let currentAssistantEl = null;
+  let currentTextEl = null;
+
+  /* ── Markdown renderer ── */
+  function renderMarkdown(text) {
+    if (!text) return '';
+    let html = escapeForMd(text);
+
+    // fenced code blocks
+    html = html.replace(/\`\`\`(\\w*?)\\n([\\s\\S]*?)\`\`\`/g, (_, lang, code) => {
+      const langLabel = lang || 'text';
+      const highlighted = highlightCode(code, langLabel);
+      const id = 'cb-' + Math.random().toString(36).slice(2, 8);
+      return '<div class="code-wrapper"><div class="code-header">' +
+        '<span>' + langLabel + '</span>' +
+        '<button class="code-copy-btn" data-copy-id="' + id + '">Copy</button></div>' +
+        '<code class="code-block" id="' + id + '">' + highlighted + '</code></div>';
+    });
+
+    // inline code
+    html = html.replace(/\`([^\`]+?)\`/g, '<code>$1</code>');
+
+    // headings
+    html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+    html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+    html = html.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+
+    // blockquotes
+    html = html.replace(/^&gt; (.+)$/gm, '<blockquote>$1</blockquote>');
+
+    // hr
+    html = html.replace(/^---$/gm, '<hr/>');
+
+    // bold / italic
+    html = html.replace(/\\*\\*(.+?)\\*\\*/g, '<strong>$1</strong>');
+    html = html.replace(/\\*(.+?)\\*/g, '<em>$1</em>');
+
+    // links
+    html = html.replace(/\\[([^\\]]+)\\]\\(([^)]+)\\)/g, '<a href="$2" title="$2">$1</a>');
+
+    // unordered lists (simple)
+    html = html.replace(/^[\\-\\*] (.+)$/gm, '<li>$1</li>');
+    html = html.replace(/((?:<li>.*<\\/li>\\n?)+)/g, '<ul>$1</ul>');
+
+    // ordered lists
+    html = html.replace(/^\\d+\\. (.+)$/gm, '<li>$1</li>');
+
+    // paragraphs (double newline)
+    html = html.replace(/\\n\\n/g, '</p><p>');
+    html = '<p>' + html + '</p>';
+    html = html.replace(/<p><\\/p>/g, '');
+    html = html.replace(/<p>(<h[123]>)/g, '$1');
+    html = html.replace(/(<\\/h[123]>)<\\/p>/g, '$1');
+    html = html.replace(/<p>(<ul>)/g, '$1');
+    html = html.replace(/(<\\/ul>)<\\/p>/g, '$1');
+    html = html.replace(/<p>(<blockquote>)/g, '$1');
+    html = html.replace(/(<\\/blockquote>)<\\/p>/g, '$1');
+    html = html.replace(/<p>(<hr\\/>)/g, '$1');
+    html = html.replace(/(<hr\\/>)<\\/p>/g, '$1');
+    html = html.replace(/<p>(<div class="code-wrapper">)/g, '$1');
+    html = html.replace(/(<\\/div>)<\\/p>/g, '$1');
+
+    return html;
+  }
+
+  function escapeForMd(text) {
+    return text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+  }
+
+  function highlightCode(code, lang) {
+    let result = code;
+    const kwPattern = /\\b(const|let|var|function|return|if|else|for|while|class|import|export|from|async|await|try|catch|throw|new|typeof|instanceof|switch|case|break|default|continue|do|in|of|yield|void|delete|true|false|null|undefined|this|super|extends|implements|interface|type|enum|public|private|protected|static|readonly|abstract|def|print|self|elif|except|finally|with|as|lambda|pass|raise|None|True|False)\\b/g;
+    const strPattern = /(&quot;[^&]*?&quot;|&#39;[^&]*?&#39;|'[^']*?'|"[^"]*?")/g;
+    const commentPattern = /(\\/{2}.*$|#.*$)/gm;
+    const numPattern = /\\b(\\d+\\.?\\d*)\\b/g;
+
+    result = result.replace(commentPattern, '<span class="hl-comment">$1</span>');
+    result = result.replace(strPattern, '<span class="hl-string">$1</span>');
+    result = result.replace(kwPattern, '<span class="hl-keyword">$1</span>');
+    result = result.replace(numPattern, '<span class="hl-number">$1</span>');
+
+    return result;
+  }
+
+  /* ── DOM helpers ── */
+  function scrollToBottom() {
+    requestAnimationFrame(() => {
+      messagesEl.scrollTop = messagesEl.scrollHeight;
+    });
+  }
+
+  function hideWelcome() {
+    if (welcomeEl) welcomeEl.style.display = 'none';
+  }
+
+  function showWelcome() {
+    if (welcomeEl) welcomeEl.style.display = 'flex';
+  }
+
+  function setStreaming(val, label) {
+    isStreaming = val;
+    abortBtn.style.display = val ? 'block' : 'none';
+    sendBtn.disabled = val;
+    typingIndicator.classList.toggle('visible', val);
+    statusDot.className = 'status-dot ' + (val ? 'streaming' : 'connected');
+    statusText.textContent = label || (val ? 'Generating...' : 'Ready');
+  }
+
+  function setStatusLabel(label) {
+    statusText.textContent = label;
+  }
+
+  function appendUserMessage(text) {
+    hideWelcome();
+    const el = document.createElement('div');
+    el.className = 'msg-user';
+    el.textContent = text;
+    messagesEl.appendChild(el);
+    scrollToBottom();
+  }
+
+  function getOrCreateAssistantEl() {
+    if (!currentAssistantEl) {
+      hideWelcome();
+      currentAssistantEl = document.createElement('div');
+      currentAssistantEl.className = 'msg-assistant';
+      currentTextEl = document.createElement('div');
+      currentTextEl.className = 'md-content';
+      currentAssistantEl.appendChild(currentTextEl);
+      messagesEl.appendChild(currentAssistantEl);
+    }
+    return { container: currentAssistantEl, textEl: currentTextEl };
+  }
+
+  function finalizeAssistant() {
+    // Hide the text div if it's empty (model went straight to tool use)
+    if (currentTextEl && !currentTextEl.textContent.trim()) {
+      currentTextEl.style.display = 'none';
+    }
+    // Remove the entire bubble if it has no visible content at all
+    if (currentAssistantEl) {
+      const hasText = currentTextEl && currentTextEl.textContent.trim();
+      const hasToolCards = currentAssistantEl.querySelector('.tool-card');
+      if (!hasText && !hasToolCards) {
+        currentAssistantEl.remove();
+      }
+    }
+    currentAssistantEl = null;
+    currentTextEl = null;
+  }
+
+  function appendToolCard(toolUse) {
+    const { container } = getOrCreateAssistantEl();
+    const card = document.createElement('div');
+    card.className = 'tool-card expanded';
+    card.dataset.toolId = toolUse.id || '';
+    const statusClass = toolUse.status || 'running';
+    const statusLabel = statusClass === 'running' ? 'Running...'
+      : statusClass === 'error' ? 'Error' : 'Done';
+
+    var inputSummary = '';
+    if (toolUse.input && typeof toolUse.input === 'object') {
+      if (toolUse.input.file_path || toolUse.input.path) {
+        inputSummary = (toolUse.input.file_path || toolUse.input.path);
+      }
+      if (toolUse.input.command) {
+        inputSummary = toolUse.input.command;
+      }
+    }
+    if (!inputSummary) inputSummary = toolUse.inputPreview || '';
+
+    var inputDetail = '';
+    if (toolUse.input && typeof toolUse.input === 'object') {
+      if (toolUse.input.new_string || toolUse.input.content) {
+        var content = toolUse.input.new_string || toolUse.input.content || '';
+        if (content.length > 500) content = content.slice(0, 500) + '... (truncated)';
+        inputDetail = '<div class="tool-input-label">Changes</div>' +
+          '<div class="tool-input-content">' + escapeForMd(content) + '</div>';
+      }
+      if (toolUse.input.old_string && toolUse.input.new_string) {
+        var oldStr = toolUse.input.old_string;
+        var newStr = toolUse.input.new_string;
+        if (oldStr.length > 300) oldStr = oldStr.slice(0, 300) + '...';
+        if (newStr.length > 300) newStr = newStr.slice(0, 300) + '...';
+        inputDetail = '<div class="tool-input-label">Replace</div>' +
+          '<div class="tool-input-content tool-diff-old">' + escapeForMd(oldStr) + '</div>' +
+          '<div class="tool-input-label">With</div>' +
+          '<div class="tool-input-content tool-diff-new">' + escapeForMd(newStr) + '</div>';
+      }
+    }
+
+    var isFileTool = inputSummary && !toolUse.input?.command;
+    var fileLink = isFileTool
+      ? '<a class="file-link" data-filepath="' + escapeForMd(inputSummary) + '" title="Open in editor">' + escapeForMd(inputSummary.split(/[\\/]/).pop() || inputSummary) + '</a>'
+      : (inputSummary ? escapeForMd(inputSummary.split(/[\\/]/).pop() || inputSummary) : '');
+    var pathDisplay = isFileTool
+      ? '<div class="tool-input-label">Path</div><div class="tool-input-content"><a class="file-link" data-filepath="' + escapeForMd(inputSummary) + '" title="Open in editor">' + escapeForMd(inputSummary) + '</a></div>'
+      : (inputSummary ? '<div class="tool-input-label">' + (toolUse.input?.command ? 'Command' : 'Path') + '</div><div class="tool-input-content">' + escapeForMd(inputSummary) + '</div>' : '');
+
+    card.innerHTML =
+      '<div class="tool-header">' +
+        '<span class="tool-icon">' + (toolUse.icon || '') + '</span>' +
+        '<span class="tool-name">' + escapeForMd(toolUse.displayName || toolUse.name || 'Tool') +
+          (fileLink ? ' <span class="tool-path">' + fileLink + '</span>' : '') +
+        '</span>' +
+        '<span class="tool-status ' + statusClass + '">' + statusLabel + '</span>' +
+        '<span class="tool-chevron">&#9654;</span>' +
+      '</div>' +
+      '<div class="tool-body">' +
+        pathDisplay +
+        inputDetail +
+        '<div class="tool-output-label">Output</div>' +
+        '<div class="tool-output-content" data-tool-output="' + (toolUse.id || '') + '">Running...</div>' +
+      '</div>';
+    card.querySelector('.tool-header').addEventListener('click', () => {
+      card.classList.toggle('expanded');
+    });
+    container.appendChild(card);
+    scrollToBottom();
+    return card;
+  }
+
+  function updateToolResult(toolUseId, content, isError) {
+    const outputEl = document.querySelector('[data-tool-output="' + toolUseId + '"]');
+    if (outputEl) {
+      outputEl.textContent = content || '(done)';
+      if (isError) outputEl.classList.add('error');
+    }
+    const card = document.querySelector('[data-tool-id="' + toolUseId + '"]');
+    if (card) {
+      const statusEl = card.querySelector('.tool-status');
+      if (statusEl) {
+        statusEl.className = 'tool-status ' + (isError ? 'error' : 'complete');
+        statusEl.textContent = isError ? 'Error' : 'Done';
+      }
+    }
+  }
+
+  function updateToolInput(toolUseId, input, toolName) {
+    const card = document.querySelector('[data-tool-id="' + toolUseId + '"]');
+    if (!card) return;
+    const body = card.querySelector('.tool-body');
+    if (!body) return;
+
+    if (!input || typeof input !== 'object') return;
+
+    // Update the header with clickable file path
+    const nameEl = card.querySelector('.tool-name');
+    if (nameEl && (input.file_path || input.path)) {
+      const fp = input.file_path || input.path;
+      const shortName = fp.split(/[\\/]/).pop() || fp;
+      if (!nameEl.querySelector('.tool-path')) {
+        nameEl.insertAdjacentHTML('beforeend', ' <span class="tool-path"><a class="file-link" data-filepath="' + escapeForMd(fp) + '" title="Open in editor">' + escapeForMd(shortName) + '</a></span>');
+      }
+    }
+
+    // Update path display
+    var pathHtml = '';
+    if (input.file_path || input.path) {
+      var fp = input.file_path || input.path;
+      pathHtml = '<div class="tool-input-label">Path</div><div class="tool-input-content">' +
+        '<a class="file-link" data-filepath="' + escapeForMd(fp) + '" title="Open in editor">' + escapeForMd(fp) + '</a></div>';
+    }
+    if (input.command) {
+      pathHtml = '<div class="tool-input-label">Command</div><div class="tool-input-content">' +
+        escapeForMd(input.command) + '</div>';
+    }
+
+    // Build diff display for edit operations
+    var diffHtml = '';
+    if (input.old_string && input.new_string) {
+      var oldStr = input.old_string;
+      var newStr = input.new_string;
+      if (oldStr.length > 500) oldStr = oldStr.slice(0, 500) + '... (truncated)';
+      if (newStr.length > 500) newStr = newStr.slice(0, 500) + '... (truncated)';
+      diffHtml = '<div class="tool-input-label">Replace</div>' +
+        '<div class="tool-input-content tool-diff-old">' + escapeForMd(oldStr) + '</div>' +
+        '<div class="tool-input-label">With</div>' +
+        '<div class="tool-input-content tool-diff-new">' + escapeForMd(newStr) + '</div>';
+    } else if (input.content || input.new_string) {
+      var content = input.content || input.new_string || '';
+      if (content.length > 800) content = content.slice(0, 800) + '... (truncated)';
+      diffHtml = '<div class="tool-input-label">Content</div>' +
+        '<div class="tool-input-content tool-diff-new">' + escapeForMd(content) + '</div>';
+    }
+
+    // Keep the output element
+    const outputEl = body.querySelector('[data-tool-output]');
+    const outputHtml = outputEl ? outputEl.outerHTML : '';
+    const outputLabel = '<div class="tool-output-label">Output</div>';
+
+    body.innerHTML = pathHtml + diffHtml + outputLabel + outputHtml;
+    card.classList.add('expanded');
+    scrollToBottom();
+  }
+
+  function appendPermissionCard(perm) {
+    hideWelcome();
+    const el = document.createElement('div');
+    el.className = 'perm-card';
+    el.dataset.requestId = perm.requestId || '';
+    const sessionLabel = perm.sessionLabel
+      ? 'Yes, ' + escapeForMd(perm.sessionLabel)
+      : 'Allow for session';
+    el.innerHTML =
+      '<div class="perm-title">Permission Required: ' + escapeForMd(perm.displayName || perm.toolName || 'Tool') + '</div>' +
+      (perm.warning ? '<div class="perm-warning">' + escapeForMd(perm.warning) + '</div>' : '') +
+      (perm.plan ? '<div class="perm-plan">' + escapeForMd(perm.plan) + '</div>' : '') +
+      (perm.inputPreview && !perm.plan ? '<div class="perm-input">' + escapeForMd(perm.inputPreview) + '</div>' : '') +
+      '<div class="perm-actions">' +
+        '<button class="perm-btn allow" data-action="allow">Allow</button>' +
+        '<button class="perm-btn deny" data-action="deny">Deny</button>' +
+        (perm.hasSuggestions ? '<button class="perm-btn allow-session" data-action="allow-session">' + sessionLabel + '</button>' : '') +
+      '</div>';
+    el.querySelectorAll('.perm-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const action = btn.dataset.action;
+        vscode.postMessage({
+          type: 'permission_response',
+          requestId: perm.requestId,
+          toolUseId: perm.toolUseId || null,
+          action: action,
+        });
+        el.querySelectorAll('.perm-btn').forEach(b => { b.disabled = true; b.style.opacity = '0.4'; });
+        btn.style.opacity = '1';
+      });
+    });
+    messagesEl.appendChild(el);
+    scrollToBottom();
+  }
+
+  function appendStatusMessage(text) {
+    const el = document.createElement('div');
+    el.className = 'msg-status';
+    el.textContent = text;
+    messagesEl.appendChild(el);
+    scrollToBottom();
+  }
+
+  /* ── Thinking block ── */
+  const thinkingBlock = document.getElementById('thinkingBlock');
+  const thinkingLabel = document.getElementById('thinkingLabel');
+  const thinkingMeta = document.getElementById('thinkingMeta');
+
+  function showThinkingBlock() {
+    thinkingBlock.classList.add('visible');
+    thinkingLabel.textContent = 'Thinking...';
+    thinkingMeta.textContent = '';
+    setStatusLabel('Thinking...');
+    scrollToBottom();
+  }
+
+  function updateThinkingBlock(tokens, elapsed) {
+    const elapsedStr = elapsed >= 60
+      ? Math.floor(elapsed / 60) + 'm ' + (elapsed % 60) + 's'
+      : elapsed + 's';
+    thinkingLabel.textContent = 'Thinking...';
+    thinkingMeta.textContent = elapsedStr + ' · ~' + tokens + ' tokens';
+    setStatusLabel('Thinking... (' + elapsedStr + ')');
+  }
+
+  function hideThinkingBlock() {
+    thinkingBlock.classList.remove('visible');
+    setStatusLabel('Generating...');
+  }
+
+  /* ── Session list ── */
+  function renderSessionList(sessions) {
+    if (!sessions || sessions.length === 0) {
+      sessionList.innerHTML = '<div class="session-empty">No sessions found</div>';
+      return;
+    }
+    const groups = groupByDate(sessions);
+    let html = '';
+    for (const [label, items] of groups) {
+      html += '<div class="session-group-label">' + escapeForMd(label) + '</div>';
+      for (const s of items) {
+        html += '<div class="session-item" data-session-id="' + escapeForMd(s.id || '') + '">' +
+          '<div class="session-item-title">' + escapeForMd(s.title || s.id || 'Untitled') + '</div>' +
+          '<div class="session-item-preview">' + escapeForMd(s.preview || '') + '</div>' +
+          '<div class="session-item-time">' + escapeForMd(s.timeLabel || '') + '</div>' +
+        '</div>';
+      }
+    }
+    sessionList.innerHTML = html;
+    sessionList.querySelectorAll('.session-item').forEach(el => {
+      el.addEventListener('click', () => {
+        vscode.postMessage({ type: 'resume_session', sessionId: el.dataset.sessionId });
+        sessionOverlay.classList.remove('visible');
+      });
+    });
+  }
+
+  function groupByDate(sessions) {
+    const now = new Date();
+    const today = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+    const yesterday = today - 86400000;
+    const weekAgo = today - 604800000;
+    const groups = new Map();
+    for (const s of sessions) {
+      const t = s.timestamp || 0;
+      let label;
+      if (t >= today) label = 'Today';
+      else if (t >= yesterday) label = 'Yesterday';
+      else if (t >= weekAgo) label = 'This Week';
+      else label = 'Older';
+      if (!groups.has(label)) groups.set(label, []);
+      groups.get(label).push(s);
+    }
+    return groups;
+  }
+
+  /* ── Input handling ── */
+  function sendMessage() {
+    const text = inputEl.value.trim();
+    if (!text || isStreaming) return;
+    appendUserMessage(text);
+    vscode.postMessage({ type: 'send_message', text });
+    inputEl.value = '';
+    autoResizeInput();
+    setStreaming(true);
+  }
+
+  function autoResizeInput() {
+    inputEl.style.height = 'auto';
+    inputEl.style.height = Math.min(inputEl.scrollHeight, 160) + 'px';
+  }
+
+  inputEl.addEventListener('input', autoResizeInput);
+  inputEl.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      sendMessage();
+    }
+  });
+  sendBtn.addEventListener('click', sendMessage);
+  abortBtn.addEventListener('click', () => vscode.postMessage({ type: 'abort' }));
+  newChatBtn.addEventListener('click', () => vscode.postMessage({ type: 'new_session' }));
+  historyBtn.addEventListener('click', () => {
+    sessionOverlay.classList.toggle('visible');
+    if (sessionOverlay.classList.contains('visible')) {
+      vscode.postMessage({ type: 'request_sessions' });
+      sessionSearch.focus();
+    }
+  });
+  closeSessionsBtn.addEventListener('click', () => sessionOverlay.classList.remove('visible'));
+  sessionSearch.addEventListener('input', () => {
+    const q = sessionSearch.value.toLowerCase();
+    sessionList.querySelectorAll('.session-item').forEach(el => {
+      const text = el.textContent.toLowerCase();
+      el.style.display = text.includes(q) ? '' : 'none';
+    });
+  });
+
+  // Copy code handler (event delegation)
+  document.addEventListener('click', (e) => {
+    const copyBtn = e.target.closest('.code-copy-btn');
+    if (copyBtn) {
+      const id = copyBtn.dataset.copyId;
+      const codeEl = document.getElementById(id);
+      if (codeEl) {
+        const text = codeEl.textContent;
+        vscode.postMessage({ type: 'copy_code', text });
+        copyBtn.textContent = 'Copied!';
+        setTimeout(() => { copyBtn.textContent = 'Copy'; }, 1500);
+      }
+      return;
+    }
+
+    const fileLink = e.target.closest('.file-link');
+    if (fileLink) {
+      e.preventDefault();
+      e.stopPropagation();
+      const filepath = fileLink.dataset.filepath;
+      if (filepath) {
+        vscode.postMessage({ type: 'open_file', path: filepath });
+      }
+      return;
+    }
+  });
+
+  /* ── Message handling from extension ── */
+  window.addEventListener('message', (event) => {
+    const msg = event.data;
+    if (!msg) return;
+
+    switch (msg.type) {
+      case 'stream_start':
+        setStreaming(true, 'Generating...');
+        getOrCreateAssistantEl();
+        break;
+
+      case 'stream_delta': {
+        setStatusLabel('Generating...');
+        const { textEl } = getOrCreateAssistantEl();
+        textEl.innerHTML = renderMarkdown(msg.text || '');
+        scrollToBottom();
+        break;
+      }
+
+      case 'stream_end':
+        if (msg.text) {
+          const { textEl } = getOrCreateAssistantEl();
+          textEl.innerHTML = renderMarkdown(msg.text);
+        }
+        finalizeAssistant();
+        if (msg.usage) {
+          const u = msg.usage;
+          statusUsage.textContent = (u.input_tokens || 0) + ' in / ' + (u.output_tokens || 0) + ' out';
+        }
+        if (msg.final) {
+          setStreaming(false);
+        }
+        scrollToBottom();
+        break;
+
+      case 'tool_use':
+        appendToolCard(msg.toolUse);
+        setStatusLabel('Running: ' + (msg.toolUse.displayName || msg.toolUse.name || 'tool') + '...');
+        break;
+
+      case 'tool_result':
+        updateToolResult(msg.toolUseId, msg.content, msg.isError);
+        break;
+
+      case 'tool_input_ready':
+        updateToolInput(msg.toolUseId, msg.input, msg.name);
+        break;
+
+      case 'permission_request':
+        appendPermissionCard(msg);
+        setStatusLabel('Waiting for permission...');
+        break;
+
+      case 'status':
+        setStatusLabel(msg.content || 'Working...');
+        break;
+
+      case 'thinking_start':
+        showThinkingBlock();
+        break;
+
+      case 'thinking_delta':
+        updateThinkingBlock(msg.tokens || 0, msg.elapsed || 0);
+        break;
+
+      case 'thinking_end':
+        hideThinkingBlock();
+        break;
+
+      case 'system_info':
+        if (msg.model) {
+          statusUsage.textContent = msg.model;
+        }
+        break;
+
+      case 'error':
+        setStreaming(false);
+        finalizeAssistant();
+        statusDot.className = 'status-dot error';
+        statusText.textContent = 'Error: ' + (msg.message || 'Unknown error');
+        break;
+
+      case 'session_list':
+        renderSessionList(msg.sessions);
+        break;
+
+      case 'session_cleared':
+        messagesEl.innerHTML = '';
+        if (welcomeEl) {
+          messagesEl.appendChild(welcomeEl);
+          showWelcome();
+        }
+        currentAssistantEl = null;
+        currentTextEl = null;
+        setStreaming(false);
+        thinkingBlock.classList.remove('visible');
+        statusUsage.textContent = '';
+        statusDot.className = 'status-dot connected';
+        statusText.textContent = 'Ready';
+        break;
+
+      case 'restore_messages':
+        hideWelcome();
+        if (msg.messages) {
+          for (const m of msg.messages) {
+            if (m.role === 'user') {
+              appendUserMessage(m.text || '');
+            } else if (m.role === 'assistant') {
+              const { textEl } = getOrCreateAssistantEl();
+              textEl.innerHTML = renderMarkdown(m.text || '');
+              if (m.toolUses && m.toolUses.length > 0) {
+                for (const tu of m.toolUses) {
+                  var displayName = tu.name || 'Tool';
+                  var icon = '';
+                  var inputPreview = '';
+                  if (tu.input && typeof tu.input === 'object') {
+                    inputPreview = tu.input.file_path || tu.input.path || tu.input.command || '';
+                  }
+                  appendToolCard({
+                    id: tu.id,
+                    name: tu.name,
+                    displayName: displayName,
+                    icon: icon,
+                    inputPreview: inputPreview,
+                    input: tu.input,
+                    status: tu.status || 'complete',
+                  });
+                  if (tu.input) {
+                    updateToolInput(String(tu.id), tu.input, tu.name);
+                  }
+                  if (tu.result !== undefined && tu.result !== null) {
+                    updateToolResult(String(tu.id), tu.result, tu.isError || false);
+                  } else {
+                    updateToolResult(String(tu.id), '(done)', false);
+                  }
+                }
+              }
+              finalizeAssistant();
+            }
+          }
+        }
+        scrollToBottom();
+        break;
+
+      case 'connected':
+        setStreaming(false);
+        statusDot.className = 'status-dot connected';
+        statusText.textContent = msg.message || 'Connected';
+        break;
+
+      default:
+        break;
+    }
+  });
+
+  // Focus input on Ctrl/Cmd+L
+  document.addEventListener('keydown', (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'l') {
+      e.preventDefault();
+      inputEl.focus();
+    }
+  });
+
+  // Restore state
+  const prevState = vscode.getState();
+  if (prevState && prevState.hasMessages) {
+    vscode.postMessage({ type: 'restore_request' });
+  }
+
+  // Notify ready
+  vscode.postMessage({ type: 'webview_ready' });
+})();
+</script>
+</body>
+</html>`;
+}
+
+module.exports = { renderChatHtml };

--- a/vscode-extension/clawcodex-vscode/src/chat/diffController.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/diffController.js
@@ -1,0 +1,90 @@
+/**
+ * diffController — provides a TextDocumentContentProvider for virtual
+ * diff documents and helpers to open VS Code's native diff editor when
+ * tool use involves file edits.
+ */
+
+const vscode = require('vscode');
+
+const SCHEME = 'clawcodex-diff';
+let contentStore = new Map();
+
+class DiffContentProvider {
+  constructor() {
+    this._onDidChange = new vscode.EventEmitter();
+    this.onDidChange = this._onDidChange.event;
+  }
+
+  provideTextDocumentContent(uri) {
+    return contentStore.get(uri.toString()) || '';
+  }
+
+  update(uri) {
+    this._onDidChange.fire(uri);
+  }
+
+  dispose() {
+    this._onDidChange.dispose();
+  }
+}
+
+function storeContent(id, content) {
+  const uri = vscode.Uri.parse(`${SCHEME}:/${id}`);
+  contentStore.set(uri.toString(), content);
+  return uri;
+}
+
+function clearContent(id) {
+  const uri = vscode.Uri.parse(`${SCHEME}:/${id}`);
+  contentStore.delete(uri.toString());
+}
+
+function clearAll() {
+  contentStore.clear();
+}
+
+/**
+ * Opens a diff view between original and modified content.
+ * @param {object} opts
+ * @param {string} opts.filePath - Display path (for the title)
+ * @param {string} opts.original - Original file content
+ * @param {string} opts.modified - Modified file content
+ * @param {string} [opts.toolUseId] - Unique ID for this diff
+ */
+async function openDiff({ filePath, original, modified, toolUseId }) {
+  const id = toolUseId || Math.random().toString(36).slice(2, 10);
+  const originalUri = storeContent(`original-${id}`, original || '');
+  const modifiedUri = storeContent(`modified-${id}`, modified || '');
+  const shortName = filePath ? filePath.split(/[\\/]/).pop() : 'file';
+  const title = `${shortName} (Clawcodex Diff)`;
+
+  await vscode.commands.executeCommand('vscode.diff', originalUri, modifiedUri, title);
+}
+
+/**
+ * Opens a diff between a real file on disk and modified content from
+ * a tool use result.
+ * @param {object} opts
+ * @param {string} opts.filePath - Absolute path to the real file
+ * @param {string} opts.modified - Modified content
+ * @param {string} [opts.toolUseId]
+ */
+async function openFileDiff({ filePath, modified, toolUseId }) {
+  const id = toolUseId || Math.random().toString(36).slice(2, 10);
+  const fileUri = vscode.Uri.file(filePath);
+  const modifiedUri = storeContent(`modified-${id}`, modified || '');
+  const shortName = filePath.split(/[\\/]/).pop() || 'file';
+  const title = `${shortName} (Clawcodex Edit)`;
+
+  await vscode.commands.executeCommand('vscode.diff', fileUri, modifiedUri, title);
+}
+
+module.exports = {
+  DiffContentProvider,
+  SCHEME,
+  openDiff,
+  openFileDiff,
+  storeContent,
+  clearContent,
+  clearAll,
+};

--- a/vscode-extension/clawcodex-vscode/src/chat/messageParser.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/messageParser.js
@@ -1,0 +1,61 @@
+/**
+ * messageParser — display helpers for tool activity (names, icons, input
+ * previews) used by the chat controller and the permission cards.
+ */
+
+function parseToolInput(input) {
+  if (!input || typeof input !== 'object') return String(input ?? '');
+  if (input.command) return input.command;
+  if (input.file_path || input.path) return input.file_path || input.path;
+  if (input.query) return input.query;
+  try { return JSON.stringify(input, null, 2); } catch { return String(input); }
+}
+
+function toolDisplayName(name) {
+  const map = {
+    Bash: 'Terminal',
+    Read: 'Read File',
+    Write: 'Write File',
+    Edit: 'Edit File',
+    MultiEdit: 'Multi Edit',
+    Glob: 'Find Files',
+    Grep: 'Search',
+    LS: 'List Directory',
+    WebFetch: 'Web Fetch',
+    WebSearch: 'Web Search',
+    TodoRead: 'Read Todos',
+    TodoWrite: 'Write Todos',
+    Task: 'Sub-agent',
+    Agent: 'Sub-agent',
+    AskUserQuestion: 'Question',
+    NotebookEdit: 'Edit Notebook',
+    ExitPlanMode: 'Plan Approval',
+  };
+  return map[name] || name || 'Tool';
+}
+
+function toolIcon(name) {
+  const map = {
+    Bash: '\u{1F4BB}',
+    Read: '\u{1F4C4}',
+    Write: '\u{270F}️',
+    Edit: '\u{270F}️',
+    MultiEdit: '\u{270F}️',
+    NotebookEdit: '\u{270F}️',
+    Glob: '\u{1F50D}',
+    Grep: '\u{1F50E}',
+    LS: '\u{1F4C2}',
+    WebFetch: '\u{1F310}',
+    WebSearch: '\u{1F310}',
+    Task: '\u{1F916}',
+    Agent: '\u{1F916}',
+    ExitPlanMode: '\u{1F4CB}',
+  };
+  return map[name] || '\u{1F527}';
+}
+
+module.exports = {
+  toolDisplayName,
+  toolIcon,
+  parseToolInput,
+};

--- a/vscode-extension/clawcodex-vscode/src/chat/messageParser.test.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/messageParser.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { parseToolInput, toolDisplayName, toolIcon } = require('./messageParser');
+
+test('parseToolInput prefers command, then paths, then query, then JSON', () => {
+  assert.equal(parseToolInput({ command: 'ls -la', file_path: '/x' }), 'ls -la');
+  assert.equal(parseToolInput({ file_path: '/a/b.txt' }), '/a/b.txt');
+  assert.equal(parseToolInput({ path: '/c' }), '/c');
+  assert.equal(parseToolInput({ query: 'find me' }), 'find me');
+  assert.equal(parseToolInput({ other: 1 }), JSON.stringify({ other: 1 }, null, 2));
+  assert.equal(parseToolInput(null), '');
+  assert.equal(parseToolInput('plain'), 'plain');
+});
+
+test('toolDisplayName maps known tools and falls back to the raw name', () => {
+  assert.equal(toolDisplayName('Bash'), 'Terminal');
+  assert.equal(toolDisplayName('Edit'), 'Edit File');
+  assert.equal(toolDisplayName('Agent'), 'Sub-agent');
+  assert.equal(toolDisplayName('ExitPlanMode'), 'Plan Approval');
+  assert.equal(toolDisplayName('SomethingNew'), 'SomethingNew');
+  assert.equal(toolDisplayName(undefined), 'Tool');
+});
+
+test('toolIcon maps known tools and falls back to the wrench', () => {
+  assert.equal(toolIcon('Bash'), '\u{1F4BB}');
+  assert.equal(toolIcon('WebSearch'), '\u{1F310}');
+  assert.equal(toolIcon('Unmapped'), '\u{1F527}');
+});

--- a/vscode-extension/clawcodex-vscode/src/chat/permissionResponse.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/permissionResponse.js
@@ -1,0 +1,51 @@
+/**
+ * Build can_use_tool control_response payloads for the VS Code chat host.
+ *
+ * The clawcodex agent-server reads `behavior`, `updatedInput`, and — for the
+ * "allow for session" path — `chosen_updates` (the permission-rule updates the
+ * user accepted, echoed back from the request's `suggestions`). The reference
+ * extension sent `updatedPermissions`, which this server ignores.
+ */
+
+/**
+ * @param {'allow' | 'deny' | 'allow-session'} action
+ * @param {{
+ *   input?: Record<string, unknown> | null,
+ *   toolUseId?: string | null,
+ *   permissionSuggestions?: unknown[] | null,
+ * }} ctx
+ */
+function buildPermissionControlResult(action, ctx = {}) {
+  const toolUseID = ctx.toolUseId || undefined;
+  const input =
+    ctx.input && typeof ctx.input === 'object' && !Array.isArray(ctx.input)
+      ? ctx.input
+      : {};
+
+  if (action === 'deny') {
+    return {
+      behavior: 'deny',
+      message: 'User denied permission',
+      toolUseID,
+    };
+  }
+
+  const result = {
+    behavior: 'allow',
+    updatedInput: input,
+    toolUseID,
+  };
+
+  if (action === 'allow-session') {
+    const suggestions = Array.isArray(ctx.permissionSuggestions)
+      ? ctx.permissionSuggestions
+      : [];
+    if (suggestions.length > 0) {
+      result.chosen_updates = suggestions;
+    }
+  }
+
+  return result;
+}
+
+module.exports = { buildPermissionControlResult };

--- a/vscode-extension/clawcodex-vscode/src/chat/permissionResponse.test.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/permissionResponse.test.js
@@ -1,0 +1,54 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { buildPermissionControlResult } = require('./permissionResponse');
+
+test('buildPermissionControlResult allow includes behavior and updatedInput', () => {
+  const input = { file_path: 'C:\\project\\foo.txt', old_string: 'a', new_string: 'b' };
+  assert.deepEqual(buildPermissionControlResult('allow', {
+    input,
+    toolUseId: 'toolu_123',
+  }), {
+    behavior: 'allow',
+    updatedInput: input,
+    toolUseID: 'toolu_123',
+  });
+});
+
+test('buildPermissionControlResult allow-session echoes suggestions as chosen_updates', () => {
+  const suggestions = [{
+    type: 'addRules',
+    rules: [{ tool_name: 'Edit', rule_content: 'C:\\project' }],
+    behavior: 'allow',
+    destination: 'session',
+  }];
+  assert.deepEqual(buildPermissionControlResult('allow-session', {
+    input: { file_path: 'C:\\project\\foo.txt' },
+    toolUseId: 'toolu_456',
+    permissionSuggestions: suggestions,
+  }), {
+    behavior: 'allow',
+    updatedInput: { file_path: 'C:\\project\\foo.txt' },
+    toolUseID: 'toolu_456',
+    chosen_updates: suggestions,
+  });
+});
+
+test('buildPermissionControlResult allow-session without suggestions omits chosen_updates', () => {
+  assert.deepEqual(buildPermissionControlResult('allow-session', {
+    input: { file_path: '/tmp/foo.txt' },
+    toolUseId: 'toolu_457',
+    permissionSuggestions: [],
+  }), {
+    behavior: 'allow',
+    updatedInput: { file_path: '/tmp/foo.txt' },
+    toolUseID: 'toolu_457',
+  });
+});
+
+test('buildPermissionControlResult deny uses deny behavior', () => {
+  assert.deepEqual(buildPermissionControlResult('deny', { toolUseId: 'toolu_789' }), {
+    behavior: 'deny',
+    message: 'User denied permission',
+    toolUseID: 'toolu_789',
+  });
+});

--- a/vscode-extension/clawcodex-vscode/src/chat/processManager.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/processManager.js
@@ -1,0 +1,271 @@
+/**
+ * ProcessManager — spawns the clawcodex agent-server in --stdio mode and
+ * manages the NDJSON stdin/stdout lifecycle.
+ *
+ * Usage:
+ *   const pm = new ProcessManager({ command, cwd, env });
+ *   pm.onMessage(msg => { ... });
+ *   pm.onError(err => { ... });
+ *   pm.onExit(code => { ... });
+ *   pm.start();
+ *   pm.sendUserMessage('Hello');
+ *   await pm.sendControlRequest('resume', { session_id });  // RPC with reply
+ *   pm.abort();          // 'interrupt' control (graceful, fire-and-forget)
+ *   pm.kill();           // SIGTERM (hard)
+ *   pm.dispose();
+ */
+
+const { spawn } = require('child_process');
+const vscode = require('vscode');
+const {
+  parseStdoutLine,
+  serializeStdinMessage,
+  buildUserMessage,
+  buildControlResponse,
+  buildControlRequest,
+  getControlResponseId,
+  getControlResponsePayload,
+} = require('./protocol');
+
+const DEFAULT_RPC_TIMEOUT_MS = 15000;
+
+// The agent-server logs diagnostics to stderr; only clearly severe lines are
+// surfaced as chat errors. Substring match on purpose: `\berror\b` would miss
+// `ValueError` / `KeyError` and friends.
+const STDERR_SEVERE_RE = /error|traceback|exception|fatal|critical/i;
+
+class ProcessManager {
+  /**
+   * @param {object} opts
+   * @param {string} opts.command - The clawcodex binary (e.g. 'clawcodex')
+   * @param {string} [opts.cwd] - Workspace root (passed as --workspace)
+   * @param {Record<string,string>} [opts.env] - Extra env vars
+   * @param {string} [opts.permissionMode] - default|acceptEdits|plan|bypassPermissions|auto
+   * @param {string} [opts.provider] - Provider override (--provider)
+   * @param {string} [opts.model] - Model override (--model)
+   * @param {string[]} [opts.extraArgs] - Additional CLI flags
+   */
+  constructor(opts) {
+    this._command = opts.command || 'clawcodex';
+    this._cwd = opts.cwd || undefined;
+    this._env = opts.env || {};
+    this._permissionMode = opts.permissionMode || 'acceptEdits';
+    this._provider = opts.provider || null;
+    this._model = opts.model || null;
+    this._extraArgs = opts.extraArgs || [];
+    this._sessionId = null;
+    this._process = null;
+    this._buffer = '';
+    this._disposed = false;
+    /** @type {Map<string, { resolve: Function, reject: Function, timer: NodeJS.Timeout }>} */
+    this._pendingRpcs = new Map();
+
+    this._onMessageEmitter = new vscode.EventEmitter();
+    this._onErrorEmitter = new vscode.EventEmitter();
+    this._onExitEmitter = new vscode.EventEmitter();
+    this.onMessage = this._onMessageEmitter.event;
+    this.onError = this._onErrorEmitter.event;
+    this.onExit = this._onExitEmitter.event;
+  }
+
+  get running() {
+    return this._process !== null && !this._process.killed;
+  }
+
+  get sessionId() {
+    return this._sessionId;
+  }
+
+  buildArgs() {
+    const args = [
+      'agent-server',
+      '--stdio',
+      '--permission-mode', this._permissionMode || 'acceptEdits',
+    ];
+
+    if (this._cwd) {
+      args.push('--workspace', this._cwd);
+    }
+    if (this._provider) {
+      args.push('--provider', this._provider);
+    }
+    if (this._model) {
+      args.push('--model', this._model);
+    }
+
+    args.push(...this._extraArgs);
+    return args;
+  }
+
+  start() {
+    if (this._disposed) throw new Error('ProcessManager is disposed');
+    if (this._process) throw new Error('Process already started');
+
+    const args = this.buildArgs();
+    const spawnEnv = { ...process.env, ...this._env };
+    const isWin = process.platform === 'win32';
+
+    if (isWin) {
+      // On Windows, installer shims are often .cmd files that spawn()
+      // cannot find without a shell. Build one command string so the
+      // deprecation warning about unsanitised args does not fire.
+      const cmdLine = [this._command, ...args].join(' ');
+      this._process = spawn(cmdLine, [], {
+        cwd: this._cwd,
+        env: spawnEnv,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        shell: true,
+        windowsHide: true,
+      });
+    } else {
+      this._process = spawn(this._command, args, {
+        cwd: this._cwd,
+        env: spawnEnv,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+    }
+
+    this._process.stdout.setEncoding('utf8');
+    this._process.stderr.setEncoding('utf8');
+
+    this._process.stdout.on('data', (chunk) => this._onData(chunk));
+    this._process.stderr.on('data', (chunk) => this._onStderr(chunk));
+    this._process.on('error', (err) => this._onErrorEmitter.fire(err));
+    this._process.on('close', (code, signal) => {
+      this._process = null;
+      this._rejectAllRpcs(new Error('agent-server exited'));
+      this._onExitEmitter.fire({ code, signal });
+    });
+  }
+
+  _onData(chunk) {
+    this._buffer += chunk;
+    const lines = this._buffer.split('\n');
+    this._buffer = lines.pop() || '';
+
+    for (const line of lines) {
+      const msg = parseStdoutLine(line);
+      if (!msg) continue;
+      this._extractSessionId(msg);
+      if (this._resolveRpc(msg)) continue;
+      this._onMessageEmitter.fire(msg);
+    }
+  }
+
+  _extractSessionId(msg) {
+    if (msg.session_id && !this._sessionId) {
+      this._sessionId = msg.session_id;
+    }
+  }
+
+  /**
+   * Resolve an inbound control_response against a pending client RPC.
+   * Returns true when the message was consumed. Replies with unknown
+   * request_ids fall through to onMessage (harmless).
+   */
+  _resolveRpc(msg) {
+    const requestId = getControlResponseId(msg);
+    if (!requestId) return false;
+    const pending = this._pendingRpcs.get(requestId);
+    if (!pending) return false;
+    this._pendingRpcs.delete(requestId);
+    clearTimeout(pending.timer);
+    pending.resolve(getControlResponsePayload(msg));
+    return true;
+  }
+
+  _rejectAllRpcs(err) {
+    for (const pending of this._pendingRpcs.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(err);
+    }
+    this._pendingRpcs.clear();
+  }
+
+  _onStderr(chunk) {
+    for (const rawLine of String(chunk).split('\n')) {
+      const trimmed = rawLine.trim();
+      if (!trimmed) continue;
+      // Suppress non-error noise (deprecation warnings, INFO logs, etc.)
+      if (/^\(node:\d+\)|^DeprecationWarning|^ExperimentalWarning/i.test(trimmed)) continue;
+      if (!STDERR_SEVERE_RE.test(trimmed)) continue;
+      this._onErrorEmitter.fire(new Error(trimmed));
+    }
+  }
+
+  sendUserMessage(text) {
+    this._write(buildUserMessage(text));
+  }
+
+  sendControlResponse(requestId, result) {
+    this._write(buildControlResponse(requestId, result));
+  }
+
+  /**
+   * Fire a client → server RPC and await the server's control_response.
+   * `interrupt` is fire-and-forget on the server side — use abort() for it.
+   */
+  sendControlRequest(subtype, payload, options = {}) {
+    const envelope = buildControlRequest(subtype, payload);
+    const requestId = envelope.request_id;
+    const timeoutMs = options.timeoutMs || DEFAULT_RPC_TIMEOUT_MS;
+
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this._pendingRpcs.delete(requestId);
+        reject(new Error(`${subtype} request timed out`));
+      }, timeoutMs);
+      this._pendingRpcs.set(requestId, { resolve, reject, timer });
+      try {
+        this._write(envelope);
+      } catch (err) {
+        this._pendingRpcs.delete(requestId);
+        clearTimeout(timer);
+        reject(err);
+      }
+    });
+  }
+
+  write(msg) {
+    if (!this._process || !this._process.stdin.writable) {
+      throw new Error('Process is not running');
+    }
+    this._process.stdin.write(serializeStdinMessage(msg));
+  }
+
+  _write(msg) {
+    this.write(msg);
+  }
+
+  /**
+   * Graceful turn abort: the `interrupt` control aborts the in-flight turn
+   * (the server emits result/cancelled) while the session stays alive.
+   * SIGINT would kill the whole server and lose session state.
+   */
+  abort() {
+    if (!this.running) return;
+    try {
+      this._write(buildControlRequest('interrupt'));
+    } catch (err) {
+      this._onErrorEmitter.fire(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  kill() {
+    if (this._process && !this._process.killed) {
+      this._process.kill('SIGTERM');
+    }
+  }
+
+  dispose() {
+    this._disposed = true;
+    this._rejectAllRpcs(new Error('ProcessManager disposed'));
+    this.kill();
+    this._onMessageEmitter.dispose();
+    this._onErrorEmitter.dispose();
+    this._onExitEmitter.dispose();
+  }
+}
+
+module.exports = { ProcessManager, DEFAULT_RPC_TIMEOUT_MS, STDERR_SEVERE_RE };

--- a/vscode-extension/clawcodex-vscode/src/chat/processManager.test.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/processManager.test.js
@@ -1,0 +1,153 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { ProcessManager, STDERR_SEVERE_RE } = require('./processManager');
+
+test('buildArgs spawns the agent-server with workspace and permission mode', () => {
+  const pm = new ProcessManager({
+    command: 'clawcodex',
+    cwd: '/workspace/project',
+    permissionMode: 'acceptEdits',
+  });
+
+  assert.deepEqual(pm.buildArgs(), [
+    'agent-server',
+    '--stdio',
+    '--permission-mode', 'acceptEdits',
+    '--workspace', '/workspace/project',
+  ]);
+});
+
+test('buildArgs forwards provider, model, and extra args', () => {
+  const pm = new ProcessManager({
+    command: 'clawcodex',
+    cwd: '/w',
+    permissionMode: 'plan',
+    provider: 'deepseek',
+    model: 'deepseek-chat',
+    extraArgs: ['--max-turns', '10'],
+  });
+
+  assert.deepEqual(pm.buildArgs(), [
+    'agent-server',
+    '--stdio',
+    '--permission-mode', 'plan',
+    '--workspace', '/w',
+    '--provider', 'deepseek',
+    '--model', 'deepseek-chat',
+    '--max-turns', '10',
+  ]);
+});
+
+test('stderr severity filter matches Python failure shapes and skips log noise', () => {
+  for (const line of [
+    'Traceback (most recent call last):',
+    "ValueError: bad thing",
+    'KeyError: missing',
+    'RuntimeError: exploded',
+    'CRITICAL something broke',
+    'fatal: repository not found',
+  ]) {
+    assert.ok(STDERR_SEVERE_RE.test(line), `expected severe: ${line}`);
+  }
+  for (const line of [
+    'INFO [agent-server] session started',
+    'DEBUG loading tool registry',
+    'listening for input',
+  ]) {
+    assert.ok(!STDERR_SEVERE_RE.test(line), `expected quiet: ${line}`);
+  }
+});
+
+function startEchoServer(pm, script) {
+  // A tiny stand-in agent-server: reads NDJSON lines from stdin and answers
+  // per the script function, exercising the real spawn + framing path.
+  pm._command = process.execPath;
+  pm.buildArgs = () => ['-e', script];
+  pm.start();
+}
+
+const RPC_ECHO_SCRIPT = `
+  let buffer = '';
+  process.stdin.setEncoding('utf8');
+  process.stdin.on('data', chunk => {
+    buffer += chunk;
+    const lines = buffer.split('\\n');
+    buffer = lines.pop() || '';
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      const msg = JSON.parse(line);
+      if (msg.type === 'control_request' && msg.request.subtype === 'list_sessions') {
+        process.stdout.write(JSON.stringify({
+          type: 'control_response',
+          response: {
+            subtype: 'success',
+            request_id: msg.request_id,
+            response: { sessions: [{ session_id: 'fake' }] },
+          },
+        }) + '\\n');
+      }
+      if (msg.type === 'control_request' && msg.request.subtype === 'interrupt') {
+        process.stdout.write(JSON.stringify({ type: 'result', subtype: 'cancelled', session_id: 's1', num_turns: 0, result: '' }) + '\\n');
+      }
+      if (msg.type === 'user') {
+        process.stdout.write(JSON.stringify({ type: 'system', subtype: 'init', session_id: 's1' }) + '\\n');
+      }
+    }
+  });
+`;
+
+test('sendControlRequest round-trips an RPC against a fake server', async () => {
+  const pm = new ProcessManager({ command: 'unused' });
+  startEchoServer(pm, RPC_ECHO_SCRIPT);
+
+  try {
+    const reply = await pm.sendControlRequest('list_sessions', {}, { timeoutMs: 5000 });
+    assert.deepEqual(reply, { sessions: [{ session_id: 'fake' }] });
+  } finally {
+    pm.dispose();
+  }
+});
+
+test('non-RPC messages still reach onMessage while RPC replies are consumed', async () => {
+  const pm = new ProcessManager({ command: 'unused' });
+  const seen = [];
+  pm.onMessage(msg => seen.push(msg.type));
+  startEchoServer(pm, RPC_ECHO_SCRIPT);
+
+  try {
+    pm.sendUserMessage('hello');
+    // interrupt: fire-and-forget control that triggers a result frame
+    pm.abort();
+    await new Promise(resolve => setTimeout(resolve, 300));
+    const rpc = await pm.sendControlRequest('list_sessions', {}, { timeoutMs: 5000 });
+    assert.ok(rpc.sessions);
+    assert.ok(seen.includes('system'), `system init should reach onMessage (saw ${seen})`);
+    assert.ok(seen.includes('result'), `result should reach onMessage (saw ${seen})`);
+    assert.ok(!seen.includes('control_response'), 'RPC replies must be consumed, not forwarded');
+    assert.equal(pm.sessionId, 's1');
+  } finally {
+    pm.dispose();
+  }
+});
+
+test('sendControlRequest rejects on timeout and on process exit', async () => {
+  const pm = new ProcessManager({ command: 'unused' });
+  startEchoServer(pm, 'setInterval(() => {}, 1000);'); // never answers
+
+  await assert.rejects(
+    pm.sendControlRequest('resume', { session_id: 'x' }, { timeoutMs: 100 }),
+    /timed out/,
+  );
+
+  const pending = pm.sendControlRequest('resume', { session_id: 'y' }, { timeoutMs: 60000 });
+  const rejection = assert.rejects(pending, /exited|disposed/);
+  pm.dispose();
+  await rejection;
+});
+
+test('write throws when the process is not running', () => {
+  const pm = new ProcessManager({ command: 'unused' });
+  assert.throws(() => pm.sendUserMessage('hi'), /not running/);
+  pm.dispose();
+});

--- a/vscode-extension/clawcodex-vscode/src/chat/protocol.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/protocol.js
@@ -1,0 +1,189 @@
+/**
+ * NDJSON protocol helpers and message type constants for the clawcodex
+ * agent-server stream wire format.
+ *
+ * The extension spawns `clawcodex agent-server --stdio --workspace <cwd>` and
+ * speaks NDJSON over stdin/stdout. Outbound (client → server): `user` message
+ * envelopes, `control_response` (permission replies), and `control_request`
+ * RPCs (interrupt / resume / list_sessions — replied to with an inbound
+ * `control_response` correlated by request_id). Inbound (server → client):
+ * `system` (init + status), `assistant` / `user` SDK envelopes, `stream_event`
+ * (Anthropic-style content_block_delta with text_delta | thinking_delta),
+ * `control_request` (subtype can_use_tool — permission prompts), and a
+ * per-turn terminal `result`.
+ *
+ * This module provides lightweight parsing, serialization, and type guards so
+ * the rest of the extension never touches raw JSON strings.
+ */
+
+const MESSAGE_TYPES = {
+  ASSISTANT: 'assistant',
+  USER: 'user',
+  RESULT: 'result',
+  SYSTEM: 'system',
+  STREAM_EVENT: 'stream_event',
+  CONTROL_REQUEST: 'control_request',
+  CONTROL_RESPONSE: 'control_response',
+  AGENT_PROGRESS: 'agent_progress',
+};
+
+let requestCounter = 0;
+
+function nextRequestId() {
+  requestCounter += 1;
+  return `vscode-${Date.now().toString(36)}-${requestCounter}`;
+}
+
+function parseStdoutLine(line) {
+  const trimmed = (line || '').trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+}
+
+function serializeStdinMessage(msg) {
+  return JSON.stringify(msg) + '\n';
+}
+
+function buildUserMessage(text) {
+  return {
+    type: 'user',
+    message: {
+      role: 'user',
+      content: text,
+    },
+    parent_tool_use_id: null,
+  };
+}
+
+function buildControlResponse(requestId, result) {
+  return {
+    type: 'control_response',
+    response: {
+      subtype: 'success',
+      request_id: requestId,
+      response: result || {},
+    },
+  };
+}
+
+/**
+ * Client → server RPC envelope. The server replies with a `control_response`
+ * whose `response.request_id` matches (except fire-and-forget subtypes like
+ * `interrupt`, which send no reply).
+ */
+function buildControlRequest(subtype, payload, requestId) {
+  return {
+    type: 'control_request',
+    request_id: requestId || nextRequestId(),
+    request: { subtype, ...(payload || {}) },
+  };
+}
+
+function isAssistantMessage(msg) {
+  return msg && msg.type === MESSAGE_TYPES.ASSISTANT;
+}
+
+function isStreamEvent(msg) {
+  return Boolean(msg && msg.type === MESSAGE_TYPES.STREAM_EVENT && msg.event);
+}
+
+function isContentBlockDelta(msg) {
+  return isStreamEvent(msg) && msg.event.type === 'content_block_delta';
+}
+
+function isResultMessage(msg) {
+  return msg && msg.type === MESSAGE_TYPES.RESULT;
+}
+
+function isSystemInit(msg) {
+  return msg && msg.type === MESSAGE_TYPES.SYSTEM && msg.subtype === 'init';
+}
+
+function isSystemStatus(msg) {
+  return msg && msg.type === MESSAGE_TYPES.SYSTEM && msg.subtype === 'status';
+}
+
+/** Server → client permission ask (`request.subtype === 'can_use_tool'`). */
+function isControlRequest(msg) {
+  return msg && msg.type === MESSAGE_TYPES.CONTROL_REQUEST;
+}
+
+function isPermissionRequest(msg) {
+  return (
+    isControlRequest(msg) &&
+    msg.request &&
+    typeof msg.request === 'object' &&
+    msg.request.subtype === 'can_use_tool'
+  );
+}
+
+/** Server → client reply to a client-initiated control_request RPC. */
+function isControlResponse(msg) {
+  return msg && msg.type === MESSAGE_TYPES.CONTROL_RESPONSE;
+}
+
+function getControlResponseId(msg) {
+  if (!isControlResponse(msg)) return null;
+  const response = msg.response;
+  if (!response || typeof response !== 'object') return null;
+  return typeof response.request_id === 'string' ? response.request_id : null;
+}
+
+function getControlResponsePayload(msg) {
+  if (!isControlResponse(msg)) return null;
+  const response = msg.response;
+  if (!response || typeof response !== 'object') return null;
+  const inner = response.response;
+  return inner && typeof inner === 'object' ? inner : {};
+}
+
+function isToolUse(block) {
+  return block && block.type === 'tool_use';
+}
+
+function isTextBlock(block) {
+  return block && block.type === 'text';
+}
+
+function getTextContent(message) {
+  if (!message) return '';
+  if (typeof message.content === 'string') return message.content;
+  if (!Array.isArray(message.content)) return '';
+  return message.content
+    .filter(b => b && b.type === 'text')
+    .map(b => b.text || '')
+    .join('');
+}
+
+function getToolUseBlocks(message) {
+  if (!message || !Array.isArray(message.content)) return [];
+  return message.content.filter(b => b && b.type === 'tool_use');
+}
+
+module.exports = {
+  MESSAGE_TYPES,
+  parseStdoutLine,
+  serializeStdinMessage,
+  buildUserMessage,
+  buildControlResponse,
+  buildControlRequest,
+  isAssistantMessage,
+  isStreamEvent,
+  isContentBlockDelta,
+  isResultMessage,
+  isSystemInit,
+  isSystemStatus,
+  isControlRequest,
+  isPermissionRequest,
+  isControlResponse,
+  getControlResponseId,
+  getControlResponsePayload,
+  isToolUse,
+  isTextBlock,
+  getTextContent,
+  getToolUseBlocks,
+};

--- a/vscode-extension/clawcodex-vscode/src/chat/protocol.test.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/protocol.test.js
@@ -1,0 +1,133 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  parseStdoutLine,
+  serializeStdinMessage,
+  buildUserMessage,
+  buildControlResponse,
+  buildControlRequest,
+  isAssistantMessage,
+  isStreamEvent,
+  isContentBlockDelta,
+  isResultMessage,
+  isSystemInit,
+  isSystemStatus,
+  isPermissionRequest,
+  isControlResponse,
+  getControlResponseId,
+  getControlResponsePayload,
+  getTextContent,
+  getToolUseBlocks,
+} = require('./protocol');
+
+test('parseStdoutLine parses NDJSON and rejects garbage', () => {
+  assert.deepEqual(parseStdoutLine('{"type":"result"}'), { type: 'result' });
+  assert.equal(parseStdoutLine('not json'), null);
+  assert.equal(parseStdoutLine(''), null);
+  assert.equal(parseStdoutLine('   '), null);
+});
+
+test('serializeStdinMessage appends a newline', () => {
+  assert.equal(serializeStdinMessage({ a: 1 }), '{"a":1}\n');
+});
+
+test('buildUserMessage matches the agent-server inbound envelope', () => {
+  assert.deepEqual(buildUserMessage('hello'), {
+    type: 'user',
+    message: { role: 'user', content: 'hello' },
+    parent_tool_use_id: null,
+  });
+});
+
+test('buildControlResponse wraps the result in the SDK envelope', () => {
+  assert.deepEqual(buildControlResponse('req-1', { behavior: 'allow' }), {
+    type: 'control_response',
+    response: {
+      subtype: 'success',
+      request_id: 'req-1',
+      response: { behavior: 'allow' },
+    },
+  });
+});
+
+test('buildControlRequest carries subtype, payload, and a unique request_id', () => {
+  const first = buildControlRequest('resume', { session_id: 'abc' });
+  const second = buildControlRequest('interrupt');
+
+  assert.equal(first.type, 'control_request');
+  assert.deepEqual(first.request, { subtype: 'resume', session_id: 'abc' });
+  assert.ok(typeof first.request_id === 'string' && first.request_id.length > 0);
+  assert.deepEqual(second.request, { subtype: 'interrupt' });
+  assert.notEqual(first.request_id, second.request_id);
+});
+
+test('system guards distinguish init from status', () => {
+  const init = { type: 'system', subtype: 'init', session_id: 's', model: 'm' };
+  const status = { type: 'system', subtype: 'status', level: 'info', message: 'hi' };
+  assert.ok(isSystemInit(init));
+  assert.ok(!isSystemInit(status));
+  assert.ok(isSystemStatus(status));
+  assert.ok(!isSystemStatus(init));
+});
+
+test('stream event guards match content_block_delta envelopes', () => {
+  const delta = {
+    type: 'stream_event',
+    session_id: 's',
+    event: { type: 'content_block_delta', delta: { type: 'text_delta', text: 'hi' } },
+  };
+  assert.ok(isStreamEvent(delta));
+  assert.ok(isContentBlockDelta(delta));
+  assert.ok(!isStreamEvent({ type: 'stream_event' }));
+});
+
+test('permission request guard requires subtype can_use_tool', () => {
+  const perm = {
+    type: 'control_request',
+    request_id: 'r1',
+    request: { subtype: 'can_use_tool', tool_name: 'Write', input: {} },
+  };
+  const other = {
+    type: 'control_request',
+    request_id: 'r2',
+    request: { subtype: 'something_else' },
+  };
+  assert.ok(isPermissionRequest(perm));
+  assert.ok(!isPermissionRequest(other));
+});
+
+test('control response accessors correlate RPC replies', () => {
+  const reply = {
+    type: 'control_response',
+    response: {
+      subtype: 'success',
+      request_id: 'vscode-1',
+      response: { sessions: [{ session_id: 'a' }] },
+    },
+  };
+  assert.ok(isControlResponse(reply));
+  assert.equal(getControlResponseId(reply), 'vscode-1');
+  assert.deepEqual(getControlResponsePayload(reply), { sessions: [{ session_id: 'a' }] });
+  assert.equal(getControlResponseId({ type: 'control_response' }), null);
+});
+
+test('assistant and result guards plus content accessors', () => {
+  const assistant = {
+    type: 'assistant',
+    session_id: 's',
+    message: {
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'Let me edit that.' },
+        { type: 'tool_use', id: 'tu1', name: 'Edit', input: { file_path: '/a.txt' } },
+      ],
+    },
+  };
+  assert.ok(isAssistantMessage(assistant));
+  assert.equal(getTextContent(assistant.message), 'Let me edit that.');
+  assert.deepEqual(getToolUseBlocks(assistant.message).map(b => b.id), ['tu1']);
+  assert.equal(getTextContent({ content: 'plain string' }), 'plain string');
+
+  assert.ok(isResultMessage({ type: 'result', subtype: 'success' }));
+  assert.ok(!isResultMessage(assistant));
+});

--- a/vscode-extension/clawcodex-vscode/src/chat/sessionManager.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/sessionManager.js
@@ -1,0 +1,255 @@
+/**
+ * sessionManager — reads saved clawcodex sessions from disk, lists them,
+ * and provides message history for the session list / restore UI.
+ *
+ * Session files live as flat JSON documents under:
+ *   $CLAWCODEX_CONFIG_DIR/sessions/<sessionId>.json   (default ~/.clawcodex)
+ *
+ * Each file carries {session_id, updated_at (epoch seconds, float), preview,
+ * name, message_count, model, cwd, conversation: {messages: [{role, content}]}}
+ * — the same store the agent-server's /resume reads. There is deliberately no
+ * ~/.claude fallback: clawcodex never shares state with Claude Code.
+ */
+
+const fs = require('fs');
+const fsp = require('fs/promises');
+const path = require('path');
+const os = require('os');
+
+// Output cap only. The scan itself is unbounded, mirroring the server's own
+// _list_saved_sessions: with a flat sessions/ dir (no per-project bucketing),
+// any input-side cap can push every session of the CURRENT workspace out of
+// the scanned window on a machine whose other projects were touched more
+// recently — turning Resume into a silent "no sessions". listSessions runs
+// async off the UI thread, so a full scan-parse of a few thousand files is
+// affordable and correct.
+const MAX_SESSIONS = 30;
+
+function resolveConfigDir() {
+  const envDir = process.env.CLAWCODEX_CONFIG_DIR;
+  if (envDir) return envDir;
+  return path.join(os.homedir(), '.clawcodex');
+}
+
+function getSessionsDir() {
+  return path.join(resolveConfigDir(), 'sessions');
+}
+
+/**
+ * Symlink-tolerant path identity. The agent-server stores a `.resolve()`d
+ * cwd (e.g. /private/var/... on macOS) while VS Code hands out the
+ * unresolved workspace path — realpath both sides before comparing.
+ * Returns null when the path cannot be resolved (caller decides fallback).
+ */
+function tryRealpath(value) {
+  if (!value) return null;
+  try {
+    return fs.realpathSync.native(String(value));
+  } catch {
+    return null;
+  }
+}
+
+function normalizeForCompare(value) {
+  if (!value) return '';
+  const normalized = path.resolve(String(value));
+  // Darwin and Windows default to case-insensitive filesystems.
+  return process.platform === 'win32' || process.platform === 'darwin'
+    ? normalized.toLowerCase()
+    : normalized;
+}
+
+class SessionManager {
+  constructor() {
+    this._cwd = null;
+  }
+
+  setCwd(cwd) {
+    this._cwd = cwd;
+  }
+
+  async listSessions() {
+    const dir = getSessionsDir();
+    let entries;
+    try {
+      entries = await fsp.readdir(dir);
+    } catch {
+      return [];
+    }
+
+    const sessions = [];
+    for (const name of entries) {
+      if (!name.endsWith('.json')) continue;
+      const meta = await this._extractSessionMeta(path.join(dir, name));
+      if (meta) sessions.push(meta);
+    }
+
+    const filtered = this._filterByWorkspace(sessions);
+    filtered.sort((a, b) => b.timestamp - a.timestamp);
+    return filtered.slice(0, MAX_SESSIONS);
+  }
+
+  /**
+   * Keep sessions whose stored cwd is the current workspace (realpath both
+   * sides). When the workspace path itself cannot be realpath'd, fall back
+   * to the full list — a normalization failure must degrade to "show all",
+   * never to an empty resume list. A workspace that resolves fine but has
+   * no sessions yet stays honestly empty.
+   */
+  _filterByWorkspace(sessions) {
+    if (!this._cwd) return sessions;
+    const wsReal = tryRealpath(this._cwd);
+    if (!wsReal) return sessions;
+    const wsKey = normalizeForCompare(wsReal);
+    return sessions.filter(s => {
+      if (!s.cwd) return false;
+      const sessionKey = normalizeForCompare(tryRealpath(s.cwd) || s.cwd);
+      return sessionKey === wsKey;
+    });
+  }
+
+  async _extractSessionMeta(filePath) {
+    let data;
+    try {
+      data = JSON.parse(await fsp.readFile(filePath, 'utf8'));
+    } catch {
+      return null;
+    }
+    if (!data || typeof data !== 'object') return null;
+
+    const sessionId = typeof data.session_id === 'string' && data.session_id
+      ? data.session_id
+      : path.basename(filePath, '.json');
+    // updated_at is epoch SECONDS (float) in the store.
+    const updatedAt = Number(data.updated_at);
+    const timestamp = Number.isFinite(updatedAt) && updatedAt > 0
+      ? updatedAt * 1000
+      : (await fsp.stat(filePath).then(s => s.mtimeMs).catch(() => Date.now()));
+    const preview = typeof data.preview === 'string' ? data.preview.slice(0, 120) : '';
+    const name = typeof data.name === 'string' ? data.name : '';
+
+    return {
+      id: sessionId,
+      title: name || preview.slice(0, 60) || 'Untitled session',
+      preview,
+      timestamp,
+      timeLabel: formatRelativeTime(timestamp),
+      model: typeof data.model === 'string' ? data.model : '',
+      cwd: typeof data.cwd === 'string' ? data.cwd : '',
+      messageCount: Number(data.message_count) || 0,
+      filePath,
+    };
+  }
+
+  async loadSession(sessionId) {
+    if (typeof sessionId !== 'string' || !sessionId) return null;
+    // Ids come from our own listing / the server, but harden anyway: a
+    // separator or dot-segment must not escape the sessions dir.
+    if (/[\\/]/.test(sessionId) || sessionId === '.' || sessionId === '..') return null;
+    const filePath = path.join(getSessionsDir(), `${sessionId}.json`);
+    let data;
+    try {
+      data = JSON.parse(await fsp.readFile(filePath, 'utf8'));
+    } catch {
+      return null;
+    }
+    const conversation = data && typeof data === 'object' ? data.conversation : null;
+    const rawMessages = conversation && Array.isArray(conversation.messages)
+      ? conversation.messages
+      : [];
+    return parseConversationMessages(rawMessages);
+  }
+}
+
+/**
+ * Shape stored conversation messages into the chat view model: user text
+ * bubbles plus assistant bubbles with tool_use blocks paired to their
+ * tool_result outputs. System-reminder-only user messages are dropped so a
+ * restore looks like the original chat did.
+ */
+function parseConversationMessages(rawMessages) {
+  const toolResults = new Map();
+
+  for (const entry of rawMessages) {
+    if (!entry || entry.role !== 'user' || !Array.isArray(entry.content)) continue;
+    for (const block of entry.content) {
+      if (block && block.type === 'tool_result' && block.tool_use_id) {
+        toolResults.set(String(block.tool_use_id), {
+          content: blockText(block.content).slice(0, 2000),
+          isError: block.is_error || false,
+        });
+      }
+    }
+  }
+
+  const messages = [];
+  for (const entry of rawMessages) {
+    if (!entry || typeof entry !== 'object') continue;
+    const content = entry.content;
+
+    if (entry.role === 'user') {
+      if (Array.isArray(content) && content.some(b => b && b.type === 'tool_result')) {
+        continue;
+      }
+      const text = typeof content === 'string' ? content : blockText(content);
+      if (!text || isSystemReminderOnly(text)) continue;
+      messages.push({ role: 'user', text });
+    } else if (entry.role === 'assistant') {
+      const text = typeof content === 'string' ? content : blockText(content);
+      const toolUses = Array.isArray(content)
+        ? content
+            .filter(b => b && b.type === 'tool_use')
+            .map(tu => {
+              const result = toolResults.get(String(tu.id));
+              return {
+                id: tu.id,
+                name: tu.name,
+                input: tu.input || null,
+                status: result ? (result.isError ? 'error' : 'complete') : 'complete',
+                result: result ? result.content : null,
+                isError: result ? result.isError : false,
+              };
+            })
+        : [];
+      if (!text && toolUses.length === 0) continue;
+      messages.push({ role: 'assistant', text, toolUses });
+    }
+  }
+
+  return messages;
+}
+
+function blockText(content) {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  return content
+    .filter(b => b && b.type === 'text')
+    .map(b => b.text || '')
+    .join('');
+}
+
+function isSystemReminderOnly(text) {
+  const trimmed = text.trim();
+  return trimmed.startsWith('<system-reminder>') && trimmed.endsWith('</system-reminder>');
+}
+
+function formatRelativeTime(ts) {
+  const now = Date.now();
+  const diff = now - ts;
+  const mins = Math.floor(diff / 60000);
+  if (mins < 1) return 'Just now';
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const date = new Date(ts);
+  return date.toLocaleDateString();
+}
+
+module.exports = {
+  SessionManager,
+  parseConversationMessages,
+  resolveConfigDir,
+  getSessionsDir,
+};

--- a/vscode-extension/clawcodex-vscode/src/chat/sessionManager.test.js
+++ b/vscode-extension/clawcodex-vscode/src/chat/sessionManager.test.js
@@ -1,0 +1,234 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const { SessionManager, parseConversationMessages, getSessionsDir } = require('./sessionManager');
+
+function withTempConfigDir(t) {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawcodex-sessions-'));
+  const previous = process.env.CLAWCODEX_CONFIG_DIR;
+  process.env.CLAWCODEX_CONFIG_DIR = tempDir;
+  fs.mkdirSync(path.join(tempDir, 'sessions'), { recursive: true });
+  t.after(() => {
+    if (previous === undefined) delete process.env.CLAWCODEX_CONFIG_DIR;
+    else process.env.CLAWCODEX_CONFIG_DIR = previous;
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+  return tempDir;
+}
+
+function writeSession(tempDir, id, doc) {
+  fs.writeFileSync(
+    path.join(tempDir, 'sessions', `${id}.json`),
+    JSON.stringify({ session_id: id, ...doc }),
+  );
+}
+
+test('getSessionsDir honors CLAWCODEX_CONFIG_DIR', t => {
+  const tempDir = withTempConfigDir(t);
+  assert.equal(getSessionsDir(), path.join(tempDir, 'sessions'));
+});
+
+test('listSessions reads the flat clawcodex format newest-first with null name coerced', async t => {
+  const tempDir = withTempConfigDir(t);
+  writeSession(tempDir, 'older', {
+    updated_at: 1784000000.5,
+    preview: 'first prompt',
+    name: null,
+    message_count: 2,
+    model: 'claude-opus-4-6',
+    cwd: '/some/project',
+  });
+  writeSession(tempDir, 'newer', {
+    updated_at: 1784000100.25,
+    preview: 'second prompt',
+    name: 'named session',
+    message_count: 4,
+    model: 'deepseek-chat',
+    cwd: '/some/project',
+  });
+
+  const manager = new SessionManager();
+  const sessions = await manager.listSessions();
+
+  assert.deepEqual(sessions.map(s => s.id), ['newer', 'older']);
+  assert.equal(sessions[0].title, 'named session');
+  assert.equal(sessions[1].title, 'first prompt');
+  // updated_at (epoch seconds) is converted to ms for display grouping.
+  assert.equal(sessions[0].timestamp, 1784000100.25 * 1000);
+});
+
+test('listSessions filters by workspace with symlink-tolerant comparison', async t => {
+  const tempDir = withTempConfigDir(t);
+  const realWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'clawcodex-ws-'));
+  const linkPath = path.join(tempDir, 'ws-link');
+  fs.symlinkSync(realWorkspace, linkPath);
+  t.after(() => fs.rmSync(realWorkspace, { recursive: true, force: true }));
+
+  // Stored cwd is the RESOLVED path (as the agent-server writes it) while
+  // the workspace handed to the extension is the symlink.
+  writeSession(tempDir, 'mine', {
+    updated_at: 1784000200,
+    preview: 'in this workspace',
+    cwd: fs.realpathSync.native(realWorkspace),
+    conversation: { messages: [] },
+  });
+  writeSession(tempDir, 'other', {
+    updated_at: 1784000300,
+    preview: 'elsewhere',
+    cwd: '/entirely/different/project',
+    conversation: { messages: [] },
+  });
+
+  const manager = new SessionManager();
+  manager.setCwd(linkPath);
+  const sessions = await manager.listSessions();
+
+  assert.deepEqual(sessions.map(s => s.id), ['mine']);
+});
+
+test('listSessions finds workspace sessions even when many other projects are newer', async t => {
+  // Regression: with a flat sessions/ dir, an input-side scan cap could push
+  // every session of the current workspace out of the scanned window when
+  // other projects were touched more recently — Resume silently showed
+  // nothing. The scan is unbounded (server parity); only output is capped.
+  const tempDir = withTempConfigDir(t);
+  const workspace = fs.mkdtempSync(path.join(os.tmpdir(), 'clawcodex-busy-'));
+  t.after(() => fs.rmSync(workspace, { recursive: true, force: true }));
+
+  // Written FIRST so it is the oldest by mtime AND updated_at, buried under
+  // >200 newer files — the exact shape that emptied Resume under an
+  // input-side scan cap.
+  writeSession(tempDir, 'mine-old', {
+    updated_at: 1784000000,
+    preview: 'the one that matters',
+    cwd: fs.realpathSync.native(workspace),
+  });
+  for (let i = 0; i < 210; i++) {
+    writeSession(tempDir, `noise-${i}`, {
+      updated_at: 1784100000 + i,
+      preview: `other project ${i}`,
+      cwd: `/other/project-${i}`,
+    });
+  }
+
+  const manager = new SessionManager();
+  manager.setCwd(workspace);
+  const sessions = await manager.listSessions();
+
+  assert.deepEqual(sessions.map(s => s.id), ['mine-old']);
+});
+
+test('listSessions keeps an honest empty list for a fresh resolvable workspace', async t => {
+  const tempDir = withTempConfigDir(t);
+  writeSession(tempDir, 'other', {
+    updated_at: 1784000300,
+    preview: 'elsewhere',
+    cwd: '/entirely/different/project',
+  });
+  const freshWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'clawcodex-fresh-'));
+  t.after(() => fs.rmSync(freshWorkspace, { recursive: true, force: true }));
+
+  const manager = new SessionManager();
+  manager.setCwd(freshWorkspace);
+  assert.deepEqual(await manager.listSessions(), []);
+});
+
+test('listSessions falls back to all sessions when the workspace cannot be resolved', async t => {
+  const tempDir = withTempConfigDir(t);
+  writeSession(tempDir, 'any', {
+    updated_at: 1784000300,
+    preview: 'somewhere',
+    cwd: '/entirely/different/project',
+  });
+
+  const manager = new SessionManager();
+  manager.setCwd(path.join(tempDir, 'does-not-exist'));
+  const sessions = await manager.listSessions();
+  assert.deepEqual(sessions.map(s => s.id), ['any']);
+});
+
+test('loadSession pairs tool uses with results and drops reminder-only messages', async t => {
+  const tempDir = withTempConfigDir(t);
+  writeSession(tempDir, 'convo', {
+    updated_at: 1784000400,
+    preview: 'fix the bug',
+    cwd: '/p',
+    conversation: {
+      messages: [
+        { role: 'user', content: 'fix the bug' },
+        {
+          role: 'user',
+          content: '<system-reminder>\ninjected context\n</system-reminder>',
+        },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'text', text: 'Editing now.' },
+            { type: 'tool_use', id: 'tu1', name: 'Edit', input: { file_path: '/p/a.py' } },
+          ],
+        },
+        {
+          role: 'user',
+          content: [
+            { type: 'tool_result', tool_use_id: 'tu1', content: 'ok', is_error: false },
+          ],
+        },
+        { role: 'assistant', content: [{ type: 'text', text: 'Done.' }] },
+      ],
+    },
+  });
+
+  const manager = new SessionManager();
+  const messages = await manager.loadSession('convo');
+
+  assert.deepEqual(messages, [
+    { role: 'user', text: 'fix the bug' },
+    {
+      role: 'assistant',
+      text: 'Editing now.',
+      toolUses: [
+        {
+          id: 'tu1',
+          name: 'Edit',
+          input: { file_path: '/p/a.py' },
+          status: 'complete',
+          result: 'ok',
+          isError: false,
+        },
+      ],
+    },
+    { role: 'assistant', text: 'Done.', toolUses: [] },
+  ]);
+});
+
+test('loadSession returns null for unknown or path-traversal ids', async t => {
+  withTempConfigDir(t);
+  const manager = new SessionManager();
+  assert.equal(await manager.loadSession('missing'), null);
+  assert.equal(await manager.loadSession(''), null);
+  assert.equal(await manager.loadSession(null), null);
+  assert.equal(await manager.loadSession('../escape'), null);
+  assert.equal(await manager.loadSession('a/b'), null);
+});
+
+test('parseConversationMessages tolerates string content and error results', () => {
+  const messages = parseConversationMessages([
+    { role: 'user', content: 'run it' },
+    {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id: 'tu9', name: 'Bash', input: { command: 'false' } }],
+    },
+    {
+      role: 'user',
+      content: [{ type: 'tool_result', tool_use_id: 'tu9', content: [{ type: 'text', text: 'boom' }], is_error: true }],
+    },
+  ]);
+
+  assert.equal(messages.length, 2);
+  assert.equal(messages[1].toolUses[0].isError, true);
+  assert.equal(messages[1].toolUses[0].result, 'boom');
+  assert.equal(messages[1].toolUses[0].status, 'error');
+});

--- a/vscode-extension/clawcodex-vscode/src/extension.js
+++ b/vscode-extension/clawcodex-vscode/src/extension.js
@@ -1,0 +1,1247 @@
+const vscode = require('vscode');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const {
+  chooseLaunchWorkspace,
+  describeProviderState,
+  findCommandPath,
+  getExecutableFromCommand,
+  isPathInsideWorkspace,
+  parseProjectSettings,
+  readClawcodexConfig,
+  resolveCommandCheckPath,
+  resolveConfigDir,
+} = require('./state');
+const { buildControlCenterViewModel } = require('./presentation');
+const { ChatController, ClawcodexChatViewProvider, ClawcodexChatPanelManager } = require('./chat/chatProvider');
+const { SessionManager } = require('./chat/sessionManager');
+const { DiffContentProvider, SCHEME: DIFF_SCHEME } = require('./chat/diffController');
+
+const CLAWCODEX_REPO_URL = 'https://github.com/agentforce314/clawcodex';
+const CLAWCODEX_SETUP_URL = 'https://github.com/agentforce314/clawcodex/blob/main/README.md#-quick-install';
+const INSTALL_HINT = 'curl -fsSL https://clawcodex.app/install.sh | bash';
+const PROJECT_SETTINGS_RELPATH = path.join('.clawcodex', 'settings.json');
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+async function isCommandAvailable(command, launchCwd) {
+  return Boolean(findCommandPath(command, { cwd: launchCwd }));
+}
+
+function getWorkspacePaths() {
+  return (vscode.workspace.workspaceFolders || []).map(folder => folder.uri.fsPath);
+}
+
+function getActiveWorkspacePath() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.uri.scheme !== 'file') {
+    return null;
+  }
+
+  const workspaceFolder = vscode.workspace.getWorkspaceFolder(editor.document.uri);
+  return workspaceFolder ? workspaceFolder.uri.fsPath : null;
+}
+
+function getActiveFilePath() {
+  const editor = vscode.window.activeTextEditor;
+  if (!editor || editor.document.uri.scheme !== 'file') {
+    return null;
+  }
+
+  return editor.document.uri.fsPath || null;
+}
+
+function resolveLaunchTargets({ activeFilePath, workspacePath, workspaceSourceLabel, executable } = {}) {
+  const activeFileDirectory = isPathInsideWorkspace(activeFilePath, workspacePath)
+    ? path.dirname(activeFilePath)
+    : null;
+  const normalizedExecutable = String(executable || '').trim();
+  const commandPath = normalizedExecutable
+    ? resolveCommandCheckPath(normalizedExecutable, workspacePath)
+    : null;
+  const relativeCommandRequiresWorkspaceRoot = Boolean(
+    workspacePath && commandPath && !path.isAbsolute(normalizedExecutable),
+  );
+
+  if (relativeCommandRequiresWorkspaceRoot) {
+    return {
+      projectAwareCwd: workspacePath,
+      projectAwareCwdLabel: workspacePath,
+      projectAwareSourceLabel: 'workspace root (required by relative launch command)',
+      workspaceRootCwd: workspacePath,
+      workspaceRootCwdLabel: workspacePath,
+      launchActionsShareTarget: true,
+      launchActionsShareTargetReason: 'relative-launch-command',
+    };
+  }
+
+  if (activeFileDirectory) {
+    return {
+      projectAwareCwd: activeFileDirectory,
+      projectAwareCwdLabel: activeFileDirectory,
+      projectAwareSourceLabel: 'active file directory',
+      workspaceRootCwd: workspacePath || null,
+      workspaceRootCwdLabel: workspacePath || 'No workspace open',
+      launchActionsShareTarget: false,
+      launchActionsShareTargetReason: null,
+    };
+  }
+
+  if (workspacePath) {
+    return {
+      projectAwareCwd: workspacePath,
+      projectAwareCwdLabel: workspacePath,
+      projectAwareSourceLabel: workspaceSourceLabel || 'workspace root',
+      workspaceRootCwd: workspacePath,
+      workspaceRootCwdLabel: workspacePath,
+      launchActionsShareTarget: true,
+      launchActionsShareTargetReason: null,
+    };
+  }
+
+  return {
+    projectAwareCwd: null,
+    projectAwareCwdLabel: 'VS Code default terminal cwd',
+    projectAwareSourceLabel: 'VS Code default terminal cwd',
+    workspaceRootCwd: null,
+    workspaceRootCwdLabel: 'No workspace open',
+    launchActionsShareTarget: false,
+    launchActionsShareTargetReason: null,
+  };
+}
+
+function resolveLaunchWorkspace() {
+  return chooseLaunchWorkspace({
+    activeWorkspacePath: getActiveWorkspacePath(),
+    workspacePaths: getWorkspacePaths(),
+  });
+}
+
+function getWorkspaceSourceLabel(source) {
+  switch (source) {
+    case 'active-workspace':
+      return 'active editor workspace';
+    case 'first-workspace':
+      return 'first workspace folder';
+    default:
+      return 'no workspace open';
+  }
+}
+
+function getProviderSourceLabel(source) {
+  switch (source) {
+    case 'setting':
+      return 'VS Code setting';
+    case 'config':
+      return 'clawcodex config';
+    case 'env':
+      return 'environment';
+    default:
+      return 'unknown';
+  }
+}
+
+function readWorkspaceProfile(profilePath) {
+  if (!profilePath || !fs.existsSync(profilePath)) {
+    return {
+      profile: null,
+      statusLabel: 'Missing',
+      statusHint: `${PROJECT_SETTINGS_RELPATH} not found in the workspace root`,
+      filePath: null,
+    };
+  }
+
+  try {
+    const raw = fs.readFileSync(profilePath, 'utf8');
+    const profile = parseProjectSettings(raw);
+    if (!profile) {
+      return {
+        profile: null,
+        statusLabel: 'Invalid',
+        statusHint: `${profilePath} has invalid JSON`,
+        filePath: profilePath,
+      };
+    }
+
+    return {
+      profile,
+      statusLabel: 'Found',
+      statusHint: profilePath,
+      filePath: profilePath,
+    };
+  } catch (error) {
+    return {
+      profile: null,
+      statusLabel: 'Unreadable',
+      statusHint: `${profilePath} (${error instanceof Error ? error.message : 'read failed'})`,
+      filePath: profilePath,
+    };
+  }
+}
+
+async function collectControlCenterState() {
+  const configured = vscode.workspace.getConfiguration('clawcodex');
+  const launchCommand = configured.get('launchCommand', 'clawcodex');
+  const terminalName = configured.get('terminalName', 'Clawcodex');
+  const settingsProvider = (configured.get('provider', '') || '').trim();
+  const settingsModel = (configured.get('model', '') || '').trim();
+  const executable = getExecutableFromCommand(launchCommand);
+  const launchWorkspace = resolveLaunchWorkspace();
+  const workspaceFolder = launchWorkspace.workspacePath;
+  const workspaceSourceLabel = getWorkspaceSourceLabel(launchWorkspace.source);
+  const launchTargets = resolveLaunchTargets({
+    activeFilePath: getActiveFilePath(),
+    workspacePath: workspaceFolder,
+    workspaceSourceLabel,
+    executable,
+  });
+  const installed = await isCommandAvailable(executable, launchTargets.projectAwareCwd);
+  const profilePath = workspaceFolder
+    ? path.join(workspaceFolder, PROJECT_SETTINGS_RELPATH)
+    : null;
+
+  const profileState = workspaceFolder
+    ? readWorkspaceProfile(profilePath)
+    : {
+        profile: null,
+        statusLabel: 'No workspace',
+        statusHint: 'Open a workspace folder to detect project settings',
+        filePath: null,
+      };
+
+  const { config } = readClawcodexConfig();
+  const providerState = describeProviderState({
+    config,
+    env: process.env,
+    settingsProvider,
+    settingsModel,
+  });
+
+  return {
+    installed,
+    executable,
+    launchCommand,
+    terminalName,
+    workspaceFolder,
+    workspaceSourceLabel,
+    launchCwd: launchTargets.projectAwareCwd,
+    launchCwdLabel: launchTargets.projectAwareCwdLabel,
+    launchCwdSourceLabel: launchTargets.projectAwareSourceLabel,
+    workspaceRootCwd: launchTargets.workspaceRootCwd,
+    workspaceRootCwdLabel: launchTargets.workspaceRootCwdLabel,
+    launchActionsShareTarget: launchTargets.launchActionsShareTarget,
+    launchActionsShareTargetReason: launchTargets.launchActionsShareTargetReason,
+    canLaunchInWorkspaceRoot: Boolean(workspaceFolder),
+    profileStatusLabel: profileState.statusLabel,
+    profileStatusHint: profileState.statusHint,
+    workspaceProfilePath: profileState.filePath,
+    providerState,
+    providerSourceLabel: getProviderSourceLabel(providerState.source),
+  };
+}
+
+async function launchClawcodex(options = {}) {
+  const { requireWorkspace = false } = options;
+  const configured = vscode.workspace.getConfiguration('clawcodex');
+  const launchCommand = configured.get('launchCommand', 'clawcodex');
+  const terminalName = configured.get('terminalName', 'Clawcodex');
+  const executable = getExecutableFromCommand(launchCommand);
+  const launchWorkspace = resolveLaunchWorkspace();
+
+  if (requireWorkspace && !launchWorkspace.workspacePath) {
+    await vscode.window.showWarningMessage(
+      'Open a workspace folder before using Launch in Workspace Root.',
+    );
+    return;
+  }
+
+  const launchTargets = resolveLaunchTargets({
+    activeFilePath: getActiveFilePath(),
+    workspacePath: launchWorkspace.workspacePath,
+    workspaceSourceLabel: getWorkspaceSourceLabel(launchWorkspace.source),
+    executable,
+  });
+  const targetCwd = requireWorkspace
+    ? launchTargets.workspaceRootCwd
+    : launchTargets.projectAwareCwd;
+  const installed = await isCommandAvailable(executable, targetCwd);
+
+  if (!installed) {
+    const action = await vscode.window.showErrorMessage(
+      `Clawcodex command not found: ${executable}. Install it with: ${INSTALL_HINT}`,
+      'Open Setup Guide',
+      'Open Repository',
+    );
+
+    if (action === 'Open Setup Guide') {
+      await vscode.env.openExternal(vscode.Uri.parse(CLAWCODEX_SETUP_URL));
+    } else if (action === 'Open Repository') {
+      await vscode.env.openExternal(vscode.Uri.parse(CLAWCODEX_REPO_URL));
+    }
+
+    return;
+  }
+
+  const terminalOptions = {
+    name: terminalName,
+    env: {},
+  };
+
+  if (targetCwd) {
+    terminalOptions.cwd = targetCwd;
+  }
+
+  const terminal = vscode.window.createTerminal(terminalOptions);
+  terminal.show(true);
+  terminal.sendText(launchCommand, true);
+}
+
+async function openWorkspaceProfile() {
+  const state = await collectControlCenterState();
+
+  if (!state.workspaceProfilePath) {
+    await vscode.window.showInformationMessage(
+      `No ${PROJECT_SETTINGS_RELPATH} file was found for the current workspace.`,
+    );
+    return;
+  }
+
+  const document = await vscode.workspace.openTextDocument(
+    vscode.Uri.file(state.workspaceProfilePath),
+  );
+  await vscode.window.showTextDocument(document, { preview: false });
+}
+
+async function openProviderConfig() {
+  const configPath = path.join(resolveConfigDir(), 'config.json');
+  if (!fs.existsSync(configPath)) {
+    await vscode.window.showInformationMessage(
+      `No clawcodex config found at ${configPath}. Run \`clawcodex\` once in a terminal to create it.`,
+    );
+    return;
+  }
+  const document = await vscode.workspace.openTextDocument(vscode.Uri.file(configPath));
+  await vscode.window.showTextDocument(document, { preview: false });
+}
+
+function getToneClass(tone) {
+  switch (tone) {
+    case 'accent':
+      return 'tone-accent';
+    case 'positive':
+      return 'tone-positive';
+    case 'warning':
+      return 'tone-warning';
+    case 'critical':
+      return 'tone-critical';
+    default:
+      return 'tone-neutral';
+  }
+}
+
+function renderHeaderBadge(badge) {
+  return `<div class="rail-pill ${getToneClass(badge.tone)}" title="${escapeHtml(badge.label)}: ${escapeHtml(badge.value)}">
+    <span class="rail-label">${escapeHtml(badge.label)}</span>
+    <span class="rail-value">${escapeHtml(badge.value)}</span>
+  </div>`;
+}
+
+function renderSummaryCard(card) {
+  const detail = card.detail || '';
+  return `<section class="summary-card" aria-label="${escapeHtml(card.label)}">
+    <div class="summary-label">${escapeHtml(card.label)}</div>
+    <div class="summary-value" title="${escapeHtml(card.value)}">${escapeHtml(card.value)}</div>
+    ${detail ? `<div class="summary-detail" title="${escapeHtml(detail)}">${escapeHtml(detail)}</div>` : ''}
+  </section>`;
+}
+
+function renderDetailRow(row) {
+  return `<div class="detail-row ${getToneClass(row.tone)}">
+    <div class="detail-label">${escapeHtml(row.label)}</div>
+    <div class="detail-summary" title="${escapeHtml(row.summary)}">${escapeHtml(row.summary)}</div>
+    ${row.detail ? `<div class="detail-meta" title="${escapeHtml(row.detail)}">${escapeHtml(row.detail)}</div>` : ''}
+  </div>`;
+}
+
+function renderDetailSection(section) {
+  const sectionId = `section-${String(section.title || 'section').toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
+  return `<section class="detail-module" aria-labelledby="${escapeHtml(sectionId)}">
+    <h2 class="module-title" id="${escapeHtml(sectionId)}">${escapeHtml(section.title)}</h2>
+    <div class="detail-list">${section.rows.map(renderDetailRow).join('')}</div>
+  </section>`;
+}
+
+function renderActionButton(action, variant = 'secondary') {
+  return `<button class="action-button ${variant}" id="${escapeHtml(action.id)}" type="button" ${action.disabled ? 'disabled aria-disabled="true"' : ''}>
+    <span class="action-label">${escapeHtml(action.label)}</span>
+    <span class="action-detail">${escapeHtml(action.detail)}</span>
+  </button>`;
+}
+
+function renderProfileEmptyState(detail) {
+  return `<div class="action-empty" role="status" aria-live="polite">
+    <div class="action-empty-title">No project settings yet</div>
+    <div class="action-empty-detail">${escapeHtml(detail)}</div>
+  </div>`;
+}
+
+function getPrimaryLaunchActionDetail(status) {
+  if (status.launchActionsShareTargetReason === 'relative-launch-command' && status.launchCwd) {
+    return `Project-aware launch is anchored to the workspace root by the relative command · ${status.launchCwdLabel}`;
+  }
+
+  if (status.launchCwd && status.launchCwdSourceLabel === 'active file directory') {
+    return `Starts beside the active file · ${status.launchCwdLabel}`;
+  }
+
+  if (status.launchCwd) {
+    return `Project-aware launch. Currently resolves to ${status.launchCwdSourceLabel} · ${status.launchCwdLabel}`;
+  }
+
+  return 'Project-aware launch. Uses the VS Code default terminal cwd';
+}
+
+function getWorkspaceRootActionDetail(status, fallbackDetail) {
+  if (!status.canLaunchInWorkspaceRoot) {
+    return fallbackDetail;
+  }
+
+  if (status.launchActionsShareTargetReason === 'relative-launch-command') {
+    return `Same workspace-root target as Launch Clawcodex because the relative command resolves from the workspace root · ${status.workspaceRootCwdLabel}`;
+  }
+
+  return `Always starts at the workspace root · ${status.workspaceRootCwdLabel}`;
+}
+
+function getRenderableViewModel(status) {
+  const viewModel = buildControlCenterViewModel(status);
+  const summaryCards = viewModel.summaryCards.map(card => {
+    if (card.key !== 'launchCwd' || card.detail) {
+      return card;
+    }
+
+    return {
+      ...card,
+      detail: status.launchCwdSourceLabel || '',
+    };
+  });
+
+  return {
+    ...viewModel,
+    summaryCards,
+    actions: {
+      ...viewModel.actions,
+      primary: {
+        ...viewModel.actions.primary,
+        detail: getPrimaryLaunchActionDetail(status),
+      },
+      launchRoot: {
+        ...viewModel.actions.launchRoot,
+        detail: getWorkspaceRootActionDetail(status, viewModel.actions.launchRoot.detail),
+      },
+    },
+  };
+}
+
+function renderControlCenterHtml(status, options = {}) {
+  const nonce = options.nonce || crypto.randomBytes(16).toString('base64');
+  const platform = options.platform || process.platform;
+  const viewModel = getRenderableViewModel(status);
+  const profileActionOrEmpty = viewModel.actions.openProfile
+    ? renderActionButton(viewModel.actions.openProfile)
+    : renderProfileEmptyState(status.profileStatusHint || 'Open a workspace folder to detect project settings');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <style>
+    :root {
+      --oc-bg: #050505;
+      --oc-panel: #110d0c;
+      --oc-panel-strong: #17110f;
+      --oc-panel-soft: #1d1512;
+      --oc-border: #645041;
+      --oc-border-soft: rgba(220, 195, 170, 0.14);
+      --oc-text: #f7efe5;
+      --oc-text-dim: #dcc3aa;
+      --oc-text-soft: #aa9078;
+      --oc-accent: #d77757;
+      --oc-accent-bright: #f09464;
+      --oc-accent-soft: rgba(240, 148, 100, 0.18);
+      --oc-positive: #e8b86b;
+      --oc-warning: #f3c969;
+      --oc-critical: #ff8a6c;
+      --oc-focus: #ffd3a1;
+    }
+    * {
+      box-sizing: border-box;
+    }
+    h1, h2, p {
+      margin: 0;
+    }
+    html, body {
+      margin: 0;
+      min-height: 100%;
+    }
+    body {
+      padding: 16px;
+      font-family: var(--vscode-font-family, "Segoe UI", sans-serif);
+      color: var(--oc-text);
+      background:
+        radial-gradient(circle at top right, rgba(240, 148, 100, 0.16), transparent 34%),
+        radial-gradient(circle at 20% 0%, rgba(215, 119, 87, 0.14), transparent 28%),
+        linear-gradient(180deg, #090706, #050505 58%, #090706);
+      line-height: 1.45;
+    }
+    button {
+      font: inherit;
+    }
+    .shell {
+      position: relative;
+      overflow: hidden;
+      border: 1px solid var(--oc-border-soft);
+      border-radius: 20px;
+      background:
+        linear-gradient(180deg, rgba(255, 255, 255, 0.02), transparent 16%),
+        linear-gradient(180deg, rgba(17, 13, 12, 0.98), rgba(9, 7, 6, 0.98));
+      box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35), inset 0 1px 0 rgba(255, 255, 255, 0.03);
+    }
+    .shell::before {
+      content: "";
+      position: absolute;
+      inset: 0 0 auto;
+      height: 2px;
+      background: linear-gradient(90deg, #ffb464, #f09464, #d77757, #814334);
+      opacity: 0.95;
+    }
+    .sunset-gradient {
+      background: linear-gradient(90deg, #ffb464, #f09464, #d77757, #814334);
+    }
+    .frame {
+      display: grid;
+      gap: 18px;
+      padding: 18px;
+    }
+    .hero {
+      display: grid;
+      gap: 14px;
+      padding: 18px;
+      border-radius: 16px;
+      background:
+        linear-gradient(135deg, rgba(240, 148, 100, 0.06), rgba(215, 119, 87, 0.02) 55%, transparent),
+        var(--oc-panel);
+      border: 1px solid var(--oc-border-soft);
+    }
+    .hero-top {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+    .brand {
+      display: grid;
+      gap: 6px;
+      min-width: 0;
+    }
+    .eyebrow {
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      color: var(--oc-text-soft);
+    }
+    .wordmark {
+      font-size: 24px;
+      line-height: 1;
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      color: var(--oc-text);
+    }
+    .wordmark-accent {
+      color: var(--oc-accent-bright);
+    }
+    .headline {
+      display: grid;
+      gap: 4px;
+      max-width: 44ch;
+    }
+    .headline-title {
+      font-size: 15px;
+      font-weight: 600;
+      color: var(--oc-text);
+    }
+    .headline-subtitle {
+      font-size: 12px;
+      color: var(--oc-text-dim);
+    }
+    .status-rail {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      align-items: center;
+      justify-content: flex-end;
+      flex: 1 1 250px;
+    }
+    .rail-pill {
+      display: grid;
+      gap: 2px;
+      min-width: 94px;
+      padding: 8px 10px;
+      border-radius: 999px;
+      border: 1px solid var(--oc-border-soft);
+      background: rgba(255, 255, 255, 0.02);
+    }
+    .rail-label {
+      font-size: 10px;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      color: var(--oc-text-soft);
+    }
+    .rail-value {
+      font-size: 12px;
+      font-weight: 700;
+      color: var(--oc-text);
+    }
+    .refresh-button {
+      border: 1px solid rgba(240, 148, 100, 0.28);
+      border-radius: 999px;
+      padding: 8px 12px;
+      background: rgba(240, 148, 100, 0.08);
+      color: var(--oc-text-dim);
+      cursor: pointer;
+      white-space: nowrap;
+    }
+    .summary-grid {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    }
+    .summary-card {
+      display: grid;
+      gap: 6px;
+      min-width: 0;
+      padding: 14px;
+      border-radius: 14px;
+      background: var(--oc-panel-strong);
+      border: 1px solid var(--oc-border-soft);
+    }
+    .summary-label,
+    .detail-label,
+    .module-title,
+    .action-section-title,
+    .support-title {
+      font-size: 10px;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--oc-text-soft);
+    }
+    .summary-value,
+    .detail-summary {
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--oc-text);
+    }
+    .summary-detail,
+    .detail-meta,
+    .action-detail,
+    .action-empty-detail,
+    .support-copy,
+    .footer-note {
+      font-size: 12px;
+      color: var(--oc-text-dim);
+    }
+    .modules {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+    .detail-module,
+    .support-card {
+      display: grid;
+      gap: 12px;
+      padding: 16px;
+      border-radius: 16px;
+      background: var(--oc-panel);
+      border: 1px solid var(--oc-border-soft);
+    }
+    .detail-list,
+    .action-stack,
+    .support-stack {
+      display: grid;
+      gap: 10px;
+    }
+    .detail-row {
+      display: grid;
+      gap: 4px;
+      min-width: 0;
+      padding: 12px;
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.02);
+      border: 1px solid rgba(220, 195, 170, 0.08);
+    }
+    .actions-layout {
+      display: grid;
+      gap: 14px;
+      grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+      align-items: start;
+    }
+    .action-panel {
+      display: grid;
+      gap: 12px;
+      padding: 16px;
+      border-radius: 16px;
+      background: var(--oc-panel);
+      border: 1px solid var(--oc-border-soft);
+    }
+    .action-button {
+      width: 100%;
+      display: grid;
+      gap: 4px;
+      padding: 14px;
+      text-align: left;
+      border-radius: 14px;
+      border: 1px solid rgba(220, 195, 170, 0.14);
+      background: rgba(255, 255, 255, 0.02);
+      color: var(--oc-text);
+      cursor: pointer;
+      transition: border-color 140ms ease, transform 140ms ease, background 140ms ease, box-shadow 140ms ease;
+    }
+    .action-button.primary {
+      border-color: rgba(240, 148, 100, 0.44);
+      background:
+        linear-gradient(135deg, rgba(255, 180, 100, 0.22), rgba(215, 119, 87, 0.12) 58%, rgba(129, 67, 52, 0.12)),
+        #241713;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    }
+    .action-button.secondary:hover:enabled,
+    .action-button.primary:hover:enabled,
+    .refresh-button:hover {
+      border-color: rgba(240, 148, 100, 0.48);
+      transform: translateY(-1px);
+      background-color: rgba(240, 148, 100, 0.1);
+    }
+    .action-button:disabled {
+      cursor: not-allowed;
+      opacity: 0.58;
+      transform: none;
+    }
+    .action-label,
+    .action-empty-title,
+    .support-link-label {
+      font-size: 13px;
+      font-weight: 700;
+      color: var(--oc-text);
+    }
+    .action-empty {
+      display: grid;
+      gap: 4px;
+      padding: 14px;
+      border-radius: 14px;
+      border: 1px dashed rgba(220, 195, 170, 0.16);
+      background: rgba(255, 255, 255, 0.015);
+    }
+    .support-link {
+      width: 100%;
+      display: grid;
+      gap: 4px;
+      padding: 12px 0;
+      border: 0;
+      border-top: 1px solid rgba(220, 195, 170, 0.08);
+      background: transparent;
+      color: inherit;
+      cursor: pointer;
+      text-align: left;
+    }
+    .support-link:first-of-type {
+      border-top: 0;
+      padding-top: 0;
+    }
+    .tone-positive .rail-value,
+    .tone-positive .detail-summary {
+      color: var(--oc-positive);
+    }
+    .tone-warning .rail-value,
+    .tone-warning .detail-summary {
+      color: var(--oc-warning);
+    }
+    .tone-critical .rail-value,
+    .tone-critical .detail-summary {
+      color: var(--oc-critical);
+    }
+    .tone-accent .rail-value,
+    .tone-accent .detail-summary {
+      color: var(--oc-accent-bright);
+    }
+    .action-button:focus-visible,
+    .support-link:focus-visible,
+    .refresh-button:focus-visible {
+      outline: 2px solid var(--oc-focus);
+      outline-offset: 2px;
+      box-shadow: 0 0 0 4px rgba(255, 211, 161, 0.16);
+    }
+    code {
+      padding: 1px 6px;
+      border-radius: 999px;
+      border: 1px solid rgba(240, 148, 100, 0.18);
+      background: rgba(240, 148, 100, 0.08);
+      color: var(--oc-accent-bright);
+      font-family: var(--vscode-editor-font-family, Consolas, monospace);
+      font-size: 11px;
+    }
+    .footer-note {
+      padding-top: 2px;
+    }
+    @media (max-width: 720px) {
+      body {
+        padding: 12px;
+      }
+      .frame,
+      .hero {
+        padding: 14px;
+      }
+      .actions-layout {
+        grid-template-columns: 1fr;
+      }
+      .status-rail {
+        justify-content: flex-start;
+      }
+      .rail-pill {
+        min-width: 0;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="shell" aria-labelledby="control-center-title">
+    <div class="frame">
+      <header class="hero">
+        <div class="hero-top">
+          <div class="brand">
+            <div class="eyebrow">${escapeHtml(viewModel.header.eyebrow)}</div>
+            <div class="wordmark" aria-label="Clawcodex wordmark">claw<span class="wordmark-accent">codex</span></div>
+            <div class="headline">
+              <h1 class="headline-title" id="control-center-title">${escapeHtml(viewModel.header.title)}</h1>
+              <p class="headline-subtitle">${escapeHtml(viewModel.header.subtitle)}</p>
+            </div>
+          </div>
+          <div class="status-rail" role="group" aria-label="Runtime, provider, and project-settings status">
+            ${viewModel.headerBadges.map(renderHeaderBadge).join('')}
+            <button class="refresh-button" id="refresh" type="button">Refresh</button>
+          </div>
+        </div>
+        <section class="summary-grid" aria-label="Current launch summary">
+          ${viewModel.summaryCards.map(renderSummaryCard).join('')}
+        </section>
+      </header>
+
+      <section class="modules" aria-label="Control center details">
+        ${viewModel.detailSections.map(renderDetailSection).join('')}
+      </section>
+
+      <section class="actions-layout" aria-label="Control center actions">
+        <section class="action-panel" aria-labelledby="actions-title">
+          <h2 class="action-section-title" id="actions-title">Launch & Project</h2>
+          ${renderActionButton(viewModel.actions.primary, 'primary')}
+          <div class="action-stack">
+            ${renderActionButton(viewModel.actions.launchRoot)}
+            ${profileActionOrEmpty}
+          </div>
+        </section>
+
+        <section class="support-card" aria-labelledby="quick-links-title">
+          <h2 class="support-title" id="quick-links-title">Quick Links</h2>
+          <div class="support-copy">Settings and workspace status stay in view here. Reference links stay secondary.</div>
+          <div class="support-stack">
+            <button class="support-link" id="setup" type="button">
+              <span class="support-link-label">Open Setup Guide</span>
+              <span class="summary-detail">Jump to install and provider setup docs.</span>
+            </button>
+            <button class="support-link" id="repo" type="button">
+              <span class="support-link-label">Open Repository</span>
+              <span class="summary-detail">Browse the upstream clawcodex project.</span>
+            </button>
+            <button class="support-link" id="commands" type="button">
+              <span class="support-link-label">Open Command Palette</span>
+              <span class="summary-detail">Access VS Code and Clawcodex commands quickly.</span>
+            </button>
+            <button class="support-link" id="providerConfig" type="button">
+              <span class="support-link-label">Provider config</span>
+              <span class="summary-detail">Inspect ~/.clawcodex/config.json providers and models.</span>
+            </button>
+          </div>
+        </section>
+      </section>
+
+      <p class="footer-note">
+        Quick trigger: use <code>${escapeHtml(platform === 'darwin' ? 'Cmd+Shift+P' : 'Ctrl+Shift+P')}</code> for the command palette, then refresh this panel after workspace or settings changes.
+      </p>
+    </div>
+  </main>
+
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    document.getElementById('launch').addEventListener('click', () => vscode.postMessage({ type: 'launch' }));
+    document.getElementById('launchRoot').addEventListener('click', () => vscode.postMessage({ type: 'launchRoot' }));
+    document.getElementById('repo').addEventListener('click', () => vscode.postMessage({ type: 'repo' }));
+    document.getElementById('setup').addEventListener('click', () => vscode.postMessage({ type: 'setup' }));
+    document.getElementById('commands').addEventListener('click', () => vscode.postMessage({ type: 'commands' }));
+    document.getElementById('providerConfig').addEventListener('click', () => vscode.postMessage({ type: 'providerConfig' }));
+    document.getElementById('refresh').addEventListener('click', () => vscode.postMessage({ type: 'refresh' }));
+
+    const profileButton = document.getElementById('openProfile');
+    if (profileButton) {
+      profileButton.addEventListener('click', () => vscode.postMessage({ type: 'openProfile' }));
+    }
+  </script>
+</body>
+</html>`;
+}
+
+class ClawcodexControlCenterProvider {
+  constructor() {
+    this.webviewView = null;
+  }
+
+  async resolveWebviewView(webviewView) {
+    this.webviewView = webviewView;
+    webviewView.webview.options = { enableScripts: true };
+
+    webviewView.onDidDispose(() => {
+      if (this.webviewView === webviewView) {
+        this.webviewView = null;
+      }
+    });
+
+    webviewView.webview.onDidReceiveMessage(async message => {
+      switch (message?.type) {
+        case 'launch':
+          await launchClawcodex();
+          break;
+        case 'launchRoot':
+          await launchClawcodex({ requireWorkspace: true });
+          break;
+        case 'openProfile':
+          await openWorkspaceProfile();
+          break;
+        case 'repo':
+          await vscode.env.openExternal(vscode.Uri.parse(CLAWCODEX_REPO_URL));
+          break;
+        case 'setup':
+          await vscode.env.openExternal(vscode.Uri.parse(CLAWCODEX_SETUP_URL));
+          break;
+        case 'commands':
+          await vscode.commands.executeCommand('workbench.action.showCommands');
+          break;
+        case 'providerConfig':
+          await openProviderConfig();
+          break;
+        case 'refresh':
+        default:
+          break;
+      }
+
+      await this.refresh();
+    });
+
+    await this.refresh();
+  }
+
+  async refresh() {
+    if (!this.webviewView) {
+      return;
+    }
+
+    try {
+      const status = await collectControlCenterState();
+      this.webviewView.webview.html = this.getHtml(status);
+    } catch (error) {
+      this.webviewView.webview.html = this.getErrorHtml(error);
+    }
+  }
+
+  getErrorHtml(error) {
+    const nonce = crypto.randomBytes(16).toString('base64');
+    const message =
+      error instanceof Error ? error.message : 'Unknown Control Center error';
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <style>
+    body {
+      font-family: var(--vscode-font-family);
+      padding: 16px;
+      color: var(--vscode-foreground);
+      background: var(--vscode-sideBar-background);
+    }
+    .panel {
+      border: 1px solid var(--vscode-errorForeground);
+      border-radius: 8px;
+      padding: 14px;
+      background: color-mix(in srgb, var(--vscode-sideBar-background) 88%, black);
+    }
+    .title {
+      color: var(--vscode-errorForeground);
+      font-weight: 700;
+      margin-bottom: 8px;
+    }
+    .message {
+      color: var(--vscode-descriptionForeground);
+      margin-bottom: 12px;
+      line-height: 1.5;
+    }
+    button {
+      border: 1px solid var(--vscode-button-border, transparent);
+      background: var(--vscode-button-background);
+      color: var(--vscode-button-foreground);
+      border-radius: 6px;
+      padding: 8px 10px;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <div class="panel">
+    <div class="title">Control Center Error</div>
+    <div class="message">${escapeHtml(message)}</div>
+    <button id="refresh">Refresh</button>
+  </div>
+  <script nonce="${nonce}">
+    const vscode = acquireVsCodeApi();
+    document.getElementById('refresh').addEventListener('click', () => {
+      vscode.postMessage({ type: 'refresh' });
+    });
+  </script>
+</body>
+</html>`;
+  }
+
+  getHtml(status) {
+    const nonce = crypto.randomBytes(16).toString('base64');
+    return renderControlCenterHtml(status, { nonce, platform: process.platform });
+  }
+}
+
+/**
+ * @param {vscode.ExtensionContext} context
+ */
+function activate(context) {
+  // ── Control Center ──
+  const provider = new ClawcodexControlCenterProvider();
+  const refreshProvider = () => {
+    void provider.refresh();
+  };
+
+  // ── Chat system ──
+  const sessionManager = new SessionManager();
+  const folders = vscode.workspace.workspaceFolders;
+  if (folders && folders.length > 0) {
+    sessionManager.setCwd(folders[0].uri.fsPath);
+  }
+
+  const chatController = new ChatController(sessionManager);
+  const chatViewProvider = new ClawcodexChatViewProvider(chatController);
+  const chatPanelManager = new ClawcodexChatPanelManager(chatController);
+
+  // ── Diff content provider ──
+  const diffProvider = new DiffContentProvider();
+  const diffProviderReg = vscode.workspace.registerTextDocumentContentProvider(
+    DIFF_SCHEME,
+    diffProvider,
+  );
+
+  // ── Status bar ──
+  const statusBarItem = vscode.window.createStatusBarItem(
+    vscode.StatusBarAlignment.Right,
+    100,
+  );
+  statusBarItem.text = '$(comment-discussion) Clawcodex';
+  statusBarItem.tooltip = 'Open Clawcodex Chat';
+  statusBarItem.command = 'clawcodex.openChat';
+  statusBarItem.show();
+
+  chatController.onDidChangeState((state) => {
+    switch (state) {
+      case 'streaming':
+        statusBarItem.text = '$(sync~spin) Clawcodex';
+        statusBarItem.tooltip = 'Clawcodex is generating...';
+        break;
+      case 'connected':
+        statusBarItem.text = '$(comment-discussion) Clawcodex';
+        statusBarItem.tooltip = 'Clawcodex connected';
+        break;
+      default:
+        statusBarItem.text = '$(comment-discussion) Clawcodex';
+        statusBarItem.tooltip = 'Open Clawcodex Chat';
+        break;
+    }
+  });
+
+  // ── Commands ──
+  const startCommand = vscode.commands.registerCommand('clawcodex.start', async () => {
+    await launchClawcodex();
+  });
+
+  const startInWorkspaceRootCommand = vscode.commands.registerCommand(
+    'clawcodex.startInWorkspaceRoot',
+    async () => {
+      await launchClawcodex({ requireWorkspace: true });
+    },
+  );
+
+  const openDocsCommand = vscode.commands.registerCommand('clawcodex.openDocs', async () => {
+    await vscode.env.openExternal(vscode.Uri.parse(CLAWCODEX_REPO_URL));
+  });
+
+  const openSetupDocsCommand = vscode.commands.registerCommand(
+    'clawcodex.openSetupDocs',
+    async () => {
+      await vscode.env.openExternal(vscode.Uri.parse(CLAWCODEX_SETUP_URL));
+    },
+  );
+
+  const openWorkspaceSettingsCommand = vscode.commands.registerCommand(
+    'clawcodex.openWorkspaceSettings',
+    async () => {
+      await openWorkspaceProfile();
+    },
+  );
+
+  const openProviderConfigCommand = vscode.commands.registerCommand(
+    'clawcodex.openProviderConfig',
+    async () => {
+      await openProviderConfig();
+    },
+  );
+
+  const openUiCommand = vscode.commands.registerCommand('clawcodex.openControlCenter', async () => {
+    await vscode.commands.executeCommand('workbench.view.extension.clawcodex');
+  });
+
+  // ── Chat commands ──
+  const newChatCommand = vscode.commands.registerCommand('clawcodex.newChat', () => {
+    chatController.stopSession();
+    chatController._currentSessionId = null;
+    chatController._messages = [];
+    chatController.broadcast({ type: 'session_cleared' });
+  });
+
+  const openChatCommand = vscode.commands.registerCommand('clawcodex.openChat', () => {
+    chatPanelManager.openPanel();
+  });
+
+  const resumeSessionCommand = vscode.commands.registerCommand('clawcodex.resumeSession', async () => {
+    const sessions = await sessionManager.listSessions();
+    if (sessions.length === 0) {
+      await vscode.window.showInformationMessage('No sessions found to resume.');
+      return;
+    }
+    const items = sessions.map(s => ({
+      label: s.title || s.id,
+      description: s.timeLabel,
+      detail: s.preview,
+      sessionId: s.id,
+    }));
+    const picked = await vscode.window.showQuickPick(items, {
+      placeHolder: 'Select a session to resume',
+    });
+    if (picked) {
+      chatController.stopSession();
+      chatController.broadcast({ type: 'session_cleared' });
+      const messages = await sessionManager.loadSession(picked.sessionId);
+      if (messages && messages.length > 0) {
+        chatController._messages = messages;
+        chatController.broadcast({ type: 'restore_messages', messages });
+      }
+      await chatController.startSession({ sessionId: picked.sessionId });
+    }
+  });
+
+  const abortChatCommand = vscode.commands.registerCommand('clawcodex.abortChat', () => {
+    chatController.abort();
+  });
+
+  // ── Register providers ──
+  const controlCenterProviderReg = vscode.window.registerWebviewViewProvider(
+    'clawcodex.controlCenter',
+    provider,
+  );
+
+  const chatViewProviderReg = vscode.window.registerWebviewViewProvider(
+    'clawcodex.chat',
+    chatViewProvider,
+    { webviewOptions: { retainContextWhenHidden: true } },
+  );
+
+  const profileWatcher = vscode.workspace.createFileSystemWatcher('**/.clawcodex/settings.json');
+
+  context.subscriptions.push(
+    startCommand,
+    startInWorkspaceRootCommand,
+    openDocsCommand,
+    openSetupDocsCommand,
+    openWorkspaceSettingsCommand,
+    openProviderConfigCommand,
+    openUiCommand,
+    controlCenterProviderReg,
+    newChatCommand,
+    openChatCommand,
+    resumeSessionCommand,
+    abortChatCommand,
+    chatViewProviderReg,
+    diffProviderReg,
+    statusBarItem,
+    profileWatcher,
+    vscode.workspace.onDidChangeConfiguration(event => {
+      if (event.affectsConfiguration('clawcodex')) {
+        refreshProvider();
+      }
+    }),
+    vscode.workspace.onDidChangeWorkspaceFolders(() => {
+      refreshProvider();
+      const currentFolders = vscode.workspace.workspaceFolders;
+      if (currentFolders && currentFolders.length > 0) {
+        sessionManager.setCwd(currentFolders[0].uri.fsPath);
+      }
+    }),
+    vscode.window.onDidChangeActiveTextEditor(refreshProvider),
+    profileWatcher.onDidCreate(refreshProvider),
+    profileWatcher.onDidChange(refreshProvider),
+    profileWatcher.onDidDelete(refreshProvider),
+    { dispose: () => chatController.dispose() },
+    { dispose: () => chatPanelManager.dispose() },
+    { dispose: () => diffProvider.dispose() },
+  );
+}
+
+function deactivate() {}
+
+module.exports = {
+  activate,
+  deactivate,
+  ClawcodexControlCenterProvider,
+  renderControlCenterHtml,
+  resolveLaunchTargets,
+  ChatController,
+  ClawcodexChatViewProvider,
+  ClawcodexChatPanelManager,
+};

--- a/vscode-extension/clawcodex-vscode/src/extension.test.js
+++ b/vscode-extension/clawcodex-vscode/src/extension.test.js
@@ -1,0 +1,223 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+// `vscode` resolves to test/vscode-stub.js via the --require preload.
+const {
+  renderControlCenterHtml,
+  resolveLaunchTargets,
+  ClawcodexControlCenterProvider,
+} = require('./extension');
+
+function createStatus(overrides = {}) {
+  return {
+    installed: true,
+    executable: 'clawcodex',
+    launchCommand: 'clawcodex --verbose',
+    terminalName: 'Clawcodex',
+    workspaceFolder: '/workspace/clawcodex/very/long/path/example-project',
+    workspaceSourceLabel: 'active editor workspace',
+    launchCwd: '/workspace/clawcodex/very/long/path/example-project',
+    launchCwdLabel: '/workspace/clawcodex/very/long/path/example-project',
+    canLaunchInWorkspaceRoot: true,
+    profileStatusLabel: 'Found',
+    profileStatusHint: '/workspace/clawcodex/very/long/path/example-project/.clawcodex/settings.json',
+    workspaceProfilePath: '/workspace/clawcodex/very/long/path/example-project/.clawcodex/settings.json',
+    providerState: {
+      label: 'DeepSeek',
+      detail: 'deepseek-chat',
+      source: 'config',
+    },
+    providerSourceLabel: 'clawcodex config',
+    ...overrides,
+  };
+}
+
+test('renderControlCenterHtml uses the clawcodex wordmark, status rail, and warm action hierarchy', () => {
+  const html = renderControlCenterHtml(createStatus(), { nonce: 'test-nonce', platform: 'win32' });
+
+  assert.match(html, /claw<span class="wordmark-accent">codex<\/span>/);
+  assert.match(html, /class="status-rail"/);
+  assert.match(html, /\.sunset-gradient\s*\{/);
+  assert.match(html, /class="action-button primary" id="launch"/);
+  assert.match(html, /class="action-button secondary" id="launchRoot"/);
+  assert.match(
+    html,
+    /title="\/workspace\/clawcodex\/very\/long\/path\/example-project"[^>]*>\/workspace\/clawcodex\/very\/long\/path\/example-project<\//,
+  );
+});
+
+test('renderControlCenterHtml shows explicit disabled and empty states when workspace data is missing', () => {
+  const html = renderControlCenterHtml(
+    createStatus({
+      workspaceFolder: null,
+      workspaceSourceLabel: 'no workspace open',
+      launchCwd: null,
+      launchCwdLabel: 'VS Code default terminal cwd',
+      canLaunchInWorkspaceRoot: false,
+      profileStatusLabel: 'No workspace',
+      profileStatusHint: 'Open a workspace folder to detect project settings',
+      workspaceProfilePath: null,
+    }),
+    { nonce: 'test-nonce', platform: 'linux' },
+  );
+
+  assert.match(
+    html,
+    /class="action-button secondary" id="launchRoot"[^>]*disabled[^>]*>[\s\S]*Open a workspace folder to enable workspace-root launch/,
+  );
+  assert.match(html, /No project settings yet/);
+  assert.match(html, /Open a workspace folder to detect project settings/);
+  assert.doesNotMatch(html, /id="openProfile"/);
+});
+
+test('renderControlCenterHtml links provider config instead of the Azure subsystem', () => {
+  const html = renderControlCenterHtml(createStatus(), { nonce: 'test-nonce', platform: 'linux' });
+
+  assert.match(html, /id="providerConfig"/);
+  assert.match(html, /config\.json/);
+  assert.doesNotMatch(html, /azure/i);
+});
+
+test('ClawcodexControlCenterProvider.getHtml supplies a nonce to the renderer', () => {
+  const provider = new ClawcodexControlCenterProvider();
+
+  assert.doesNotThrow(() => provider.getHtml(createStatus()));
+
+  const html = provider.getHtml(createStatus());
+  assert.match(html, /script-src 'nonce-[^']+'/);
+  assert.match(html, /<script nonce="[^"]+">/);
+  assert.doesNotMatch(html, /nonce-undefined/);
+  assert.doesNotMatch(html, /<script nonce="undefined">/);
+});
+
+test('resolveLaunchTargets distinguishes project-aware launch from workspace-root launch', () => {
+  assert.deepEqual(
+    resolveLaunchTargets({
+      activeFilePath: '/workspace/clawcodex/src/panels/control-center.js',
+      workspacePath: '/workspace/clawcodex',
+      workspaceSourceLabel: 'active editor workspace',
+    }),
+    {
+      projectAwareCwd: '/workspace/clawcodex/src/panels',
+      projectAwareCwdLabel: '/workspace/clawcodex/src/panels',
+      projectAwareSourceLabel: 'active file directory',
+      workspaceRootCwd: '/workspace/clawcodex',
+      workspaceRootCwdLabel: '/workspace/clawcodex',
+      launchActionsShareTarget: false,
+      launchActionsShareTargetReason: null,
+    },
+  );
+});
+
+test('resolveLaunchTargets anchors relative launch commands to the workspace root', () => {
+  assert.deepEqual(
+    resolveLaunchTargets({
+      executable: './bin/clawcodex',
+      activeFilePath: '/workspace/clawcodex/src/panels/control-center.js',
+      workspacePath: '/workspace/clawcodex',
+      workspaceSourceLabel: 'active editor workspace',
+    }),
+    {
+      projectAwareCwd: '/workspace/clawcodex',
+      projectAwareCwdLabel: '/workspace/clawcodex',
+      projectAwareSourceLabel: 'workspace root (required by relative launch command)',
+      workspaceRootCwd: '/workspace/clawcodex',
+      workspaceRootCwdLabel: '/workspace/clawcodex',
+      launchActionsShareTarget: true,
+      launchActionsShareTargetReason: 'relative-launch-command',
+    },
+  );
+});
+
+test('resolveLaunchTargets ignores active files outside the selected workspace', () => {
+  assert.deepEqual(
+    resolveLaunchTargets({
+      executable: 'clawcodex',
+      activeFilePath: '/tmp/notes/scratch.js',
+      workspacePath: '/workspace/clawcodex',
+      workspaceSourceLabel: 'first workspace folder',
+    }),
+    {
+      projectAwareCwd: '/workspace/clawcodex',
+      projectAwareCwdLabel: '/workspace/clawcodex',
+      projectAwareSourceLabel: 'first workspace folder',
+      workspaceRootCwd: '/workspace/clawcodex',
+      workspaceRootCwdLabel: '/workspace/clawcodex',
+      launchActionsShareTarget: true,
+      launchActionsShareTargetReason: null,
+    },
+  );
+});
+
+test('renderControlCenterHtml restores landmark and heading semantics', () => {
+  const html = renderControlCenterHtml(createStatus(), { nonce: 'test-nonce', platform: 'win32' });
+
+  assert.match(html, /<main class="shell" aria-labelledby="control-center-title">/);
+  assert.match(html, /<header class="hero">/);
+  assert.match(html, /<h1 class="headline-title" id="control-center-title">/);
+  assert.match(html, /<section class="modules" aria-label="Control center details">/);
+  assert.match(html, /<h2 class="module-title" id="section-project">Project<\/h2>/);
+  assert.match(html, /<section class="actions-layout" aria-label="Control center actions">/);
+});
+
+test('renderControlCenterHtml explains distinct launch targets when an active file directory is available', () => {
+  const html = renderControlCenterHtml(
+    createStatus({
+      launchCwd: '/workspace/clawcodex/src/panels',
+      launchCwdLabel: '/workspace/clawcodex/src/panels',
+      launchCwdSourceLabel: 'active file directory',
+      workspaceRootCwd: '/workspace/clawcodex',
+      workspaceRootCwdLabel: '/workspace/clawcodex',
+    }),
+    { nonce: 'test-nonce', platform: 'linux' },
+  );
+
+  assert.match(html, /Starts beside the active file · \/workspace\/clawcodex\/src\/panels/);
+  assert.match(html, /Always starts at the workspace root · \/workspace\/clawcodex/);
+});
+
+test('renderControlCenterHtml makes shared workspace-root launches explicit for relative commands', () => {
+  const html = renderControlCenterHtml(
+    createStatus({
+      launchCwd: '/workspace/clawcodex',
+      launchCwdLabel: '/workspace/clawcodex',
+      launchCwdSourceLabel: 'workspace root (required by relative launch command)',
+      workspaceRootCwd: '/workspace/clawcodex',
+      workspaceRootCwdLabel: '/workspace/clawcodex',
+      launchActionsShareTarget: true,
+      launchActionsShareTargetReason: 'relative-launch-command',
+    }),
+    { nonce: 'test-nonce', platform: 'linux' },
+  );
+
+  assert.match(html, /Project-aware launch is anchored to the workspace root by the relative command · \/workspace\/clawcodex/);
+  assert.match(html, /Same workspace-root target as Launch Clawcodex because the relative command resolves from the workspace root · \/workspace\/clawcodex/);
+});
+
+test('renderControlCenterHtml escapes hostile text and title values', () => {
+  const html = renderControlCenterHtml(
+    createStatus({
+      launchCommand: '<img src=x onerror="boom()">',
+      workspaceFolder: '"/><script>workspace()</script>',
+      workspaceSourceLabel: 'active <b>workspace</b>',
+      launchCwdLabel: '"><script>cwd()</script>',
+      profileStatusHint: '<svg onload="profile()">',
+      workspaceProfilePath: '"/><script>profile-path()</script>',
+      providerState: {
+        label: 'Provider "><img src=x onerror="label()">',
+        detail: '<script>provider-detail()</script>',
+        source: 'config',
+      },
+    }),
+    { nonce: 'test-nonce', platform: 'linux' },
+  );
+
+  assert.match(html, /&lt;img src=x onerror=&quot;boom\(\)&quot;&gt;/);
+  assert.match(html, /&quot;\/&gt;&lt;script&gt;workspace\(\)&lt;\/script&gt;/);
+  assert.match(html, /active &lt;b&gt;workspace&lt;\/b&gt;/);
+  assert.match(html, /&lt;svg onload=&quot;profile\(\)&quot;&gt;/);
+  assert.match(html, /Provider &quot;&gt;&lt;img src=x onerror=&quot;label\(\)&quot;&gt;/);
+  assert.match(html, /&lt;script&gt;provider-detail\(\)&lt;\/script&gt; · clawcodex config/);
+  assert.doesNotMatch(html, /<script>workspace\(\)<\/script>/);
+  assert.doesNotMatch(html, /<img src=x onerror="boom\(\)">/);
+});

--- a/vscode-extension/clawcodex-vscode/src/presentation.js
+++ b/vscode-extension/clawcodex-vscode/src/presentation.js
@@ -1,0 +1,193 @@
+function truncateMiddle(value, maxLength) {
+  const text = String(value || '');
+  if (!text || text.length <= maxLength) {
+    return text;
+  }
+
+  const basename = text.split(/[\\/]/).filter(Boolean).pop() || '';
+  if (basename && basename.length + 4 <= maxLength) {
+    const separator = text.includes('\\') ? '\\' : '/';
+    return `...${separator}${basename}`;
+  }
+
+  if (maxLength <= 3) {
+    return '.'.repeat(Math.max(maxLength, 0));
+  }
+
+  const available = maxLength - 3;
+  const startLength = Math.ceil(available / 2);
+  const endLength = Math.floor(available / 2);
+  return `${text.slice(0, startLength)}...${text.slice(text.length - endLength)}`;
+}
+
+function getPathTail(value) {
+  const text = String(value || '');
+  if (!text) {
+    return '';
+  }
+
+  return text.split(/[\\/]/).filter(Boolean).pop() || text;
+}
+
+function buildActionModel({ canLaunchInWorkspaceRoot, workspaceProfilePath } = {}) {
+  return {
+    primary: {
+      id: 'launch',
+      label: 'Launch Clawcodex',
+      detail: 'Use the resolved project-aware launch directory',
+      tone: 'accent',
+      disabled: false,
+    },
+    launchRoot: {
+      id: 'launchRoot',
+      label: 'Launch in Workspace Root',
+      detail: canLaunchInWorkspaceRoot
+        ? 'Launch directly from the resolved workspace root'
+        : 'Open a workspace folder to enable workspace-root launch',
+      tone: 'neutral',
+      disabled: !canLaunchInWorkspaceRoot,
+    },
+    openProfile: workspaceProfilePath
+      ? {
+          id: 'openProfile',
+          label: 'Open Project Settings',
+          detail: `Inspect ${truncateMiddle(workspaceProfilePath, 40)}`,
+          tone: 'neutral',
+          disabled: false,
+        }
+      : null,
+  };
+}
+
+function getRuntimeTone(installed) {
+  return installed ? 'positive' : 'critical';
+}
+
+function getProfileTone(profileStatusLabel) {
+  return profileStatusLabel === 'Invalid' || profileStatusLabel === 'Unreadable'
+    ? 'warning'
+    : 'neutral';
+}
+
+function getProviderTone(providerState) {
+  return providerState?.source === 'unknown' ? 'warning' : 'neutral';
+}
+
+function getProviderDetail(providerState, providerSourceLabel) {
+  const detail = providerState?.detail || '';
+  if (!detail) {
+    return providerSourceLabel || '';
+  }
+
+  switch (providerState?.source) {
+    case 'unknown':
+      return detail;
+    default:
+      return [detail, providerSourceLabel].filter(Boolean).join(' · ');
+  }
+}
+
+function buildControlCenterViewModel(status = {}) {
+  const runtimeSummary = status.installed ? 'Installed' : 'Missing';
+  const runtimeDetail = status.executable || 'Unknown command';
+  const providerDetail = getProviderDetail(status.providerState, status.providerSourceLabel);
+  const providerTone = getProviderTone(status.providerState);
+  const workspaceSummary = status.workspaceFolder ? getPathTail(status.workspaceFolder) : 'No workspace open';
+  const workspaceDetail = [status.workspaceFolder, status.workspaceSourceLabel]
+    .filter(Boolean)
+    .join(' · ') || 'no workspace open';
+
+  return {
+    header: {
+      eyebrow: 'Clawcodex Control Center',
+      title: 'Project-aware Clawcodex companion',
+      subtitle:
+        'Useful local status, predictable launch behavior, and quick access to the workflows you actually use.',
+    },
+    headerBadges: [
+      {
+        key: 'runtime',
+        label: 'Runtime',
+        value: runtimeSummary,
+        tone: getRuntimeTone(status.installed),
+      },
+      {
+        key: 'provider',
+        label: 'Provider',
+        value: status.providerState?.label || 'Unknown',
+        tone: providerTone,
+      },
+      {
+        key: 'profileStatus',
+        label: 'Project settings',
+        value: status.profileStatusLabel || 'Unknown',
+        tone: getProfileTone(status.profileStatusLabel),
+      },
+    ],
+    summaryCards: [
+      {
+        key: 'workspace',
+        label: 'Workspace',
+        value: status.workspaceFolder || 'No workspace open',
+        detail: status.workspaceSourceLabel || 'no workspace open',
+      },
+      {
+        key: 'launchCwd',
+        label: 'Launch cwd',
+        value: status.launchCwdLabel || 'VS Code default terminal cwd',
+      },
+      {
+        key: 'launchCommand',
+        label: 'Launch command',
+        value: status.launchCommand || '',
+        detail: status.terminalName ? `Integrated terminal: ${status.terminalName}` : '',
+      },
+    ],
+    detailSections: [
+      {
+        title: 'Project',
+        rows: [
+          {
+            key: 'workspace',
+            label: 'Workspace folder',
+            summary: workspaceSummary,
+            detail: workspaceDetail,
+          },
+          {
+            key: 'profileStatus',
+            label: 'Project settings',
+            summary: status.profileStatusLabel || 'Unknown',
+            detail: status.profileStatusHint || '',
+            tone: getProfileTone(status.profileStatusLabel),
+          },
+        ],
+      },
+      {
+        title: 'Runtime',
+        rows: [
+          {
+            key: 'runtime',
+            label: 'Clawcodex executable',
+            summary: runtimeSummary,
+            detail: runtimeDetail,
+            tone: getRuntimeTone(status.installed),
+          },
+          {
+            key: 'provider',
+            label: 'Detected provider',
+            summary: status.providerState?.label || 'Unknown',
+            detail: providerDetail,
+            tone: providerTone,
+          },
+        ],
+      },
+    ],
+    actions: buildActionModel(status),
+  };
+}
+
+module.exports = {
+  truncateMiddle,
+  buildActionModel,
+  buildControlCenterViewModel,
+};

--- a/vscode-extension/clawcodex-vscode/src/presentation.test.js
+++ b/vscode-extension/clawcodex-vscode/src/presentation.test.js
@@ -1,0 +1,269 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+function loadPresentation() {
+  return require('./presentation');
+}
+
+test('truncateMiddle keeps the settings filename visible', () => {
+  const { truncateMiddle } = loadPresentation();
+
+  assert.equal(
+    truncateMiddle('/Users/example/projects/clawcodex/workspace/.clawcodex/settings.json', 30),
+    '.../settings.json',
+  );
+});
+
+test('truncateMiddle keeps the filename visible for Windows-style paths', () => {
+  const { truncateMiddle } = loadPresentation();
+
+  assert.equal(
+    truncateMiddle('C:\\Users\\example\\clawcodex\\workspace\\.clawcodex\\settings.json', 30),
+    '...\\settings.json',
+  );
+});
+
+test('buildActionModel disables workspace-root launch without a workspace', () => {
+  const { buildActionModel } = loadPresentation();
+
+  const model = buildActionModel({
+    canLaunchInWorkspaceRoot: false,
+    workspaceProfilePath: null,
+  });
+
+  assert.deepEqual(model.launchRoot, {
+    id: 'launchRoot',
+    label: 'Launch in Workspace Root',
+    detail: 'Open a workspace folder to enable workspace-root launch',
+    tone: 'neutral',
+    disabled: true,
+  });
+});
+
+test('buildActionModel hides project-settings action when no settings file exists', () => {
+  const { buildActionModel } = loadPresentation();
+
+  const model = buildActionModel({
+    canLaunchInWorkspaceRoot: true,
+    workspaceProfilePath: null,
+  });
+
+  assert.deepEqual(model.primary, {
+    id: 'launch',
+    label: 'Launch Clawcodex',
+    detail: 'Use the resolved project-aware launch directory',
+    tone: 'accent',
+    disabled: false,
+  });
+  assert.equal(model.openProfile, null);
+});
+
+test('buildActionModel includes project-settings action when the file exists', () => {
+  const { buildActionModel } = loadPresentation();
+
+  const model = buildActionModel({
+    canLaunchInWorkspaceRoot: true,
+    workspaceProfilePath: 'C:\\Users\\example\\clawcodex\\workspace\\.clawcodex\\settings.json',
+  });
+
+  assert.deepEqual(model.openProfile, {
+    id: 'openProfile',
+    label: 'Open Project Settings',
+    detail: 'Inspect ...\\settings.json',
+    tone: 'neutral',
+    disabled: false,
+  });
+});
+
+function createStatus(overrides = {}) {
+  return {
+    installed: true,
+    executable: 'clawcodex',
+    launchCommand: 'clawcodex --verbose',
+    terminalName: 'Clawcodex',
+    workspaceFolder: '/workspace/clawcodex',
+    workspaceSourceLabel: 'active editor workspace',
+    launchCwd: '/workspace/clawcodex',
+    launchCwdLabel: '/workspace/clawcodex',
+    canLaunchInWorkspaceRoot: true,
+    profileStatusLabel: 'Found',
+    profileStatusHint: '/workspace/clawcodex/.clawcodex/settings.json',
+    workspaceProfilePath: '/workspace/clawcodex/.clawcodex/settings.json',
+    providerState: {
+      label: 'DeepSeek',
+      detail: 'deepseek-chat',
+      source: 'config',
+    },
+    providerSourceLabel: 'clawcodex config',
+    ...overrides,
+  };
+}
+
+test('buildControlCenterViewModel keeps header badges and summary cards non-redundant', () => {
+  const { buildControlCenterViewModel } = loadPresentation();
+
+  const viewModel = buildControlCenterViewModel(createStatus());
+  const headerKeys = new Set(viewModel.headerBadges.map(badge => badge.key));
+  const summaryKeys = new Set(viewModel.summaryCards.map(card => card.key));
+
+  assert.deepEqual([...headerKeys].sort(), ['profileStatus', 'provider', 'runtime']);
+  assert.deepEqual([...summaryKeys].sort(), ['launchCommand', 'launchCwd', 'workspace']);
+
+  for (const key of headerKeys) {
+    assert.equal(summaryKeys.has(key), false);
+  }
+});
+
+test('buildControlCenterViewModel uses stable semantic tones for badges and actions', () => {
+  const { buildControlCenterViewModel } = loadPresentation();
+
+  const viewModel = buildControlCenterViewModel(createStatus({
+    installed: false,
+    profileStatusLabel: 'Invalid',
+    providerState: {
+      label: 'Unknown',
+      detail: 'no clawcodex config found',
+      source: 'unknown',
+    },
+    providerSourceLabel: 'unknown',
+  }));
+
+  assert.deepEqual(viewModel.headerBadges, [
+    {
+      key: 'runtime',
+      label: 'Runtime',
+      value: 'Missing',
+      tone: 'critical',
+    },
+    {
+      key: 'provider',
+      label: 'Provider',
+      value: 'Unknown',
+      tone: 'warning',
+    },
+    {
+      key: 'profileStatus',
+      label: 'Project settings',
+      value: 'Invalid',
+      tone: 'warning',
+    },
+  ]);
+
+  assert.equal(viewModel.actions.primary.tone, 'accent');
+  assert.equal(viewModel.actions.launchRoot.tone, 'neutral');
+});
+
+test('buildControlCenterViewModel uses a concise project summary before full path detail', () => {
+  const { buildControlCenterViewModel } = loadPresentation();
+
+  const viewModel = buildControlCenterViewModel(createStatus());
+
+  assert.deepEqual(viewModel.detailSections, [
+    {
+      title: 'Project',
+      rows: [
+        {
+          key: 'workspace',
+          label: 'Workspace folder',
+          summary: 'clawcodex',
+          detail: '/workspace/clawcodex · active editor workspace',
+        },
+        {
+          key: 'profileStatus',
+          label: 'Project settings',
+          summary: 'Found',
+          detail: '/workspace/clawcodex/.clawcodex/settings.json',
+          tone: 'neutral',
+        },
+      ],
+    },
+    {
+      title: 'Runtime',
+      rows: [
+        {
+          key: 'runtime',
+          label: 'Clawcodex executable',
+          summary: 'Installed',
+          detail: 'clawcodex',
+          tone: 'positive',
+        },
+        {
+          key: 'provider',
+          label: 'Detected provider',
+          summary: 'DeepSeek',
+          detail: 'deepseek-chat · clawcodex config',
+          tone: 'neutral',
+        },
+      ],
+    },
+  ]);
+});
+
+test('buildControlCenterViewModel keeps launch command only in summary cards', () => {
+  const { buildControlCenterViewModel } = loadPresentation();
+
+  const viewModel = buildControlCenterViewModel(createStatus());
+
+  assert.deepEqual(viewModel.summaryCards.find(card => card.key === 'launchCommand'), {
+    key: 'launchCommand',
+    label: 'Launch command',
+    value: 'clawcodex --verbose',
+    detail: 'Integrated terminal: Clawcodex',
+  });
+
+  assert.equal(
+    viewModel.detailSections.some(section => section.rows.some(row => row.key === 'launchCommand')),
+    false,
+  );
+});
+
+test('buildControlCenterViewModel keeps unknown provider detail honest', () => {
+  const { buildControlCenterViewModel } = loadPresentation();
+
+  const viewModel = buildControlCenterViewModel(createStatus({
+    providerState: {
+      label: 'Unknown',
+      detail: 'no clawcodex config found',
+      source: 'unknown',
+    },
+    providerSourceLabel: 'unknown',
+  }));
+
+  assert.deepEqual(viewModel.detailSections[1].rows.find(row => row.key === 'provider'), {
+    key: 'provider',
+    label: 'Detected provider',
+    summary: 'Unknown',
+    detail: 'no clawcodex config found',
+    tone: 'warning',
+  });
+});
+
+test('buildControlCenterViewModel appends the source label to configured provider detail', () => {
+  const { buildControlCenterViewModel } = loadPresentation();
+
+  const viewModel = buildControlCenterViewModel(createStatus({
+    providerState: {
+      label: 'Anthropic',
+      detail: 'claude-opus-4-6 · key from ANTHROPIC_API_KEY',
+      source: 'env',
+    },
+    providerSourceLabel: 'environment',
+  }));
+
+  assert.deepEqual(viewModel.detailSections[1].rows.find(row => row.key === 'provider'), {
+    key: 'provider',
+    label: 'Detected provider',
+    summary: 'Anthropic',
+    detail: 'claude-opus-4-6 · key from ANTHROPIC_API_KEY · environment',
+    tone: 'neutral',
+  });
+});
+
+test('buildControlCenterViewModel carries forward the existing action model', () => {
+  const { buildControlCenterViewModel, buildActionModel } = loadPresentation();
+
+  const status = createStatus();
+  const viewModel = buildControlCenterViewModel(status);
+
+  assert.deepEqual(viewModel.actions, buildActionModel(status));
+});

--- a/vscode-extension/clawcodex-vscode/src/state.js
+++ b/vscode-extension/clawcodex-vscode/src/state.js
@@ -1,0 +1,347 @@
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Display names for the providers clawcodex ships specs for. Anything not
+// listed renders with a capitalized fallback of its config key.
+const PROVIDER_LABELS = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  deepseek: 'DeepSeek',
+  gemini: 'Gemini',
+  zai: 'Z.ai',
+  minimax: 'MiniMax',
+  openrouter: 'OpenRouter',
+  moonshot: 'Moonshot',
+  ollama: 'Ollama',
+  together: 'Together AI',
+  fireworks: 'Fireworks',
+  huggingface: 'Hugging Face',
+  meta: 'Meta',
+  novita: 'Novita',
+  deepinfra: 'DeepInfra',
+  stepfun: 'StepFun',
+  siliconflow: 'SiliconFlow',
+  vllm: 'vLLM',
+  sglang: 'SGLang',
+};
+
+// Env-var candidates per provider for display-only key detection — mirrors
+// clawcodex's resolve_api_key fallback (configured key first, then env).
+const PROVIDER_ENV_VARS = {
+  anthropic: ['ANTHROPIC_API_KEY'],
+  openai: ['OPENAI_API_KEY'],
+  deepseek: ['DEEPSEEK_API_KEY'],
+  gemini: ['GEMINI_API_KEY', 'GOOGLE_API_KEY'],
+  zai: ['ZAI_API_KEY', 'Z_AI_API_KEY'],
+  minimax: ['MINIMAX_API_KEY'],
+  openrouter: ['OPENROUTER_API_KEY'],
+  moonshot: ['MOONSHOT_API_KEY'],
+  together: ['TOGETHER_API_KEY'],
+  fireworks: ['FIREWORKS_API_KEY'],
+  huggingface: ['HF_TOKEN', 'HUGGINGFACE_API_KEY'],
+  meta: ['META_API_KEY', 'LLAMA_API_KEY'],
+};
+
+function asNonEmptyString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+/** First token of a launch command, honoring a quoted executable path. */
+function getExecutableFromCommand(command) {
+  const normalized = String(command || '').trim();
+  if (!normalized) {
+    return '';
+  }
+
+  const doubleQuotedMatch = normalized.match(/^"([^"]+)"/);
+  if (doubleQuotedMatch) {
+    return doubleQuotedMatch[1];
+  }
+
+  const singleQuotedMatch = normalized.match(/^'([^']+)'/);
+  if (singleQuotedMatch) {
+    return singleQuotedMatch[1];
+  }
+
+  return normalized.split(/\s+/)[0];
+}
+
+function chooseLaunchWorkspace({ activeWorkspacePath, workspacePaths }) {
+  const activePath = asNonEmptyString(activeWorkspacePath);
+  if (activePath) {
+    return { workspacePath: activePath, source: 'active-workspace' };
+  }
+
+  const firstWorkspacePath = Array.isArray(workspacePaths)
+    ? asNonEmptyString(workspacePaths[0])
+    : null;
+
+  if (firstWorkspacePath) {
+    return { workspacePath: firstWorkspacePath, source: 'first-workspace' };
+  }
+
+  return { workspacePath: null, source: 'none' };
+}
+
+/**
+ * Resolve the clawcodex user config directory: $CLAWCODEX_CONFIG_DIR or
+ * ~/.clawcodex. Never falls back to ~/.claude — clawcodex deliberately does
+ * not share state with a Claude Code install on the same machine.
+ */
+function resolveConfigDir(env = process.env) {
+  const override = asNonEmptyString(env.CLAWCODEX_CONFIG_DIR);
+  if (override) return override;
+  return path.join(os.homedir(), '.clawcodex');
+}
+
+/**
+ * Parse ~/.clawcodex/config.json into the slice the Control Center needs.
+ * Returns null when the file is missing, unreadable, or not a JSON object —
+ * the provider state then reports 'unknown' instead of guessing.
+ */
+function parseClawcodexConfig(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    const providers =
+      parsed.providers && typeof parsed.providers === 'object' && !Array.isArray(parsed.providers)
+        ? parsed.providers
+        : {};
+    return {
+      defaultProvider: asNonEmptyString(parsed.default_provider),
+      providers,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function readClawcodexConfig(env = process.env) {
+  const configPath = path.join(resolveConfigDir(env), 'config.json');
+  try {
+    if (!fs.existsSync(configPath)) return { config: null, configPath };
+    return { config: parseClawcodexConfig(fs.readFileSync(configPath, 'utf8')), configPath };
+  } catch {
+    return { config: null, configPath };
+  }
+}
+
+/**
+ * Parse a workspace `.clawcodex/settings.json`. Valid = any JSON object;
+ * clawcodex project settings have no mandatory fields.
+ */
+function parseProjectSettings(raw) {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function providerLabel(name) {
+  const normalized = asNonEmptyString(name);
+  if (!normalized) return 'Unknown';
+  if (PROVIDER_LABELS[normalized]) return PROVIDER_LABELS[normalized];
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
+function envKeyFor(providerName, env) {
+  const candidates = PROVIDER_ENV_VARS[providerName] || [
+    `${String(providerName || '').toUpperCase().replace(/[^A-Z0-9]/g, '_')}_API_KEY`,
+  ];
+  for (const key of candidates) {
+    if (asNonEmptyString(env?.[key])) return key;
+  }
+  return null;
+}
+
+/**
+ * Conservative provider summary for the Control Center.
+ *
+ * Sources, in precedence order:
+ *   'setting' — VS Code setting clawcodex.provider overrides the config default
+ *   'config'  — config.json default_provider with a configured api_key
+ *   'env'     — provider selected but keyed via an environment variable
+ *   'unknown' — no config file / no provider — shown honestly, never guessed
+ */
+function describeProviderState({ config, env = {}, settingsProvider, settingsModel } = {}) {
+  const overrideProvider = asNonEmptyString(settingsProvider);
+  const providerName = overrideProvider || config?.defaultProvider || null;
+
+  if (!providerName) {
+    return {
+      label: 'Unknown',
+      detail: config ? 'no default provider configured' : 'no clawcodex config found',
+      source: 'unknown',
+    };
+  }
+
+  const providerCfg =
+    config?.providers && typeof config.providers[providerName] === 'object'
+      ? config.providers[providerName]
+      : {};
+  const model =
+    asNonEmptyString(settingsModel) ||
+    asNonEmptyString(providerCfg.default_model) ||
+    null;
+  const detailBase = model || asNonEmptyString(providerCfg.base_url) || 'provider default model';
+
+  const hasConfiguredKey = Boolean(asNonEmptyString(providerCfg.api_key));
+  const envKey = hasConfiguredKey ? null : envKeyFor(providerName, env);
+
+  let source;
+  if (overrideProvider) {
+    source = 'setting';
+  } else if (hasConfiguredKey) {
+    source = 'config';
+  } else if (envKey) {
+    source = 'env';
+  } else {
+    source = 'config';
+  }
+
+  let detail = detailBase;
+  if (!hasConfiguredKey && envKey) {
+    detail = `${detailBase} · key from ${envKey}`;
+  } else if (!hasConfiguredKey && !envKey) {
+    detail = `${detailBase} · no API key detected`;
+  }
+
+  return {
+    label: providerLabel(providerName),
+    detail,
+    source,
+  };
+}
+
+function resolveCommandCheckPath(command, workspacePath) {
+  const normalized = asNonEmptyString(command);
+  if (!normalized) {
+    return null;
+  }
+
+  if (!normalized.includes(path.sep) && !normalized.includes('/')) {
+    return null;
+  }
+
+  if (path.isAbsolute(normalized)) {
+    return normalized;
+  }
+
+  return workspacePath
+    ? path.resolve(workspacePath, normalized)
+    : path.resolve(normalized);
+}
+
+function getEnvValue(env, key) {
+  if (!env || typeof env !== 'object') {
+    return '';
+  }
+
+  const matchedKey = Object.keys(env).find(candidate => candidate.toUpperCase() === key);
+  return matchedKey ? env[matchedKey] : '';
+}
+
+function canAccessExecutable(filePath, platform) {
+  try {
+    fs.accessSync(filePath, platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function findCommandPath(command, options = {}) {
+  const normalized = asNonEmptyString(command);
+  if (!normalized) {
+    return null;
+  }
+
+  const cwd = asNonEmptyString(options.cwd);
+  const env = options.env || process.env;
+  const platform = options.platform || process.platform;
+  const hasPathSeparators = normalized.includes(path.sep) || normalized.includes('/');
+
+  if (hasPathSeparators) {
+    if (!path.isAbsolute(normalized) && !cwd) {
+      return null;
+    }
+
+    const directPath = resolveCommandCheckPath(normalized, cwd);
+    return directPath && canAccessExecutable(directPath, platform) ? directPath : null;
+  }
+
+  const pathValue = getEnvValue(env, 'PATH');
+  if (!pathValue) {
+    return null;
+  }
+
+  const pathExtValue = getEnvValue(env, 'PATHEXT');
+  const hasExplicitExtension = Boolean(path.extname(normalized));
+  const extensions = platform === 'win32'
+    ? (hasExplicitExtension
+        ? ['']
+        : (pathExtValue || '.COM;.EXE;.BAT;.CMD')
+            .split(';')
+            .map(extension => extension.trim())
+            .filter(Boolean))
+    : [''];
+
+  for (const directory of pathValue.split(path.delimiter)) {
+    const baseDirectory = asNonEmptyString(directory);
+    if (!baseDirectory) {
+      continue;
+    }
+
+    for (const extension of extensions) {
+      const candidatePath = path.join(baseDirectory, `${normalized}${extension}`);
+      if (canAccessExecutable(candidatePath, platform)) {
+        return candidatePath;
+      }
+    }
+  }
+
+  return null;
+}
+
+function isPathInsideWorkspace(filePath, workspacePath) {
+  const normalizedFilePath = asNonEmptyString(filePath);
+  const normalizedWorkspacePath = asNonEmptyString(workspacePath);
+  if (!normalizedFilePath || !normalizedWorkspacePath) {
+    return false;
+  }
+
+  const resolvedFilePath = path.resolve(normalizedFilePath);
+  const resolvedWorkspacePath = path.resolve(normalizedWorkspacePath);
+  const comparableFilePath = process.platform === 'win32'
+    ? resolvedFilePath.toLowerCase()
+    : resolvedFilePath;
+  const comparableWorkspacePath = process.platform === 'win32'
+    ? resolvedWorkspacePath.toLowerCase()
+    : resolvedWorkspacePath;
+  const relativePath = path.relative(comparableWorkspacePath, comparableFilePath);
+
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+}
+
+module.exports = {
+  chooseLaunchWorkspace,
+  describeProviderState,
+  findCommandPath,
+  getExecutableFromCommand,
+  isPathInsideWorkspace,
+  parseClawcodexConfig,
+  parseProjectSettings,
+  providerLabel,
+  readClawcodexConfig,
+  resolveCommandCheckPath,
+  resolveConfigDir,
+  PROVIDER_ENV_VARS,
+};

--- a/vscode-extension/clawcodex-vscode/src/state.test.js
+++ b/vscode-extension/clawcodex-vscode/src/state.test.js
@@ -1,0 +1,202 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  chooseLaunchWorkspace,
+  describeProviderState,
+  findCommandPath,
+  parseClawcodexConfig,
+  parseProjectSettings,
+  resolveCommandCheckPath,
+  resolveConfigDir,
+} = require('./state');
+
+test('chooseLaunchWorkspace prefers the active workspace folder', () => {
+  assert.deepEqual(
+    chooseLaunchWorkspace({
+      activeWorkspacePath: '/repo-b',
+      workspacePaths: ['/repo-a', '/repo-b'],
+    }),
+    { workspacePath: '/repo-b', source: 'active-workspace' },
+  );
+});
+
+test('chooseLaunchWorkspace falls back to the first workspace folder', () => {
+  assert.deepEqual(
+    chooseLaunchWorkspace({
+      activeWorkspacePath: null,
+      workspacePaths: ['/repo-a', '/repo-b'],
+    }),
+    { workspacePath: '/repo-a', source: 'first-workspace' },
+  );
+});
+
+test('resolveConfigDir honors CLAWCODEX_CONFIG_DIR and never falls back to ~/.claude', () => {
+  assert.equal(resolveConfigDir({ CLAWCODEX_CONFIG_DIR: '/custom/dir' }), '/custom/dir');
+  const fallback = resolveConfigDir({});
+  assert.equal(fallback, path.join(os.homedir(), '.clawcodex'));
+  assert.ok(!fallback.includes('.claude' + path.sep) && !fallback.endsWith('.claude'));
+});
+
+test('parseClawcodexConfig returns null for invalid JSON', () => {
+  assert.equal(parseClawcodexConfig('{bad json}'), null);
+});
+
+test('parseClawcodexConfig returns null for non-object documents', () => {
+  assert.equal(parseClawcodexConfig('[1, 2, 3]'), null);
+  assert.equal(parseClawcodexConfig('"provider"'), null);
+});
+
+test('parseClawcodexConfig extracts default provider and providers map', () => {
+  assert.deepEqual(
+    parseClawcodexConfig(JSON.stringify({
+      default_provider: 'deepseek',
+      providers: {
+        deepseek: { api_key: 'sk-x', base_url: 'https://api.deepseek.com', default_model: 'deepseek-chat' },
+      },
+      session: {},
+    })),
+    {
+      defaultProvider: 'deepseek',
+      providers: {
+        deepseek: { api_key: 'sk-x', base_url: 'https://api.deepseek.com', default_model: 'deepseek-chat' },
+      },
+    },
+  );
+});
+
+test('parseProjectSettings accepts any JSON object and rejects the rest', () => {
+  assert.deepEqual(parseProjectSettings('{"permissions": {}}'), { permissions: {} });
+  assert.equal(parseProjectSettings('[1]'), null);
+  assert.equal(parseProjectSettings('not json'), null);
+});
+
+test('resolveCommandCheckPath resolves workspace-relative executables', () => {
+  assert.equal(
+    resolveCommandCheckPath('./node_modules/.bin/clawcodex', '/repo'),
+    path.resolve('/repo', './node_modules/.bin/clawcodex'),
+  );
+});
+
+test('resolveCommandCheckPath leaves bare commands alone', () => {
+  assert.equal(resolveCommandCheckPath('clawcodex', '/repo'), null);
+});
+
+test('findCommandPath treats shell-like input as a literal executable name', t => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawcodex-command-'));
+  t.after(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const commandName = process.platform === 'win32'
+    ? 'clawcodex & whoami'
+    : 'clawcodex && whoami';
+  const executableName = process.platform === 'win32'
+    ? `${commandName}.cmd`
+    : commandName;
+  const executablePath = path.join(tempDir, executableName);
+
+  fs.writeFileSync(executablePath, process.platform === 'win32' ? '@echo off\r\n' : '#!/bin/sh\n');
+  if (process.platform !== 'win32') {
+    fs.chmodSync(executablePath, 0o755);
+  }
+
+  const resolvedPath = findCommandPath(commandName, {
+    cwd: null,
+    env: {
+      PATH: tempDir,
+      PATHEXT: '.CMD;.EXE',
+    },
+    platform: process.platform,
+  });
+
+  assert.ok(resolvedPath);
+  assert.equal(resolvedPath.toLowerCase(), executablePath.toLowerCase());
+});
+
+function makeConfig(overrides = {}) {
+  return {
+    defaultProvider: 'anthropic',
+    providers: {
+      anthropic: { api_key: 'sk-ant', base_url: '', default_model: 'claude-opus-4-6' },
+      deepseek: { api_key: '', base_url: 'https://api.deepseek.com', default_model: 'deepseek-chat' },
+      ...((overrides.providers) || {}),
+    },
+    ...overrides,
+  };
+}
+
+test('describeProviderState reports the config default provider with a configured key', () => {
+  assert.deepEqual(
+    describeProviderState({ config: makeConfig(), env: {} }),
+    {
+      label: 'Anthropic',
+      detail: 'claude-opus-4-6',
+      source: 'config',
+    },
+  );
+});
+
+test('describeProviderState lets the VS Code setting override the config default', () => {
+  const state = describeProviderState({
+    config: makeConfig(),
+    env: { DEEPSEEK_API_KEY: 'sk-ds' },
+    settingsProvider: 'deepseek',
+  });
+  assert.equal(state.label, 'DeepSeek');
+  assert.equal(state.source, 'setting');
+  assert.match(state.detail, /deepseek-chat/);
+});
+
+test('describeProviderState reports env-sourced keys for unkeyed providers', () => {
+  const config = makeConfig({ defaultProvider: 'deepseek' });
+  assert.deepEqual(
+    describeProviderState({ config, env: { DEEPSEEK_API_KEY: 'sk-ds' } }),
+    {
+      label: 'DeepSeek',
+      detail: 'deepseek-chat · key from DEEPSEEK_API_KEY',
+      source: 'env',
+    },
+  );
+});
+
+test('describeProviderState flags a provider with no detectable key', () => {
+  const config = makeConfig({ defaultProvider: 'deepseek' });
+  const state = describeProviderState({ config, env: {} });
+  assert.equal(state.source, 'config');
+  assert.match(state.detail, /no API key detected/);
+});
+
+test('describeProviderState prefers the settings model in the detail line', () => {
+  const state = describeProviderState({
+    config: makeConfig(),
+    env: {},
+    settingsModel: 'claude-sonnet-5',
+  });
+  assert.equal(state.detail, 'claude-sonnet-5');
+});
+
+test('describeProviderState stays honest when nothing is configured', () => {
+  assert.deepEqual(
+    describeProviderState({ config: null, env: {} }),
+    {
+      label: 'Unknown',
+      detail: 'no clawcodex config found',
+      source: 'unknown',
+    },
+  );
+});
+
+test('describeProviderState stays honest when the config has no default provider', () => {
+  assert.deepEqual(
+    describeProviderState({ config: { defaultProvider: null, providers: {} }, env: {} }),
+    {
+      label: 'Unknown',
+      detail: 'no default provider configured',
+      source: 'unknown',
+    },
+  );
+});

--- a/vscode-extension/clawcodex-vscode/test/register-vscode-stub.js
+++ b/vscode-extension/clawcodex-vscode/test/register-vscode-stub.js
@@ -1,0 +1,18 @@
+/**
+ * Preload hook (`node --require`) that serves the local stub whenever code
+ * under test does `require('vscode')` — the real module only exists inside
+ * the VS Code extension host.
+ */
+
+const Module = require('module');
+const path = require('path');
+
+const stubPath = path.join(__dirname, 'vscode-stub.js');
+const originalResolve = Module._resolveFilename;
+
+Module._resolveFilename = function resolveWithVscodeStub(request, ...rest) {
+  if (request === 'vscode') {
+    return stubPath;
+  }
+  return originalResolve.call(this, request, ...rest);
+};

--- a/vscode-extension/clawcodex-vscode/test/vscode-stub.js
+++ b/vscode-extension/clawcodex-vscode/test/vscode-stub.js
@@ -1,0 +1,106 @@
+/**
+ * Minimal functional `vscode` module stub for `node --test` runs.
+ *
+ * The EventEmitter is real (fire → listeners) — processManager tests depend
+ * on actual event dispatch, not a no-op. Everything UI-facing is inert.
+ */
+
+class EventEmitter {
+  constructor() {
+    this._listeners = new Set();
+    this.event = (listener) => {
+      this._listeners.add(listener);
+      return { dispose: () => this._listeners.delete(listener) };
+    };
+  }
+
+  fire(payload) {
+    for (const listener of [...this._listeners]) {
+      listener(payload);
+    }
+  }
+
+  dispose() {
+    this._listeners.clear();
+  }
+}
+
+class Uri {
+  constructor(value) {
+    this._value = String(value);
+  }
+
+  static parse(value) {
+    return new Uri(value);
+  }
+
+  static file(value) {
+    const uri = new Uri(`file://${value}`);
+    uri.fsPath = String(value);
+    return uri;
+  }
+
+  toString() {
+    return this._value;
+  }
+}
+
+const disposable = () => ({ dispose() {} });
+
+module.exports = {
+  EventEmitter,
+  Uri,
+  ViewColumn: { Active: 1, Beside: -2 },
+  StatusBarAlignment: { Left: 1, Right: 2 },
+  ConfigurationTarget: { Global: 1, Workspace: 2 },
+  workspace: {
+    workspaceFolders: [],
+    getConfiguration: () => ({
+      get: (_key, fallback) => fallback,
+    }),
+    getWorkspaceFolder: () => null,
+    openTextDocument: async () => ({}),
+    registerTextDocumentContentProvider: disposable,
+    createFileSystemWatcher: () => ({
+      onDidCreate: disposable,
+      onDidChange: disposable,
+      onDidDelete: disposable,
+      dispose() {},
+    }),
+    onDidChangeConfiguration: disposable,
+    onDidChangeWorkspaceFolders: disposable,
+  },
+  window: {
+    activeTextEditor: null,
+    createWebviewPanel: () => ({
+      webview: { postMessage() {}, onDidReceiveMessage: disposable },
+      onDidDispose: disposable,
+      reveal() {},
+      dispose() {},
+    }),
+    registerWebviewViewProvider: disposable,
+    createStatusBarItem: () => ({
+      show() {},
+      hide() {},
+      dispose() {},
+      text: '',
+      tooltip: '',
+      command: '',
+    }),
+    createTerminal: () => ({ show() {}, sendText() {}, dispose() {} }),
+    showInformationMessage: async () => undefined,
+    showWarningMessage: async () => undefined,
+    showErrorMessage: async () => undefined,
+    showTextDocument: async () => undefined,
+    showQuickPick: async () => undefined,
+    onDidChangeActiveTextEditor: disposable,
+  },
+  env: {
+    openExternal: async () => true,
+    clipboard: { writeText: async () => undefined },
+  },
+  commands: {
+    registerCommand: disposable,
+    executeCommand: async () => undefined,
+  },
+};

--- a/vscode-extension/clawcodex-vscode/themes/Clawcodex-Terminal-Black.json
+++ b/vscode-extension/clawcodex-vscode/themes/Clawcodex-Terminal-Black.json
@@ -1,0 +1,78 @@
+{
+  "$schema": "vscode://schemas/color-theme",
+  "name": "Clawcodex Terminal Black",
+  "type": "dark",
+  "colors": {
+    "editor.background": "#090B10",
+    "editor.foreground": "#D6E2FF",
+    "editorCursor.foreground": "#66D9EF",
+    "editorLineNumber.foreground": "#3D4458",
+    "editorLineNumber.activeForeground": "#7F8AA3",
+    "editor.selectionBackground": "#1C2333",
+    "editor.inactiveSelectionBackground": "#141A27",
+    "editor.wordHighlightBackground": "#1C233344",
+    "editor.wordHighlightStrongBackground": "#24304B66",
+    "editorIndentGuide.background1": "#131825",
+    "editorIndentGuide.activeBackground1": "#2A3350",
+    "editorBracketMatch.background": "#25304B66",
+    "editorBracketMatch.border": "#66D9EF",
+    "terminal.background": "#090B10",
+    "terminal.foreground": "#D6E2FF",
+    "terminalCursor.background": "#66D9EF",
+    "terminalCursor.foreground": "#66D9EF",
+    "terminal.ansiBlack": "#090B10",
+    "terminal.ansiRed": "#FF6B6B",
+    "terminal.ansiGreen": "#89DD7C",
+    "terminal.ansiYellow": "#F2C14E",
+    "terminal.ansiBlue": "#5CA9FF",
+    "terminal.ansiMagenta": "#C792EA",
+    "terminal.ansiCyan": "#66D9EF",
+    "terminal.ansiWhite": "#D6E2FF",
+    "terminal.ansiBrightBlack": "#4A5165",
+    "terminal.ansiBrightRed": "#FF8787",
+    "terminal.ansiBrightGreen": "#A4EFA0",
+    "terminal.ansiBrightYellow": "#FFD479",
+    "terminal.ansiBrightBlue": "#86C1FF",
+    "terminal.ansiBrightMagenta": "#D8B0F5",
+    "terminal.ansiBrightCyan": "#9DE9FF",
+    "terminal.ansiBrightWhite": "#E8F0FF",
+    "statusBar.background": "#0F1420",
+    "statusBar.foreground": "#D6E2FF",
+    "activityBar.background": "#0D111B",
+    "activityBar.foreground": "#D6E2FF",
+    "sideBar.background": "#0B0F18",
+    "sideBar.foreground": "#B3BDD4",
+    "titleBar.activeBackground": "#0B0F18",
+    "titleBar.activeForeground": "#D6E2FF"
+  },
+  "tokenColors": [
+    {
+      "scope": ["comment", "punctuation.definition.comment"],
+      "settings": { "foreground": "#5A637B", "fontStyle": "italic" }
+    },
+    {
+      "scope": ["keyword", "storage.type", "storage.modifier"],
+      "settings": { "foreground": "#C792EA" }
+    },
+    {
+      "scope": ["string", "constant.other.symbol"],
+      "settings": { "foreground": "#89DD7C" }
+    },
+    {
+      "scope": ["constant.numeric", "constant.language"],
+      "settings": { "foreground": "#F2C14E" }
+    },
+    {
+      "scope": ["entity.name.function", "support.function"],
+      "settings": { "foreground": "#5CA9FF" }
+    },
+    {
+      "scope": ["variable", "entity.name.variable"],
+      "settings": { "foreground": "#D6E2FF" }
+    },
+    {
+      "scope": ["entity.name.type", "support.type", "entity.name.class"],
+      "settings": { "foreground": "#66D9EF" }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Ports upstream TypeScript implementation's the upstream TypeScript VS Code extension (in-repo `typescript/` reference) to clawcodex at **`vscode-extension/clawcodex-vscode/`**, and ships a backend fix the port surfaced. Design and implementation each went through a full critic REVISE→APPROVE loop.

### The extension

- **Chat** (activity-bar sidebar + editor panel, `Cmd/Ctrl+Shift+L`): streaming text and thinking deltas, tool-use cards with inputs/outputs, per-turn usage, session history with resume — and **working interactive permission prompts**: Allow / Deny / "Yes, `<session_label>`" persistent grants, destructive-command warnings, and ExitPlanMode plan bodies.
- **Control Center**: runtime-installed status, project-aware launch-cwd resolution, `.clawcodex/settings.json` project-settings detection, provider summary read from `~/.clawcodex/config.json` + env key candidates (`unknown` shown instead of guessing; the extension never writes config).
- **Terminal launch**, status-bar spinner, `Clawcodex Terminal Black` theme, activity-bar icon.

### Key design decision

The chat spawns **`clawcodex agent-server --stdio --workspace <cwd> --permission-mode <m>`** (the backend the Ink TUI uses) rather than the reference's `--print` stream-json flags: headless `-p` auto-denies permission asks and lacks `control_request` + per-turn `result`, which would leave the permission UI dead. The agent-server speaks the same SDK wire family the reference extension already consumed. Adaptations (all documented in `PORT_NOTES.md`):

- Client→server RPCs (`resume`, `list_sessions`) with `control_response` replies correlated by `request_id`; `interrupt` control for abort (SIGINT would kill the session) — fire-and-forget per the server contract.
- `allow-session` persists rules via `chosen_updates` (the server ignores the reference's `updatedPermissions`).
- Sessions read from flat `~/.clawcodex/sessions/*.json` (`updated_at` epoch-seconds, nullable `name`, **resolved** `cwd` → realpath-normalized workspace filter, fallback-to-all only when the workspace itself can't be resolved; unbounded scan with output-only cap so a busy machine can't silently empty Resume).
- Streaming state derives from the first delta (no `message_start` on this wire); Azure/Foundry env subsystem replaced by clawcodex-native provider detection.

### Backend fix: interrupt hang mid-stream

An agent-server `interrupt` during a live Anthropic stream stopped the deltas but **never emitted `result/cancelled`** — reproduced on the installed build too, so this also affected the TUI's ESC. Faulthandler showed the worker parked in `ssl.read()`: `response.close()` from the abort listener cannot wake a blocked reader (and the stream watchdog's own timeout close had the same flaw). New `force_close_response()` (`src/utils/stream_watchdog.py`) shuts the underlying socket down (`SHUT_RDWR` via httpcore's `network_stream` extension) before closing, now used by both `StreamAbortGuard` and the watchdog. After the fix: interrupt → `result/cancelled` instantly, session stays usable.

## Testing

- **Node**: 84/84 `node --test` cases (Node ≥21) behind a local `vscode` stub — protocol guards/builders, RPC map (round-trip / consumed-vs-forwarded / timeout / exit-reject against a fake NDJSON server), controller state machine (12 tests over recorded frames), session manager (symlink filter, >200-noise-files regression, tool pairing, traversal guard), permission payloads, control-center rendering incl. XSS escapes. `npm run lint` clean.
- **Python**: watchdog + abort-guard suites (incl. a real-socketpair blocked-`recv` unblock regression test), provider abort suites, `tests/server` + `tests/providers` (274), abort-controller + entrypoints — all green.
- **Live e2e** (`scripts/e2e-agent-server.mjs`, real agent-server + real provider): 8/8 — init handshake, `list_sessions` RPC, streaming turn, permission round-trip (`can_use_tool` with `session_label`, deny honored, file not created), interrupt → cancelled, post-interrupt turn success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)