### PR TITLE
feat: support pasting an image as input

### DIFF
--- a/src/providers/gemini_provider.py
+++ b/src/providers/gemini_provider.py
@@ -12,6 +12,7 @@ content-part schemas that reject our typical message payloads.
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Generator, Optional
 
 try:
@@ -23,6 +24,8 @@ except ModuleNotFoundError:  # pragma: no cover
 
 from .base import BaseProvider, ChatResponse, MessageInput, TextChunkCallback
 
+logger = logging.getLogger(__name__)
+
 
 def _ensure_sdk() -> None:
     if genai is None:
@@ -30,6 +33,52 @@ def _ensure_sdk() -> None:
             "google-genai package is not installed. Run "
             "`pip install google-genai` to use GeminiProvider."
         )
+
+
+class _GeminiImageUnsupported(Exception):
+    """The installed SDK exposes no way to send inline image bytes."""
+
+
+def _gemini_image_part(block: dict[str, Any]):
+    """Anthropic base64 image block -> a Gemini inline-data Part, or None.
+
+    Returns ``None`` for a MALFORMED block (no base64 source, empty or
+    undecodable data) and raises :class:`_GeminiImageUnsupported` when the SDK
+    itself cannot carry inline images. Two distinct failures with two distinct
+    remedies: telling someone with a corrupt payload to "switch models" is
+    useless advice, so the caller must be able to tell them apart.
+
+    ``Part.from_bytes`` is the documented modern entry point; the
+    ``inline_data``/``Blob`` form is the older shape, kept as a fallback so an
+    SDK pin doesn't silently disable image input.
+    """
+    source = block.get("source")
+    if not isinstance(source, dict) or source.get("type") != "base64":
+        return None
+    data = source.get("data")
+    mime = str(source.get("media_type") or "image/png")
+    if not isinstance(data, str) or not data:
+        return None
+    import base64
+
+    try:
+        raw = base64.b64decode(data, validate=True)
+    except Exception:  # noqa: BLE001 — a corrupt payload is not a capability gap
+        return None
+    if not raw:
+        return None
+
+    from_bytes = getattr(genai_types.Part, "from_bytes", None)
+    if callable(from_bytes):
+        return from_bytes(data=raw, mime_type=mime)
+    blob = getattr(genai_types, "Blob", None)
+    if blob is not None:
+        return genai_types.Part(inline_data=blob(data=raw, mime_type=mime))
+    raise _GeminiImageUnsupported(
+        "This model cannot receive images: the installed google-genai SDK "
+        "exposes neither Part.from_bytes nor Blob. Switch to an Anthropic or "
+        "OpenAI-compatible model to send images."
+    )
 
 
 def _text_from_anthropic_block(block: dict[str, Any]) -> str:
@@ -194,6 +243,25 @@ class GeminiProvider(BaseProvider):
                         text = block.get("text", "")
                         if text:
                             parts.append(genai_types.Part.from_text(text=str(text)))
+                    elif btype == "image":
+                        # Without this branch an image block fell through to
+                        # nothing at all: the block was skipped, the request went
+                        # out text-only, and because pasted images also carry an
+                        # "[Image: source: …]" metadata line the model received a
+                        # DESCRIPTION of an image it never saw and confabulated an
+                        # answer instead of failing. Silent wrong answers are the
+                        # worst failure mode available here.
+                        # A capability gap raises out of here (see
+                        # _gemini_image_part); a malformed block returns None and
+                        # is skipped with a warning rather than killing the turn.
+                        part = _gemini_image_part(block)
+                        if part is None:
+                            logger.warning(
+                                "skipping a malformed image block (no decodable "
+                                "base64 source) on the Gemini wire"
+                            )
+                        else:
+                            parts.append(part)
                     elif btype == "tool_use":
                         # Assistant message asking to call a tool — Gemini calls
                         # this a FunctionCall part. ``input`` becomes ``args``.

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -163,6 +163,12 @@ class _AgentSession:
     # real turn (inside the async context; _build_runtime runs sync in an
     # executor with no live loop). Guarded so it fires exactly once.
     _session_start_fired: bool = False
+    # Images attached (clipboard paste, /image, dropped path) but not yet sent.
+    # Drained into the NEXT user message as image content blocks -- the client
+    # holds no bytes, it only shows the "📎 Attached image" notice, so the
+    # pending list is the single source of truth. Cleared by /clear so a reset
+    # conversation cannot smuggle an image from the previous one.
+    _pending_images: list = field(default_factory=list)
     # Completed user turns — the "turns: N" odometer on the client's session
     # stats line (the deleted REPL's ``_stats_turns``, repl/core.py). Counts
     # successful non-internal, non-btw turns; /resume seeds it from the
@@ -285,6 +291,14 @@ class _AgentSession:
             content = _extract_prompt_content(msg)  # str, or blocks for multimodal
             mm = msg.get("message")
             ephemeral = bool(msg.get("ephemeral") or (isinstance(mm, dict) and mm.get("ephemeral")))
+            # Attached-but-unsent images ride along with this prompt. Drained
+            # (not copied) so a resend cannot duplicate them.
+            #
+            # NOT for an ephemeral "btw" message: ``_run_turn(btw=True)`` restores
+            # a pre-turn snapshot afterwards, so draining here would consume the
+            # image and then throw it away. Leave it queued for the real turn.
+            if not ephemeral:
+                content = self._drain_pending_images(content)
             self._inbox.put({"__btw__": True, "content": content} if ephemeral else content)
             return
         if msg_type == "control_response":
@@ -541,6 +555,15 @@ class _AgentSession:
         if subtype == "set_effort":
             self._do_set_effort(request_id, inner.get("effort"))
             return
+        if subtype == "attach_image":
+            await self._do_attach_image(request_id, inner.get("path"))
+            return
+        if subtype == "clipboard_image":
+            await self._do_clipboard_image(request_id)
+            return
+        if subtype == "detect_file_drop":
+            await self._do_detect_file_drop(request_id, inner.get("text"))
+            return
         if subtype == "workflows":
             self._do_workflows(request_id)
             return
@@ -764,6 +787,11 @@ class _AgentSession:
             try:
                 if self.session is not None:
                     self.session.conversation.clear()
+                # An image attached but never sent belongs to the conversation
+                # the user just discarded; carrying it into the fresh one would
+                # silently attach it to an unrelated prompt.
+                with self._lock:
+                    self._pending_images = []
                 # /clear starts a FRESH plan file (TS clearAllPlanSlugs on
                 # clear — plans.ts:75-86): drop every session's slug so the
                 # next plan-mode turn mints a new file instead of appending
@@ -859,6 +887,209 @@ class _AgentSession:
     def _ack(self, request_id: object) -> None:
         if isinstance(request_id, str):
             self._reply(request_id, {"ok": True})
+
+    # ─── image attachment (clipboard paste / /image / dropped path) ────────
+
+    def _drain_pending_images(self, content):
+        """Prepend any attached images to this prompt's content.
+
+        Returns ``content`` untouched when nothing is pending, so the common
+        text-only path keeps sending a plain string (which
+        ``_extract_prompt_content`` and ``add_user_message`` both prefer).
+
+        Block order is images, then the USER'S TEXT, then the coordinate-mapping
+        metadata. The metadata matters for screenshots (a downsampled image needs
+        the scale factor or the model's pixel coordinates are wrong, see
+        ``create_image_metadata_text``) but it must not come first, because three
+        consumers flatten content by concatenating text blocks with no separator
+        (``_extract_prompt_text``) and then read the FRONT of the result:
+
+        * ``_parse_turn_budget`` -- its regexes are ``^``-anchored, so a leading
+          ``[Image: source: …]`` makes a ``+500k`` directive silently no-op.
+        * ``_first_prompt_preview`` -- takes the first text block, so ``/resume``
+          and branch names would show the metadata instead of the prompt.
+        * UserPromptSubmit hooks -- any ``^``-anchored or ``startswith`` matcher
+          stops firing.
+
+        Images stay first (the API prefers image-before-question).
+        """
+        with self._lock:
+            pending = self._pending_images
+            self._pending_images = []
+        if not pending:
+            return content
+
+        from src.utils.image_processor import create_image_metadata_text
+
+        blocks: list[dict] = []
+        trailing: list[dict] = []
+        for image in pending:
+            blocks.append({
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": image.media_type,
+                    "data": image.base64,
+                },
+            })
+            meta = create_image_metadata_text(image.dimensions, image.source_path)
+            if meta:
+                trailing.append({"type": "text", "text": meta})
+
+        if isinstance(content, list):
+            return blocks + content + trailing
+        text = content if isinstance(content, str) else str(content or "")
+        if text:
+            blocks.append({"type": "text", "text": text})
+        return blocks + trailing
+
+    #: Cap on images queued for one prompt. Without it, N pastes all go out in a
+    #: single request, the API 400s on total size, and because the drain is
+    #: destructive the images are already gone -- the user sees an opaque error
+    #: and has lost the attachments. Refusing the (N+1)th with a clear message is
+    #: strictly better than losing all N.
+    MAX_PENDING_IMAGES = 8
+
+    def _queue_image(self, image) -> bool:
+        """Append under the lock, honoring the cap. False when already full.
+
+        Single entry point so every producer (clipboard, ``/image``, dropped
+        path) is capped -- an inline append in one of them would silently bypass
+        it.
+        """
+        with self._lock:
+            if len(self._pending_images) >= self.MAX_PENDING_IMAGES:
+                return False
+            self._pending_images.append(image)
+            return True
+
+    def _too_many_images_error(self) -> dict:
+        return {
+            "error": (
+                f"already holding {self.MAX_PENDING_IMAGES} attached images "
+                "— send them or run /clear before attaching another"
+            ),
+        }
+
+    def _attach_image(
+        self, request_id: object, image, *, remainder: str = "", extra: dict | None = None
+    ) -> None:
+        """Queue ``image`` and reply in the client's ImageAttachResponse shape."""
+        from src.utils.image_paste import dimensions_to_wire
+
+        if not self._queue_image(image):
+            # Spread ``extra`` into the error too: the drop routes key on
+            # ``matched``, so an error reply without it reads as "not a file
+            # drop" and the cap message never reaches the user — the paste
+            # silently inserts the path as text instead.
+            self._reply(request_id, {**(extra or {}), **self._too_many_images_error()})
+            return
+        name = Path(image.source_path).name if image.source_path else "clipboard image"
+        self._reply(request_id, {
+            "name": name,
+            "token_estimate": image.token_estimate,
+            "remainder": remainder,
+            **dimensions_to_wire(image.dimensions),
+            **(extra or {}),
+        })
+
+    async def _do_attach_image(self, request_id: object, raw_path: object) -> None:
+        """``/image <path>`` and the dropped-path paste route."""
+        from src.utils.image_paste import as_image_file_path, try_read_image_from_path
+
+        text = str(raw_path or "").strip()
+        if not text:
+            self._reply(request_id, {"error": "no path given"})
+            return
+        if as_image_file_path(text) is None:
+            # Not an image path at all -- decline so the caller falls through to
+            # its generic file-drop / plain-text handling rather than reporting
+            # a phantom attachment.
+            self._reply(request_id, {})
+            return
+        try:
+            image = await asyncio.to_thread(
+                try_read_image_from_path, text, cwd=Path(self.cwd or ".")
+            )
+        except Exception as exc:  # noqa: BLE001 — a bad paste must not kill the session
+            logger.debug("[agent-server] attach_image failed", exc_info=True)
+            self._reply(request_id, {"error": str(exc)})
+            return
+        if image is None:
+            self._reply(request_id, {"error": f"could not read image: {text}"})
+            return
+        self._attach_image(request_id, image)
+
+    async def _do_clipboard_image(self, request_id: object) -> None:
+        """Ctrl+V / Cmd+V with an image on the clipboard."""
+        from src.utils.image_paste import (
+            clipboard_tooling_available,
+            get_image_from_clipboard,
+        )
+
+        if not clipboard_tooling_available():
+            # Distinguishable from "no image": the client falls back to a text
+            # paste either way, but only this case is worth telling the user
+            # about (install xclip / wl-clipboard).
+            self._reply(request_id, {"unavailable": True})
+            return
+        try:
+            image = await asyncio.to_thread(get_image_from_clipboard)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[agent-server] clipboard_image failed", exc_info=True)
+            self._reply(request_id, {"error": str(exc)})
+            return
+        if image is None:
+            self._reply(request_id, {})  # no image on the clipboard
+            return
+        self._attach_image(request_id, image)
+
+    async def _do_detect_file_drop(self, request_id: object, raw_text: object) -> None:
+        """Classify a paste that looks like a dragged-in path.
+
+        Images are ATTACHED here (so a dropped screenshot works with one paste);
+        non-image files are only reported, and the caller decides what to insert.
+        """
+        from src.utils.image_paste import (
+            as_image_file_path,
+            looks_like_dropped_path,
+            resolve_dropped_file,
+            try_read_image_from_path,
+        )
+
+        text = str(raw_text or "")
+        if not looks_like_dropped_path(text):
+            self._reply(request_id, {"matched": False})
+            return
+        cwd = Path(self.cwd or ".")
+        if as_image_file_path(text) is not None:
+            try:
+                image = await asyncio.to_thread(
+                    try_read_image_from_path, text, cwd=cwd
+                )
+            except Exception:  # noqa: BLE001
+                logger.debug("[agent-server] detect_file_drop image read failed", exc_info=True)
+                image = None
+            if image is not None:
+                # Same queue-and-reply as /image, plus the drop-specific fields.
+                # ``text: ""`` because an attached image inserts nothing into the
+                # composer -- the notice is the whole feedback.
+                self._attach_image(
+                    request_id, image, extra={"matched": True, "is_image": True, "text": ""}
+                )
+                return
+        resolved = await asyncio.to_thread(resolve_dropped_file, text, cwd=cwd)
+        if resolved is None:
+            self._reply(request_id, {"matched": False})
+            return
+        # A real non-image file: hand back an @-reference the model can read
+        # with the Read tool, which is what the path was pasted for.
+        self._reply(request_id, {
+            "matched": True,
+            "is_image": False,
+            "name": resolved.name,
+            "text": f"@{resolved}",
+        })
 
     def _reply(self, request_id: object, response: dict) -> None:
         if not isinstance(request_id, str):
