### PR TITLE
fix: retry transient transport failures; stop Read leaking image base64

### DIFF
--- a/src/providers/anthropic_provider.py
+++ b/src/providers/anthropic_provider.py
@@ -16,6 +16,8 @@ from .base import BaseProvider, ChatResponse, MessageInput, TextChunkCallback
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    import httpx
+
     from src.utils.abort_controller import AbortSignal
 
 
@@ -161,6 +163,59 @@ def _api_timeout_seconds() -> float:
     return DEFAULT_API_TIMEOUT_S
 
 
+#: Seconds allowed to establish the TCP+TLS connection. The Anthropic SDK's
+#: stock default is 5s (``anthropic._constants.DEFAULT_TIMEOUT``), which is
+#: tight enough that an ordinary DNS or TLS hiccup -- a VPN waking up, a
+#: roaming laptop, a cold resolver -- fails the request outright. The stock SDK
+#: hides that behind 2 automatic retries, but foreground turns disable those
+#: (``sdk_max_retries=0``, query.py) so the manual lane can own retry
+#: accounting. Widening the handshake budget removes the spurious failure at
+#: the source instead of paying a retry round-trip for it.
+DEFAULT_API_CONNECT_TIMEOUT_S = 15.0
+
+
+def _api_connect_timeout_seconds() -> float:
+    """Connect-phase timeout, env-tunable via ``API_CONNECT_TIMEOUT_MS``."""
+    raw = os.environ.get("API_CONNECT_TIMEOUT_MS", "").strip()
+    if raw.isdigit() and int(raw) > 0:
+        return int(raw) / 1000.0
+    return DEFAULT_API_CONNECT_TIMEOUT_S
+
+
+def _client_timeout() -> "httpx.Timeout | None":
+    """httpx timeout for Anthropic requests on both the streaming and
+    non-streaming paths.
+
+    Without this the client inherits the SDK default
+    ``Timeout(connect=5.0, read=600, write=600, pool=600)``. Two problems with
+    leaving it implicit:
+
+    * ``connect=5.0`` is the aggressive value documented on
+      :data:`DEFAULT_API_CONNECT_TIMEOUT_S`.
+    * only the non-streaming ``chat()`` path passed an explicit per-request
+      ``timeout``; the streaming (agentic) path -- i.e. every interactive turn
+      -- passed none at all, so its timeouts were whatever the SDK happened to
+      default to rather than anything this repo chose.
+
+    A bare float would set all four phases at once, giving ``connect`` the full
+    600s and letting a black-holed SYN hang for ten minutes, so build a real
+    ``httpx.Timeout`` and keep the phases separate.
+
+    The import guard is load-bearing, not defensive boilerplate: the module
+    ``__getattr__`` above substitutes a ``_MissingAnthropic`` stub when the SDK
+    is absent, whose job is to raise one clear "anthropic package is not
+    installed" message. httpx is an anthropic dependency, so it is missing in
+    exactly that situation -- returning ``None`` here keeps that clear message
+    intact instead of replacing it with an ImportError from this helper.
+    """
+    try:
+        import httpx
+    except Exception:  # noqa: BLE001 — never fail client creation over timeout cfg
+        return None
+    total = _api_timeout_seconds()
+    return httpx.Timeout(total, connect=_api_connect_timeout_seconds())
+
+
 # Mid-stream drop classification is shared with the OpenAI-compatible
 # wire (src/providers/stream_retry.py) — DeepSeek trials were dying on the
 # exact error this path already survived. Re-exported under the original
@@ -253,7 +308,16 @@ class AnthropicProvider(BaseProvider):
         # are visible. The first access triggers the PEP 562
         # ``__getattr__`` lazy-load above.
         mod = sys.modules[__name__]
-        self.client = mod.anthropic.Anthropic(**self._client_kwargs)
+        # Phase-split timeout for every request on this client, streaming
+        # included (see ``_client_timeout``). Applied here rather than stored in
+        # ``_client_kwargs`` so the env overrides are read when the client is
+        # actually built, and so ``_client_kwargs`` keeps holding only auth /
+        # header config that callers and tests inspect directly.
+        client_kwargs = dict(self._client_kwargs)
+        timeout = _client_timeout()
+        if timeout is not None:
+            client_kwargs.setdefault("timeout", timeout)
+        self.client = mod.anthropic.Anthropic(**client_kwargs)
         return self.client
 
     def _prepare_messages(self, messages: list[Any]) -> list[dict[str, Any]]:
@@ -586,7 +650,15 @@ class AnthropicProvider(BaseProvider):
         # take longer than 10 minutes"), so with opus-class 32K defaults
         # every non-streaming caller (compaction summarize, session title,
         # judges) was one large request away from a hard ValueError.
-        kwargs.setdefault("timeout", _api_timeout_seconds())
+        #
+        # Pass the phase-split ``httpx.Timeout``, never a bare float: httpx
+        # expands a float across ALL four phases, so the previous
+        # ``_api_timeout_seconds()`` here silently reset ``connect`` from the
+        # client-level 15s back to 600s. A black-holed SYN on a compaction
+        # summarize would then hang for ten minutes. Falls back to the float if
+        # httpx is unavailable, which still satisfies the SDK's "timeout must be
+        # set" requirement described above.
+        kwargs.setdefault("timeout", _client_timeout() or _api_timeout_seconds())
 
         response = client.messages.create(
             model=model,

--- a/src/providers/minimax_provider.py
+++ b/src/providers/minimax_provider.py
@@ -54,7 +54,20 @@ class MinimaxProvider(BaseProvider):
     def _ensure_client(self):
         if self.client is not None:
             return self.client
-        self.client = anthropic.Anthropic(**self._client_kwargs)
+        # Minimax speaks the Anthropic wire through the same SDK, the same
+        # ``_stream_abort`` guard and the same query-loop retry lane, so it has
+        # the same exposure to the SDK's tight 5s connect default that made a
+        # routine TLS hiccup fail a whole turn. Share the phase-split timeout
+        # rather than re-deriving it. (Deliberately NOT sharing
+        # ``add_cache_breakpoints`` -- that asymmetry is documented in
+        # ``anthropic_provider.chat_stream_response``.)
+        from .anthropic_provider import _client_timeout
+
+        client_kwargs = dict(self._client_kwargs)
+        timeout = _client_timeout()
+        if timeout is not None:
+            client_kwargs.setdefault("timeout", timeout)
+        self.client = anthropic.Anthropic(**client_kwargs)
         return self.client
 
     def _prepare_messages(self, messages: list[Any]) -> list[dict[str, Any]]:

--- a/src/providers/stream_retry.py
+++ b/src/providers/stream_retry.py
@@ -58,6 +58,22 @@ def is_transient_stream_drop(exc: BaseException) -> bool:
     # Anything carrying an HTTP status is a server verdict, not a drop.
     if getattr(exc, "status_code", None) is not None:
         return False
+    # Exact class name, NOT the MRO -- and that exclusion is deliberate, not an
+    # oversight. ``anthropic.APITimeoutError`` subclasses the listed
+    # ``APIConnectionError``, so an MRO walk would admit timeouts here. Timeouts
+    # are owned by the query-loop lane instead (``categorize_retryable_api_error``
+    # -> ``is_transport_error``), for two reasons:
+    #
+    #   * Contract: this predicate answers "did a stream die mid-response?" A
+    #     connect timeout never established a stream, so it isn't ours.
+    #   * Budget: this lane re-attempts up to ``stream_idle_max_attempts`` with
+    #     no backoff, and the query lane independently retries up to
+    #     ``DEFAULT_MAX_RETRIES``. Both owning the same error class multiplies
+    #     (3 x 11 = 33 wire attempts), turning a dead network into ~13 minutes
+    #     of silent waiting instead of one bounded, user-visible retry series.
+    #
+    # So: do not "fix" this into an isinstance/MRO check without moving the
+    # timeout family out of the query lane first.
     if type(exc).__name__ in _TRANSIENT_STREAM_DROP_TYPES:
         return True
     text = str(exc).lower()

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -4390,6 +4390,10 @@ def _display_tool_result(value: Any) -> dict | None:
       (language/shebang detection only; the original uses the pre-edit first
       line — differs only when line 1 itself changed); create-type keeps
       ``content`` for the file preview.
+    * Read-an-image (``type: "image"`` + ``file``) — reduced to ``originalSize``,
+      the only input the one-line render needs ("Read image (12.3KB)", UI.tsx
+      renderToolResultMessage). The base64 payload is dropped: it belongs on the
+      model-facing tool_result content, never on a display envelope.
     * WebSearch (``query``/``results``/``duration_seconds``) — reduced to the
       two numbers the original's one-line render needs (UI.tsx
       renderToolResultMessage: "Did N searches in Xs"): ``searchCount`` per
