### PR TITLE
eval(harbor): trim removed-behavior history from the settings docstring

### DIFF
--- a/eval/harbor/clawcodex_agent.py
+++ b/eval/harbor/clawcodex_agent.py
@@ -456,15 +456,9 @@ class Clawcodex(BaseInstalledAgent):
         — the global-config path deliberately does not follow
         CLAWCODEX_CONFIG_DIR) makes the requested effort session-wide.
 
-        This seeds NOTHING but effort. An earlier version also appended
-        Harbor's wall-clock deadline to the system prompt ("stop broad
-        exploration, switch to the narrowest checks"). That is harness-shaped
-        guidance no other agent receives: the built-in claude-code adapter
-        appends nothing, so it made clawcodex-vs-Claude-Code trajectories
-        non-comparable, and it would not exist on a submitted run scored by
-        the official tooling. Any behavior worth having under a deadline
-        belongs in the product's own prompt, applied to every task, not
-        injected by an eval adapter.
+        Effort is the ONLY thing seeded here: guidance an eval adapter gives
+        one agent and not another does not belong in a comparison, and would
+        not exist on a run scored by the official tooling.
         """
         settings: dict[str, Any] = {}
         effort = self._resolved_flags.get("effort")


### PR DESCRIPTION
Follow-up to #751. Most of `_seed_container_settings`'s docstring described behavior the function no longer has — the rationale for removing the deadline injection belongs in the commit that removed it (`02fbcc91`), not in a permanent comment outliving it.

Reduces 9 lines of history to one sentence stating the invariant that matters: effort is the only thing seeded, because guidance an eval adapter gives one agent and not another doesn't belong in a comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)