@@ -1931,6 +2162,11 @@ class _AgentSession:
             data = json.loads(f.read_text(encoding="utf-8"))
             conv = Conversation.from_dict(data.get("conversation", {"messages": []}))
             self.session.conversation = conv
+            # Same reasoning as /clear: an image attached but never sent belongs
+            # to the conversation being switched away from. Carrying it over
+            # would attach it to the first prompt of the resumed session.
+            with self._lock:
+                self._pending_images = []
             # Seed the turns odometer so the stats line continues where the
             # resumed session left off (its token/cost siblings restore below
             # via restore_cost_state). Prefer the exact persisted counter

--- a/src/utils/image_paste.py
+++ b/src/utils/image_paste.py
@@ -1,0 +1,617 @@
+"""Clipboard / dropped-path image ingestion.
+
+Port of ``typescript/src/utils/imagePaste.ts``. Reads an image out of the system
+clipboard (a screenshot, a Cmd+C'd image) or off a path the user dragged into
+the terminal, then runs it through the existing Pillow pipeline in
+``src/utils/image_processor.py`` so it lands inside the API's size and dimension
+envelope.
+
+Deliberately NOT ported:
+
+* The native ``image-processor-napi`` NSPasteboard fast path (~5ms vs ~1.5s for
+  osascript) and its GrowthBook kill switch. There is no such native module
+  here, and the TS code treats it purely as an optimization with the osascript
+  path as its documented fallback -- so the fallback is the whole port.
+* ``IMAGE_EXTENSION_REGEX``'s coupling to ``BriefTool/upload.ts``'s MIME table
+  (a remote-viewer thumbnail concern with no clawcodex equivalent).
+
+Shell safety: no caller-supplied text is ever interpolated into a shell string.
+The darwin and win32 commands run argv-style with no shell at all. Only the
+Linux readers need a shell (they are ``||`` fallback chains across
+xclip/wl-paste), and the single value interpolated there is the temp path this
+module chose itself.
+"""
+
+from __future__ import annotations
+
+import base64 as _base64
+import logging
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from .image_processor import (
+    ImageDimensions,
+    ImageProcessingError,
+    detect_image_format_from_buffer,
+    estimate_image_tokens_from_base64_length,
+    maybe_resize_image,
+)
+
+logger = logging.getLogger(__name__)
+
+#: Characters of pasted text above which the original treats a paste as "large"
+#: (imagePaste.ts PASTE_THRESHOLD). Exported for parity; the composer owns the
+#: policy.
+PASTE_THRESHOLD = 800
+
+#: Bounded so a hung/absent clipboard helper cannot wedge the turn. osascript
+#: on a large clipboard image is ~1.5s in the original's own measurement, so
+#: this leaves generous headroom without being unbounded.
+CLIPBOARD_TIMEOUT_S = 20.0
+
+LINUX_CLIPBOARD_IMAGE_MIME_TYPES = (
+    "image/png",
+    "image/jpeg",
+    "image/jpg",
+    "image/gif",
+    "image/webp",
+    "image/bmp",
+)
+
+#: Kept in sync with ``IMAGE_MIME_TYPES`` in ``src/tool_system/tools/read.py``.
+#: ``bmp`` is accepted for INPUT (screenshot tools and WSL2 hand us BMP) but is
+#: always converted to PNG before it reaches the API, which rejects image/bmp.
+IMAGE_EXTENSION_RE = re.compile(r"\.(png|jpe?g|gif|webp|bmp)$", re.IGNORECASE)
+
+_SCREENSHOT_FILENAME = "clawcodex_cli_latest_screenshot.png"
+
+_WIN32_HAS_IMAGE_CMD = (
+    "Add-Type -AssemblyName System.Windows.Forms; "
+    "[System.Windows.Forms.Clipboard]::ContainsImage()"
+)
+
+
+@dataclass(frozen=True)
+class PastedImage:
+    """An image ready for the wire."""
+
+    base64: str
+    media_type: str
+    dimensions: ImageDimensions | None = None
+    #: Set only when the image came from a path (clipboard images have none).
+    source_path: str | None = None
+
+    @property
+    def token_estimate(self) -> int:
+        return estimate_image_tokens_from_base64_length(len(self.base64))
+
+
+def _screenshot_path() -> Path:
+    """A fresh, private, unpredictable path for the clipboard hand-off.
+
+    The reference uses one fixed filename in the shared temp dir. On Linux that
+    is a symlink-follow write primitive (the save command is a ``>`` redirect),
+    and a predictable name in a world-writable directory is CWE-377/59. It also
+    put an environment-derived value inside an AppleScript string literal and a
+    PowerShell single-quoted string, where a quote character would break out.
+
+    ``mkdtemp`` closes all of that at once: 0700, unguessable, and quote-free
+    because we generate it.
+    """
+    base = os.environ.get("CLAWCODEX_TMPDIR") or None
+    directory = tempfile.mkdtemp(prefix="clawcodex-clip-", dir=base)
+    return Path(directory) / _SCREENSHOT_FILENAME
+
+
+def build_linux_clipboard_check_command() -> str:
+    pattern = "|".join(m.replace("/", r"\/") for m in LINUX_CLIPBOARD_IMAGE_MIME_TYPES)
+    return (
+        f'xclip -selection clipboard -t TARGETS -o 2>/dev/null | grep -E "{pattern}"'
+        f' || wl-paste -l 2>/dev/null | grep -E "{pattern}"'
+    )
+
+
+def build_linux_clipboard_save_command(screenshot_path: str) -> str:
+    parts: list[str] = []
+    for mime in LINUX_CLIPBOARD_IMAGE_MIME_TYPES:
+        parts.append(
+            f'xclip -selection clipboard -t {mime} -o > "{screenshot_path}" 2>/dev/null'
+        )
+        parts.append(f'wl-paste --type {mime} > "{screenshot_path}" 2>/dev/null')
+    return " || ".join(parts)
+
+
+def _run(argv: list[str], *, shell: bool = False) -> subprocess.CompletedProcess | None:
+    """Run a clipboard helper, returning None if it is missing or times out."""
+    try:
+        return subprocess.run(  # noqa: S603 — argv is module-owned, see module docstring
+            argv if not shell else argv[0],
+            shell=shell,
+            capture_output=True,
+            timeout=CLIPBOARD_TIMEOUT_S,
+        )
+    except FileNotFoundError:
+        # No osascript / xclip / powershell on this box.
+        return None
+    except subprocess.TimeoutExpired:
+        logger.debug("clipboard helper timed out: %s", argv[:1], exc_info=True)
+        return None
+    except Exception:  # noqa: BLE001 — a clipboard probe must never kill a turn
+        logger.debug("clipboard helper failed: %s", argv[:1], exc_info=True)
+        return None
+
+
+def has_image_in_clipboard() -> bool:
+    """True when the clipboard holds an image.
+
+    NOT cheap, despite reading like a probe: on darwin the coercion
+    ``the clipboard as «class PNGf»`` prints the entire image as hex, which is
+    most of the ~1.5 s that the full read costs. Do NOT wire this into a
+    keystroke handler as a pre-check — it buys nothing over just calling
+    :func:`get_image_from_clipboard` and treating ``None`` as "no image", which
+    is what the paste path does.
+
+    Kept because it is part of the reference's API surface
+    (``hasImageInClipboard``) and a caller may yet want it off the hot path.
+    """
+    if sys.platform == "win32":
+        result = _run(["powershell", "-NoProfile", "-Command", _WIN32_HAS_IMAGE_CMD])
+        return bool(
+            result
+            and result.returncode == 0
+            and result.stdout.decode("utf-8", "replace").strip() == "True"
+        )
+    if sys.platform == "darwin":
+        result = _run(["osascript", "-e", "the clipboard as «class PNGf»"])
+        return bool(result and result.returncode == 0)
+    result = _run([build_linux_clipboard_check_command()], shell=True)
+    return bool(result and result.returncode == 0 and result.stdout.strip())
+
+
+def _read_clipboard_bytes() -> bytes | None:
+    """Platform clipboard -> raw image bytes, or None."""
+    path = _screenshot_path()
+    target = str(path)
+    if sys.platform == "darwin":
+        # argv form, no shell: the path lands inside an AppleScript string
+        # literal passed as its own argument.
+        saved = _run([
+            "osascript",
+            "-e", "set png_data to (the clipboard as «class PNGf»)",
+            "-e", f'set fp to open for access POSIX file "{target}" with write permission',
+            "-e", "write png_data to fp",
+            "-e", "close access fp",
+        ])
+    elif sys.platform == "win32":
+        script = (
+            "$ErrorActionPreference = 'Stop'; "
+            "Add-Type -AssemblyName System.Windows.Forms; "
+            "$img = [System.Windows.Forms.Clipboard]::GetImage(); "
+            "if (-not $img) { exit 1 }; "
+            f"$img.Save('{_escape_powershell_single_quoted(target)}',"
+            " [System.Drawing.Imaging.ImageFormat]::Png)"
+        )
+        saved = _run(["powershell", "-NoProfile", "-Command", script])
+    else:
+        saved = _run([build_linux_clipboard_save_command(target)], shell=True)
+    if saved is None or saved.returncode != 0:
+        _cleanup(path)
+        return None
+    try:
+        data = path.read_bytes()
+    except OSError:
+        return None
+    finally:
+        _cleanup(path)
+    return data or None
+
+
+def _cleanup(path: Path) -> None:
+    """Remove the hand-off file AND the private directory mkdtemp made for it."""
+    try:
+        path.unlink(missing_ok=True)
+        path.parent.rmdir()
+    except OSError:  # pragma: no cover — best effort
+        logger.debug("could not remove %s", path, exc_info=True)
+
+
+def _escape_powershell_single_quoted(value: str) -> str:
+    """Double every ``'`` for a PowerShell single-quoted string.
+
+    Ported from the reference's ``escapePowerShellSingleQuotedString``. Not
+    theoretical: ``%TEMP%`` for a user named ``O'Brien`` is
+    ``C:\\Users\\O'Brien\\AppData\\Local\\Temp``, and an unescaped apostrophe
+    there is a parse error, so clipboard paste would fail for that user with no
+    diagnostic.
+    """
+    return value.replace("'", "''")
+
+
+#: The only four the API accepts. Anything else must be re-encoded, not relabeled.
+#: BMP needs no special case: it simply fails the magic sniff below and takes the
+#: same re-encode path as any other non-API container.
+_API_MEDIA_TYPES = frozenset(
+    {"image/png", "image/jpeg", "image/gif", "image/webp"}
+)
+
+#: PNG/JPEG/GIF/WebP magic. Deliberately narrower than
+#: ``detect_image_format_from_buffer``, which DEFAULTS to ``image/png`` on
+#: unrecognized bytes -- fine for its callers, fatal here: a TIFF written to
+#: ``x.png`` would be shipped labeled ``image/png`` and 400 at the API.
+_MAGIC = (
+    (b"\x89PNG\r\n\x1a\n", "image/png"),
+    (b"\xff\xd8\xff", "image/jpeg"),
+    (b"GIF87a", "image/gif"),
+    (b"GIF89a", "image/gif"),
+)
+
+
+def _sniff_api_media_type(buf: bytes) -> str | None:
+    """Media type from magic bytes, or None when it is not an API format."""
+    for magic, media_type in _MAGIC:
+        if buf.startswith(magic):
+            return media_type
+    if buf[:4] == b"RIFF" and buf[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def _as_media_type(hint: str | None) -> str:
+    """Normalize a format hint to a media type.
+
+    ``maybe_resize_image`` uses ``format_hint`` as the media-type FALLBACK when
+    Pillow's own ``img.format`` isn't in its map (``_pil_format_to_media_type``),
+    and then hands that value straight to the encoder. A bare extension like
+    ``"png"`` therefore reaches ``_encode_image`` and raises
+    "Unsupported image encoding type: png" -- which silently dropped every BMP
+    over the size/dimension caps, i.e. exactly the full-screen Windows/WSL2
+    screenshot BMP exists to handle. Every other caller in the repo passes a
+    media type; so must this one.
+    """
+    if not hint:
+        return "image/png"
+    lowered = hint.strip().lower()
+    if lowered.startswith("image/"):
+        return lowered if lowered in _API_MEDIA_TYPES else "image/png"
+    ext = lowered.lstrip(".")
+    if ext in ("jpg", "jpeg"):
+        return "image/jpeg"
+    if ext in ("png", "gif", "webp"):
+        return f"image/{ext}"
+    # bmp, tif, heic, anything unknown: re-encoded to PNG below.
+    return "image/png"
+
+
+def _reencode_png(buf: bytes) -> bytes | None:
+    """Re-encode any Pillow-decodable image as PNG.
+
+    Keeps the source's alpha rather than forcing RGBA on everything: adding an
+    alpha channel to a BMP or TIFF that never had one just inflates the PNG.
+    """
+    try:
+        import io
+
+        from PIL import Image  # noqa: PLC0415 — lazy, Pillow is a heavy import
+
+        img = Image.open(io.BytesIO(buf))
+        has_alpha = img.mode in ("RGBA", "LA", "PA") or "transparency" in img.info
+        out = io.BytesIO()
+        img.convert("RGBA" if has_alpha else "RGB").save(out, format="PNG")
+        return out.getvalue()
+    except Exception:  # noqa: BLE001
+        logger.debug("PNG re-encode failed", exc_info=True)
+        return None
+
+
+def _to_pasted_image(
+    buf: bytes,
+    *,
+    format_hint: str | None = None,
+    source_path: str | None = None,
+) -> PastedImage | None:
+    """Normalize raw bytes into an API-acceptable image.
+
+    Anything whose magic bytes are not one of the four API formats is re-encoded
+    as PNG, then everything goes through the shared resize/downsample envelope.
+    BMP is not a special case, just the most common instance of that rule
+    (Windows/WSL2 hand us BMP for a plain screenshot paste, and the API rejects
+    ``image/bmp``).
+    """
+    if not buf:
+        return None
+
+    # Convert to PNG BEFORE the resize, matching the reference (imagePaste.ts
+    # runs sharp(...).png() ahead of maybeResizeAndDownsampleImageBuffer). Doing
+    # it after would leave the re-encoded bytes unchecked against
+    # IMAGE_TARGET_RAW_SIZE -- a photographic TIFF already inside the dimension
+    # cap can still re-encode past the byte cap and 400 at the API.
+    #
+    # Magic bytes are authoritative here, not the file extension or the
+    # container's self-report: detect_image_format_from_buffer DEFAULTS to
+    # image/png on unknown magic, which would ship a TIFF-in-a-.png as PNG.
+    if _sniff_api_media_type(buf) is None:
+        converted = _reencode_png(buf)
+        if converted is None:
+            logger.debug("pasted image is not an API-supported format")
+            return None
+        buf = converted
+
+    # A media type, never a bare extension -- see _as_media_type.
+    hint = _as_media_type(format_hint)
+    try:
+        resized = maybe_resize_image(buf, len(buf), hint)
+        data, dimensions = resized.data, resized.dimensions
+    except ImageProcessingError:
+        logger.debug("could not decode pasted image", exc_info=True)
+        return None
+
+    # Re-sniff: the resize may have re-encoded (e.g. degraded PNG -> JPEG to fit
+    # the byte budget), so the pre-resize type is not necessarily still true.
+    media_type = _sniff_api_media_type(data)
+    if media_type is None:
+        logger.debug("resized image is not an API-supported format")
+        return None
+
+    return PastedImage(
+        base64=_base64.b64encode(data).decode("ascii"),
+        media_type=media_type,
+        dimensions=dimensions,
+        source_path=source_path,
+    )
+
+
+def get_image_from_clipboard() -> PastedImage | None:
+    """Read an image out of the system clipboard, resized for the API."""
+    buf = _read_clipboard_bytes()
+    if buf is None:
+        return None
+    return _to_pasted_image(buf, format_hint="png")
+
+
+def get_image_path_from_clipboard() -> str | None:
+    """Clipboard as a file path (Finder/Explorer copy of an image file)."""
+    if sys.platform == "darwin":
+        result = _run([
+            "osascript", "-e", "get POSIX path of (the clipboard as «class furl»)"
+        ])
+    elif sys.platform == "win32":
+        result = _run(["powershell", "-NoProfile", "-Command", "Get-Clipboard"])
+    else:
+        result = _run([
+            "xclip -selection clipboard -t text/plain -o 2>/dev/null || wl-paste 2>/dev/null"
+        ], shell=True)
+    if result is None or result.returncode != 0:
+        return None
+    text = result.stdout.decode("utf-8", "replace").strip()
+    return text or None
+
+
+def _from_file_uri(text: str) -> str:
+    """``file:///a/b%20c.png`` -> ``/a/b c.png``; anything else unchanged.
+
+    Load-bearing, not cosmetic: the client gates a paste with its own
+    ``looksLikeDroppedPath`` (useComposerState.ts), which deliberately accepts
+    ``file://`` URIs because that is what macOS puts on the clipboard when you
+    drag a screenshot out of the Finder or the screenshot HUD. Without decoding
+    here, every one of those pastes arrives percent-encoded, misses on disk, and
+    silently degrades to pasting the URI as text.
+
+    Only ``file://`` is decoded. An ``http(s)://`` URL is not a local file and
+    must not be unquoted into something that looks like one.
+    """
+    if not text.lower().startswith("file://"):
+        return text
+    from urllib.parse import unquote, urlparse
+
+    parsed = urlparse(text)
+    # A UNC-style host ("file://server/share") is not a local path; only the
+    # empty and "localhost" authorities name this machine.
+    if parsed.netloc and parsed.netloc.lower() != "localhost":
+        return text
+    path = unquote(parsed.path)
+    # ``file:///C:/Users/a/b.png`` parses to ``/C:/Users/a/b.png``, which
+    # ``PureWindowsPath`` reads as RELATIVE (no drive), so it would get joined
+    # onto the session cwd as ``D:\C:\Users\...``. Strip the leading slash that
+    # only exists to satisfy the URI grammar.
+    if path.startswith("/") and _DRIVE_RE.match(path[1:]):
+        path = path[1:]
+    return path or text
+
+
+def _remove_outer_quotes(text: str) -> str:
+    if len(text) >= 2 and (
+        (text.startswith('"') and text.endswith('"'))
+        or (text.startswith("'") and text.endswith("'"))
+    ):
+        return text[1:-1]
+    return text
+
+
+def _strip_backslash_escapes(path: str) -> str:
+    r"""Undo shell escaping a terminal adds to a dragged-in path.
+
+    ``name\ \(15\).png`` -> ``name (15).png``. Double backslashes are real
+    backslashes in the filename, so they are parked behind a random-salted
+    placeholder first -- a fixed sentinel would let a filename containing the
+    sentinel steer the result (the injection the TS port calls out).
+    """
+    if sys.platform == "win32":
+        # Backslashes ARE the separator here.
+        return path
+    salt = _base64.b16encode(os.urandom(8)).decode("ascii")
+    placeholder = f"__DOUBLE_BACKSLASH_{salt}__"
+    parked = path.replace("\\\\", placeholder)
+    unescaped = re.sub(r"\\(.)", r"\1", parked)
+    return unescaped.replace(placeholder, "\\")
+
+
+def _normalize_dropped(text: str) -> str:
+    """Quotes off, ``file://`` decoded, shell escapes undone -- in that order.
+
+    Order matters: the URI decode has to see the bare value (quotes stripped),
+    and escape-stripping has to run last or it would eat backslashes that
+    percent-decoding just produced on Windows paths.
+    """
+    return _strip_backslash_escapes(_from_file_uri(_remove_outer_quotes(text.strip())))
+
+
+#: A scheme-bearing URL that is NOT ``file:`` names something remote. Matched
+#: before the extension test so ``https://example.com/logo.png`` is declined
+#: rather than treated as a local path -- otherwise it reports a read error
+#: instead of falling through to an ordinary text paste, which is what pasting a
+#: link should do. Mirrors the client's ``looksLikeDroppedPath`` rejecting
+#: non-``file://`` URLs (useComposerState.ts).
+_REMOTE_URL_RE = re.compile(r"^(?!file:)[a-zA-Z][a-zA-Z0-9+.\-]*://")
+
+
+def as_image_file_path(text: str) -> str | None:
+    """Normalize ``text`` to a local image path, or None if it isn't one."""
+    cleaned = _normalize_dropped(text)
+    if _REMOTE_URL_RE.match(cleaned):
+        return None
+    # A surviving ``file://`` prefix means ``_from_file_uri`` DECLINED to decode
+    # it -- i.e. a UNC-style ``file://host/share`` naming another machine. Not a
+    # path here, so decline rather than hand the raw URI on as one.
+    if cleaned.lower().startswith("file://"):
+        return None
+    return cleaned if IMAGE_EXTENSION_RE.search(cleaned) else None
+
+
+def is_image_file_path(text: str) -> bool:
+    return as_image_file_path(text) is not None
+
+
+def try_read_image_from_path(text: str, *, cwd: Path | None = None) -> PastedImage | None:
+    """Read an image the user dragged/pasted as a path.
+
+    A relative path is resolved against ``cwd`` first, then against the
+    clipboard's own path by basename -- VS Code's terminal pastes only the
+    filename on Cmd+V, so the clipboard is the only place the directory
+    survives (TS tryReadImageFromPath).
+    """
+    cleaned = as_image_file_path(text)
+    if not cleaned:
+        return None
+
+    candidate = Path(cleaned).expanduser()
+    buf: bytes | None = None
+    resolved: str | None = None
+
+    try:
+        if candidate.is_absolute() and candidate.is_file():
+            buf, resolved = candidate.read_bytes(), str(candidate)
+        else:
+            local = ((cwd or Path.cwd()) / candidate).resolve()
+            if local.is_file():
+                buf, resolved = local.read_bytes(), str(local)
+            elif " " not in cleaned:
+                # Bare filename with no directory: VS Code's terminal pastes only
+                # the name on Cmd+V, so the clipboard is the only place the
+                # directory survives. Gated on "no spaces" so a prose string that
+                # happens to end in ".png" ("what is wrong with logo.png") cannot
+                # trigger a clipboard shell-out.
+                clip = get_image_path_from_clipboard()
+                if clip and candidate.name == Path(clip).name:
+                    clip_path = Path(clip)
+                    if clip_path.is_file():
+                        buf, resolved = clip_path.read_bytes(), str(clip_path)
+    except OSError:
+        logger.debug("could not read pasted image path", exc_info=True)
+        return None
+
+    if not buf:
+        if resolved is not None:
+            logger.warning("pasted image file is empty: %s", resolved)
+        return None
+
+    ext = candidate.suffix.lstrip(".").lower() or "png"
+    return _to_pasted_image(buf, format_hint=ext, source_path=resolved)
+
+
+def dimensions_to_wire(dims: ImageDimensions | None) -> dict[str, int]:
+    """Flatten dimensions into the ``width``/``height`` the client renders.
+
+    The client shows the size it will actually send, i.e. the DISPLAY size after
+    downsampling, falling back to the original when no resize happened.
+    """
+    if dims is None:
+        return {}
+    width = dims.display_width or dims.original_width
+    height = dims.display_height or dims.original_height
+    out: dict[str, int] = {}
+    if width:
+        out["width"] = int(width)
+    if height:
+        out["height"] = int(height)
+    return out
+
+
+#: Windows drive prefix, optionally quoted: ``C:\`` / ``"C:/``.
+_DRIVE_RE = re.compile(r"^[\"']?[A-Za-z]:[/\\]")
+
+
+def looks_like_dropped_path(text: str) -> bool:
+    """Does this look like a dragged-in path rather than prose?
+
+    A FAITHFUL port of ``looksLikeDroppedPath`` in
+    ``ui-tui/src/app/useComposerState.ts``. The two must agree: the client uses
+    it to decide whether to consult the server, and ``useSubmission.ts`` runs
+    ``input.detect_drop`` on submitted prompts, so a loose predicate here
+    rewrites ordinary prompts.
+
+    That is not hypothetical. The first version of this function only rejected
+    tabs and NULs, so ``hello world``, ``fix the bug in main.py`` and
+    ``README.md`` all returned True -- and ``README.md`` resolves to a real file,
+    so the prompt would have been silently replaced with ``@/abs/path/README.md``.
+
+    The rule is a PREFIX test, deliberately: a path is recognized by how it
+    starts, not by containing a dot somewhere. Bare relative names
+    (``README.md``) are NOT paths here -- too many prompts look like one.
+    """
+    stripped = text.strip()
+    if not stripped or "\n" in stripped:
+        return False
+    # Explicit path forms: URI, home-relative, dot-relative, quoted absolute,
+    # Windows drive.
+    if stripped.startswith((
+        "file://", "~/", "./", "../", '"/', "'/", '"~', "'~",
+    )):
+        return True
+    if _DRIVE_RE.match(stripped):
+        return True
+    # A bare absolute path needs a second separator or a dot, so that "/help"
+    # and "/model sonnet" stay slash-commands rather than path probes.
+    if stripped.startswith("/"):
+        rest = stripped[1:]
+        return "/" in rest or "." in rest
+    return False
+
+
+def resolve_dropped_file(text: str, *, cwd: Path | None = None) -> Path | None:
+    """Resolve a dropped path to an existing file, image or not."""
+    stripped = _normalize_dropped(text)
+    if not stripped:
+        return None
+    candidate = Path(stripped).expanduser()
+    try:
+        if candidate.is_absolute():
+            return candidate if candidate.is_file() else None
+        local = ((cwd or Path.cwd()) / candidate).resolve()
+        return local if local.is_file() else None
+    except OSError:  # pragma: no cover — exotic path errors
+        return None
+
+
+def clipboard_tooling_available() -> bool:
+    """Whether this platform has the helper binaries the readers need."""
+    if sys.platform == "darwin":
+        return shutil.which("osascript") is not None
+    if sys.platform == "win32":
+        return shutil.which("powershell") is not None
+    return shutil.which("xclip") is not None or shutil.which("wl-paste") is not None

--- a/tests/server/test_image_attach_control.py
+++ b/tests/server/test_image_attach_control.py
@@ -1,0 +1,467 @@
+"""agent-server image attachment: attach_image / clipboard_image / detect_file_drop.
+
+The client holds no image bytes — it only renders the "📎 Attached image" notice
+— so the server's pending list is the single source of truth, and the drain onto
+the next prompt is the behaviour that matters.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from src.utils.image_paste import PastedImage
+from src.utils.image_processor import ImageDimensions
+
+
+def _png(width: int = 40, height: int = 20) -> bytes:
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (10, 20, 200)).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _session(cwd: str = "/tmp"):
+    from src.server.agent_server import AgentServerConfig, _AgentSession
+
+    emitted: list = []
+    sess = _AgentSession(
+        session_id="s1",
+        cwd=cwd,
+        config=AgentServerConfig(single_session=True),
+        loop=mock.MagicMock(),
+        out_queue=mock.MagicMock(),
+    )
+    sess._emit = lambda env: emitted.append(env)
+    return sess, emitted
+
+
+def _reply_of(emitted: list) -> dict:
+    return emitted[-1]["response"]["response"]
+
+
+def _fake_image(*, resized: bool = False, source: str | None = None) -> PastedImage:
+    dims = (
+        ImageDimensions(
+            original_width=2400, original_height=1400,
+            display_width=1568, display_height=914,
+        )
+        if resized
+        else ImageDimensions(
+            original_width=40, original_height=20, display_width=40, display_height=20
+        )
+    )
+    return PastedImage(
+        base64="aGVsbG8=", media_type="image/png", dimensions=dims, source_path=source
+    )
+
+
+class TestDrainPendingImages(unittest.TestCase):
+    def test_no_pending_leaves_a_plain_string_alone(self) -> None:
+        """The text-only path must not be turned into a block list."""
+        sess, _ = _session()
+        self.assertEqual(sess._drain_pending_images("hello"), "hello")
+
+    def test_image_precedes_the_text(self) -> None:
+        sess, _ = _session()
+        sess._pending_images.append(_fake_image())
+        out = sess._drain_pending_images("what is this?")
+        self.assertIsInstance(out, list)
+        self.assertEqual(out[0]["type"], "image")
+        self.assertEqual(out[0]["source"]["media_type"], "image/png")
+        self.assertEqual(out[0]["source"]["data"], "aGVsbG8=")
+        self.assertEqual(out[-1], {"type": "text", "text": "what is this?"})
+
+    def test_resized_image_carries_scale_metadata(self) -> None:
+        """A downsampled screenshot needs the scale factor or coordinates lie."""
+        sess, _ = _session()
+        sess._pending_images.append(_fake_image(resized=True))
+        out = sess._drain_pending_images("click the button")
+        texts = [b["text"] for b in out if b["type"] == "text"]
+        self.assertTrue(
+            any("Multiply coordinates by" in t for t in texts),
+            f"expected coordinate-mapping metadata, got {texts}",
+        )
+
+    def test_unresized_clipboard_image_has_no_metadata_noise(self) -> None:
+        sess, _ = _session()
+        sess._pending_images.append(_fake_image(resized=False))
+        out = sess._drain_pending_images("hi")
+        self.assertEqual([b["type"] for b in out], ["image", "text"])
+
+    def test_drain_is_destructive(self) -> None:
+        """A resend must not duplicate the image."""
+        sess, _ = _session()
+        sess._pending_images.append(_fake_image())
+        first = sess._drain_pending_images("a")
+        self.assertIsInstance(first, list)
+        self.assertEqual(sess._pending_images, [])
+        self.assertEqual(sess._drain_pending_images("b"), "b")
+
+    def test_empty_text_yields_no_empty_text_block(self) -> None:
+        sess, _ = _session()
+        sess._pending_images.append(_fake_image())
+        out = sess._drain_pending_images("")
+        self.assertEqual([b["type"] for b in out], ["image"])
+
+    def test_existing_blocks_are_preserved(self) -> None:
+        sess, _ = _session()
+        sess._pending_images.append(_fake_image())
+        existing = [{"type": "text", "text": "hi"}]
+        out = sess._drain_pending_images(existing)
+        self.assertEqual(out[0]["type"], "image")
+        self.assertIn({"type": "text", "text": "hi"}, out)
+
+    def test_multiple_images_all_ride_along(self) -> None:
+        sess, _ = _session()
+        sess._pending_images.extend([_fake_image(), _fake_image()])
+        out = sess._drain_pending_images("two")
+        self.assertEqual(sum(1 for b in out if b["type"] == "image"), 2)
+
+
+class TestAttachImageControl(unittest.TestCase):
+    def _tmpimage(self, name: str = "a.png") -> Path:
+        import shutil
+        import tempfile
+
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
+        p = d / name
+        p.write_bytes(_png())
+        return p
+
+    def test_attach_by_path_queues_and_replies(self) -> None:
+        sess, emitted = _session()
+        path = self._tmpimage()
+        asyncio.run(sess._do_attach_image("r1", str(path)))
+        reply = _reply_of(emitted)
+        self.assertEqual(reply["name"], "a.png")
+        self.assertEqual(reply["width"], 40)
+        self.assertEqual(reply["height"], 20)
+        self.assertGreater(reply["token_estimate"], 0)
+        self.assertEqual(len(sess._pending_images), 1)
+
+    def test_reply_never_carries_base64(self) -> None:
+        """Bytes stay server-side; the client has no use for them."""
+        sess, emitted = _session()
+        asyncio.run(sess._do_attach_image("r1", str(self._tmpimage())))
+        self.assertNotIn("base64", repr(_reply_of(emitted)))
+
+    def test_non_image_path_declines_without_error(self) -> None:
+        """Caller must be free to fall through to generic file-drop handling."""
+        sess, emitted = _session()
+        asyncio.run(sess._do_attach_image("r1", "/tmp/notes.txt"))
+        self.assertEqual(_reply_of(emitted), {})
+        self.assertEqual(sess._pending_images, [])
+
+    def test_missing_image_reports_an_error(self) -> None:
+        sess, emitted = _session()
+        asyncio.run(sess._do_attach_image("r1", "/nonexistent/nope.png"))
+        self.assertIn("error", _reply_of(emitted))
+        self.assertEqual(sess._pending_images, [])
+
+    def test_empty_path_reports_an_error(self) -> None:
+        sess, emitted = _session()
+        asyncio.run(sess._do_attach_image("r1", ""))
+        self.assertIn("error", _reply_of(emitted))
+
+    def test_reader_exception_does_not_escape(self) -> None:
+        sess, emitted = _session()
+        with mock.patch(
+            "src.utils.image_paste.try_read_image_from_path",
+            side_effect=RuntimeError("boom"),
+        ):
+            asyncio.run(sess._do_attach_image("r1", "/tmp/a.png"))
+        self.assertIn("error", _reply_of(emitted))
+
+
+class TestClipboardImageControl(unittest.TestCase):
+    def test_attaches_a_clipboard_image(self) -> None:
+        sess, emitted = _session()
+        with mock.patch(
+            "src.utils.image_paste.get_image_from_clipboard", return_value=_fake_image()
+        ), mock.patch(
+            "src.utils.image_paste.clipboard_tooling_available", return_value=True
+        ):
+            asyncio.run(sess._do_clipboard_image("r1"))
+        reply = _reply_of(emitted)
+        self.assertEqual(reply["name"], "clipboard image")
+        self.assertEqual(len(sess._pending_images), 1)
+
+    def test_empty_clipboard_replies_empty(self) -> None:
+        """Distinct from unavailable: the client falls back to a text paste."""
+        sess, emitted = _session()
+        with mock.patch(
+            "src.utils.image_paste.get_image_from_clipboard", return_value=None
+        ), mock.patch(
+            "src.utils.image_paste.clipboard_tooling_available", return_value=True
+        ):
+            asyncio.run(sess._do_clipboard_image("r1"))
+        self.assertEqual(_reply_of(emitted), {})
+        self.assertEqual(sess._pending_images, [])
+
+    def test_missing_tooling_is_distinguishable(self) -> None:
+        sess, emitted = _session()
+        with mock.patch(
+            "src.utils.image_paste.clipboard_tooling_available", return_value=False
+        ):
+            asyncio.run(sess._do_clipboard_image("r1"))
+        self.assertTrue(_reply_of(emitted).get("unavailable"))
+
+    def test_reader_exception_does_not_escape(self) -> None:
+        sess, emitted = _session()
+        with mock.patch(
+            "src.utils.image_paste.get_image_from_clipboard",
+            side_effect=RuntimeError("boom"),
+        ), mock.patch(
+            "src.utils.image_paste.clipboard_tooling_available", return_value=True
+        ):
+            asyncio.run(sess._do_clipboard_image("r1"))
+        self.assertIn("error", _reply_of(emitted))
+
+
+class TestDetectFileDrop(unittest.TestCase):
+    def _tmpfile(self, name: str, data: bytes) -> Path:
+        import shutil
+        import tempfile
+
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
+        p = d / name
+        p.write_bytes(data)
+        return p
+
+    def test_dropped_image_is_attached(self) -> None:
+        sess, emitted = _session()
+        p = self._tmpfile("shot.png", _png())
+        asyncio.run(sess._do_detect_file_drop("r1", str(p)))
+        reply = _reply_of(emitted)
+        self.assertTrue(reply["matched"])
+        self.assertTrue(reply["is_image"])
+        self.assertEqual(reply["name"], "shot.png")
+        self.assertEqual(reply["text"], "", "an attached image inserts no text")
+        self.assertEqual(len(sess._pending_images), 1)
+
+    def test_dropped_non_image_becomes_an_at_reference(self) -> None:
+        sess, emitted = _session()
+        p = self._tmpfile("data.csv", b"a,b\n1,2\n")
+        asyncio.run(sess._do_detect_file_drop("r1", str(p)))
+        reply = _reply_of(emitted)
+        self.assertTrue(reply["matched"])
+        self.assertFalse(reply["is_image"])
+        self.assertEqual(reply["text"], f"@{p}")
+        self.assertEqual(sess._pending_images, [])
+
+    def test_prose_does_not_match(self) -> None:
+        sess, emitted = _session()
+        asyncio.run(sess._do_detect_file_drop("r1", "please look at\nthis thing"))
+        self.assertEqual(_reply_of(emitted), {"matched": False})
+
+    def test_nonexistent_path_does_not_match(self) -> None:
+        sess, emitted = _session()
+        asyncio.run(sess._do_detect_file_drop("r1", "/nonexistent/whatever.csv"))
+        self.assertEqual(_reply_of(emitted), {"matched": False})
+
+    def test_unreadable_image_falls_through_to_file_handling(self) -> None:
+        """A .png that isn't decodable is still a real file on disk."""
+        sess, emitted = _session()
+        p = self._tmpfile("liar.png", b"not an image")
+        asyncio.run(sess._do_detect_file_drop("r1", str(p)))
+        reply = _reply_of(emitted)
+        self.assertTrue(reply["matched"])
+        self.assertFalse(reply["is_image"])
+        self.assertEqual(sess._pending_images, [])
+
+
+class TestPendingImagesLifecycle(unittest.TestCase):
+    def test_user_message_drains_the_queue(self) -> None:
+        """The whole point: an attached image reaches the model with the prompt."""
+
+        sess, _ = _session()
+        sess._pending_images.append(_fake_image())
+        put: list = []
+        sess._inbox = mock.Mock(put=put.append)
+
+        asyncio.run(
+            sess.send_to_agent({"type": "user", "message": {"role": "user", "content": "hi"}})
+        )
+
+        self.assertEqual(len(put), 1)
+        content = put[0]
+        self.assertIsInstance(content, list)
+        self.assertEqual(content[0]["type"], "image")
+        self.assertEqual(sess._pending_images, [])
+
+    def test_text_only_turn_still_puts_a_string(self) -> None:
+
+        sess, _ = _session()
+        put: list = []
+        sess._inbox = mock.Mock(put=put.append)
+
+        asyncio.run(
+            sess.send_to_agent({"type": "user", "message": {"role": "user", "content": "hi"}})
+        )
+
+        self.assertEqual(put, ["hi"])
+
+    def test_ephemeral_turn_does_not_consume_the_image(self) -> None:
+        """A "btw" message must leave the queue alone.
+
+        ``_run_turn(btw=True)`` restores a pre-turn snapshot, so draining into an
+        ephemeral message would consume the image and then discard it. The
+        earlier version of this test asserted the opposite and pinned the bug.
+        """
+        sess, _ = _session()
+        sess._pending_images.append(_fake_image())
+        put: list = []
+        sess._inbox = mock.Mock(put=put.append)
+
+        asyncio.run(
+            sess.send_to_agent({
+                "type": "user",
+                "ephemeral": True,
+                "message": {"role": "user", "content": "btw"},
+            })
+        )
+
+        self.assertTrue(put[0]["__btw__"])
+        self.assertEqual(put[0]["content"], "btw", "no image blocks on an ephemeral turn")
+        self.assertEqual(len(sess._pending_images), 1, "image must survive for the real turn")
+
+    def test_ephemeral_envelope_shape_preserved(self) -> None:
+        """The __btw__ wrapper still applies with nothing queued."""
+        sess, _ = _session()
+        put: list = []
+        sess._inbox = mock.Mock(put=put.append)
+
+        asyncio.run(
+            sess.send_to_agent({
+                "type": "user",
+                "ephemeral": True,
+                "message": {"role": "user", "content": "btw"},
+            })
+        )
+
+        self.assertEqual(put[0], {"__btw__": True, "content": "btw"})
+
+
+
+class TestClearDropsPendingImages(unittest.TestCase):
+    """An unsent image belongs to the conversation the user just discarded.
+
+    Carrying it across /clear would silently attach it to an unrelated prompt in
+    a fresh context.
+    """
+
+    def test_clear_empties_the_queue(self) -> None:
+
+        sess, emitted = _session()
+        sess._pending_images.append(_fake_image())
+
+        asyncio.run(
+            sess._handle_control_request({"request_id": "c1", "request": {"subtype": "clear"}})
+        )
+
+        self.assertEqual(sess._pending_images, [])
+
+    def test_clear_refused_mid_turn_keeps_the_queue(self) -> None:
+        """A refused clear must not have side effects."""
+
+        sess, emitted = _session()
+        sess._pending_images.append(_fake_image())
+        sess._current_abort = object()  # an active turn
+
+        asyncio.run(
+            sess._handle_control_request({"request_id": "c1", "request": {"subtype": "clear"}})
+        )
+
+        self.assertFalse(_reply_of(emitted).get("ok"))
+        self.assertEqual(len(sess._pending_images), 1)
+
+
+class TestBlockOrderConsumers(unittest.TestCase):
+    """The user's text must be the FIRST text block.
+
+    Three consumers flatten content by concatenating text blocks with no
+    separator and then read the front of the result, so leading metadata broke
+    all three: ``_parse_turn_budget`` (``^``-anchored, so ``+500k`` no-ops),
+    ``_first_prompt_preview`` (/resume + branch names), and UserPromptSubmit
+    hooks (``^``-anchored matchers).
+    """
+
+    def test_metadata_trails_the_user_text(self) -> None:
+        sess, _ = _session()
+        sess._pending_images.append(_fake_image(resized=True, source="/tmp/shot.png"))
+        out = sess._drain_pending_images("+500k refactor this")
+        texts = [b["text"] for b in out if b["type"] == "text"]
+        self.assertEqual(texts[0], "+500k refactor this")
+        self.assertTrue(any("Multiply coordinates by" in t for t in texts[1:]))
+        self.assertEqual(out[0]["type"], "image", "images still lead")
+
+    def test_flattened_text_starts_with_the_prompt(self) -> None:
+        from src.server.agent_server import _extract_prompt_text
+
+        sess, _ = _session()
+        sess._pending_images.append(_fake_image(resized=True, source="/tmp/shot.png"))
+        out = sess._drain_pending_images("+500k do the thing")
+        flat = _extract_prompt_text({"message": {"role": "user", "content": out}})
+        self.assertTrue(
+            flat.startswith("+500k do the thing"),
+            f"a ^-anchored consumer would miss: {flat[:60]!r}",
+        )
+
+    def test_first_prompt_preview_shows_the_prompt(self) -> None:
+        from src.server.agent_server import _first_prompt_preview
+        from src.types.messages import create_user_message
+
+        sess, _ = _session()
+        sess._pending_images.append(_fake_image(resized=True, source="/tmp/shot.png"))
+        out = sess._drain_pending_images("what is in this screenshot?")
+        preview = _first_prompt_preview([create_user_message(out)])
+        self.assertIsNotNone(preview)
+        self.assertNotIn("[Image", preview)
+        self.assertIn("screenshot", preview)
+
+
+class TestPendingImageCap(unittest.TestCase):
+    """Unbounded queueing plus a destructive drain loses every image at once."""
+
+    def test_cap_refuses_the_overflow_attach(self) -> None:
+        sess, emitted = _session()
+        for _ in range(sess.MAX_PENDING_IMAGES):
+            self.assertTrue(sess._queue_image(_fake_image()))
+        self.assertFalse(sess._queue_image(_fake_image()))
+        self.assertEqual(len(sess._pending_images), sess.MAX_PENDING_IMAGES)
+
+    def test_overflow_reports_an_actionable_error(self) -> None:
+        sess, emitted = _session()
+        for _ in range(sess.MAX_PENDING_IMAGES):
+            sess._queue_image(_fake_image())
+        sess._attach_image("r1", _fake_image())
+        error = _reply_of(emitted).get("error", "")
+        self.assertIn("/clear", error)
+        self.assertNotIn("name", _reply_of(emitted))
+
+    def test_dropped_path_route_is_also_capped(self) -> None:
+        """Every producer goes through _queue_image, not an inline append."""
+        import shutil
+        import tempfile
+
+        sess, emitted = _session()
+        for _ in range(sess.MAX_PENDING_IMAGES):
+            sess._queue_image(_fake_image())
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
+        p = d / "extra.png"
+        p.write_bytes(_png())
+        asyncio.run(sess._do_detect_file_drop("r1", str(p)))
+        self.assertEqual(len(sess._pending_images), sess.MAX_PENDING_IMAGES)
+        self.assertIn("error", _reply_of(emitted))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gemini_image_blocks.py
+++ b/tests/test_gemini_image_blocks.py
@@ -1,0 +1,170 @@
+"""Gemini's image-block conversion.
+
+The converter had branches for text / tool_use / tool_result and **no image
+branch and no else**, so an image block was silently skipped: the request went
+out text-only, and because a pasted image also carries an ``[Image: source: …]``
+metadata line, the model received a DESCRIPTION of an image it never saw and
+confabulated an answer. A wrong answer delivered confidently is a worse failure
+than an error.
+
+``google-genai`` is not installed in this environment, so these tests stub
+``genai_types``. That is enough to pin the dispatch — which constructor is
+called, with which keywords, and how each failure is classified — because
+``_gemini_image_part`` is pure. It does NOT prove the SDK accepts the Part; that
+needs a machine with the SDK.
+"""
+
+from __future__ import annotations
+
+import base64
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from src.providers import gemini_provider as gp
+
+PNG = base64.b64encode(b"\x89PNG\r\n\x1a\nfake").decode("ascii")
+
+
+def _block(data: str = PNG, media_type: str = "image/png", **overrides) -> dict:
+    source = {"type": "base64", "media_type": media_type, "data": data}
+    source.update(overrides.pop("source", {}))
+    return {"type": "image", "source": source, **overrides}
+
+
+class _ModernPart:
+    """Stub exposing only the modern Part.from_bytes constructor."""
+
+    calls: list = []
+
+    @staticmethod
+    def from_bytes(*, data, mime_type):
+        _ModernPart.calls.append({"data": data, "mime_type": mime_type})
+        return SimpleNamespace(kind="from_bytes", data=data, mime_type=mime_type)
+
+
+class TestModernConstructor(unittest.TestCase):
+    def setUp(self) -> None:
+        _ModernPart.calls = []
+        self.types = SimpleNamespace(Part=_ModernPart)  # no Blob attribute
+
+    def test_uses_from_bytes_with_documented_keywords(self) -> None:
+        with mock.patch.object(gp, "genai_types", self.types):
+            part = gp._gemini_image_part(_block())
+        self.assertEqual(part.kind, "from_bytes")
+        self.assertEqual(_ModernPart.calls[0]["mime_type"], "image/png")
+        self.assertEqual(_ModernPart.calls[0]["data"], base64.b64decode(PNG))
+
+    def test_media_type_is_forwarded(self) -> None:
+        with mock.patch.object(gp, "genai_types", self.types):
+            gp._gemini_image_part(_block(media_type="image/jpeg"))
+        self.assertEqual(_ModernPart.calls[0]["mime_type"], "image/jpeg")
+
+    def test_missing_media_type_defaults_to_png(self) -> None:
+        block = {"type": "image", "source": {"type": "base64", "data": PNG}}
+        with mock.patch.object(gp, "genai_types", self.types):
+            gp._gemini_image_part(block)
+        self.assertEqual(_ModernPart.calls[0]["mime_type"], "image/png")
+
+
+class TestLegacyConstructor(unittest.TestCase):
+    def test_falls_back_to_inline_data_blob(self) -> None:
+        """An SDK pin must not silently disable image input."""
+        made: list = []
+
+        class _Blob:
+            def __init__(self, *, data, mime_type):
+                made.append({"data": data, "mime_type": mime_type})
+                self.data, self.mime_type = data, mime_type
+
+        class _Part:
+            def __init__(self, *, inline_data):
+                self.inline_data = inline_data
+
+        types = SimpleNamespace(Part=_Part, Blob=_Blob)  # no from_bytes
+        with mock.patch.object(gp, "genai_types", types):
+            part = gp._gemini_image_part(_block())
+        self.assertIsInstance(part.inline_data, _Blob)
+        self.assertEqual(made[0]["mime_type"], "image/png")
+
+
+class TestCapabilityGap(unittest.TestCase):
+    def test_raises_when_neither_constructor_exists(self) -> None:
+        types = SimpleNamespace(Part=SimpleNamespace())  # no from_bytes, no Blob
+        with mock.patch.object(gp, "genai_types", types):
+            with self.assertRaises(gp._GeminiImageUnsupported) as ctx:
+                gp._gemini_image_part(_block())
+        self.assertIn("Switch to an Anthropic", str(ctx.exception))
+
+
+class TestMalformedBlocks(unittest.TestCase):
+    """A corrupt payload is NOT a capability gap.
+
+    Both used to return None and produce the same "switch models" message, which
+    is useless advice for someone holding a bad base64 string.
+    """
+
+    def setUp(self) -> None:
+        self.types = SimpleNamespace(Part=_ModernPart)
+
+    def _declines(self, block: dict) -> None:
+        with mock.patch.object(gp, "genai_types", self.types):
+            self.assertIsNone(gp._gemini_image_part(block))
+
+    def test_url_source_declined(self) -> None:
+        self._declines({"type": "image", "source": {"type": "url", "url": "http://x/y.png"}})
+
+    def test_missing_source_declined(self) -> None:
+        self._declines({"type": "image"})
+
+    def test_empty_data_declined(self) -> None:
+        self._declines(_block(data=""))
+
+    def test_non_string_data_declined(self) -> None:
+        self._declines({"type": "image", "source": {"type": "base64", "data": 123}})
+
+    def test_undecodable_base64_declined(self) -> None:
+        self._declines(_block(data="!!!not base64!!!"))
+
+    def test_whitespace_only_base64_declined(self) -> None:
+        self._declines(_block(data="   "))
+
+
+class TestConverterIntegration(unittest.TestCase):
+    """The image branch reaches parts, and a malformed block does not kill the turn."""
+
+    def _convert(self, content):
+        types = SimpleNamespace(
+            Part=_ModernPart,
+            Content=lambda **kw: SimpleNamespace(**kw),
+        )
+        types.Part.from_text = staticmethod(
+            lambda *, text: SimpleNamespace(kind="text", text=text)
+        )
+        provider = gp.GeminiProvider.__new__(gp.GeminiProvider)
+        # _convert_messages gates on _ensure_sdk(), which needs a non-None
+        # `genai`. Stub it: the conversion itself only touches genai_types.
+        with mock.patch.object(gp, "genai_types", types), \
+                mock.patch.object(gp, "genai", SimpleNamespace()):
+            return provider._convert_messages([{"role": "user", "content": content}])
+
+    def test_image_block_reaches_parts(self) -> None:
+        _ModernPart.calls = []
+        contents, _system = self._convert(
+            [{"type": "text", "text": "what is this?"}, _block()]
+        )
+        kinds = [getattr(p, "kind", None) for p in contents[0].parts]
+        self.assertIn("from_bytes", kinds, f"image block was dropped: {kinds}")
+        self.assertIn("text", kinds)
+
+    def test_malformed_image_block_is_skipped_not_fatal(self) -> None:
+        _ModernPart.calls = []
+        contents, _system = self._convert(
+            [{"type": "text", "text": "hi"}, _block(data="!!bad!!")]
+        )
+        kinds = [getattr(p, "kind", None) for p in contents[0].parts]
+        self.assertEqual(kinds, ["text"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_image_paste.py
+++ b/tests/test_image_paste.py
@@ -1,0 +1,486 @@
+"""Clipboard / dropped-path image ingestion.
+
+Covers ``src/utils/image_paste.py`` (the port of
+``typescript/src/utils/imagePaste.ts``) and the agent-server control handlers
+that queue an attached image onto the next prompt.
+
+Before this existed, ui-tui called ``image.attach`` / ``input.detect_drop`` on
+every pasted path and ``gatewayClient`` had no case for either, so both resolved
+``{}`` and the paste silently degraded to inserting the path as literal text.
+There was no clipboard-bytes path at all — pasting a screenshot did nothing.
+"""
+
+from __future__ import annotations
+
+import base64
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from src.utils import image_paste as ip
+from src.utils.image_processor import ImageDimensions
+
+
+def _png(width: int = 40, height: int = 20, color=(10, 20, 200)) -> bytes:
+    import io
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _bmp(width: int = 30, height: int = 30) -> bytes:
+    import io
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (200, 10, 10)).save(buf, format="BMP")
+    return buf.getvalue()
+
+
+class TestPathNormalization(unittest.TestCase):
+    def test_plain_image_paths(self) -> None:
+        for path in ("/tmp/a.png", "/tmp/a.JPG", "shot.jpeg", "x.gif", "y.webp", "z.bmp"):
+            with self.subTest(path=path):
+                self.assertTrue(ip.is_image_file_path(path))
+
+    def test_non_image_paths_declined(self) -> None:
+        for path in ("/tmp/notes.txt", "/tmp/archive.tar.gz", "README", "a.png.txt"):
+            with self.subTest(path=path):
+                self.assertFalse(ip.is_image_file_path(path))
+
+    def test_outer_quotes_stripped(self) -> None:
+        self.assertEqual(ip.as_image_file_path('"/tmp/b.jpeg"'), "/tmp/b.jpeg")
+        self.assertEqual(ip.as_image_file_path("'/tmp/b.jpeg'"), "/tmp/b.jpeg")
+
+    @unittest.skipIf(sys.platform == "win32", "backslashes are separators on Windows")
+    def test_shell_escapes_removed(self) -> None:
+        """A terminal escapes a dragged path; the file name has no backslashes."""
+        self.assertEqual(
+            ip.as_image_file_path(r"/tmp/name\ \(15\).png"), "/tmp/name (15).png"
+        )
+
+    @unittest.skipIf(sys.platform == "win32", "backslashes are separators on Windows")
+    def test_double_backslash_is_a_literal_backslash(self) -> None:
+        self.assertEqual(ip.as_image_file_path(r"/tmp/a\\b.png"), "/tmp/a\\b.png")
+
+    @unittest.skipIf(sys.platform == "win32", "backslashes are separators on Windows")
+    def test_placeholder_in_filename_cannot_steer_unescaping(self) -> None:
+        """The salted placeholder defends against a crafted filename.
+
+        A fixed sentinel would let a path containing that sentinel come back out
+        as a backslash. The salt makes the sentinel unguessable per call.
+
+        Pin it properly: force a KNOWN salt, then feed the exact sentinel that
+        salt produces. Without the salt (a fixed sentinel) this input would come
+        back with a backslash spliced in. A test using an arbitrary
+        ``__DOUBLE_BACKSLASH_deadbeef__`` string passes with or without the salt
+        and proves nothing.
+        """
+        salt = "ab" * 8  # b16encode(os.urandom(8)) is 16 hex chars
+        sentinel = f"__DOUBLE_BACKSLASH_{salt}__"
+        crafted = f"/tmp/{sentinel}.png"
+        with mock.patch("os.urandom", return_value=bytes.fromhex(salt.lower())):
+            got = ip.as_image_file_path(crafted)
+        self.assertEqual(got, crafted, "a crafted sentinel must survive verbatim")
+        self.assertNotIn("\\", got)
+
+    def test_looks_like_dropped_path_rejects_prose(self) -> None:
+        self.assertFalse(ip.looks_like_dropped_path("here is a\nmultiline paste"))
+        self.assertFalse(ip.looks_like_dropped_path("   "))
+        self.assertTrue(ip.looks_like_dropped_path("/tmp/a.png"))
+
+
+class TestReadFromPath(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = mock.patch.dict("os.environ", {}, clear=False)
+        self._tmp.start()
+        self.addCleanup(self._tmp.stop)
+
+    def _write(self, name: str, data: bytes) -> Path:
+        import tempfile
+
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: __import__("shutil").rmtree(d, ignore_errors=True))
+        p = d / name
+        p.write_bytes(data)
+        return p
+
+    def test_reads_absolute_path(self) -> None:
+        p = self._write("a.png", _png())
+        got = ip.try_read_image_from_path(str(p))
+        self.assertIsNotNone(got)
+        self.assertEqual(got.media_type, "image/png")
+        self.assertEqual(got.source_path, str(p))
+        self.assertTrue(base64.b64decode(got.base64).startswith(b"\x89PNG"))
+
+    def test_reads_relative_path_against_cwd(self) -> None:
+        p = self._write("rel.png", _png())
+        got = ip.try_read_image_from_path("rel.png", cwd=p.parent)
+        self.assertIsNotNone(got)
+        self.assertEqual(got.media_type, "image/png")
+
+    def test_downsamples_past_the_dimension_cap(self) -> None:
+        from src.utils.image_processor import IMAGE_MAX_WIDTH
+
+        p = self._write("big.png", _png(2400, 1400))
+        got = ip.try_read_image_from_path(str(p))
+        self.assertIsNotNone(got)
+        self.assertEqual(got.dimensions.original_width, 2400)
+        self.assertEqual(got.dimensions.display_width, IMAGE_MAX_WIDTH)
+        self.assertLess(got.dimensions.display_width, got.dimensions.original_width)
+
+    def test_bmp_converted_to_png(self) -> None:
+        """The API rejects image/bmp, and Windows/WSL2 paste BMP for a screenshot."""
+        p = self._write("shot.bmp", _bmp())
+        got = ip.try_read_image_from_path(str(p))
+        self.assertIsNotNone(got)
+        self.assertEqual(got.media_type, "image/png")
+        self.assertTrue(base64.b64decode(got.base64).startswith(b"\x89PNG"))
+
+    def test_missing_file_declines(self) -> None:
+        self.assertIsNone(ip.try_read_image_from_path("/nonexistent/nope.png"))
+
+    def test_empty_file_declines(self) -> None:
+        p = self._write("empty.png", b"")
+        self.assertIsNone(ip.try_read_image_from_path(str(p)))
+
+    def test_non_image_bytes_with_image_extension_decline(self) -> None:
+        """A .png that isn't a PNG must not reach the API as one."""
+        p = self._write("liar.png", b"this is not an image")
+        self.assertIsNone(ip.try_read_image_from_path(str(p)))
+
+    def test_non_image_extension_never_read(self) -> None:
+        p = self._write("notes.txt", b"hello")
+        self.assertIsNone(ip.try_read_image_from_path(str(p)))
+
+    def test_basename_falls_back_to_clipboard_path(self) -> None:
+        """VS Code pastes only the filename; the clipboard holds the directory."""
+        p = self._write("vscode.png", _png())
+        with mock.patch.object(ip, "get_image_path_from_clipboard", return_value=str(p)):
+            got = ip.try_read_image_from_path("vscode.png", cwd=Path("/nonexistent"))
+        self.assertIsNotNone(got)
+        self.assertEqual(got.source_path, str(p))
+
+
+class TestClipboardRead(unittest.TestCase):
+    def test_returns_none_when_helper_missing(self) -> None:
+        with mock.patch.object(ip, "_run", return_value=None):
+            self.assertIsNone(ip.get_image_from_clipboard())
+            self.assertFalse(ip.has_image_in_clipboard())
+
+    def test_returns_none_when_clipboard_has_no_image(self) -> None:
+        fail = mock.Mock(returncode=1, stdout=b"", stderr=b"")
+        with mock.patch.object(ip, "_run", return_value=fail):
+            self.assertIsNone(ip.get_image_from_clipboard())
+
+    def test_decodes_written_bytes(self) -> None:
+        """The helper writes a temp PNG; the reader picks it up and cleans up."""
+        import shutil
+        import tempfile
+
+        payload = _png(60, 30)
+        # _screenshot_path() mints a FRESH private mkdtemp per call (so a shared
+        # /tmp cannot be symlink-attacked and no quote can reach the AppleScript
+        # literal), so pin it here rather than calling it twice.
+        holder = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(holder, ignore_errors=True))
+        target = holder / "shot.png"
+
+        def fake_run(argv, *, shell=False):
+            target.write_bytes(payload)
+            return mock.Mock(returncode=0, stdout=b"", stderr=b"")
+
+        with mock.patch.object(ip, "_screenshot_path", return_value=target), \
+                mock.patch.object(ip, "_run", side_effect=fake_run):
+            got = ip.get_image_from_clipboard()
+
+        self.assertIsNotNone(got)
+        self.assertEqual(got.media_type, "image/png")
+        self.assertIsNone(got.source_path, "clipboard images have no source path")
+        self.assertFalse(target.exists(), "temp screenshot must be cleaned up")
+
+    def test_temp_path_is_private_and_unpredictable(self) -> None:
+        """No fixed name in a shared temp dir (CWE-377/59 on Linux)."""
+        import stat
+
+        first = ip._screenshot_path()
+        second = ip._screenshot_path()
+        self.addCleanup(lambda: first.parent.rmdir())
+        self.addCleanup(lambda: second.parent.rmdir())
+        self.assertNotEqual(first.parent, second.parent)
+        mode = stat.S_IMODE(first.parent.stat().st_mode)
+        self.assertEqual(mode, 0o700, f"temp dir must be private, got {oct(mode)}")
+        self.assertNotIn("'", str(first))
+        self.assertNotIn('"', str(first))
+
+    def test_timeout_is_bounded(self) -> None:
+        """A wedged clipboard helper must not hang the turn forever."""
+        import subprocess
+
+        with mock.patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="osascript", timeout=1),
+        ):
+            self.assertIsNone(ip._run(["osascript", "-e", "x"]))
+        self.assertLessEqual(ip.CLIPBOARD_TIMEOUT_S, 60)
+
+
+class TestLinuxCommands(unittest.TestCase):
+    def test_check_command_covers_every_mime(self) -> None:
+        cmd = ip.build_linux_clipboard_check_command()
+        for mime in ip.LINUX_CLIPBOARD_IMAGE_MIME_TYPES:
+            self.assertIn(mime.replace("/", r"\/"), cmd)
+        self.assertIn("xclip", cmd)
+        self.assertIn("wl-paste", cmd)
+
+    def test_save_command_tries_both_backends(self) -> None:
+        cmd = ip.build_linux_clipboard_save_command("/tmp/x.png")
+        self.assertIn("xclip -selection clipboard -t image/png", cmd)
+        self.assertIn("wl-paste --type image/png", cmd)
+        self.assertIn(" || ", cmd)
+
+
+class TestDimensionsWire(unittest.TestCase):
+    def test_prefers_display_size(self) -> None:
+        dims = ImageDimensions(
+            original_width=2400, original_height=1400,
+            display_width=1568, display_height=914,
+        )
+        self.assertEqual(ip.dimensions_to_wire(dims), {"width": 1568, "height": 914})
+
+    def test_falls_back_to_original(self) -> None:
+        dims = ImageDimensions(original_width=40, original_height=20)
+        self.assertEqual(ip.dimensions_to_wire(dims), {"width": 40, "height": 20})
+
+    def test_none_is_empty(self) -> None:
+        self.assertEqual(ip.dimensions_to_wire(None), {})
+
+
+
+class TestFileUriDecoding(unittest.TestCase):
+    """macOS puts a percent-encoded file:// URI on the clipboard for a dragged
+    screenshot, and the client's looksLikeDroppedPath deliberately accepts those.
+    Without decoding here every such paste missed on disk and degraded to text.
+    """
+
+    def test_percent_encoded_screenshot_uri(self) -> None:
+        uri = (
+            "file:///var/folders/x/T/TemporaryItems/"
+            "Screenshot%202026-04-21%20at%201.04.43%20PM.png"
+        )
+        self.assertEqual(
+            ip.as_image_file_path(uri),
+            "/var/folders/x/T/TemporaryItems/Screenshot 2026-04-21 at 1.04.43 PM.png",
+        )
+
+    def test_plain_file_uri(self) -> None:
+        self.assertEqual(ip.as_image_file_path("file:///tmp/plain.png"), "/tmp/plain.png")
+
+    def test_localhost_authority_is_local(self) -> None:
+        self.assertEqual(
+            ip.as_image_file_path("file://localhost/tmp/local.png"), "/tmp/local.png"
+        )
+
+    def test_unc_authority_is_not_treated_as_local(self) -> None:
+        """file://server/share is a remote host, not a path on this machine."""
+        self.assertIsNone(ip.as_image_file_path("file://server/share/remote.png"))
+
+    def test_remote_urls_declined(self) -> None:
+        """A pasted link must fall through to a text paste, not error as a path."""
+        for url in (
+            "https://example.com/image.png",
+            "http://localhost/x.png",
+            "ftp://host/y.jpg",
+            "data:image/png;base64,AAAA",
+        ):
+            with self.subTest(url=url):
+                self.assertIsNone(ip.as_image_file_path(url))
+
+    def test_reads_a_real_file_through_a_uri(self) -> None:
+        import shutil
+        import tempfile
+
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
+        p = d / "shot with spaces.png"
+        p.write_bytes(_png())
+        uri = "file://" + str(p).replace(" ", "%20")
+        got = ip.try_read_image_from_path(uri)
+        self.assertIsNotNone(got)
+        self.assertEqual(got.source_path, str(p))
+
+
+class TestApiFormatEnvelope(unittest.TestCase):
+    """Everything handed to the API must BE one of its four formats.
+
+    Two silent-failure bugs lived here. (1) ``format_hint`` was passed as a bare
+    extension, but ``maybe_resize_image`` uses it as the media-type fallback and
+    then hands it to the encoder -- so every BMP over the size/dimension caps
+    raised "Unsupported image encoding type: png" and was dropped. That is
+    exactly the full-screen Windows/WSL2 screenshot BMP exists for, and the
+    original 30x30 BMP test took the fast path and never reached the encoder.
+    (2) ``detect_image_format_from_buffer`` DEFAULTS to image/png on unknown
+    magic, so a TIFF in a .png shipped labeled image/png and 400'd.
+    """
+
+    def _write(self, name: str, data: bytes) -> Path:
+        import shutil
+        import tempfile
+
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
+        p = d / name
+        p.write_bytes(data)
+        return p
+
+    def _save(self, fmt: str, size=(1920, 1080)) -> bytes:
+        import io
+
+        from PIL import Image
+
+        buf = io.BytesIO()
+        Image.new("RGB", size, (40, 80, 160)).save(buf, format=fmt)
+        return buf.getvalue()
+
+    def test_oversized_bmp_survives_the_resize_path(self) -> None:
+        from src.utils.image_processor import IMAGE_MAX_WIDTH
+
+        got = ip.try_read_image_from_path(str(self._write("big.bmp", self._save("BMP"))))
+        self.assertIsNotNone(got, "an oversized BMP must not be dropped")
+        self.assertEqual(got.media_type, "image/png")
+        self.assertEqual(got.dimensions.display_width, IMAGE_MAX_WIDTH)
+        self.assertTrue(base64.b64decode(got.base64).startswith(b"\x89PNG"))
+
+    def test_unsupported_extension_declined_before_reading(self) -> None:
+        """``.tiff`` is not an accepted input extension, so it never gets read.
+
+        The gate is the extension allow-list (``IMAGE_EXTENSION_RE``), matching
+        the reference's ``IMAGE_EXTENSION_REGEX``. TIFF *content* inside an
+        accepted extension is a different case -- covered below, where it must be
+        re-encoded rather than relabeled.
+        """
+        self.assertIsNone(
+            ip.try_read_image_from_path(str(self._write("shot.tiff", self._save("TIFF"))))
+        )
+
+    def test_tiff_bytes_in_a_png_filename(self) -> None:
+        got = ip.try_read_image_from_path(
+            str(self._write("liar.png", self._save("TIFF", (20, 20))))
+        )
+        self.assertIsNotNone(got)
+        raw = base64.b64decode(got.base64)
+        self.assertEqual(got.media_type, "image/png")
+        self.assertTrue(raw.startswith(b"\x89PNG"), "must not ship TIFF bytes as PNG")
+
+    def test_declared_media_type_always_matches_the_bytes(self) -> None:
+        magic = {
+            "image/png": b"\x89PNG",
+            "image/jpeg": b"\xff\xd8\xff",
+            "image/gif": b"GIF8",
+            "image/webp": b"RIFF",
+        }
+        # Every extension the input allow-list accepts, at a size that forces the
+        # resize path (where the encoder is reached and the old hint bug fired).
+        for fmt, name in (("PNG", "a.png"), ("JPEG", "b.jpg"), ("GIF", "c.gif"),
+                          ("WEBP", "d.webp"), ("BMP", "e.bmp")):
+            with self.subTest(fmt=fmt):
+                got = ip.try_read_image_from_path(
+                    str(self._write(name, self._save(fmt, (2400, 1400))))
+                )
+                self.assertIsNotNone(got, f"{fmt} was dropped")
+                self.assertIn(got.media_type, magic, f"{got.media_type} not API-supported")
+                self.assertTrue(
+                    base64.b64decode(got.base64).startswith(magic[got.media_type]),
+                    f"{fmt} declared {got.media_type} but the bytes disagree",
+                )
+
+    def test_as_media_type_normalizes_extensions(self) -> None:
+        self.assertEqual(ip._as_media_type("png"), "image/png")
+        self.assertEqual(ip._as_media_type("jpg"), "image/jpeg")
+        self.assertEqual(ip._as_media_type("jpeg"), "image/jpeg")
+        self.assertEqual(ip._as_media_type("bmp"), "image/png")
+        self.assertEqual(ip._as_media_type("tiff"), "image/png")
+        self.assertEqual(ip._as_media_type("image/webp"), "image/webp")
+        self.assertEqual(ip._as_media_type("image/bmp"), "image/png")
+        self.assertEqual(ip._as_media_type(None), "image/png")
+
+
+class TestDroppedPathPredicate(unittest.TestCase):
+    """A faithful port of the client's looksLikeDroppedPath.
+
+    ``useSubmission.ts`` runs ``input.detect_drop`` on submitted prompts, and
+    wiring that RPC made the backend gate live for the first time. The original
+    predicate only rejected tabs and NULs, so ``README.md`` matched, resolved to
+    a real file, and the user's typed prompt would have been silently rewritten
+    to ``@/abs/path/README.md``.
+    """
+
+    def test_prose_is_never_a_path(self) -> None:
+        for text in (
+            "hello world",
+            "fix the bug in main.py",
+            "what is this?",
+            "README.md",
+            "src/utils/image_paste.py",
+            "explain README.md to me",
+            "/help",
+            "/model sonnet",
+            "/api",
+            "",
+            "   ",
+        ):
+            with self.subTest(text=text):
+                self.assertFalse(
+                    ip.looks_like_dropped_path(text), f"{text!r} must not look like a path"
+                )
+
+    def test_explicit_path_forms_match(self) -> None:
+        for text in (
+            "/tmp/a.png",
+            "/etc/hosts",
+            "/usr/bin/test",
+            "~/Desktop/shot.png",
+            "./rel.png",
+            "../up.png",
+            '"/tmp/quoted abs.png"',
+            "'/tmp/single.png'",
+            "file:///tmp/z.png",
+            "C:/Users/a/b.png",
+            r"C:\Users\a\b.png",
+            '"C:/Users/a/b.png"',
+        ):
+            with self.subTest(text=text):
+                self.assertTrue(ip.looks_like_dropped_path(text), f"{text!r} is a path")
+
+    def test_multiline_never_matches(self) -> None:
+        self.assertFalse(ip.looks_like_dropped_path("/tmp/a.png\n/tmp/b.png"))
+
+    def test_prose_ending_in_an_extension_does_not_shell_out(self) -> None:
+        """A miss must not reach the clipboard just because it ends in .png."""
+        with mock.patch.object(ip, "get_image_path_from_clipboard") as clip:
+            ip.try_read_image_from_path("what is wrong with logo.png")
+        clip.assert_not_called()
+
+
+class TestWindowsFileUri(unittest.TestCase):
+    def test_drive_letter_uri_is_absolute(self) -> None:
+        """file:///C:/… parses to /C:/…, which PureWindowsPath reads as RELATIVE."""
+        self.assertEqual(
+            ip.as_image_file_path("file:///C:/Users/a/b.png"), "C:/Users/a/b.png"
+        )
+
+    def test_powershell_single_quotes_escaped(self) -> None:
+        """%TEMP% for a user named O'Brien would otherwise be a parse error."""
+        self.assertEqual(
+            ip._escape_powershell_single_quoted(r"C:\Users\O'Brien\Temp"),
+            r"C:\Users\O''Brien\Temp",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -785,6 +785,69 @@ describe('GatewayClient NDJSON adapter', () => {
     const resp = sent.find(m => m.type === 'control_response')?.response?.response
     expect(resp.chosen_updates[0]).toEqual(bundle) // whole bundle, untouched
   })
+
+  // ── image attachment ──────────────────────────────────────────────────────
+  // These three RPCs were called by the composer and /image from the start but
+  // had no case here, so they fell to `default` and resolved `{}`. The composer
+  // read that as "not an image" and pasted the path as literal text; Ctrl+V with
+  // a screenshot did nothing at all.
+
+  it('maps image.attach to the attach_image control and returns its metadata', async () => {
+    const p = gw.request('image.attach', { path: '/tmp/shot.png' })
+    await replyToControl('attach_image', {
+      height: 914, name: 'shot.png', token_estimate: 976, width: 1568
+    })
+    await expect(p).resolves.toEqual({
+      height: 914, name: 'shot.png', token_estimate: 976, width: 1568
+    })
+  })
+
+  it('forwards the pasted path verbatim so the backend can unescape it', async () => {
+    // Shell escapes and file:// percent-encoding are the backend's job; mangling
+    // the text here would make a dragged screenshot miss on disk.
+    const raw = 'file:///var/T/Screenshot%202026-04-21%20at%201.04.43%20PM.png'
+
+    void gw.request('image.attach', { path: raw })
+    await vi.waitFor(() => {
+      seen.push(...stdinFrames())
+      const req = seen.find(f => f.request?.subtype === 'attach_image')
+      expect(req?.request?.path).toBe(raw)
+    })
+  })
+
+  it('maps image.clipboard to the clipboard_image control', async () => {
+    const p = gw.request('image.clipboard', {})
+    await replyToControl('clipboard_image', {
+      height: 220, name: 'clipboard image', token_estimate: 300, width: 760
+    })
+    await expect(p).resolves.toMatchObject({ name: 'clipboard image' })
+  })
+
+  it('resolves image.clipboard to {} when the clipboard holds no image', async () => {
+    // The composer needs a falsy `name` here to fall back to a text paste.
+    const p = gw.request('image.clipboard', {})
+    await replyToControl('clipboard_image', {})
+    await expect(p).resolves.toEqual({})
+  })
+
+  it('maps input.detect_drop to the detect_file_drop control', async () => {
+    const p = gw.request('input.detect_drop', { text: '/tmp/data.csv' })
+    await replyToControl('detect_file_drop', {
+      is_image: false, matched: true, name: 'data.csv', text: '@/tmp/data.csv'
+    })
+    await expect(p).resolves.toMatchObject({
+      is_image: false, matched: true, text: '@/tmp/data.csv'
+    })
+  })
+
+  it('never resolves an image RPC to undefined', async () => {
+    // The composer does `attached?.name`, but `input.detect_drop`'s caller reads
+    // `dropped.matched` after a truthiness check — a bare undefined from a
+    // backend that predates these controls must still be an object.
+    const p = gw.request('image.clipboard', {})
+    await replyToControl('clipboard_image', null)
+    await expect(p).resolves.toEqual({})
+  })
 })
 
 describe('approvalCommandText — the human-reviewable action, not a JSON dump', () => {

--- a/ui-tui/src/__tests__/imagePasteComposer.test.ts
+++ b/ui-tui/src/__tests__/imagePasteComposer.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// The REAL helper from the composer, not a reimplementation. An earlier version
+// of this file tested a local copy of the branch, which meant reordering the
+// production code left every test green — i.e. the ordering contract these tests
+// exist to protect was not actually protected.
+import { resolveHotkeyPaste } from '../app/useComposerState.js'
+import { attachedImageNotice } from '../domain/messages.js'
+
+// A real U+0000 and a control-character-heavy string: both rejected by the
+// REAL isUsableClipboardText, and both accepted by a naive `t.trim()` check --
+// which is exactly why this suite must call the production helper.
+const NUL = String.fromCharCode(0)
+const CONTROL_HEAVY = Array.from({ length: 12 }, (_, i) => String.fromCharCode(i + 1)).join('')
+
+const probing = (result: unknown) =>
+  vi.fn(async () => result as never)
+
+describe('resolveHotkeyPaste — probe ordering', () => {
+  it('does NOT probe when the clipboard has usable text', async () => {
+    // The performance contract: the probe shells out to osascript/xclip (~1.5 s
+    // for a large clipboard image), so an ordinary Ctrl+V must never pay for it.
+    const probe = probing({ name: 'clipboard image' })
+
+    const decision = await resolveHotkeyPaste({
+      probeClipboardImage: probe,
+      text: 'some copied text'
+    })
+
+    expect(probe).not.toHaveBeenCalled()
+    expect(decision).toEqual({ kind: 'text', text: 'some copied text' })
+  })
+
+  it('probes when the clipboard text is unusable', async () => {
+    // Uses the real isUsableClipboardText, which rejects more than "empty":
+    // whitespace-only, NUL-bearing, and control-character-heavy text.
+    const unusable: (null | string)[] = ['', '   \n  ', null, `has${NUL}nul`, CONTROL_HEAVY]
+
+    for (const text of unusable) {
+      const probe = probing({ name: 'clipboard image' })
+      const decision = await resolveHotkeyPaste({ probeClipboardImage: probe, text })
+
+      expect(probe, `text=${JSON.stringify(text)}`).toHaveBeenCalledTimes(1)
+      expect(decision.kind, `text=${JSON.stringify(text)}`).toBe('image')
+    }
+  })
+
+  it('ordinary text is usable and never probes', async () => {
+    // The counterpart: these must NOT be mistaken for "no usable text", or
+    // every paste of them would shell out. Note 'has nul in the words' --
+    // plain text that merely mentions nul is usable; only a real U+0000 is not.
+    for (const text of ['hello', 'has nul in the words', 'multi\nline\ntext', '  padded  ']) {
+      const probe = probing({ name: 'clipboard image' })
+      const decision = await resolveHotkeyPaste({ probeClipboardImage: probe, text })
+
+      expect(probe, `text=${JSON.stringify(text)}`).not.toHaveBeenCalled()
+      expect(decision, `text=${JSON.stringify(text)}`).toEqual({ kind: 'text', text })
+    }
+  })
+
+  it('returns the image payload so the caller can render its metadata', async () => {
+    const image = { height: 220, name: 'clipboard image', token_estimate: 300, width: 760 }
+
+    const decision = await resolveHotkeyPaste({
+      probeClipboardImage: probing(image),
+      text: ''
+    })
+
+    expect(decision).toEqual({ image, kind: 'image' })
+  })
+
+  it('resolves to none when the clipboard holds no image', async () => {
+    // Not a failure — the caller falls back to its text-paste path.
+    const decision = await resolveHotkeyPaste({ probeClipboardImage: probing({}), text: '' })
+
+    expect(decision).toEqual({ kind: 'none' })
+  })
+
+  it('surfaces a read failure instead of appearing to do nothing', async () => {
+    const image = { error: 'could not read image: /tmp/x.png' }
+    const decision = await resolveHotkeyPaste({ probeClipboardImage: probing(image), text: '' })
+
+    expect(decision).toEqual({ image, kind: 'image' })
+  })
+
+  it('surfaces missing clipboard tooling', async () => {
+    const image = { unavailable: true }
+    const decision = await resolveHotkeyPaste({ probeClipboardImage: probing(image), text: '' })
+
+    expect(decision).toEqual({ image, kind: 'image' })
+  })
+
+  it('a rejected probe degrades to none rather than throwing', async () => {
+    const decision = await resolveHotkeyPaste({
+      probeClipboardImage: () => Promise.reject(new Error('backend gone')),
+      text: ''
+    })
+
+    expect(decision).toEqual({ kind: 'none' })
+  })
+
+  it('a null probe result degrades to none', async () => {
+    // What an unwired backend resolves to; must not be mistaken for an attach.
+    const decision = await resolveHotkeyPaste({ probeClipboardImage: probing(null), text: '' })
+
+    expect(decision).toEqual({ kind: 'none' })
+  })
+})
+
+describe('attachedImageNotice', () => {
+  it('confirms a real attach with its metadata', () => {
+    expect(
+      attachedImageNotice({ height: 914, name: 'shot.png', token_estimate: 976, width: 1568 })
+    ).toContain('📎 Attached image: shot.png')
+  })
+
+  it('does NOT claim an attach when the backend reported an error', () => {
+    // This printed "📎 Attached image" for a FAILED /image before: the notice
+    // only checked `name`, and `name` is absent on failure.
+    const msg = attachedImageNotice({ error: 'could not read image: /tmp/nope.png' })
+
+    expect(msg).not.toContain('📎')
+    expect(msg).toContain('not attached')
+    expect(msg).toContain('/tmp/nope.png')
+  })
+
+  it('names the missing tooling so the user can fix it', () => {
+    const msg = attachedImageNotice({ unavailable: true })
+
+    expect(msg).not.toContain('📎')
+    expect(msg).toMatch(/xclip|wl-clipboard/)
+  })
+
+  it('does not claim an attach for an empty reply', () => {
+    expect(attachedImageNotice({})).not.toContain('📎')
+    expect(attachedImageNotice(null)).not.toContain('📎')
+  })
+})

--- a/ui-tui/src/__tests__/useComposerState.test.ts
+++ b/ui-tui/src/__tests__/useComposerState.test.ts
@@ -57,3 +57,29 @@ describe('looksLikeDroppedPath', () => {
     expect(looksLikeDroppedPath('/etc/hosts')).toBe(true) // has second /
   })
 })
