### PR TITLE
fix(context): honor runtime 1M model limits end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,7 +580,13 @@ The configuration file is saved in `~/.clawcodex/config.json`. Example structure
     "advisor_enabled": false,
     "advisor_model": "claude-sonnet-4-6",
     "advisor_client_mode": false,
-    "advisor_provider": "openai"
+    "advisor_provider": "openai",
+    "modelLimits": {
+      "private-1m-model": {
+        "contextWindow": 1000000,
+        "maxOutputTokens": 32768
+      }
+    }
   },
   "env": {
     "TAVILY_API_KEY": "tvly-YOUR-TAVILY-API-KEY"
@@ -598,6 +604,7 @@ The final Messages request URLs are
 
 - **`session`** — REPL session persistence: `auto_save` writes each session automatically; `max_history` caps retained turns.
 - **`settings`** — the advisor (reviewer) feature. **`advisor_enabled` is the master switch — `false` by default, so the advisor is OFF unless you opt in** (set it to `true`, or run `/advisor <provider>:<model>` which flips it on). `advisor_provider` / `advisor_model` pick the reviewer model; `advisor_client_mode` routes the call via the client.
+- **`settings.modelLimits`** — context/output limits for private or gateway models absent from the built-in catalog. Keys may be exact model IDs, model prefixes, or host-qualified IDs such as `localhost:4000:private-model`; exact matches beat prefixes and host-qualified keys beat bare keys within the same match type. Built-in catalog metadata remains authoritative.
 - **`env`** — secrets and environment values injected at startup (e.g. `TAVILY_API_KEY` for web search). Managed via `clawcodex config`; keys here are exported into the process environment without overriding anything you already set in your shell.
 
 ### Run

--- a/src/context_system/context_analyzer.py
+++ b/src/context_system/context_analyzer.py
@@ -81,10 +81,8 @@ def get_context_window_for_model(model: str) -> int:
     registry had 1M but this table didn't, and the display reads this function.
     """
     model_lower = model.lower()
-    for name, window in MODEL_CONTEXT_WINDOWS.items():
-        if name in model_lower:
-            return window
-    # Defer to the canonical model registry for ids not in the local table.
+    # Prefer the canonical registry/settings resolver. The old local-first
+    # order could hide a user-declared 1M limit behind a broad substring row.
     try:
         from ..models.context import (
             DEFAULT_CONTEXT_WINDOW as _REGISTRY_DEFAULT,
@@ -96,6 +94,9 @@ def get_context_window_for_model(model: str) -> int:
             return win
     except Exception:
         pass
+    for name, window in MODEL_CONTEXT_WINDOWS.items():
+        if name in model_lower:
+            return window
     # Try to extract a numeric window from model name (e.g., "gpt-4-32k")
     match = re.search(r'(\d+)k', model_lower)
     if match:

--- a/src/models/context.py
+++ b/src/models/context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import os
+from urllib.parse import urlparse
 
 from .configs import get_model_config
 
@@ -37,7 +38,68 @@ def strip_1m_context_suffix(model_id: str) -> str:
     return model_id
 
 
-def get_context_window_for_model(model_id: str) -> int:
+def _settings_limit(
+    model_id: str, field: str, *, base_url: str | None = None,
+) -> int | None:
+    """Resolve an exact/prefix ``modelLimits`` setting.
+
+    Exact model keys beat prefixes; within either tier a host-qualified key
+    beats a bare key. Invalid/non-positive values are ignored. This mirrors
+    the upstream settings override used for private OpenAI-compatible models.
+    """
+    try:
+        from src.settings.settings import get_settings
+
+        limits = get_settings().model_limits
+    except Exception:
+        return None
+    if not limits or not isinstance(model_id, str):
+        return None
+
+    model = strip_1m_context_suffix(model_id).lower()
+    host = ""
+    if base_url:
+        try:
+            host = (urlparse(base_url).netloc or "").lower()
+        except Exception:
+            host = ""
+
+    exact_host: list[object] = []
+    exact_bare: list[object] = []
+    prefix_host: list[tuple[int, object]] = []
+    prefix_bare: list[tuple[int, object]] = []
+    for raw_key, limit in limits.items():
+        key = str(raw_key).lower()
+        qualified = False
+        candidate = key
+        if host and key.startswith(f"{host}:"):
+            qualified = True
+            candidate = key[len(host) + 1 :]
+        elif ":" in key:
+            continue
+        if candidate == model:
+            (exact_host if qualified else exact_bare).append(limit)
+        elif model.startswith(candidate):
+            (prefix_host if qualified else prefix_bare).append(
+                (len(candidate), limit)
+            )
+
+    selected = None
+    if exact_host:
+        selected = exact_host[0]
+    elif exact_bare:
+        selected = exact_bare[0]
+    elif prefix_host:
+        selected = max(prefix_host, key=lambda item: item[0])[1]
+    elif prefix_bare:
+        selected = max(prefix_bare, key=lambda item: item[0])[1]
+    value = getattr(selected, field, None) if selected is not None else None
+    return value if isinstance(value, int) and not isinstance(value, bool) and value > 0 else None
+
+
+def get_context_window_for_model(
+    model_id: str, *, base_url: str | None = None,
+) -> int:
     """Get the context window size for a model.
 
     Recognizes the ``[1m]`` opt-in suffix (WI-5.3) and returns 1_000_000
@@ -49,10 +111,15 @@ def get_context_window_for_model(model_id: str) -> int:
     config = get_model_config(model_id)
     if config:
         return config.context_window
+    configured = _settings_limit(model_id, "context_window", base_url=base_url)
+    if configured is not None:
+        return configured
     return DEFAULT_CONTEXT_WINDOW
 
 
-def get_model_max_output_tokens(model_id: str) -> int:
+def get_model_max_output_tokens(
+    model_id: str, *, base_url: str | None = None,
+) -> int:
     """Get the maximum output tokens for a model.
 
     The ``[1m]`` suffix doesn't change max_output_tokens (only the input
@@ -63,11 +130,19 @@ def get_model_max_output_tokens(model_id: str) -> int:
     config = get_model_config(base_id)
     if config:
         return config.max_output_tokens
+    configured = _settings_limit(
+        model_id, "max_output_tokens", base_url=base_url
+    )
+    if configured is not None:
+        return configured
     return DEFAULT_MAX_OUTPUT_TOKENS
 
 
 def resolve_max_output_tokens(
-    override: int | None, model_id: str | None
+    override: int | None,
+    model_id: str | None,
+    *,
+    base_url: str | None = None,
 ) -> int:
     """Resolve the request-path ``max_tokens`` (ch04 round-3 G0).
 
@@ -103,5 +178,5 @@ def resolve_max_output_tokens(
             "ignoring invalid CLAUDE_CODE_MAX_OUTPUT_TOKENS=%r", raw
         )
     if model_id:
-        return get_model_max_output_tokens(model_id)
+        return get_model_max_output_tokens(model_id, base_url=base_url)
     return DEFAULT_MAX_OUTPUT_TOKENS

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -347,6 +347,16 @@ def _get_context_window(provider: BaseProvider) -> int:
     cw = getattr(provider, "context_window", None)
     if isinstance(cw, int) and cw > 0:
         return cw
+    model = getattr(provider, "model", None)
+    if isinstance(model, str) and model:
+        try:
+            from src.models.context import get_context_window_for_model
+
+            return get_context_window_for_model(
+                model, base_url=getattr(provider, "base_url", None)
+            )
+        except Exception:
+            logger.debug("model context-window resolution failed", exc_info=True)
     return 200_000
 
 
@@ -1023,7 +1033,9 @@ async def _call_model_sync(
         from ..models.context import resolve_max_output_tokens
 
         call_kwargs["max_tokens"] = resolve_max_output_tokens(
-            max_output_tokens_override, getattr(provider, "model", None)
+            max_output_tokens_override,
+            getattr(provider, "model", None),
+            base_url=getattr(provider, "base_url", None),
         )
     elif max_output_tokens_override is not None:
         call_kwargs["max_tokens"] = max_output_tokens_override

--- a/src/services/compact/pipeline.py
+++ b/src/services/compact/pipeline.py
@@ -70,6 +70,7 @@ class PipelineConfig:
 
     # Layer 5: autocompact
     context_window: int = 200_000
+    max_output_tokens: int | None = None
     autocompact_threshold: float = 0.80
     autocompact_tracking: AutoCompactTracking | None = None
 
@@ -110,9 +111,29 @@ def build_production_pipeline_config(
         for path, fp in fingerprints.items()
         if isinstance(fp, (tuple, list)) and fp
     }
+    model = getattr(provider, "model", "") or ""
+    context_window = 200_000
+    max_output_tokens = None
+    if model:
+        try:
+            from src.models.context import (
+                get_context_window_for_model,
+                get_model_max_output_tokens,
+            )
+
+            context_window = get_context_window_for_model(
+                model, base_url=getattr(provider, "base_url", None)
+            )
+            max_output_tokens = get_model_max_output_tokens(
+                model, base_url=getattr(provider, "base_url", None)
+            )
+        except Exception:
+            logger.debug("model context-window resolution failed", exc_info=True)
     return PipelineConfig(
         provider=provider,
-        model=getattr(provider, "model", "") or "",
+        model=model,
+        context_window=context_window,
+        max_output_tokens=max_output_tokens,
         read_file_state=read_file_state or None,
         autocompact_tracking=autocompact_tracking,
     )
@@ -239,6 +260,7 @@ class CompressionPipeline:
                     cfg.context_window,
                     cfg.provider,
                     cfg.model,
+                    max_output_tokens=cfg.max_output_tokens,
                     threshold_fraction=cfg.autocompact_threshold,
                     tracking=cfg.autocompact_tracking,
                     custom_instructions=cfg.custom_instructions,

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -83,6 +83,14 @@ class CompactSettings:
 
 
 @dataclass
+class ModelLimitSettings:
+    """User-declared runtime limits for custom/private model IDs."""
+
+    context_window: int | None = None
+    max_output_tokens: int | None = None
+
+
+@dataclass
 class HookSettings:
     """Hook configuration."""
     enabled: bool = True
@@ -117,6 +125,10 @@ class SettingsSchema:
     # vacuous and let /model mutate provider selection.
     model_provider: str = ""
     small_fast_model: str = ""
+    # Per-model limits for gateways/private deployments whose metadata is not
+    # in the built-in catalog. JSON accepts both modelLimits/contextWindow and
+    # the Python-native snake_case spellings.
+    model_limits: dict[str, ModelLimitSettings] = field(default_factory=dict)
     # /goal turn-budget backstop (src/goals). Claude Code ships the goal
     # loop unbounded; the port pauses the goal after this many evaluated
     # turns so a mis-judging evaluator can't spend unbounded tokens —
@@ -258,6 +270,13 @@ class SettingsSchema:
     def from_dict(cls, data: dict[str, Any]) -> SettingsSchema:
         """Deserialize from dict."""
         import dataclasses
+        data = dict(data)
+        if "modelLimits" in data:
+            # Defaults are materialized in snake_case before user settings are
+            # merged, so both keys can coexist. The explicit camelCase user
+            # value must replace that default rather than being relegated to
+            # ``extra``.
+            data["model_limits"] = data.pop("modelLimits")
         known_fields = {f.name for f in dataclasses.fields(cls)}
         known: dict[str, Any] = {}
         extra: dict[str, Any] = {}
@@ -292,6 +311,21 @@ class SettingsSchema:
             known["spinner_verbs"] = SpinnerVerbsSettings(**known["spinner_verbs"])
         if "compact" in known and isinstance(known["compact"], dict):
             known["compact"] = CompactSettings(**known["compact"])
+        if "model_limits" in known and isinstance(known["model_limits"], dict):
+            converted: dict[str, ModelLimitSettings] = {}
+            for name, value in known["model_limits"].items():
+                if isinstance(value, ModelLimitSettings):
+                    converted[str(name)] = value
+                elif isinstance(value, dict):
+                    converted[str(name)] = ModelLimitSettings(
+                        context_window=value.get(
+                            "contextWindow", value.get("context_window")
+                        ),
+                        max_output_tokens=value.get(
+                            "maxOutputTokens", value.get("max_output_tokens")
+                        ),
+                    )
+            known["model_limits"] = converted
         if "hooks" in known and isinstance(known["hooks"], dict):
             known["hooks"] = HookSettings(**known["hooks"])
         if "tools" in known and isinstance(known["tools"], dict):

--- a/tests/test_context_runtime_limits.py
+++ b/tests/test_context_runtime_limits.py
@@ -1,0 +1,112 @@
+"""Runtime context-limit parity for 1M and private gateway models."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.models.context import (
+    get_context_window_for_model,
+    get_model_max_output_tokens,
+)
+from src.services.compact.pipeline import build_production_pipeline_config
+from src.query.query import _get_context_window
+from src.settings.types import ModelLimitSettings, SettingsSchema
+from src.settings.settings import load_settings
+
+
+def _settings(limits: dict[str, ModelLimitSettings]) -> SettingsSchema:
+    return SettingsSchema(model_limits=limits)
+
+
+def test_production_pipeline_uses_registered_1m_window() -> None:
+    provider = SimpleNamespace(
+        model="glm-5.2", base_url="https://api.z.ai/v1"
+    )
+    context = SimpleNamespace(read_file_fingerprints={})
+    cfg = build_production_pipeline_config(provider, context, None)
+    assert cfg.context_window == 1_000_000
+    assert cfg.max_output_tokens == 8_192
+    assert _get_context_window(provider) == 1_000_000
+
+
+def test_explicit_provider_runtime_window_wins() -> None:
+    provider = SimpleNamespace(
+        model="unknown", base_url=None, context_window=1_048_576
+    )
+    assert _get_context_window(provider) == 1_048_576
+
+
+def test_unknown_model_uses_settings_limits() -> None:
+    configured = _settings({
+        "qwen3.6-plus": ModelLimitSettings(
+            context_window=1_048_576, max_output_tokens=32_768
+        )
+    })
+    with patch("src.settings.settings.get_settings", return_value=configured):
+        assert get_context_window_for_model("qwen3.6-plus") == 1_048_576
+        assert get_model_max_output_tokens("qwen3.6-plus") == 32_768
+
+
+def test_exact_key_beats_prefix_and_host_qualifies_equal_match() -> None:
+    configured = _settings({
+        "qwen": ModelLimitSettings(context_window=300_000),
+        "qwen3.6-plus": ModelLimitSettings(context_window=500_000),
+        "localhost:4000:qwen3.6-plus": ModelLimitSettings(
+            context_window=1_000_000
+        ),
+    })
+    with patch("src.settings.settings.get_settings", return_value=configured):
+        assert get_context_window_for_model("qwen3.6-plus") == 500_000
+        assert get_context_window_for_model(
+            "qwen3.6-plus", base_url="http://localhost:4000/v1"
+        ) == 1_000_000
+
+
+def test_catalog_metadata_remains_above_settings_override() -> None:
+    configured = _settings({
+        "glm-5.2": ModelLimitSettings(context_window=128_000)
+    })
+    with patch("src.settings.settings.get_settings", return_value=configured):
+        assert get_context_window_for_model("glm-5.2") == 1_000_000
+
+
+def test_settings_schema_accepts_upstream_camel_case_shape() -> None:
+    settings = SettingsSchema.from_dict({
+        "modelLimits": {
+            "private-model": {
+                "contextWindow": 1_000_000,
+                "maxOutputTokens": 64_000,
+            }
+        }
+    })
+    limit = settings.model_limits["private-model"]
+    assert limit.context_window == 1_000_000
+    assert limit.max_output_tokens == 64_000
+
+
+def test_loader_camel_case_overrides_materialized_default() -> None:
+    manager = SimpleNamespace(
+        load_global=lambda: {
+            "settings": {
+                "modelLimits": {
+                    "gateway-model": {"contextWindow": 1_000_000}
+                }
+            }
+        },
+        load_project=lambda: {},
+        load_local=lambda: {},
+    )
+    loaded = load_settings(config_manager=manager)
+    assert loaded.model_limits["gateway-model"].context_window == 1_000_000
+
+
+def test_invalid_settings_limits_fall_back_safely() -> None:
+    configured = _settings({
+        "private-model": ModelLimitSettings(
+            context_window=-1, max_output_tokens=True
+        )
+    })
+    with patch("src.settings.settings.get_settings", return_value=configured):
+        assert get_context_window_for_model("private-model") == 200_000
+        assert get_model_max_output_tokens("private-model") == 8_192


### PR DESCRIPTION
## Summary

Ports the applicable context-window and model-limit improvements from the recent upstream TypeScript history, primarily `06e0ae6e`, `5a796978`, `d0843bed`, `cd13a615`, and `de6b6bdd`.

### Fixed

- production compression now resolves the active model's registered context window instead of retaining the generic 200K `PipelineConfig` default
- query blocking guards fall back to canonical model metadata when the provider does not expose an explicit runtime window
- context analysis prefers the canonical resolver, preventing broad local substring entries from hiding configured limits
- output-token metadata is propagated into auto-compaction so its reservation matches the active model
- private and gateway models can declare `contextWindow` and `maxOutputTokens` through `settings.modelLimits`
- model-limit keys support exact, prefix, and host-qualified matching; exact matches beat prefixes, host-qualified keys beat bare keys within the same match type, and built-in catalog metadata remains authoritative
- camelCase settings load correctly even after snake_case defaults have been materialized

This closes a concrete 1M-window bug: registered models such as `glm-5.2` could display a 1M window while the live compression pipeline still compacted them using a 200K default.

## Configuration

```json
{
  "settings": {
    "modelLimits": {
      "private-1m-model": {
        "contextWindow": 1000000,
        "maxOutputTokens": 32768
      }
    }
  }
}
```

Host-qualified keys such as `localhost:4000:private-model` support deployments where the same model name has different limits at different endpoints.

## Verification

- 231 focused and adjacent tests passed, with 4 subtests
- changed Python modules compile successfully
- `git diff --check` clean

Coverage includes registered 1M models, explicit provider runtime limits, settings exact/prefix/host precedence, catalog precedence, camelCase loader behavior, invalid-value fallback, compression, query recovery, model metadata, and context status paths.