@@ -4416,6 +4420,28 @@ def _display_tool_result(value: Any) -> dict | None:
                 1 for r in value["results"] if r is not None and not isinstance(r, str)
             ),
         }
+    if value.get("type") == "image":
+        # Read-an-image: forward ONLY the byte count the one-line render needs
+        # (UI.tsx renderToolResultMessage: "Read image (12.3KB)"). The base64
+        # payload is deliberately dropped -- it belongs on the tool_result
+        # content bound for the model, never on the display envelope. Without
+        # this branch the function returned None, the client had no display
+        # data to key on, and its content fallback JSON-dumped the whole
+        # base64 image into the transcript.
+        file_data = value.get("file")
+        if not isinstance(file_data, dict):
+            return None
+        size = file_data.get("originalSize")
+        # ``int`` only, and never ``bool`` (an int subclass -- a True here means a
+        # buggy producer, not 1 byte). Deliberately not accepting ``float``:
+        # ``int(nan)``/``int(inf)`` RAISE, and this runs inside ``_sdk_envelope``
+        # whose caller ``on_message`` has no guard, so a stray non-finite would
+        # be turn-fatal. Every other malformed input here declines with None; a
+        # float size does too. The real producer passes ``stat.st_size``
+        # (read.py), already an int.
+        if not isinstance(size, int) or isinstance(size, bool):
+            return None
+        return {"type": "image", "originalSize": size}
     if value.get("type") not in ("create", "update"):
         return None
     if not isinstance(value.get("filePath"), str) or not isinstance(value.get("structuredPatch"), list):

