### PR TITLE
fix(headless): ask_user returns autonomous-proceed signal (not bare empty strings)

### DIFF
--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -853,12 +853,25 @@ def _auto_deny_permission_handler(stderr: IO[str]):
     return handler
 
 
+_NON_INTERACTIVE_ANSWER = (
+    "No interactive user is available (running headless/non-interactive). "
+    "Proceed autonomously with your best judgment and reasonable default "
+    "assumptions; do not ask again."
+)
+
+
 def _noop_ask_user(questions):  # type: ignore[override]
-    # In non-interactive mode, collapse every question to an empty answer.
+    # Non-interactive mode: there is no user to answer. Returning bare
+    # empty strings left the model with no signal about WHY the answer was
+    # empty — observed live (terminal-bench raman-fitting) to make it flail,
+    # re-asking / retrying instead of committing to an approach. Return an
+    # explicit "proceed autonomously" answer so the model moves on
+    # decisively. (The interactive TUI still shows the real dialog; only the
+    # headless surface — which cannot collect input — substitutes this.)
     answers: dict = {}
     for q in questions or []:
         if isinstance(q, dict) and isinstance(q.get("question"), str):
-            answers[q["question"]] = ""
+            answers[q["question"]] = _NON_INTERACTIVE_ANSWER
     return answers
 
 


### PR DESCRIPTION
## Context
Follow-up to the `AgentTimeoutError` analysis on the clawcodex opus run (0.58) vs claude-code (0.72). **Key finding: AgentTimeoutError is overwhelmingly task-inherent, not a clawcodex bug** — 7 of 9 clawcodex timeouts also time out under claude-code (the same genuinely-long tasks: CompCert compile, DOOM-for-MIPS, QEMU boots, fasttext training — which carry 2400–3600s per-task timeouts), counts are at parity (9 vs 10), and claude-code times out on 3 tasks clawcodex completes. AgentTimeout was **not** a driver of the score gap (that was the 18 watchdog crashes, fixed in #734).

## This change
Of the 2 clawcodex-specific timeouts, `raman-fitting` revealed one concrete, fixable behavior: the agent called `AskUserQuestion`, the headless `_noop_ask_user` returned **bare empty strings**, and the model — with no signal about *why* the answers were empty — flailed through 23 curve-fit attempts and timed out. This returns an explicit *"no interactive user is available; proceed autonomously with your best judgment; do not ask again"* answer so the model commits to an approach instead of re-asking.

This is a headless-decisiveness quality fix; it is **not** claimed to fix AgentTimeout broadly (see finding above).

## Test plan
- [x] `_noop_ask_user` returns the autonomous-proceed message keyed per question
- [x] `tests/test_headless_cli.py` green
- [x] Interactive TUI path unchanged (still shows the real dialog; only the headless surface substitutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)