### PR TITLE
fix(models): correct DeepSeek V4 max_output_tokens to the documented 384K

### DIFF
--- a/src/models/configs.py
+++ b/src/models/configs.py
@@ -220,18 +220,35 @@ MODEL_CONFIGS: dict[str, ModelConfig] = {
     # ``services/pricing.py`` (the single source the cost path reads). The
     # ``ModelConfig.cost_*`` defaults are unread for these models — duplicating
     # the rates here only invites 10× decimal drift between the two tables.
+    # ``max_output_tokens`` is DeepSeek's documented 384K ceiling, not the
+    # 8_192 first registered here — that was a placeholder sitting next to a
+    # 1M context window, and it under-reported the model by 47x in the
+    # token warning.
+    #
+    # It is ADVISORY on this wire, so correcting it changes little at
+    # runtime: OpenAICompatibleProvider sends no ``max_tokens`` field at all
+    # (unlike AnthropicProvider's ``_default_max_tokens`` or Gemini's
+    # ``config_kwargs["max_output_tokens"]``), so DeepSeek applies its own
+    # server-side default either way. The one live consumer is the
+    # auto-compact reservation, and it clamps to MAX_OUTPUT_TOKENS_FOR_SUMMARY
+    # (20_000), so the effective input window moves 991_808 -> 980_000 — 1.2%,
+    # in the safer direction.
+    #
+    # Recorded because the inertness is easy to mistake for a bug: this value
+    # was briefly suspected of truncating long ``effort=max`` responses on
+    # terminal-bench 2.1, and it cannot, because it never reaches the wire.
     "deepseek-v4-pro": ModelConfig(
         model_id="deepseek-v4-pro",
         display_name="DeepSeek V4 Pro",
         context_window=1_000_000,
-        max_output_tokens=8_192,
+        max_output_tokens=384_000,
         supports_cache=True,
     ),
     "deepseek-v4-flash": ModelConfig(
         model_id="deepseek-v4-flash",
         display_name="DeepSeek V4 Flash",
         context_window=1_000_000,
-        max_output_tokens=8_192,
+        max_output_tokens=384_000,
         supports_cache=True,
     ),
     # Z.ai GLM Coding Plan. glm-5.2 ships a 1M context window (like DeepSeek V4);

--- a/tests/test_deepseek_prefix_cache.py
+++ b/tests/test_deepseek_prefix_cache.py
@@ -49,7 +49,19 @@ def test_is_deepseek_flag_scoped_to_deepseek_provider():
 def test_deepseek_v4_context_windows_registered():
     assert get_context_window_for_model("deepseek-v4-pro") == 1_000_000
     assert get_context_window_for_model("deepseek-v4-flash") == 1_000_000
-    assert get_model_max_output_tokens("deepseek-v4-pro") == 8_192
+    # DeepSeek's documented ceiling. Was 8_192 — a placeholder that
+    # under-reported the model 47x in the token warning and looked absurd
+    # beside a 1M context window.
+    #
+    # Advisory on this wire: OpenAICompatibleProvider sends no ``max_tokens``
+    # field (unlike AnthropicProvider's _default_max_tokens or Gemini's
+    # config_kwargs), so DeepSeek applies its own server default either way,
+    # and the auto-compact reservation clamps to MAX_OUTPUT_TOKENS_FOR_SUMMARY
+    # (20_000). Effective input therefore moves 991_808 -> 980_000 only.
+    # Pinned so nobody "fixes" a timeout by editing this number: it cannot
+    # truncate a response, because it never reaches the request.
+    assert get_model_max_output_tokens("deepseek-v4-pro") == 384_000
+    assert get_model_max_output_tokens("deepseek-v4-flash") == 384_000
 
 
 def test_other_providers_context_window_unchanged():


### PR DESCRIPTION
Both V4 rows carried `max_output_tokens=8_192` — a placeholder sitting beside a `1_000_000` context window, under-reporting the model **47×** in the token warning. DeepSeek documents **384,000** for V4 Pro (including the max reasoning modes).

## It is advisory on this wire

Corrected and pinned, with a comment so the inertness isn't mistaken for a bug:

| provider | sends `max_tokens`? |
|---|---|
| Anthropic | **yes** — `_default_max_tokens` computes and sends one per request |
| Gemini | **yes** — `config_kwargs["max_output_tokens"]` |
| **OpenAI-compat (DeepSeek, GLM…)** | **no field at all** — server default applies |

The only live consumer is the auto-compact reservation, which clamps to `MAX_OUTPUT_TOKENS_FOR_SUMMARY` (20,000). Effective input moves **991,808 → 980,000** — 1.2%, in the more conservative direction.

## Why the disclaimer earns its lines

This field was suspected of truncating long `effort=max` responses during the terminal-bench 2.1 DeepSeek triage. **It cannot** — it never reaches the request. Per-trial durations located the real cause elsewhere:

- On the 50 trials both models completed, DeepSeek runs at **0.92× opus-5's wall-clock** — marginally *faster*. `effort=max` latency is not the problem.
- A handful of tasks stall outright: **`crack-7z-hash` burns its full 30-minute budget where opus-5 finishes in 18 seconds** — a 120× spread against a 0.92× median. That is a loop, not a token ceiling, and is tracked separately.

**No score change expected from this commit.** It fixes a displayed number and removes a false lead.

Tests: 389 passing in the affected area; the pinning test updated with the reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)