--- a/src/services/api/errors.py
+++ b/src/services/api/errors.py
@@ -169,6 +169,14 @@ _TRANSPORT_ERROR_TYPES = frozenset({
 #: ``RemoteProtocolError`` (the peer misbehaved, which a re-issue can survive) is
 #: listed explicitly above, so nothing is lost by keeping the base name out.
 #:
+#: Also deliberately NOT listed: ``StreamIdleTimeout`` (or any ``TimeoutError``
+#: base that would catch it). It reads like a timeout, so it looks like it
+#: belongs -- but the provider's idle lane ALREADY re-attempts it up to
+#: ``stream_idle_max_attempts``. Adding it here would stack this lane's budget on
+#: top of that one: 3 x 11 = 33 attempts at a 90s idle deadline, a 45-minute
+#: silent hang. It is a plain ``Exception`` today, which is what keeps the two
+#: budgets from composing; keep it that way.
+#:
 #: Kept in sync by hand with ``_TRANSIENT_STREAM_DROP_TYPES`` in
 #: ``src/providers/stream_retry.py``, which answers the narrower question "is
 #: this a mid-stream drop worth re-issuing?" and so deliberately omits the

--- a/src/services/api/errors.py
+++ b/src/services/api/errors.py
@@ -123,6 +123,81 @@ def is_invalid_api_key(error: Exception) -> bool:
     return status == 401
 
 
+#: Exception type names meaning "the request never reached an HTTP verdict":
+#: DNS/TLS/connect failures, socket timeouts, and mid-flight drops.
+#:
+#: Matched by MRO type name rather than ``isinstance`` so this module stays free
+#: of provider-SDK imports. ``errors.py`` sits in the fast-path CLI import graph
+#: (``clawcodex --help`` reaches it), and importing ``anthropic``/``openai``/
+#: ``httpx`` just to run a classification check would put a heavy SDK on that
+#: path -- the same reasoning that keeps ``providers/stream_retry.py``
+#: dependency-free.
+#:
+#: The builtin ``ConnectionError``/``TimeoutError``/``OSError`` check is not
+#: sufficient on its own, which is the bug this set fixes: the Anthropic and
+#: OpenAI SDKs derive their transport errors from their own ``APIError`` base
+#: (plain ``Exception``) and httpx derives its timeouts from
+#: ``httpx.TransportError``. None of them subclass a builtin, and only
+#: ``APIStatusError`` carries ``status_code``, so every one of them fell through
+#: to ``retryable=False, error_type="unknown"``. That silently removed the
+#: retries the interactive lane depends on: ``query.py`` passes
+#: ``sdk_max_retries=0`` on foreground turns precisely so this manual lane owns
+#: them, so a misclassification here left a foreground turn with *fewer*
+#: attempts than a stock SDK client -- a 5s connect blip the SDK would have
+#: absorbed silently became a hard, user-visible ``APITimeoutError``.
+_TRANSPORT_ERROR_TYPES = frozenset({
+    # anthropic + openai SDKs (identical class names in both)
+    "APIConnectionError",
+    "APITimeoutError",
+    # httpx
+    "TimeoutException",
+    "ConnectTimeout",
+    "ReadTimeout",
+    "WriteTimeout",
+    "PoolTimeout",
+    "ConnectError",
+    "ReadError",
+    "WriteError",
+    "RemoteProtocolError",
+    # requests, for any future call path that uses it
+    "ChunkedEncodingError",
+})
+#: Deliberately NOT listed: bare ``ProtocolError``. ``httpx.LocalProtocolError``
+#: subclasses it and means *this client* emitted something illegal (malformed
+#: header, bad body/method combination, invalid state transition). That is
+#: deterministic -- retrying reproduces it ten times and then fails anyway.
+#: ``RemoteProtocolError`` (the peer misbehaved, which a re-issue can survive) is
+#: listed explicitly above, so nothing is lost by keeping the base name out.
+#:
+#: Kept in sync by hand with ``_TRANSIENT_STREAM_DROP_TYPES`` in
+#: ``src/providers/stream_retry.py``, which answers the narrower question "is
+#: this a mid-stream drop worth re-issuing?" and so deliberately omits the
+#: timeout family -- see the lane-ownership note there. Two sets, two questions;
+#: divergence between them is exactly what produced this bug, so change them
+#: together.
+
+
+def is_transport_error(error: BaseException) -> bool:
+    """True for a failure that produced no HTTP verdict, so retrying is sound.
+
+    Walks the MRO so a *subclass* of a listed type matches too. That is the
+    exact trap this guards: ``anthropic.APITimeoutError`` subclasses the listed
+    ``APIConnectionError``, so a name-only check on ``type(error).__name__``
+    misses it.
+
+    Anything carrying a status is a server verdict, not a transport failure --
+    those are classified by the status branches in
+    :func:`categorize_retryable_api_error`, which run before this one.
+    """
+    if getattr(error, "status", getattr(error, "status_code", None)) is not None:
+        return False
+    if isinstance(error, (ConnectionError, TimeoutError, OSError)):
+        return True
+    return any(
+        klass.__name__ in _TRANSPORT_ERROR_TYPES for klass in type(error).__mro__
+    )
+
+
 def is_media_size_error(raw: str) -> bool:
     return (
         ("image exceeds" in raw and "maximum" in raw)
@@ -215,7 +290,7 @@ def categorize_retryable_api_error(error: Exception) -> ErrorClassification:
             message=f"Server error ({status})",
         )
 
-    if isinstance(error, (ConnectionError, TimeoutError, OSError)):
+    if is_transport_error(error):
         return ErrorClassification(
             retryable=True,
             error_type="connection_error",

--- a/tests/server/test_sdk_envelope_tool_result.py
+++ b/tests/server/test_sdk_envelope_tool_result.py
@@ -193,3 +193,84 @@ class TestDiffUtilsNormalization:
         after = "x\ny\n++i;\n".splitlines(keepends=True)
         hunks = unified_diff_hunks(difflib.unified_diff(before, after, fromfile="a", tofile="b", n=3, lineterm=""))
         assert hunks[0]["lines"] == [" x", "--- sql comment", " y", "+++i;"]
+
+
+class TestDisplayToolResultImage:
+    """Read-an-image forwards a byte count and nothing else.
+
+    Regression: ``_display_tool_result`` recognized only create/update and
+    web_search, so an image read returned ``None``. With no display envelope to
+    key on, the client fell back to serializing the tool_result *content* --
+    which for an image is ``[{"type":"image","source":{"type":"base64",...}}]``
+    -- and printed the whole base64 payload into the transcript.
+    """
+
+    IMAGE_OUTPUT = {
+        "type": "image",
+        "file": {
+            "filePath": "/tmp/blog-sources.png",
+            "base64": "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAK",
+            "type": "image/jpeg",
+            "originalSize": 128_000,
+            "dimensions": {
+                "originalWidth": 1920,
+                "originalHeight": 1080,
+                "displayWidth": 960,
+                "displayHeight": 540,
+            },
+        },
+    }
+
+    def test_image_forwards_only_the_size(self):
+        assert _display_tool_result(self.IMAGE_OUTPUT) == {
+            "type": "image",
+            "originalSize": 128_000,
+        }
+
+    def test_base64_never_reaches_the_display_envelope(self):
+        trimmed = _display_tool_result(self.IMAGE_OUTPUT)
+        assert "base64" not in repr(trimmed)
+        assert "/9j/4AAQ" not in repr(trimmed)
+
+    def test_source_output_is_not_mutated(self):
+        original = copy.deepcopy(self.IMAGE_OUTPUT)
+        _display_tool_result(self.IMAGE_OUTPUT)
+        assert self.IMAGE_OUTPUT == original
+
+    def test_missing_size_declines_rather_than_guessing(self):
+        out = {"type": "image", "file": {"base64": "abc", "type": "image/png"}}
+        assert _display_tool_result(out) is None
+
+    def test_bool_size_rejected(self):
+        # bool is an int subclass; a True here means a buggy producer, not 1 byte.
+        out = {"type": "image", "file": {"originalSize": True}}
+        assert _display_tool_result(out) is None
+
+    def test_float_sizes_rejected_rather_than_coerced(self):
+        """``float`` is refused on purpose -- widening it back is turn-fatal.
+
+        ``int(nan)`` raises ValueError and ``int(inf)`` raises OverflowError, and
+        this runs inside ``_sdk_envelope`` whose caller ``on_message`` has no
+        guard, so a stray non-finite would kill the turn rather than decline.
+        Every other malformed input here returns None; these do too. A plain
+        ``128000.0`` is refused for the same reason -- accepting it would mean
+        re-admitting ``float``, and with it nan/inf.
+        """
+        for bad in (float("nan"), float("inf"), float("-inf"), 128_000.0):
+            out = {"type": "image", "file": {"originalSize": bad}}
+            assert _display_tool_result(out) is None, f"{bad!r} must decline"
+
+    def test_non_numeric_sizes_rejected(self):
+        for bad in ("128000", None, [128_000], {"bytes": 1}):
+            out = {"type": "image", "file": {"originalSize": bad}}
+            assert _display_tool_result(out) is None, f"{bad!r} must decline"
+
+    def test_non_dict_file_declines(self):
+        assert _display_tool_result({"type": "image", "file": "nope"}) is None
+
+    def test_reaches_the_wire_envelope(self):
+        msg = create_user_message("ok")
+        msg.toolUseResult = self.IMAGE_OUTPUT
+        env = _sdk_envelope(msg, "sess")
+        assert env["tool_use_result"] == {"type": "image", "originalSize": 128_000}
+        assert "/9j/4AAQ" not in repr(env)

--- a/tests/test_ch04_api_round4.py
+++ b/tests/test_ch04_api_round4.py
@@ -384,3 +384,121 @@ class TestWatchdogWarning(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTransportErrorRetryLane(unittest.TestCase):
+    """End-to-end: a transient transport failure must not kill the turn.
+
+    The unit tests in ``test_transport_error_retry_classification.py`` pin the
+    predicates; these pin the property the user actually experienced. The live
+    incident was a foreground turn dying on the Anthropic SDK's raw
+    "Request timed out or interrupted..." text, with the next two prompts doing
+    the same, because ``categorize_retryable_api_error`` classified the SDK's
+    transport errors as ``unknown``/non-retryable and ``query.py`` re-raised.
+
+    Without an end-to-end pin, a future guard added anywhere in the lane can
+    silently un-fix this while every predicate test still passes.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.ws = Path(self._tmp.name)
+        self._sleep = patch("src.query.query.asyncio.sleep", new=_fast_sleep)
+        self._sleep.start()
+
+    def tearDown(self):
+        self._sleep.stop()
+        self._tmp.cleanup()
+
+    @staticmethod
+    def _sdk_timeout():
+        import httpx
+        from anthropic import APITimeoutError
+
+        return APITimeoutError(
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        )
+
+    def test_sdk_timeout_then_success_completes_the_turn(self):
+        provider = _FlakyProvider([self._sdk_timeout()])
+        params = _make_params(workspace=self.ws, provider=provider)
+        messages, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(provider.calls, 2)
+        statuses = [
+            m for m in messages
+            if isinstance(m, SystemMessage) and m.subtype == "api_retry"
+        ]
+        self.assertEqual(len(statuses), 1)
+
+    def test_httpx_connect_timeout_then_success_completes_the_turn(self):
+        import httpx
+
+        provider = _FlakyProvider([httpx.ConnectTimeout("timed out")])
+        params = _make_params(workspace=self.ws, provider=provider)
+        _, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "completed")
+        self.assertEqual(provider.calls, 2)
+
+    def test_local_protocol_error_fails_immediately(self):
+        """A deterministic client-side fault must not burn the retry budget."""
+        import httpx
+
+        provider = _FlakyProvider([httpx.LocalProtocolError("illegal header")])
+        params = _make_params(workspace=self.ws, provider=provider)
+        _, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "model_error")
+        self.assertEqual(provider.calls, 1)
+
+    def test_transport_budget_exhausts_rather_than_looping(self):
+        provider = _FlakyProvider([self._sdk_timeout()] * (DEFAULT_MAX_RETRIES + 5))
+        params = _make_params(workspace=self.ws, provider=provider)
+        _, terminal = _run(run_query(params))
+        self.assertEqual(terminal.reason, "model_error")
+        self.assertLessEqual(provider.calls, DEFAULT_MAX_RETRIES + 1)
+
+    def test_aborted_request_is_never_reissued(self):
+        """The highest-stakes property: ESC must not be laundered into a retry.
+
+        The SDK's own message names "request cancellation" as a cause of
+        ``APITimeoutError``, and ESC-abort closes the stream underneath the
+        consumer, so a cancelled turn can surface as a now-retryable transport
+        error. If the abort guards ever regress, the agent would silently
+        re-issue work the user explicitly cancelled.
+
+        The pinned property is NO RE-ISSUE (``query.py`` checks
+        ``signal.aborted`` before consulting the classification). The terminal
+        reason here is ``model_error`` rather than an abort reason only because
+        this scripted provider raises the SDK error directly; the real provider
+        converts it via ``StreamAbortGuard.reraise_if_aborted``, which
+        ``tests/test_stream_abort_guard.py`` covers. Asserting on the reason
+        would pin the harness, not the behaviour.
+        """
+        provider = _FlakyProvider([self._sdk_timeout()] * 3)
+        params = _make_params(workspace=self.ws, provider=provider)
+        params.abort_controller.abort("user_interrupt")
+        _run(run_query(params))
+        self.assertEqual(provider.calls, 1, "an aborted request must never be re-issued")
+
+    def test_abort_raised_mid_request_is_never_reissued(self):
+        """Same guard, but the signal trips DURING the call, not before it.
+
+        Stronger than the pre-turn variant: it proves the lane reads the signal's
+        CURRENT state in the except block rather than a snapshot taken at loop
+        entry. A refactor that hoisted ``aborted`` out of the handler would pass
+        the pre-turn test and fail this one. This is also the real ESC shape —
+        the user interrupts a request already on the wire.
+        """
+        controller = AbortController()
+        errors = [self._sdk_timeout() for _ in range(3)]
+
+        class _AbortMidFlight(_FlakyProvider):
+            def chat_stream_response(self, *a, **k):
+                controller.abort("user_interrupt")
+                return super().chat_stream_response(*a, **k)
+
+        provider = _AbortMidFlight(errors)
+        params = _make_params(workspace=self.ws, provider=provider)
+        params.abort_controller = controller
+        _run(run_query(params))
+        self.assertEqual(provider.calls, 1, "an aborted request must never be re-issued")

--- a/tests/test_stream_watchdog.py
+++ b/tests/test_stream_watchdog.py
@@ -379,12 +379,27 @@ class TestChatExplicitTimeout(unittest.TestCase):
             provider.chat(messages=[{"role": "user", "content": "hi"}])
         return fake_client.messages.create.call_args.kwargs
 
+    # The value is a phase-split ``httpx.Timeout``, not a bare float. httpx
+    # expands a float across all four phases, so passing one here silently reset
+    # ``connect`` from the client-level 15s back to the 600s read budget — a
+    # black-holed SYN on a compaction summarize then hung for ten minutes.
+    # Assert per phase; the class's contract (a timeout IS set, so the SDK
+    # accepts large-``max_tokens`` non-streaming calls) is unchanged.
     def test_default_timeout_is_600s(self):
-        self.assertEqual(self._chat_create_kwargs().get("timeout"), 600.0)
+        from src.providers.anthropic_provider import DEFAULT_API_CONNECT_TIMEOUT_S
+
+        timeout = self._chat_create_kwargs().get("timeout")
+        self.assertEqual(timeout.read, 600.0)
+        self.assertEqual(timeout.connect, DEFAULT_API_CONNECT_TIMEOUT_S)
 
     def test_api_timeout_ms_env_override(self):
+        from src.providers.anthropic_provider import DEFAULT_API_CONNECT_TIMEOUT_S
+
         kwargs = self._chat_create_kwargs(env={"API_TIMEOUT_MS": "120000"})
-        self.assertEqual(kwargs.get("timeout"), 120.0)
+        timeout = kwargs.get("timeout")
+        self.assertEqual(timeout.read, 120.0)
+        # The env var governs the generation budget only, not the handshake.
+        self.assertEqual(timeout.connect, DEFAULT_API_CONNECT_TIMEOUT_S)
 
     def test_caller_supplied_timeout_wins(self):
         from src.providers.anthropic_provider import AnthropicProvider

--- a/tests/test_transport_error_retry_classification.py
+++ b/tests/test_transport_error_retry_classification.py
@@ -1,0 +1,297 @@
+"""Transport-level failures must classify as retryable.
+
+Regression for a live incident (claude-opus-5, interactive TUI): a turn died
+with the Anthropic SDK's raw ``APITimeoutError`` text
+("Request timed out or interrupted...") and every follow-up prompt did the same
+until the network settled, because nothing retried it.
+
+Two layers were responsible:
+
+1. SDK auto-retry -- disabled on foreground turns (``sdk_max_retries=0``,
+   ``query.py``) so the manual lane can own retry accounting.
+2. ``categorize_retryable_api_error`` -- tested ``isinstance`` against the
+   *builtin* ``ConnectionError``/``TimeoutError``/``OSError``, which no SDK
+   transport error subclasses, so everything fell through to
+   ``retryable=False, error_type="unknown"``. THIS was the defect.
+
+Net effect: a foreground turn had strictly FEWER attempts than a stock SDK
+client would give it.
+
+A third layer, ``is_transient_stream_drop``, also declines timeouts -- and that
+is CORRECT, not part of the bug. It answers the narrower question "did a stream
+die mid-response?", and it deliberately owns neither the contract nor the budget
+for timeouts; see the lane-ownership note in ``src/providers/stream_retry.py``
+and ``TestStreamRetryLaneOwnership`` below before changing it. Admitting
+timeouts there multiplies the two retry budgets (3 x 11 = 33 wire attempts).
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import httpx
+from anthropic import (
+    APIConnectionError as SDKAPIConnectionError,
+    APITimeoutError as SDKAPITimeoutError,
+    BadRequestError,
+)
+
+from src.providers.stream_retry import is_transient_stream_drop
+from src.services.api.errors import (
+    categorize_retryable_api_error,
+    is_transport_error,
+)
+
+
+def _request() -> httpx.Request:
+    return httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+
+
+class TestSDKTransportErrorsAreRetryable(unittest.TestCase):
+    """The exact exception the user saw, plus its siblings."""
+
+    def test_sdk_api_timeout_error_is_retryable(self) -> None:
+        err = SDKAPITimeoutError(request=_request())
+        # Pin the real SDK message so a reworded SDK release is visible here.
+        self.assertIn("Request timed out or interrupted", str(err))
+        result = categorize_retryable_api_error(err)
+        self.assertTrue(result.retryable)
+        self.assertEqual(result.error_type, "connection_error")
+
+    def test_sdk_api_connection_error_is_retryable(self) -> None:
+        result = categorize_retryable_api_error(
+            SDKAPIConnectionError(request=_request())
+        )
+        self.assertTrue(result.retryable)
+        self.assertEqual(result.error_type, "connection_error")
+
+    def test_httpx_timeout_family_is_retryable(self) -> None:
+        for exc in (
+            httpx.ConnectTimeout("timed out"),
+            httpx.ReadTimeout("timed out"),
+            httpx.WriteTimeout("timed out"),
+            httpx.PoolTimeout("timed out"),
+            httpx.ConnectError("refused"),
+            httpx.ReadError("reset"),
+            httpx.RemoteProtocolError("peer closed connection"),
+        ):
+            with self.subTest(exc=type(exc).__name__):
+                result = categorize_retryable_api_error(exc)
+                self.assertTrue(result.retryable)
+                self.assertEqual(result.error_type, "connection_error")
+
+    def test_builtin_transport_errors_still_retryable(self) -> None:
+        """The original isinstance branch's coverage must not regress."""
+        for exc in (
+            ConnectionError("reset"),
+            TimeoutError("timed out"),
+            OSError("network unreachable"),
+        ):
+            with self.subTest(exc=type(exc).__name__):
+                self.assertTrue(categorize_retryable_api_error(exc).retryable)
+
+
+class TestStatusBearingErrorsStayUnretried(unittest.TestCase):
+    """A server verdict is not a transport failure."""
+
+    def test_bad_request_is_not_transport(self) -> None:
+        err = BadRequestError(
+            "invalid",
+            response=httpx.Response(400, request=_request()),
+            body=None,
+        )
+        self.assertFalse(is_transport_error(err))
+        self.assertFalse(categorize_retryable_api_error(err).retryable)
+
+    def test_status_attribute_wins_over_type_name(self) -> None:
+        """A status-bearing error must not be laundered into a retry.
+
+        Guards the widened MRO walk: an exception that merely *shares* a listed
+        class name but carries an HTTP status is a server verdict.
+        """
+
+        class APITimeoutError(Exception):  # noqa: N818 — deliberate name clash
+            status_code = 400
+
+        self.assertFalse(is_transport_error(APITimeoutError("nope")))
+
+    def test_client_side_protocol_errors_stay_unretried(self) -> None:
+        """Deterministic client-side faults must never earn a retry.
+
+        ``httpx.LocalProtocolError`` means *this client* emitted something
+        illegal (malformed header, bad method/body combination). Retrying
+        reproduces it. It subclasses ``httpx.ProtocolError``, so listing that
+        base name in the transport set would launder it into 10 pointless
+        attempts -- which is why only ``RemoteProtocolError`` is listed.
+        """
+        for exc in (
+            httpx.LocalProtocolError("illegal header"),
+            httpx.ProxyError("bad proxy"),
+            httpx.DecodingError("bad gzip"),
+            httpx.UnsupportedProtocol("gopher://"),
+            httpx.TooManyRedirects("loop"),
+            httpx.InvalidURL("nope"),
+        ):
+            with self.subTest(exc=type(exc).__name__):
+                self.assertFalse(
+                    is_transport_error(exc),
+                    f"{type(exc).__name__} must not be classified as transport",
+                )
+                self.assertFalse(categorize_retryable_api_error(exc).retryable)
+
+    def test_unknown_error_still_not_retryable(self) -> None:
+        result = categorize_retryable_api_error(ValueError("something else"))
+        self.assertFalse(result.retryable)
+        self.assertEqual(result.error_type, "unknown")
+
+    def test_prompt_too_long_precedence_over_transport(self) -> None:
+        """Classification order matters: a PTL never becomes a retry."""
+        err = SDKAPITimeoutError(request=_request())
+        err.args = ("prompt is too long: 300000 tokens > 200000",)
+        self.assertFalse(categorize_retryable_api_error(err).retryable)
+
+
+class TestStreamRetryLaneOwnership(unittest.TestCase):
+    """Layer 2 deliberately does NOT own timeouts; the query lane does.
+
+    Admitting them here would multiply the two budgets
+    (``stream_idle_max_attempts`` x ``DEFAULT_MAX_RETRIES`` = 33 wire attempts),
+    turning a dead network into ~13 minutes of silent waiting instead of one
+    bounded, user-visible retry series. It would also break this predicate's own
+    contract: a connect timeout never established a stream, so it is not a
+    "mid-stream drop".
+    """
+
+    def test_timeouts_are_not_treated_as_mid_stream_drops(self) -> None:
+        for exc in (
+            SDKAPITimeoutError(request=_request()),
+            httpx.ConnectTimeout("timed out"),
+            httpx.ReadTimeout("timed out"),
+        ):
+            with self.subTest(exc=type(exc).__name__):
+                self.assertFalse(is_transient_stream_drop(exc))
+                # ...but the query lane must still retry it.
+                self.assertTrue(categorize_retryable_api_error(exc).retryable)
+
+    def test_api_connection_error_still_matches(self) -> None:
+        self.assertTrue(
+            is_transient_stream_drop(SDKAPIConnectionError(request=_request()))
+        )
+
+    def test_status_bearing_error_still_rejected(self) -> None:
+        err = BadRequestError(
+            "invalid",
+            response=httpx.Response(400, request=_request()),
+            body=None,
+        )
+        self.assertFalse(is_transient_stream_drop(err))
+
+
+class TestAnthropicClientTimeout(unittest.TestCase):
+    """The streaming lane previously inherited the SDK's connect=5.0."""
+
+    def test_connect_phase_is_widened(self) -> None:
+        from src.providers.anthropic_provider import (
+            DEFAULT_API_CONNECT_TIMEOUT_S,
+            _client_timeout,
+        )
+
+        timeout = _client_timeout()
+        self.assertIsNotNone(timeout)
+        self.assertEqual(timeout.connect, DEFAULT_API_CONNECT_TIMEOUT_S)
+        self.assertGreater(timeout.connect, 5.0)
+        self.assertEqual(timeout.read, 600.0)
+
+    def test_env_overrides(self) -> None:
+        import os
+        from unittest import mock
+
+        from src.providers.anthropic_provider import _client_timeout
+
+        with mock.patch.dict(
+            os.environ,
+            {"API_CONNECT_TIMEOUT_MS": "25000", "API_TIMEOUT_MS": "120000"},
+        ):
+            timeout = _client_timeout()
+        self.assertEqual(timeout.connect, 25.0)
+        self.assertEqual(timeout.read, 120.0)
+
+    def test_client_is_constructed_with_the_timeout(self) -> None:
+        from unittest import mock
+
+        from src.providers.anthropic_provider import (
+            DEFAULT_API_CONNECT_TIMEOUT_S,
+            AnthropicProvider,
+        )
+
+        provider = AnthropicProvider(api_key="sk-test")
+        with mock.patch(
+            "src.providers.anthropic_provider.anthropic.Anthropic"
+        ) as ctor:
+            provider._ensure_client()
+        passed = ctor.call_args.kwargs
+        self.assertIn("timeout", passed)
+        self.assertEqual(passed["timeout"].connect, DEFAULT_API_CONNECT_TIMEOUT_S)
+
+    def test_minimax_shares_the_timeout(self) -> None:
+        """Minimax speaks the same wire through the same SDK and lane."""
+        from unittest import mock
+
+        from src.providers.anthropic_provider import DEFAULT_API_CONNECT_TIMEOUT_S
+        from src.providers.minimax_provider import MinimaxProvider
+
+        provider = MinimaxProvider(api_key="mm-test")
+        with mock.patch("src.providers.minimax_provider.anthropic.Anthropic") as ctor:
+            provider._ensure_client()
+        self.assertEqual(
+            ctor.call_args.kwargs["timeout"].connect, DEFAULT_API_CONNECT_TIMEOUT_S
+        )
+
+    def test_non_streaming_path_does_not_collapse_connect(self) -> None:
+        """The effective per-request timeout, which is where the bug lived.
+
+        ``chat()`` sets a per-request timeout so the SDK will accept a
+        non-streaming call at opus-class ``max_tokens``. Passing a bare float
+        there made httpx expand it across all four phases, silently resetting
+        ``connect`` from 15s back to 600s -- so a black-holed SYN on a
+        compaction summarize hung for ten minutes.
+        """
+        from src.providers.anthropic_provider import (
+            DEFAULT_API_CONNECT_TIMEOUT_S,
+            _api_timeout_seconds,
+            _client_timeout,
+        )
+
+        # A bare float — what the old code passed — flattens every phase, so
+        # connect inherits the full 600s read budget.
+        self.assertEqual(httpx.Timeout(_api_timeout_seconds()).connect, 600.0)
+        # The phase-split object keeps connect distinct from read.
+        split = _client_timeout()
+        self.assertEqual(split.connect, DEFAULT_API_CONNECT_TIMEOUT_S)
+        self.assertEqual(split.read, 600.0)
+        self.assertNotEqual(split.connect, split.read)
+
+    def test_chat_passes_the_phase_split_timeout(self) -> None:
+        """``chat()`` must hand the SDK an httpx.Timeout, never a float."""
+        from unittest import mock
+
+        from src.providers.anthropic_provider import (
+            DEFAULT_API_CONNECT_TIMEOUT_S,
+            AnthropicProvider,
+        )
+
+        provider = AnthropicProvider(api_key="sk-test")
+        fake_client = mock.MagicMock()
+        fake_client.messages.create.return_value = mock.MagicMock(
+            content=[], usage=None, stop_reason="end_turn"
+        )
+        with mock.patch.object(provider, "_client_for_request", return_value=fake_client):
+            provider.chat([{"role": "user", "content": "hi"}])
+        timeout = fake_client.messages.create.call_args.kwargs["timeout"]
+        self.assertIsInstance(timeout, httpx.Timeout)
+        self.assertEqual(timeout.connect, DEFAULT_API_CONNECT_TIMEOUT_S)
+        self.assertEqual(timeout.read, 600.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui-tui/src/__tests__/imageToolResult.test.ts
+++ b/ui-tui/src/__tests__/imageToolResult.test.ts
@@ -1,0 +1,225 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Fake the agent-server child so tests can feed NDJSON protocol lines and
+// observe the GatewayEvents (same harness as structuredDiff.test.ts).
+const harness = vi.hoisted(() => ({ proc: null as null | EventEmitter, spawnCalls: [] as unknown[][] }))
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => {
+    harness.spawnCalls.push(args)
+
+    return harness.proc
+  }
+}))
+
+import { flattenToolResultContent, formatFileSize, formatToolResult, GatewayClient } from '../gatewayClient.js'
+
+class FakeProc extends EventEmitter {
+  kill = vi.fn()
+  stderr = new PassThrough()
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+
+  line(obj: unknown): void {
+    this.stdout.write(JSON.stringify(obj) + '\n')
+  }
+}
+
+// A truncated stand-in for the real payload. The bug was the transcript
+// printing this envelope verbatim, wrapped over dozens of rows.
+const IMAGE_CONTENT = [
+  {
+    source: { data: '/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAYEBQYFBAYGBQYHBwYIChAKCgkJ', media_type: 'image/jpeg', type: 'base64' },
+    type: 'image'
+  }
+]
+
+// ── formatFileSize: exact port of typescript/src/utils/format.ts ────────────
+
+describe('formatFileSize', () => {
+  it('matches the original ladder', () => {
+    expect(formatFileSize(0)).toBe('0 bytes')
+    expect(formatFileSize(512)).toBe('512 bytes')
+    expect(formatFileSize(1024)).toBe('1KB')
+    expect(formatFileSize(1536)).toBe('1.5KB')
+    // Rolls over on the ROUNDED magnitude, so this is 1MB, not 1024KB.
+    expect(formatFileSize(1048575)).toBe('1MB')
+    expect(formatFileSize(1048576)).toBe('1MB')
+    expect(formatFileSize(5 * 1024 * 1024)).toBe('5MB')
+    expect(formatFileSize(3 * 1024 * 1024 * 1024)).toBe('3GB')
+  })
+})
+
+// ── flattenToolResultContent: the base64 leak itself ───────────────────────
+
+describe('flattenToolResultContent', () => {
+  it('never serializes an image block', () => {
+    const out = flattenToolResultContent(IMAGE_CONTENT)
+    expect(out).toBe('[image]')
+    expect(out).not.toContain('base64')
+    expect(out).not.toContain('/9j/4AAQ')
+  })
+
+  it('keeps text blocks and drops only the binary ones', () => {
+    expect(
+      flattenToolResultContent([{ text: 'before', type: 'text' }, ...IMAGE_CONTENT, { text: 'after', type: 'text' }])
+    ).toBe('before\n[image]\nafter')
+  })
+
+  it('placeholders a document block', () => {
+    expect(flattenToolResultContent([{ source: { data: 'JVBERi0x', type: 'base64' }, type: 'document' }])).toBe(
+      '[document]'
+    )
+  })
+
+  it('passes strings through untouched', () => {
+    expect(flattenToolResultContent('     1\tconst a = 1')).toBe('     1\tconst a = 1')
+  })
+
+  it('still summarizes an unknown block shape rather than dropping it', () => {
+    expect(flattenToolResultContent([{ type: 'mystery', value: 7 }])).toContain('mystery')
+  })
+})
+
+// ── formatToolResult: the one-line render ──────────────────────────────────
+
+describe('formatToolResult with an image envelope', () => {
+  it('renders the original one-liner', () => {
+    // FileReadTool/UI.tsx renderToolResultMessage case 'image'.
+    expect(formatToolResult('Read', '[image]', false, undefined, { originalSize: 128_000 })).toBe(
+      'Read image (125KB)'
+    )
+  })
+
+  it('omits the size when the backend predates the envelope field', () => {
+    expect(formatToolResult('Read', '[image]', false, undefined, {})).toBe('Read image')
+  })
+
+  it('omits the size rather than printing NaN when the number is unusable', () => {
+    // This calls formatToolResult directly, so imageDisplay's wire-path guard is
+    // NOT what saves it — the guard inside imageSummary is. Delete that one and
+    // formatFileSize divides/toFixed()s its way to "Read image (NaNGB)".
+    for (const bad of [Number.NaN, Infinity, -Infinity]) {
+      expect(formatToolResult('Read', '[image]', false, undefined, { originalSize: bad })).toBe('Read image')
+    }
+  })
+
+  it('does not hijack a normal text read', () => {
+    expect(formatToolResult('Read', '     1\tconst a = 1\n     2\tconst b = 2')).toBe('Read 2 lines')
+  })
+
+  it('borrows the Read wording for any tool carrying an image envelope', () => {
+    // Documents current behavior: `_display_tool_result` is shape-keyed and
+    // global, so the label is not tool-scoped the way the reference's per-tool
+    // renderToolResultMessage is. Read is the only producer today; if a second
+    // one appears this expectation should change alongside a tool-aware label.
+    expect(formatToolResult('SomeFutureTool', '[image]', false, undefined, { originalSize: 2048 })).toBe(
+      'Read image (2KB)'
+    )
+  })
+
+  it('lets a failed image read render as an error, not a summary', () => {
+    expect(formatToolResult('Read', 'EISDIR: illegal operation on a directory', true, undefined, {
+      originalSize: 128_000
+    })).toContain('EISDIR')
+  })
+})
+
+// ── End to end through the gateway ─────────────────────────────────────────
+
+describe('GatewayClient image tool_result mapping', () => {
+  const prevWs = process.env.CLAWCODEX_WORKSPACE
+  let events: any[]
+  let gw: GatewayClient
+  let proc: FakeProc
+
+  beforeEach(() => {
+    process.env.CLAWCODEX_WORKSPACE = '/ws'
+    proc = new FakeProc()
+    harness.proc = proc
+    harness.spawnCalls = []
+    events = []
+    gw = new GatewayClient()
+    gw.on('event', (e: any) => events.push(e))
+    gw.start()
+    gw.drain()
+  })
+
+  afterEach(() => {
+    gw.kill()
+
+    if (prevWs === undefined) {
+      delete process.env.CLAWCODEX_WORKSPACE
+    } else {
+      process.env.CLAWCODEX_WORKSPACE = prevWs
+    }
+  })
+
+  const last = (t: string) => [...events].reverse().find(e => e.type === t)
+
+  const completeTool = async (id: string, name: string, input: unknown, resultMsg: Record<string, unknown>) => {
+    proc.line({ message: { content: [{ id, input, name, type: 'tool_use' }] }, type: 'assistant' })
+    await vi.waitFor(() => expect(last('tool.start')).toBeTruthy())
+    proc.line(resultMsg)
+    await vi.waitFor(() => expect(last('tool.complete')).toBeTruthy())
+
+    return last('tool.complete').payload
+  }
+
+  it('renders "Read image (N)" and leaks no base64 anywhere in the payload', async () => {
+    const payload = await completeTool(
+      'i1',
+      'Read',
+      { file_path: '/tmp/blog-sources.png' },
+      {
+        message: { content: [{ content: IMAGE_CONTENT, tool_use_id: 'i1', type: 'tool_result' }] },
+        tool_use_result: { originalSize: 128_000, type: 'image' },
+        type: 'user'
+      }
+    )
+
+    expect(payload.result_text).toBe('Read image (125KB)')
+    // Read is deliberately non-expandable, so there is no raw copy either.
+    expect(payload.result_raw).toBeUndefined()
+    expect(JSON.stringify(payload)).not.toContain('/9j/4AAQ')
+    expect(JSON.stringify(payload)).not.toContain('base64')
+    expect(payload.error).toBeUndefined()
+  })
+
+  it('still degrades to a placeholder when the backend sends no envelope', async () => {
+    const payload = await completeTool(
+      'i2',
+      'Read',
+      { file_path: '/tmp/blog-sources.png' },
+      { message: { content: [{ content: IMAGE_CONTENT, tool_use_id: 'i2', type: 'tool_result' }] }, type: 'user' }
+    )
+
+    expect(payload.result_text).toBe('[image]')
+    expect(JSON.stringify(payload)).not.toContain('/9j/4AAQ')
+  })
+
+  it('does not pin one image envelope onto a later unrelated tool', async () => {
+    await completeTool(
+      'i3',
+      'Read',
+      { file_path: '/tmp/a.png' },
+      {
+        message: { content: [{ content: IMAGE_CONTENT, tool_use_id: 'i3', type: 'tool_result' }] },
+        tool_use_result: { originalSize: 2048, type: 'image' },
+        type: 'user'
+      }
+    )
+
+    const second = await completeTool(
+      'i4',
+      'Bash',
+      { command: 'echo hi' },
+      { message: { content: [{ content: 'hi', tool_use_id: 'i4', type: 'tool_result' }] }, type: 'user' }
+    )
+
+    expect(second.result_text).toBe('hi')
+  })
+})

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -196,6 +196,94 @@ function webSearchSummary(result: string, webSearch?: WebSearchDisplay): string 
   return s === undefined ? line : `${line} in ${s >= 1 ? `${Math.round(s)}s` : `${Math.round(s * 1000)}ms`}`
 }
 
+/** Image-read display data forwarded by the agent-server (`tool_use_result`
+ *  trimmed to the byte count the one-liner needs). Carries no base64 —
+ *  the payload travels on the model-facing tool_result content only. */
+export type ImageDisplay = { originalSize?: number }
+
+/** Exact port of typescript/src/utils/format.ts formatFileSize. */
+export function formatFileSize(sizeInBytes: number): string {
+  const kb = sizeInBytes / 1024
+
+  if (kb < 1) {
+    return `${sizeInBytes} bytes`
+  }
+
+  // Compare the rounded magnitude so values that round up to 1024 roll over to
+  // the next unit (e.g. 1048575 bytes → "1MB", not "1024KB").
+  if (Number(kb.toFixed(1)) < 1024) {
+    return `${kb.toFixed(1).replace(/\.0$/, '')}KB`
+  }
+
+  const mb = kb / 1024
+
+  if (Number(mb.toFixed(1)) < 1024) {
+    return `${mb.toFixed(1).replace(/\.0$/, '')}MB`
+  }
+
+  const gb = mb / 1024
+
+  return `${gb.toFixed(1).replace(/\.0$/, '')}GB`
+}
+
+// Port of FileReadTool/UI.tsx renderToolResultMessage `case 'image'`:
+// "Read image (12.3KB)". The size comes from the envelope; a backend that
+// predates it leaves the count unknown, so say only what we know rather than
+// inventing a number.
+//
+// The "Read" in the label is hardcoded, where the original earns it structurally
+// (renderToolResultMessage is per-tool, so the string cannot escape
+// FileReadTool). Here the backend's `_display_tool_result` is shape-keyed and
+// global, so a future tool emitting `{type:"image", file:{originalSize}}` would
+// borrow this wording. Read is the only producer of that shape today; give the
+// label a tool-aware branch if a second one appears.
+function imageSummary(image?: ImageDisplay): string {
+  const size = image?.originalSize
+  // Guard finiteness HERE, not only in imageDisplay: formatFileSize divides and
+  // toFixed()s, so a non-finite size renders "NaNGB". imageDisplay already
+  // filters the wire path, but this function is also reachable with a
+  // hand-built envelope, and an unknown size should read as unknown.
+  const known = typeof size === 'number' && Number.isFinite(size)
+
+  return known ? `Read image (${formatFileSize(size)})` : 'Read image'
+}
+
+/** Flatten Anthropic tool_result content for DISPLAY.
+ *
+ *  `content` is either a string or an array of content blocks. The array form
+ *  used to go through `safeJson`, which dumped megabytes of base64 into the
+ *  transcript the moment a tool returned an image block — the observed bug was
+ *  `Read` on a PNG printing
+ *  `[{"type":"image","source":{"type":"base64","data":"/9j/4AAQ…"}}]` as text.
+ *
+ *  Binary-bearing blocks are replaced by a short placeholder instead of being
+ *  serialized. Applies to every tool that can emit them (Read, PDF page
+ *  extraction, Bash image output), not just Read. */
+export function flattenToolResultContent(content: unknown): string {
+  if (typeof content === 'string') {return content}
+
+  if (!Array.isArray(content)) {return safeJson(content)}
+
+  return content
+    .map(block => {
+      if (typeof block === 'string') {return block}
+
+      if (!block || typeof block !== 'object') {return safeJson(block)}
+
+      const type = (block as { type?: unknown }).type
+
+      if (type === 'text') {return String((block as { text?: unknown }).text ?? '')}
+
+      if (type === 'image') {return '[image]'}
+
+      if (type === 'document') {return '[document]'}
+
+      return safeJson(block)
+    })
+    .filter(part => part.length > 0)
+    .join('\n')
+}
+
 // Shared with the backend Read tool (read.py FILE_NOT_FOUND_CWD_NOTE) and the
 // original (utils/file.ts:213) — the marker the per-tool error renderers key
 // "File not found" on.
@@ -244,7 +332,8 @@ export function formatToolResult(
   name: string | undefined,
   result: string,
   isError = false,
-  webSearch?: WebSearchDisplay
+  webSearch?: WebSearchDisplay,
+  image?: ImageDisplay
 ): string {
   if (isError) {
     const summary = toolSpecificErrorSummary(name, result ?? '')
@@ -285,6 +374,13 @@ export function formatToolResult(
     }
 
     return msg
+  }
+
+  // Shape-keyed ahead of the `!result` bail: an image read's display text comes
+  // entirely from the envelope, and its flattened content ("[image]") carries
+  // nothing worth printing.
+  if (image) {
+    return imageSummary(image)
   }
 
   if (!result) {return result}
@@ -1457,6 +1553,15 @@ export class GatewayClient extends EventEmitter {
     return { durationSeconds: num(value.durationSeconds), searchCount: num(value.searchCount) }
   }
 
+  private imageDisplay(value: any): ImageDisplay | undefined {
+    if (!value || typeof value !== 'object' || value.type !== 'image') {return undefined}
+    const size = value.originalSize
+
+    return {
+      originalSize: typeof size === 'number' && Number.isFinite(size) ? size : undefined
+    }
+  }
+
   // Legacy fallback (agent-server predating tool_use_result): a fake unified
   // diff from the Edit/Write tool *input* so the app can render at least a
   // colored ```diff block. No line numbers/context — superseded by
@@ -1643,6 +1748,7 @@ export class GatewayClient extends EventEmitter {
           // pin the same patch onto every result.
           let structured = this.structuredDiff(msg.tool_use_result)
           let webSearch = this.webSearchDisplay(msg.tool_use_result)
+          let image = this.imageDisplay(msg.tool_use_result)
 
           for (const b of content) {
             if (b?.type === 'tool_result') {
@@ -1650,8 +1756,8 @@ export class GatewayClient extends EventEmitter {
               // A failed edit must not render a diff at all — neither the
               // real patch nor a fabricated one for an edit that never ran.
               const isError = Boolean(b.is_error)
-              const fullText = typeof b.content === 'string' ? b.content : safeJson(b.content)
-              const resultText = formatToolResult(stored?.name, fullText, isError, webSearch)
+              const fullText = flattenToolResultContent(b.content)
+              const resultText = formatToolResult(stored?.name, fullText, isError, webSearch, image)
               const taskTodos = isError ? undefined : this.taskTodosFromResult(stored?.name, stored?.input, fullText)
               // Read shows no expand hint (the summary loses nothing the user
               // needs — the file is in context), so retain nothing for it.
@@ -1674,6 +1780,7 @@ export class GatewayClient extends EventEmitter {
               })
               structured = undefined
               webSearch = undefined
+              image = undefined
               this.toolInputs.delete(String(b.tool_use_id))
             }
           }


### PR DESCRIPTION
Two unrelated bugs hit in one `claude-opus-5` session.

## 1. A transient connect-phase failure killed an interactive turn outright

**Symptom.** A turn died with the Anthropic SDK's raw text — `Request timed out or interrupted. This could be due to a network timeout, dropped connection, or request cancellation.` — and the next two prompts did the same, until the network settled on its own a few minutes later. It looked like a wedged session; it was actually a transient blip that nothing retried.

**Root cause.** `anthropic.APITimeoutError` is raised only from `httpx.TimeoutException` (SDK `_base_client.py:1302`). Two layers were responsible:

| layer | site | why it missed |
|---|---|---|
| SDK auto-retry (2×) | `query.py:1681` | foreground turns pass `sdk_max_retries=0` so the manual lane owns retry accounting — by design |
| query-loop general retry | `errors.py` | `isinstance(error, (ConnectionError, TimeoutError, OSError))` tests **Python builtins**. No SDK transport error subclasses those, and only `APIStatusError` carries `status_code`, so anthropic/openai `APITimeoutError` + `APIConnectionError` and every httpx timeout fell through to `retryable=False, error_type="unknown"` → `query.py:1702` re-raised |

Net effect: an interactive turn had **strictly fewer** attempts than a stock SDK client. A ~5s DNS/TLS hiccup the SDK would have absorbed silently became a hard, user-visible failure. Verified empirically pre-fix — every timeout shape classified `retryable=False / "unknown"`.

**Fix.**
- `is_transport_error()`, duck-typed by MRO type name so a subclass of a listed base matches. Kept free of provider-SDK imports: `errors.py` is on the fast-path CLI import graph.
- Bare `ProtocolError` is deliberately **not** listed. `httpx.LocalProtocolError` subclasses it and means *this client* emitted something illegal — deterministic, so retrying only reproduces it 10 times. `RemoteProtocolError` is listed explicitly.
- `is_transient_stream_drop` **keeps** exact-name matching, now documented as deliberate. An MRO walk there would admit timeouts, breaking its contract (a connect timeout never established a stream, so it isn't a mid-stream drop) and multiplying the two budgets: 3 idle × 11 query = **33 wire attempts**, ~13 min of silent waiting on a dead network.
- Explicit phase-split `httpx.Timeout` on the client. The streaming path — every interactive turn — previously passed no timeout at all and inherited the SDK's `connect=5.0`. Now 15s, tunable via `API_CONNECT_TIMEOUT_MS`.
- `chat()` must pass that object, not a bare float: httpx expands a float across all four phases, so the old per-request float silently reset `connect` from 15s back to 600s — a black-holed SYN could hang a compaction summarize for ten minutes.
- `MinimaxProvider` shares the timeout; same wire, same SDK, same lane.

## 2. `Read` on an image dumped its base64 into the transcript

**Symptom.** `Read(blog-sources.png)` printed `[{"type":"image","source":{"type":"base64","data":"/9j/4AAQ..."}}]` as dozens of wrapped text rows.

**Root cause.** Display-only. `_read_map_result_to_api` was already byte-correct against the reference. But `_display_tool_result` recognized only create/update and web_search, so an image read returned `None`, leaving `gatewayClient.ts` to `safeJson(b.content)` the image blocks.

**Fix**, matching the reference's two-channel split (`mapToolResultToToolResultBlockParam` → model, `renderToolResultMessage` → screen):
- `_display_tool_result` forwards `{"type":"image","originalSize":N}` with the base64 **dropped** — payload belongs on model-facing content, never a display envelope. Size is `int`-only: `int(nan)`/`int(inf)` raise, and this runs inside `_sdk_envelope` whose caller `on_message` has no guard, so a non-finite would be turn-fatal.
- `gatewayClient` renders `Read image (125KB)` via a byte-exact `formatFileSize` port.
- `flattenToolResultContent` placeholders image/document blocks instead of serializing them — covering every tool that can emit them (PDF pages, Bash image output), not just `Read`.

## Testing

New tests fail without the fixes (verified by reverting the source and re-running):
- Classification predicates plus a **negative** table (`LocalProtocolError`, `ProxyError`, `DecodingError`, `UnsupportedProtocol`, `TooManyRedirects`, `InvalidURL`) that must stay unretried.
- Lane-ownership: layer 2 rejects timeouts, layer 3 retries them.
- End-to-end lane tests asserting the turn **survives** a transient timeout (`calls == 2`, one `api_retry`), that `LocalProtocolError` fails immediately at `calls == 1`, that the budget exhausts, and that an aborted request is **never re-issued** — both pre-turn and mid-flight.
- Image envelope: base64 never reaches the envelope, source not mutated, bool/float/non-finite/non-numeric sizes decline, one envelope never pins onto a later tool.

**Python: 8899 passed, 3 skipped, 0 failed.** ui-tui: 1451 passed with exactly the 8 pre-existing clean-tree baseline failures (useConfigSync ×2, statusRule ×2, createGatewayEventHandler ×2, virtualHeights ×1, cursorDriftRegression ×1). `tsc --noEmit` clean; 0 new lint errors.

## Known limits

- Worst case on a genuinely black-holed handshake is ~7.8 min (11 attempts × 15s connect + ~304s capped backoff). Same *attempt* budget as 429/5xx but not the same *wall-clock* budget — a 5xx fails in ms, a dead SYN burns the full 15s. Visible as `attempt N/10` and ESC-able during backoff.
- Adding `"StreamIdleTimeout"` or a `TimeoutError` base to `_TRANSPORT_ERROR_TYPES` would silently create a 33 × 90s = 45-minute path. Safe today (plain `Exception`, name absent from the set).
- `imageSummary` hardcodes the word "Read"; the reference earns it structurally via a per-tool renderer, while `_display_tool_result` is shape-keyed and global. `Read` is the only producer of that shape today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)