### PR TITLE
fix(agent): port post-0.24 upstream TypeScript implementation harness reliability updates

### DIFF
--- a/src/memdir/memdir.py
+++ b/src/memdir/memdir.py
@@ -194,7 +194,7 @@ def _how_to_save_section(skip_index: bool) -> list[str]:
         "",
         f"**Step 2** — add a pointer to that file in `{ENTRYPOINT_NAME}`. `{ENTRYPOINT_NAME}` is an index, not a memory — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. It has no frontmatter. Never write memory content directly into `{ENTRYPOINT_NAME}`.",
         "",
-        f"- `{ENTRYPOINT_NAME}` is always loaded into your conversation context — lines after {MAX_ENTRYPOINT_LINES} will be truncated, so keep the index concise",
+        f"- `{ENTRYPOINT_NAME}` is always loaded into your conversation context — it is truncated after {MAX_ENTRYPOINT_LINES} lines or {_format_file_size(MAX_ENTRYPOINT_BYTES)}, whichever comes first, so keep the index concise (one short line per entry; long or many entries lose the tail)",
         "- Keep the name, description, and type fields in memory files up-to-date with the content",
         "- Organize memory semantically by topic, not chronologically",
         "- Update or remove memories that turn out to be wrong or outdated",

--- a/src/memdir/team_mem_prompts.py
+++ b/src/memdir/team_mem_prompts.py
@@ -16,6 +16,7 @@ from typing import Iterable
 
 from .memdir import (
     ENTRYPOINT_NAME,
+    MAX_ENTRYPOINT_BYTES,
     MAX_ENTRYPOINT_LINES,
 )
 from .memory_types import (
@@ -141,7 +142,7 @@ def _how_to_save_section(skip_index: bool) -> list[str]:
         "",
         f"**Step 2** — add a pointer to that file in the same directory's `{ENTRYPOINT_NAME}`. Each directory (private and team) has its own `{ENTRYPOINT_NAME}` index — each entry should be one line, under ~150 characters: `- [Title](file.md) — one-line hook`. They have no frontmatter. Never write memory content directly into a `{ENTRYPOINT_NAME}`.",
         "",
-        f"- Both `{ENTRYPOINT_NAME}` indexes are loaded into your conversation context — lines after {MAX_ENTRYPOINT_LINES} will be truncated, so keep them concise",
+        f"- Both `{ENTRYPOINT_NAME}` indexes are loaded into your conversation context — each is truncated after {MAX_ENTRYPOINT_LINES} lines or about {MAX_ENTRYPOINT_BYTES // 1024}KB, whichever comes first, so keep them concise",
         "- Keep the name, description, and type fields in memory files up-to-date with the content",
         "- Organize memory semantically by topic, not chronologically",
         "- Update or remove memories that turn out to be wrong or outdated",

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -2293,6 +2293,11 @@ async def query(
             )
             return
 
+        advisory_messages = [
+            UserMessage(content=advisory)
+            for advisory in guard_decision.advisories
+        ]
+
         next_turn_count = turn_count + 1
 
         if params.max_turns and next_turn_count > params.max_turns:
@@ -2316,7 +2321,13 @@ async def query(
             yield inj
 
         state = QueryState(
-            messages=[*messages, *assistant_messages, *tool_results, *injected_messages],
+            messages=[
+                *messages,
+                *assistant_messages,
+                *tool_results,
+                *advisory_messages,
+                *injected_messages,
+            ],
             tool_use_context=tool_use_context,
             auto_compact_tracking=state.auto_compact_tracking,
             turn_count=next_turn_count,

--- a/src/query/tool_failure_loop_guard.py
+++ b/src/query/tool_failure_loop_guard.py
@@ -29,6 +29,7 @@ _ENV_VAR = "CLAUDE_CODE_TOOL_FAILURE_LOOP_THRESHOLD"
 
 @dataclass
 class ToolFailureLoopGuardState:
+    persistent_signature_counts: dict[str, int] = field(default_factory=dict)
     signature_counts: dict[str, int] = field(default_factory=dict)
     category_counts: dict[str, int] = field(default_factory=dict)
     path_counts: dict[str, int] = field(default_factory=dict)
@@ -37,6 +38,7 @@ class ToolFailureLoopGuardState:
 @dataclass(frozen=True)
 class ToolFailureLoopGuardDecision:
     tripped: bool
+    advisories: tuple[str, ...] = ()
     message: str | None = None
     threshold: int | None = None
     kind: Literal["signature", "category", "path"] | None = None
@@ -86,18 +88,28 @@ def update_tool_failure_loop_guard(
     }
     failures: list[tuple[str, str, str | None]] = []
     has_success = False
+    successful_tool_names: set[str] = set()
+    successful_mutation_paths: set[str] = set()
 
     for block in _get_tool_result_blocks(tool_results):
         content = _tool_result_content_to_string(getattr(block, "content", None))
+        tool_use = tool_use_by_id.get(str(getattr(block, "tool_use_id", "") or ""))
 
         if getattr(block, "is_error", None) is not True:
             has_success = True
+            if tool_use is not None:
+                tool_name = getattr(tool_use, "name", None)
+                if tool_name:
+                    successful_tool_names.add(tool_name)
+                if tool_name in {"Edit", "MultiEdit", "Write", "NotebookEdit"}:
+                    path = _extract_normalized_path(getattr(tool_use, "input", None))
+                    if path:
+                        successful_mutation_paths.add(path)
             continue
 
         if _is_ignored_synthetic_tool_result(content):
             continue
 
-        tool_use = tool_use_by_id.get(str(getattr(block, "tool_use_id", "") or ""))
         tool_name = getattr(tool_use, "name", None) or "unknown"
         error_category = _normalize_error_category(content)
         failures.append((
@@ -106,30 +118,63 @@ def update_tool_failure_loop_guard(
             _extract_normalized_path(getattr(tool_use, "input", None)),
         ))
 
-    if has_success:
-        _reset(state)
-        return _NOT_TRIPPED
+    for tool_name in successful_tool_names:
+        prefix = f"{tool_name}\0"
+        for key in tuple(state.persistent_signature_counts):
+            if key.startswith(prefix):
+                del state.persistent_signature_counts[key]
 
-    for tool_name, error_category, path in failures:
-        signature_count = _increment_counter(
-            state.signature_counts, f"{tool_name}\0{error_category}"
+    advisories: list[str] = []
+    for tool_name, error_category, _path in failures:
+        count = _increment_counter(
+            state.persistent_signature_counts, f"{tool_name}\0{error_category}"
         )
-        category_count = _increment_counter(state.category_counts, error_category)
-        path_count = (
-            _increment_counter(state.path_counts, path) if path else 0
-        )
-
-        if path and path_count >= resolved_threshold:
+        if count >= resolved_threshold:
             return ToolFailureLoopGuardDecision(
                 tripped=True,
-                kind="path",
+                kind="signature",
                 threshold=resolved_threshold,
+                tool_name=tool_name,
+                error_category=error_category,
+                message=_create_trip_message(
+                    kind="signature", threshold=resolved_threshold,
+                    tool_name=tool_name, error_category=error_category,
+                ),
+            )
+        if resolved_threshold > 1 and count == resolved_threshold - 1:
+            advisories.append(_create_advisory_message(
+                threshold=resolved_threshold,
+                tool_name=tool_name,
+                error_category=error_category,
+            ))
+
+    for tool_name, error_category, path in failures:
+        if not path or path in successful_mutation_paths:
+            continue
+        path_count = _increment_counter(state.path_counts, path)
+        if path_count >= resolved_threshold:
+            return ToolFailureLoopGuardDecision(
+                tripped=True, kind="path", threshold=resolved_threshold,
                 path=path,
                 message=_create_trip_message(
                     kind="path", threshold=resolved_threshold, path=path,
                 ),
             )
 
+    if has_success:
+        state.signature_counts.clear()
+        state.category_counts.clear()
+        for path in successful_mutation_paths:
+            state.path_counts.pop(path, None)
+        return ToolFailureLoopGuardDecision(
+            tripped=False, advisories=tuple(advisories)
+        )
+
+    for tool_name, error_category, path in failures:
+        signature_count = _increment_counter(
+            state.signature_counts, f"{tool_name}\0{error_category}"
+        )
+        category_count = _increment_counter(state.category_counts, error_category)
         if signature_count >= resolved_threshold:
             return ToolFailureLoopGuardDecision(
                 tripped=True,
@@ -158,7 +203,9 @@ def update_tool_failure_loop_guard(
                 ),
             )
 
-    return _NOT_TRIPPED
+    return ToolFailureLoopGuardDecision(
+        tripped=False, advisories=tuple(advisories)
+    )
 
 
 def _normalize_threshold(threshold: int | None) -> int:
@@ -175,9 +222,28 @@ def _normalize_threshold(threshold: int | None) -> int:
 
 
 def _reset(state: ToolFailureLoopGuardState) -> None:
+    state.persistent_signature_counts.clear()
     state.signature_counts.clear()
     state.category_counts.clear()
     state.path_counts.clear()
+
+
+def _create_advisory_message(
+    *, threshold: int, tool_name: str, error_category: str,
+) -> str:
+    safe_tool = tool_name if re.fullmatch(r"[A-Za-z0-9_.:-]+", tool_name) else "unknown tool"
+    known_categories = {
+        "InputValidationError", "NoSuchTool", "PermissionError",
+        "NotFound", "FileWriteError",
+    }
+    safe_category = error_category if error_category in known_categories else "unknown error"
+    return (
+        "Warning: repeated tool failures are close to stopping this query.\n\n"
+        f"`{safe_tool}` failed {threshold - 1}/{threshold} times with "
+        f"`{safe_category}`. One more matching failure will stop the query. "
+        "Try a different tool, or verify the path, permissions, and tool "
+        "inputs before retrying."
+    )
 
 
 def _get_tool_result_blocks(messages: list[Any]) -> list[Any]:

--- a/src/services/compact/autocompact.py
+++ b/src/services/compact/autocompact.py
@@ -36,8 +36,13 @@ logger = logging.getLogger(__name__)
 # Based on p99.99 of compact summary output being 17,387 tokens.
 MAX_OUTPUT_TOKENS_FOR_SUMMARY = 20_000
 
-# Buffer between effective context window and autocompact threshold
-AUTOCOMPACT_BUFFER_TOKENS = 13_000
+# Auto-compact earlier so long interactive sessions do not accumulate enough
+# history to make each successive turn progressively slower (openclaude
+# #1949).  Keep the effective-window floor at the old value: coupling the
+# floor to this larger threshold buffer would unnecessarily shrink small
+# context windows.
+AUTOCOMPACT_BUFFER_TOKENS = 30_000
+AUTOCOMPACT_FLOOR_BUFFER_TOKENS = 13_000
 
 # Buffer for token warning states (UI warnings)
 WARNING_THRESHOLD_BUFFER_TOKENS = 20_000
@@ -120,7 +125,7 @@ def get_effective_context_window_size(
     # Floor: effective context must be at least the summary reservation plus a
     # usable buffer. If it goes lower, the auto-compact threshold becomes
     # negative and fires on every message.
-    return max(effective, reserved + AUTOCOMPACT_BUFFER_TOKENS)
+    return max(effective, reserved + AUTOCOMPACT_FLOOR_BUFFER_TOKENS)
 
 
 def get_auto_compact_threshold(
@@ -133,7 +138,17 @@ def get_auto_compact_threshold(
     Port of ``getAutoCompactThreshold`` in autoCompact.ts.
     """
     effective = get_effective_context_window_size(context_window, max_output_tokens)
-    threshold = effective - AUTOCOMPACT_BUFFER_TOKENS
+    # Ramp the buffer from 13k to 30k for mid-sized windows.  A direct jump
+    # would make warning thresholds negative and make a one-token increase in
+    # context size trigger compaction earlier rather than later.
+    buffer = min(
+        AUTOCOMPACT_BUFFER_TOKENS,
+        max(
+            AUTOCOMPACT_FLOOR_BUFFER_TOKENS,
+            effective - AUTOCOMPACT_BUFFER_TOKENS,
+        ),
+    )
+    threshold = effective - buffer
 
     # Override for easier testing of autocompact
     env_pct = _get_env_float("CLAUDE_AUTOCOMPACT_PCT_OVERRIDE")

--- a/tests/test_autocompact.py
+++ b/tests/test_autocompact.py
@@ -25,6 +25,7 @@ from src.services.compact.autocompact import (
     MIN_INPUT_TOKENS_FOR_AUTOCOMPACT,
     MAX_CONSECUTIVE_AUTOCOMPACT_FAILURES,
     AUTOCOMPACT_BUFFER_TOKENS,
+    AUTOCOMPACT_FLOOR_BUFFER_TOKENS,
     MAX_OUTPUT_TOKENS_FOR_SUMMARY,
 )
 
@@ -50,7 +51,10 @@ class TestGetEffectiveContextWindowSize(unittest.TestCase):
     def test_floor(self):
         """Effective context has a floor to prevent negative thresholds."""
         effective = get_effective_context_window_size(25_000)
-        self.assertGreaterEqual(effective, MAX_OUTPUT_TOKENS_FOR_SUMMARY + AUTOCOMPACT_BUFFER_TOKENS)
+        self.assertGreaterEqual(
+            effective,
+            MAX_OUTPUT_TOKENS_FOR_SUMMARY + AUTOCOMPACT_FLOOR_BUFFER_TOKENS,
+        )
 
     @patch.dict(os.environ, {"CLAUDE_CODE_AUTO_COMPACT_WINDOW": "100000"})
     def test_env_override(self):
@@ -63,10 +67,22 @@ class TestGetAutoCompactThreshold(unittest.TestCase):
     """Tests for get_auto_compact_threshold()."""
 
     def test_basic_threshold(self):
-        """Threshold = effective context window - buffer."""
+        """Large windows use the full earlier-compaction buffer."""
         threshold = get_auto_compact_threshold(200_000)
         effective = get_effective_context_window_size(200_000)
         self.assertEqual(threshold, effective - AUTOCOMPACT_BUFFER_TOKENS)
+
+    def test_small_window_retains_non_negative_floor(self):
+        threshold = get_auto_compact_threshold(25_000)
+        self.assertEqual(threshold, MAX_OUTPUT_TOKENS_FOR_SUMMARY)
+
+    def test_mid_sized_window_ramps_buffer_monotonically(self):
+        thresholds = [
+            get_auto_compact_threshold(window)
+            for window in range(53_000, 90_001, 1_000)
+        ]
+        self.assertEqual(thresholds, sorted(thresholds))
+        self.assertTrue(all(value >= 0 for value in thresholds))
 
     @patch.dict(os.environ, {"CLAUDE_AUTOCOMPACT_PCT_OVERRIDE": "50"})
     def test_percentage_override(self):

--- a/tests/test_mcp_env_expansion.py
+++ b/tests/test_mcp_env_expansion.py
@@ -43,3 +43,10 @@ class TestExpandEnvVarsInString:
         result = expand_env_vars_in_string("${NONEXISTENT:-}")
         assert result.expanded == ""
         assert result.missing_vars == []
+
+    def test_default_preserves_additional_colon_dash_sequences(self) -> None:
+        # Python maxsplit already avoids openclaude #1933's JS split(limit)
+        # truncation bug; keep that parity pinned as upstream evolves.
+        result = expand_env_vars_in_string("${NONEXISTENT:-a:-b}")
+        assert result.expanded == "a:-b"
+        assert result.missing_vars == []

--- a/tests/test_memdir_memdir.py
+++ b/tests/test_memdir_memdir.py
@@ -63,6 +63,15 @@ class TruncateEntrypointTest(unittest.TestCase):
         body = out.content.split("\n\n> WARNING")[0]
         self.assertTrue(body.startswith("- "))
 
+    def test_multibyte_content_is_measured_and_cut_in_utf8_bytes(self):
+        raw = "界" * (MAX_ENTRYPOINT_BYTES // 2)
+        out = truncate_entrypoint_content(raw)
+        body = out.content.split("\n\n> WARNING")[0]
+        self.assertTrue(out.was_byte_truncated)
+        self.assertGreater(out.byte_count, MAX_ENTRYPOINT_BYTES)
+        self.assertLessEqual(len(body.encode("utf-8")), MAX_ENTRYPOINT_BYTES)
+        self.assertNotIn("\ufffd", body)
+
 
 class EnsureMemoryDirExistsTest(unittest.TestCase):
     def test_creates_directory(self):

--- a/tests/test_tool_failure_loop_guard.py
+++ b/tests/test_tool_failure_loop_guard.py
@@ -108,8 +108,8 @@ class TestThreshold(unittest.TestCase):
 
 
 class TestSuccessReset(unittest.TestCase):
-    def test_any_success_resets_all_counters(self):
-        """guard:72-75, 91-94 — one non-error block resets everything."""
+    def test_same_tool_success_resets_its_persistent_counter(self):
+        """A success resets persistent failures for that tool."""
         state = create_tool_failure_loop_guard_state()
         blocks = [_tool_use("t1", "Bash")]
         for _ in range(2):
@@ -121,6 +121,7 @@ class TestSuccessReset(unittest.TestCase):
             _update(state, blocks, [_result("t1", "ok", is_error=False)]).tripped
         )
         self.assertEqual(state.signature_counts, {})
+        self.assertEqual(state.persistent_signature_counts, {})
         # Two more failures still under threshold.
         for _ in range(2):
             self.assertFalse(
@@ -145,12 +146,11 @@ class TestSuccessReset(unittest.TestCase):
         self.assertTrue(decision.tripped)
         self.assertEqual(decision.kind, "signature")
 
-    def test_mixed_batch_with_success_does_not_count_failures(self):
-        """A batch containing any success resets even if it also has
-        failures (TS checks hasSuccess before counting, guard:91-94)."""
+    def test_mixed_batch_counts_failure_for_a_different_tool(self):
+        """An unrelated success must not conceal a repeated failure."""
         state = create_tool_failure_loop_guard_state()
         blocks = [_tool_use("t1", "Bash"), _tool_use("t2", "Read")]
-        for _ in range(5):
+        for attempt in range(3):
             decision = _update(
                 state,
                 blocks,
@@ -159,8 +159,8 @@ class TestSuccessReset(unittest.TestCase):
                     _result("t2", "fine", is_error=False),
                 ],
             )
-            self.assertFalse(decision.tripped)
-        self.assertEqual(state.signature_counts, {})
+            self.assertEqual(decision.tripped, attempt == 2)
+        self.assertEqual(decision.tool_name, "Bash")
 
 
 class TestIgnoredSynthetics(unittest.TestCase):
@@ -282,6 +282,37 @@ class TestPathHandling(unittest.TestCase):
 
 
 class TestTripPrecedence(unittest.TestCase):
+    def test_warns_one_matching_failure_before_stop(self):
+        state = create_tool_failure_loop_guard_state()
+        blocks = [_tool_use("t1", "Read")]
+        first = _update(state, blocks, [_result("t1", "ENOENT: gone")])
+        second = _update(state, blocks, [_result("t1", "ENOENT: gone")])
+        self.assertEqual(first.advisories, ())
+        self.assertEqual(len(second.advisories), 1)
+        self.assertIn("failed 2/3 times", second.advisories[0])
+
+    def test_unrelated_success_does_not_hide_repeated_failure(self):
+        state = create_tool_failure_loop_guard_state()
+        blocks = [_tool_use("bad", "Read"), _tool_use("ok", "Grep")]
+        mixed = [
+            _result("bad", "ENOENT: gone"),
+            _result("ok", "matches", is_error=False),
+        ]
+        _update(state, blocks, mixed)
+        decision = _update(state, blocks, mixed)
+        self.assertEqual(len(decision.advisories), 1)
+        decision = _update(state, blocks, mixed)
+        self.assertTrue(decision.tripped)
+        self.assertEqual(decision.tool_name, "Read")
+
+    def test_same_tool_success_resets_persistent_signature(self):
+        state = create_tool_failure_loop_guard_state()
+        blocks = [_tool_use("t1", "Read")]
+        _update(state, blocks, [_result("t1", "ENOENT: gone")])
+        _update(state, blocks, [_result("t1", "ok", is_error=False)])
+        decision = _update(state, blocks, [_result("t1", "ENOENT: gone")])
+        self.assertEqual(decision.advisories, ())
+
     def test_signature_trip(self):
         """Same tool+category, different paths → kind='signature'
         (guard:123-137)."""

--- a/uv.lock
+++ b/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "anthropic"
-version = "0.88.0"
+version = "0.117.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -25,9 +25,9 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/68/565f13059c0a6a6fd5f96f306f2a0fb478a0e1174ec18a4df16b5fac9379/anthropic-0.88.0.tar.gz", hash = "sha256:f4c7f6863d08c869913516f08d658fe53caaf8bcc4fbea3218df343d2a876c58", size = 596654, upload-time = "2026-04-01T19:59:05.287Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/0d/8f71d535edb0d438f023bd825fb65f67c14fa88a2bd6b75f292a58a63de4/anthropic-0.117.0.tar.gz", hash = "sha256:98107f2b76439641e0ae2a1754087534b8f178dbab99d6eb1bc4b7bc8c744496", size = 989933, upload-time = "2026-07-16T19:36:13.07Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/ac/68f646998160c9f2e6f9353a31dd87292ef02b915b455aaf70a52a059a75/anthropic-0.88.0-py3-none-any.whl", hash = "sha256:71898b32332bc75d9739bc10095288d40a29605da6d00da2fe832b1aa036552f", size = 478338, upload-time = "2026-04-01T19:59:03.832Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4c/917d21d6619a4475cdafc6d13a69fdb3b901ddac57e76caca5a25c117b6d/anthropic-0.117.0-py3-none-any.whl", hash = "sha256:451a0a6905f11dff7663d13e4ee5dbf909eb8942b1d049803c7b937a13ac47ec", size = 998327, upload-time = "2026-07-16T19:36:11.225Z" },
 ]
 
 [[package]]
@@ -297,8 +297,8 @@ wheels = [
 ]
 
 [[package]]
-name = "clawcodex"
-version = "1.1.0"
+name = "clawcodex-cli"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -332,27 +332,27 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic" },
+    { name = "anthropic", specifier = ">=0.116.0" },
     { name = "build", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "httpx-sse", specifier = ">=0.4" },
     { name = "markdownify", specifier = ">=0.11" },
     { name = "mcp", specifier = ">=1.27.0" },
-    { name = "openai" },
+    { name = "openai", specifier = ">=1.109.1" },
     { name = "pathspec", specifier = ">=0.11" },
     { name = "pillow", specifier = ">=10.0" },
-    { name = "prompt-toolkit" },
+    { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
-    { name = "python-dotenv" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "regex", specifier = ">=2023.0" },
-    { name = "rich" },
+    { name = "rich", specifier = ">=13.9.4" },
     { name = "textual", specifier = ">=0.79" },
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0.0" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.16.0" },
     { name = "wcwidth", specifier = ">=0.2" },
     { name = "websockets", specifier = ">=14.0" },
 ]
@@ -2069,11 +2069,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.15.0"
+version = "4.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Ports the clearest Python-applicable agent-harness reliability changes from upstream TypeScript implementation commits after the 0.24.0 release (`2ff93a10` through `1ddb7d68`).

### Upstream analysis

The post-release TypeScript history clusters into these core improvements:

- bound long-session latency with earlier message/token compaction (`a3278153`, `630fc2d9`)
- warn before repeated tool failures terminate a query (`2448ea9b`)
- enforce read-only plan mode across hooks and permission races (`1f20e92c`)
- preserve correction context after interrupted turns (`eb72c770`)
- enforce OpenAI-compatible transport deadlines and recover rejected compatibility parameters (`3808d19d`, `487cae71`)
- bound persisted tool previews while preserving UTF-8-safe head/tail context (`507ba4b8`)
- fix byte-vs-character caps, session metadata scoping, context ordering, and LRU recency (`7b9e4775`, `ffc5a6e8`, `1d053b2a`, `2970b5fd`, `9fc8806f`)
- bound attachment/team-memory file I/O and revalidate background process identity (`c11c88bd`, `af0885d8`)

This PR ports the changes that map directly to current Python production paths without duplicating TypeScript-only failure modes.

### Implemented

- move auto-compaction from a fixed 13k buffer to the upstream 13k→30k ramp, preserving the small-window floor and monotonic thresholds
- track repeated failure signatures persistently per tool, even when unrelated tools succeed
- inject a model-visible warning one matching failure before the 3-failure stop
- reset persistent failure state only when that same tool succeeds; clear path state on successful mutating operations
- document both the 200-line and UTF-8 byte memory-index caps
- pin Python's already-correct UTF-8 truncation and `${VAR:-a:-b}` behavior with upstream regressions
- refresh the stale `uv.lock` to match the current `pyproject.toml` package/dependency metadata

## Verification

- `uv run --frozen pytest -q tests/test_tool_failure_loop_guard.py tests/test_autocompact.py tests/test_memdir_memdir.py tests/test_mcp_env_expansion.py` — 80 passed, 18 subtests
- adjacent query-loop suite — 47 passed
- project suite `uv run --frozen pytest -q tests` — 2,466 passed before an existing `tests/test_agent_loop_compat_model_error.py::test_connection_error_re_raises` retry path stalled against `localhost:4000`; interrupted after 169s
- changed Python modules compile successfully
- `git diff --check` clean

Bare `pytest` is not a valid repository-wide gate currently because it recursively collects vendored `reference_projects/` and produces import-path collisions; `pytest tests` targets the project suite.