+
+// `useSubmission` runs `input.detect_drop` on SUBMITTED prompts, and that RPC
+// only became live when its gatewayClient case was added. Every prompt this
+// predicate lets through reaches a backend that may resolve it to a real file
+// and REWRITE the prompt to `@<abspath>`. These are the strings that must never
+// get that far.
+describe('looksLikeDroppedPath — submit-path gate', () => {
+  it('rejects ordinary prompts that name a real file', () => {
+    expect(looksLikeDroppedPath('README.md')).toBe(false)
+    expect(looksLikeDroppedPath('package.json')).toBe(false)
+    expect(looksLikeDroppedPath('src/gatewayClient.ts')).toBe(false)
+    expect(looksLikeDroppedPath('fix the bug in main.py')).toBe(false)
+    expect(looksLikeDroppedPath('explain README.md to me')).toBe(false)
+  })
+
+  it('rejects questions and prose that merely end in an extension', () => {
+    expect(looksLikeDroppedPath('what is wrong with logo.png')).toBe(false)
+    expect(looksLikeDroppedPath('why does test.py fail')).toBe(false)
+  })
+
+  it('still lets a genuine dragged path through', () => {
+    expect(looksLikeDroppedPath('/Users/me/Desktop/shot.png')).toBe(true)
+    expect(looksLikeDroppedPath('~/Desktop/shot.png')).toBe(true)
+    expect(looksLikeDroppedPath('./shot.png')).toBe(true)
+  })
+})

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -59,8 +59,17 @@ function insertAtCursor(value: string, cursor: number, text: string): { cursor: 
 /**
  * Quick client-side heuristic to detect text that looks like a dropped file path.
  * When this returns true the composer sends RPC calls to the server for actual
- * validation. Keep in sync with _detect_file_drop() in cli.py — see that
- * function for the canonical prefix list.
+ * validation.
+ *
+ * Keep in sync with `looks_like_dropped_path` in `src/utils/image_paste.py`,
+ * which is a deliberate mirror of this function. (This comment used to point at
+ * `_detect_file_drop() in cli.py`, which never existed — and the absence of a
+ * real counterpart is how the two rules drifted far enough apart that the
+ * backend gate accepted `README.md` as a path.)
+ *
+ * It also gates the SUBMIT path (`useSubmission.ts`), not just pastes, so
+ * loosening it means ordinary prompts get sent to the backend for path
+ * resolution and can be rewritten to `@<abspath>`.
  */
 export function looksLikeDroppedPath(text: string): boolean {
   const trimmed = text.trim()
@@ -95,6 +104,50 @@ export function looksLikeDroppedPath(text: string): boolean {
   }
 
   return false
+}
+
+/** What a Ctrl+V/Cmd+V hotkey paste resolved to. */
+export type HotkeyPasteDecision =
+  | { image: ImageAttachResponse; kind: 'image' }
+  | { kind: 'none' }
+  | { kind: 'text'; text: string }
+
+/**
+ * Decide what a hotkey paste should do, given the clipboard text and a way to
+ * ask the backend for a clipboard image.
+ *
+ * Pure and exported so the ORDERING is testable against the real code. The
+ * ordering is the whole point and it is a performance contract, not just
+ * behaviour: the image probe shells out to osascript/xclip (~1.5 s for a large
+ * clipboard image), so it must run ONLY when the clipboard has no usable text.
+ * A test against a reimplementation of this branch would stay green if the two
+ * were ever swapped, which is exactly the regression worth preventing.
+ *
+ * Usable text wins outright. A copied image FILE is not the image case — it
+ * carries its path as text, and the dropped-path branch in handleResolvedPaste
+ * handles it.
+ */
+export async function resolveHotkeyPaste({
+  probeClipboardImage,
+  text
+}: {
+  probeClipboardImage: () => Promise<ImageAttachResponse | null>
+  text: null | string
+}): Promise<HotkeyPasteDecision> {
+  if (isUsableClipboardText(text)) {
+    return { kind: 'text', text }
+  }
+
+  const image = await probeClipboardImage().catch(() => null)
+
+  // A `name` means attached. An `error`/`unavailable` is worth surfacing too —
+  // otherwise Ctrl+V appears to do nothing at all. A plain `{}` means "no image
+  // on the clipboard", which is not a failure and falls through to 'none'.
+  if (image?.name || image?.error || image?.unavailable) {
+    return { image, kind: 'image' }
+  }
+
+  return { kind: 'none' }
 }
 
 export function useComposerState({
@@ -250,8 +303,24 @@ export function useComposerState({
             })
 
         return readPreferredText.then(async preferredText => {
-          if (isUsableClipboardText(preferredText)) {
-            return handleResolvedPaste({ bracketed: false, cursor, text: preferredText, value })
+          const decision = await resolveHotkeyPaste({
+            probeClipboardImage: () =>
+              gw.request<ImageAttachResponse>('image.clipboard', {}).catch(() => null),
+            text: preferredText
+          })
+
+          if (decision.kind === 'text') {
+            return handleResolvedPaste({
+              bracketed: false, cursor, text: decision.text, value
+            })
+          }
+
+          if (decision.kind === 'image') {
+            // The backend holds the bytes and attaches them to the next prompt;
+            // nothing goes into the composer text.
+            onImageAttached?.(decision.image)
+
+            return null
           }
 
           void onClipboardPaste(false)
@@ -262,7 +331,7 @@ export function useComposerState({
 
       return handleResolvedPaste({ bracketed: !!bracketed, cursor, text, value })
     },
-    [handleResolvedPaste, onClipboardPaste, querier]
+    [gw, handleResolvedPaste, onClipboardPaste, onImageAttached, querier]
   )
 
   const openEditor = useCallback(async () => {

--- a/ui-tui/src/app/useSubmission.ts
+++ b/ui-tui/src/app/useSubmission.ts
@@ -18,6 +18,7 @@ import type { Msg } from '../types.js'
 import type { ComposerActions, ComposerRefs, ComposerState, PasteSnippet } from './interfaces.js'
 import { turnController } from './turnController.js'
 import { getUiState, patchUiState } from './uiStore.js'
+import { looksLikeDroppedPath } from './useComposerState.js'
 
 const DOUBLE_ENTER_MS = 450
 const SESSION_BUSY_RE = /session busy|waiting for model response/i
@@ -126,9 +127,19 @@ export function useSubmission(opts: UseSubmissionOptions) {
         return sys('session not ready yet')
       }
 
-      // Always ask the backend whether this looks like a file drop.
-      // The backend's _detect_file_drop handles paths with spaces, quotes,
-      // Windows drive letters, and escaped characters correctly.
+      // Gate on the same predicate the paste path uses before consulting the
+      // backend. This RPC used to be unwired (it resolved `{}`), so asking
+      // unconditionally was free; now that it is live, an ungated call means
+      // every prompt pays a round-trip AND — worse — any prompt the backend
+      // resolves to a real file gets REWRITTEN to `@<abspath>` below. Typing
+      // `README.md` would have replaced the prompt with a path.
+      //
+      // The backend applies the same rule (image_paste.looks_like_dropped_path);
+      // the two are deliberate mirrors, so keep them in sync.
+      if (!looksLikeDroppedPath(text)) {
+        return startSubmit(text, expand(text), showUserMessage)
+      }
+
       gw.request<InputDetectDropResponse>('input.detect_drop', { session_id: sid, text })
         .then(r => {
           if (!r?.matched) {

--- a/ui-tui/src/domain/messages.ts
+++ b/ui-tui/src/domain/messages.ts
@@ -12,11 +12,28 @@ export const imageTokenMeta = (info?: ImageMeta | null) => {
     .join(' · ')
 }
 
-export const attachedImageNotice = (info?: ({ name?: string } & ImageMeta) | null) => {
-  const meta = imageTokenMeta(info)
-  const label = info?.name ? `📎 Attached image: ${info.name}` : '📎 Attached image'
+export const attachedImageNotice = (
+  info?: ({ error?: string; name?: string; unavailable?: boolean } & ImageMeta) | null
+) => {
+  // A failed attach must not print an attach confirmation. The backend
+  // distinguishes "couldn't read it" (error) from "no clipboard tooling"
+  // (unavailable) and both used to render as a bare "📎 Attached image", so a
+  // failure looked identical to a success.
+  if (info?.unavailable) {
+    return '⚠ Cannot read clipboard images here — install xclip or wl-clipboard'
+  }
 
-  return `${label}${meta ? ` · ${meta}` : ''}`
+  if (info?.error) {
+    return `⚠ Image not attached: ${info.error}`
+  }
+
+  if (!info?.name) {
+    return '⚠ Image not attached'
+  }
+
+  const meta = imageTokenMeta(info)
+
+  return `📎 Attached image: ${info.name}${meta ? ` · ${meta}` : ''}`
 }
 
 export const userDisplay = (text: string) => {

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -43,6 +43,13 @@ const RPC_TIMEOUT_MS = 5_000
  *  leaving a half-deleted directory. The prompt shows an interim
  *  "Removing worktree…" state while this runs. */
 const WORKTREE_RPC_TIMEOUT_MS = 600_000
+
+/** Image attach/clipboard RPCs need more than the 5 s default: the backend
+ *  shells out to osascript/xclip (~1.5 s for a large clipboard image on macOS,
+ *  per the reference implementation's own measurement) and then decodes and
+ *  downsamples through Pillow. A timeout here would drop an image the user
+ *  watched themselves paste. */
+const IMAGE_RPC_TIMEOUT_MS = 30_000
 // clawcodex app version shown in the banner ("clawcodex v{version}"). Keep in
 // sync with the installer (install.sh INSTALLER_VERSION).
 const CLAWCODEX_VERSION = '1.1.0'
@@ -1005,6 +1012,35 @@ export class GatewayClient extends EventEmitter {
         })
 
         return Promise.resolve({ ok: true } as T)
+
+      // ── image attachment ─────────────────────────────────────────────────
+      // The composer and /image have called these since the port; without a
+      // case here they hit the `default` below and resolved `{}`, so every
+      // image paste silently degraded to pasting the path as literal text.
+      //
+      // The backend queues the decoded image and attaches it to the next user
+      // message, so these responses carry metadata only, never base64 — the
+      // client has nothing to hold and nothing to re-send.
+      case 'image.attach':
+        // Longer deadline than a normal RPC: reading + downsampling a large
+        // screenshot is Pillow work, and osascript alone is ~1.5s.
+        return this.controlQuery(
+          'attach_image',
+          { path: String(p.path ?? '') },
+          IMAGE_RPC_TIMEOUT_MS
+        ).then(r => (r ?? {}) as T)
+
+      case 'image.clipboard':
+        return this.controlQuery('clipboard_image', {}, IMAGE_RPC_TIMEOUT_MS).then(
+          r => (r ?? {}) as T
+        )
+
+      case 'input.detect_drop':
+        return this.controlQuery(
+          'detect_file_drop',
+          { text: String(p.text ?? '') },
+          IMAGE_RPC_TIMEOUT_MS
+        ).then(r => (r ?? {}) as T)
 
       default:
         // Unhandled RPC (Phase 2): resolve empty so the app degrades gracefully.

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -499,10 +499,14 @@ export interface TerminalResizeResponse {
 // ── Image attach ─────────────────────────────────────────────────────
 
 export interface ImageAttachResponse {
+  /** Set when the image could not be read; `name` is then absent. */
+  error?: string
   height?: number
   name?: string
   remainder?: string
   token_estimate?: number
+  /** Set when the platform has no clipboard-image tooling (xclip/wl-clipboard). */
+  unavailable?: boolean
   width?: number
 }
 


### PR DESCRIPTION
Pasting an image did nothing. Fixes it for all three routes: **Ctrl+V/Cmd+V with an image on the clipboard**, **`/image <path>`**, and **dragging a file into the terminal**.

## Why it was broken

ui-tui's composer had called `image.attach` and `input.detect_drop` on every pasted path since the port, but `gatewayClient` had no `case` for either — both hit its `default` ("Unhandled RPC (Phase 2): resolve empty") and resolved `{}`. The composer read that as "not an image" and pasted the path as literal text. `/image` was equally dead, and there was no clipboard-**bytes** path at all.

The backend was already multimodal-capable: `send_to_agent` → `_extract_prompt_content` preserves image blocks. Only the frontend never sent any.

## What's here

- **`src/utils/image_paste.py`** — port of `typescript/src/utils/imagePaste.ts`: platform clipboard commands (osascript / xclip+wl-paste / PowerShell), dropped-path reading, quote stripping, shell unescaping, `file://` URI decoding. Runs through the existing Pillow pipeline so images land inside the API's size/dimension envelope.
- **`agent_server`** — `attach_image` / `clipboard_image` / `detect_file_drop` controls. The backend holds the bytes in `_pending_images` and drains them onto the next user message; the client gets metadata only, matching the `ImageAttachResponse` contract it was already written against.
- **`gatewayClient`** — the three missing RPC cases.
- **Clipboard probe on hotkey paste**, gated so it runs only when the clipboard has no usable text — an ordinary Ctrl+V pays no shell-out. A copied image *file* carries its path as text and takes the existing dropped-path branch.

## ⚠️ Highest-risk item for reviewers

**`input.detect_drop` was dead and is now live on every submitted prompt.** `useSubmission.ts` calls it unconditionally, and the backend gate had never actually run. The client-side gate at `useSubmission.ts:127-142` and the Python `looks_like_dropped_path` are **load-bearing mirrors, not cosmetic** — a loose rule on either side rewrites ordinary prompts. Before the fix, `README.md` matched, resolved to a real file, and would have replaced the prompt with `@/abs/path/README.md`.

## Load-bearing details, each with a regression test

| Detail | Why |
|---|---|
| `format_hint` must be a **media type**, not an extension | `maybe_resize_image` uses it as the media-type fallback and hands it to the encoder; `"png"` raised `Unsupported image encoding type: png`, silently dropping every BMP over the caps — exactly the full-screen Windows/WSL2 screenshot BMP it exists for |
| Magic bytes decide the format | `detect_image_format_from_buffer` **defaults to `image/png`** on unknown magic, so TIFF-in-a-`.png` shipped labeled PNG. Non-API containers are re-encoded *before* the resize (per the reference) and re-sniffed *after*, since the resize can itself degrade PNG→JPEG for the byte budget |
| Block order `[images, user text, metadata]` | Three consumers flatten text blocks and read the front: `_parse_turn_budget` (`^`-anchored → `+500k` no-ops), `_first_prompt_preview` (`/resume` + branch names), UserPromptSubmit hooks |
| Gemini image branch | The converter had no `image` branch **and no `else`**, so the block was skipped — and since a pasted image also carries an `[Image: source: …]` line, the model got a *description* of an image it never saw and confabulated an answer |
| Handlers are `async` + `asyncio.to_thread` | A 20s clipboard read on the event loop froze all outbound streaming |
| Queue lifecycle | Clears on `/clear` **and** `/resume`; skipped for `ephemeral` turns (they restore a pre-turn snapshot and would discard the image); capped at 8 via a single `_queue_image` choke point |
| `mkstemp` per read | No fixed name in a shared `/tmp` (CWE-377/59 on Linux via the `>` redirect), and no environment-derived value inside the AppleScript/PowerShell string literals |

## Testing

- **Live e2e (macOS):** a clipboard PNG reading `PURPLE-ELEPHANT-42` and a 2400×1400 BMP reading `CRIMSON-WALRUS-77` both reach `claude-opus-5` and are read back correctly.
- **Mutation-proved, not just green:** swapping the clipboard-probe order fails 2 tests; reverting the Gemini branch fails 12 of 13.
- 24/24 declared-media-type-vs-magic-bytes across 6 extensions × 3 sizes.
- **Python: 8990 passed / 3 skipped / 0 failed.** ui-tui: 1473 passed, same 8 pre-existing baseline failures. `tsc --noEmit` clean.

## Known limits

- **Gemini is unverified against the live API.** `google-genai` isn't installed on the dev machine. The dispatch is covered by stubbed-SDK tests, and an unconvertible image now *raises* rather than vanishing, but nobody has run it against Google. Worth a one-line manual check the first time anyone uses Gemini with an image.
- **No `[Image #N]` chip**, so an attach can only be undone with `/clear`, and an image can't be sent without text. Deliberate: the chip needs `Cursor.ts` navigation, vim operators, and `parseReferences`, and the clawcodex wire contract carries no base64 to the client. Follow-up order: a pending-image count indicator first, then image-only submit (which must check the count *before* the empty-Enter double-tap logic, or it breaks that gesture).
- Windows and Linux paths are ported but unexercised — no machine here to run them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)