### PR TITLE
feat: show pasted images as [Image #N] and make the chip un-attach them

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -55,6 +55,7 @@ import asyncio
 import json
 import logging
 import queue as _queue
+import re
 import threading
 import time
 import uuid as _uuid
@@ -163,12 +164,17 @@ class _AgentSession:
     # real turn (inside the async context; _build_runtime runs sync in an
     # executor with no live loop). Guarded so it fires exactly once.
     _session_start_fired: bool = False
-    # Images attached (clipboard paste, /image, dropped path) but not yet sent.
-    # Drained into the NEXT user message as image content blocks -- the client
-    # holds no bytes, it only shows the "📎 Attached image" notice, so the
-    # pending list is the single source of truth. Cleared by /clear so a reset
-    # conversation cannot smuggle an image from the previous one.
+    # Images attached (clipboard paste, /image, dropped path) but not yet sent,
+    # as ``(image_id, PastedImage, expects_placeholder)``. Drained into the NEXT
+    # user message as image content blocks -- the client holds no bytes (it shows
+    # an ``[Image #N]`` chip), so this list is the single source of truth. Cleared by /clear and /resume so a
+    # switched-away conversation cannot smuggle an image into a new one.
     _pending_images: list = field(default_factory=list)
+    # Monotonic id behind the ``[Image #N]`` chip the client inserts. Increments
+    # across the session rather than per prompt: the reference only requires
+    # uniqueness within one prompt, and a session-wide counter satisfies that
+    # while matching what users actually see (#1, #2, #3 as they paste).
+    _image_seq: int = 0
     # Completed user turns — the "turns: N" odometer on the client's session
     # stats line (the deleted REPL's ``_stats_turns``, repl/core.py). Counts
     # successful non-internal, non-btw turns; /resume seeds it from the
@@ -556,13 +562,21 @@ class _AgentSession:
             self._do_set_effort(request_id, inner.get("effort"))
             return
         if subtype == "attach_image":
-            await self._do_attach_image(request_id, inner.get("path"))
+            await self._do_attach_image(
+                request_id, inner.get("path"),
+                expects_placeholder=bool(inner.get("placeholder")),
+            )
             return
         if subtype == "clipboard_image":
-            await self._do_clipboard_image(request_id)
+            await self._do_clipboard_image(
+                request_id, expects_placeholder=bool(inner.get("placeholder")),
+            )
             return
         if subtype == "detect_file_drop":
-            await self._do_detect_file_drop(request_id, inner.get("text"))
+            await self._do_detect_file_drop(
+                request_id, inner.get("text"),
+                expects_placeholder=bool(inner.get("placeholder")),
+            )
             return
         if subtype == "workflows":
             self._do_workflows(request_id)
@@ -912,6 +926,13 @@ class _AgentSession:
           stops firing.
 
         Images stay first (the API prefers image-before-question).
+
+        An image whose ``[Image #N]`` chip is gone from the text is DROPPED. That
+        is how the chip doubles as un-attach: deleting it in the composer removes
+        the image, matching the reference ("Images are only sent if their
+        [Image #N] placeholder is still in the text", handlePromptSubmit.ts:225).
+        The chip text itself stays in the prompt -- the reference leaves image
+        refs inline and sends the bytes as separate blocks (history.ts:79).
         """
         with self._lock:
             pending = self._pending_images
@@ -921,9 +942,17 @@ class _AgentSession:
 
         from src.utils.image_processor import create_image_metadata_text
 
+        referenced = _parse_image_refs(_content_text(content))
         blocks: list[dict] = []
         trailing: list[dict] = []
-        for image in pending:
+        for image_id, image, expects_placeholder in pending:
+            if expects_placeholder and image_id not in referenced:
+                logger.debug(
+                    "[agent-server] dropping image #%s: its [Image #%s] chip was "
+                    "deleted from the prompt",
+                    image_id, image_id,
+                )
+                continue
             blocks.append({
                 "type": "image",
                 "source": {
@@ -935,6 +964,10 @@ class _AgentSession:
             meta = create_image_metadata_text(image.dimensions, image.source_path)
             if meta:
                 trailing.append({"type": "text", "text": meta})
+
+        if not blocks:
+            # Every pending image was un-attached; keep the plain-string shape.
+            return content
 
         if isinstance(content, list):
             return blocks + content + trailing
@@ -950,18 +983,25 @@ class _AgentSession:
     #: strictly better than losing all N.
     MAX_PENDING_IMAGES = 8
 
-    def _queue_image(self, image) -> bool:
-        """Append under the lock, honoring the cap. False when already full.
+    def _queue_image(self, image, *, expects_placeholder: bool = False) -> int | None:
+        """Append under the lock and return the new image's id, or None if full.
 
         Single entry point so every producer (clipboard, ``/image``, dropped
-        path) is capped -- an inline append in one of them would silently bypass
-        it.
+        path) is capped and numbered -- an inline append in one of them would
+        silently bypass both.
+
+        ``expects_placeholder`` says the caller will render an ``[Image #N]`` chip
+        for this id, which makes the chip authoritative: delete it and the image
+        is dropped at submit. Callers that render no chip (headless ``-p``, the
+        VS Code bridge) leave it False and their images always send.
         """
         with self._lock:
             if len(self._pending_images) >= self.MAX_PENDING_IMAGES:
-                return False
-            self._pending_images.append(image)
-            return True
+                return None
+            self._image_seq += 1
+            image_id = self._image_seq
+            self._pending_images.append((image_id, image, expects_placeholder))
+            return image_id
 
     def _too_many_images_error(self) -> dict:
         return {
@@ -972,12 +1012,24 @@ class _AgentSession:
         }
 
     def _attach_image(
-        self, request_id: object, image, *, remainder: str = "", extra: dict | None = None
+        self,
+        request_id: object,
+        image,
+        *,
+        remainder: str = "",
+        extra: dict | None = None,
+        expects_placeholder: bool = False,
     ) -> None:
-        """Queue ``image`` and reply in the client's ImageAttachResponse shape."""
+        """Queue ``image`` and reply in the client's ImageAttachResponse shape.
+
+        ``id``/``count`` carry the number behind the client's ``[Image #N]`` chip.
+        Both names are sent: ``ImageAttachResponse`` readers want ``id``,
+        ``ClipboardPasteResponse`` readers want ``count``.
+        """
         from src.utils.image_paste import dimensions_to_wire
 
-        if not self._queue_image(image):
+        image_id = self._queue_image(image, expects_placeholder=expects_placeholder)
+        if image_id is None:
             # Spread ``extra`` into the error too: the drop routes key on
             # ``matched``, so an error reply without it reads as "not a file
             # drop" and the cap message never reaches the user — the paste
@@ -986,6 +1038,9 @@ class _AgentSession:
             return
         name = Path(image.source_path).name if image.source_path else "clipboard image"
         self._reply(request_id, {
+            "attached": True,
+            "count": image_id,
+            "id": image_id,
             "name": name,
             "token_estimate": image.token_estimate,
             "remainder": remainder,
@@ -993,7 +1048,9 @@ class _AgentSession:
             **(extra or {}),
         })
 
-    async def _do_attach_image(self, request_id: object, raw_path: object) -> None:
+    async def _do_attach_image(
+        self, request_id: object, raw_path: object, *, expects_placeholder: bool = False
+    ) -> None:
         """``/image <path>`` and the dropped-path paste route."""
         from src.utils.image_paste import as_image_file_path, try_read_image_from_path
 
@@ -1018,9 +1075,11 @@ class _AgentSession:
         if image is None:
             self._reply(request_id, {"error": f"could not read image: {text}"})
             return
-        self._attach_image(request_id, image)
+        self._attach_image(request_id, image, expects_placeholder=expects_placeholder)
 
-    async def _do_clipboard_image(self, request_id: object) -> None:
+    async def _do_clipboard_image(
+        self, request_id: object, *, expects_placeholder: bool = False
+    ) -> None:
         """Ctrl+V / Cmd+V with an image on the clipboard."""
         from src.utils.image_paste import (
             clipboard_tooling_available,
@@ -1042,9 +1101,11 @@ class _AgentSession:
         if image is None:
             self._reply(request_id, {})  # no image on the clipboard
             return
-        self._attach_image(request_id, image)
+        self._attach_image(request_id, image, expects_placeholder=expects_placeholder)
 
-    async def _do_detect_file_drop(self, request_id: object, raw_text: object) -> None:
+    async def _do_detect_file_drop(
+        self, request_id: object, raw_text: object, *, expects_placeholder: bool = False
+    ) -> None:
         """Classify a paste that looks like a dragged-in path.
 
         Images are ATTACHED here (so a dropped screenshot works with one paste);
@@ -1072,10 +1133,12 @@ class _AgentSession:
                 image = None
             if image is not None:
                 # Same queue-and-reply as /image, plus the drop-specific fields.
-                # ``text: ""`` because an attached image inserts nothing into the
-                # composer -- the notice is the whole feedback.
+                # ``text: ""`` because the client inserts an ``[Image #N]`` chip
+                # itself rather than any text this reply carries.
                 self._attach_image(
-                    request_id, image, extra={"matched": True, "is_image": True, "text": ""}
+                    request_id, image,
+                    extra={"matched": True, "is_image": True, "text": ""},
+                    expects_placeholder=expects_placeholder,
                 )
                 return
         resolved = await asyncio.to_thread(resolve_dropped_file, text, cwd=cwd)
@@ -5026,6 +5089,36 @@ def _extract_prompt_text(msg: dict) -> str:
                 parts.append(block)
         return "".join(parts)
     return str(content) if content is not None else ""
+
+
+#: The reference's reference-pattern, narrowed to image refs
+#: (``history.ts:66`` parseReferences). ``[Image #3]`` in the prompt text is what
+#: keeps image #3 attached.
+_IMAGE_REF_RE = re.compile(r"\[Image #(\d+)\]")
+
+
+def _parse_image_refs(text: str) -> set[int]:
+    """Image ids still referenced by an ``[Image #N]`` chip in ``text``.
+
+    Ids start at 1, so ``#0`` is never real — dropped here rather than left to
+    coincidentally not match, mirroring the reference's ``id > 0`` filter
+    (history.ts:74).
+    """
+    ids = {int(m.group(1)) for m in _IMAGE_REF_RE.finditer(text)}
+    return {i for i in ids if i > 0}
+
+
+def _content_text(content) -> str:
+    """Flatten prompt content to text for chip scanning."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            str(b.get("text", ""))
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return str(content or "")
 
 
 def _extract_prompt_content(msg: dict):

--- a/tests/server/test_image_attach_control.py
+++ b/tests/server/test_image_attach_control.py
@@ -1,8 +1,9 @@
 """agent-server image attachment: attach_image / clipboard_image / detect_file_drop.
 
-The client holds no image bytes — it only renders the "📎 Attached image" notice
-— so the server's pending list is the single source of truth, and the drain onto
-the next prompt is the behaviour that matters.
+The client holds no image bytes — it renders an ``[Image #N]`` chip — so the
+server's pending list is the single source of truth. Two behaviours matter: the
+drain onto the next prompt, and the chip being AUTHORITATIVE (deleting it
+un-attaches the image).
 """
 
 from __future__ import annotations
@@ -40,11 +41,18 @@ def _session(cwd: str = "/tmp"):
     return sess, emitted
 
 
+def _queue(sess, *images, placeholder: bool = False) -> list[int]:
+    """Queue via the real entry point so ids and the cap always apply."""
+    return [sess._queue_image(i, expects_placeholder=placeholder) for i in images]
+
+
 def _reply_of(emitted: list) -> dict:
     return emitted[-1]["response"]["response"]
 
 
-def _fake_image(*, resized: bool = False, source: str | None = None) -> PastedImage:
+def _fake_image(
+    *, resized: bool = False, source: str | None = None, data: str = "aGVsbG8="
+) -> PastedImage:
     dims = (
         ImageDimensions(
             original_width=2400, original_height=1400,
@@ -56,7 +64,7 @@ def _fake_image(*, resized: bool = False, source: str | None = None) -> PastedIm
         )
     )
     return PastedImage(
-        base64="aGVsbG8=", media_type="image/png", dimensions=dims, source_path=source
+        base64=data, media_type="image/png", dimensions=dims, source_path=source
     )
 
 
@@ -68,7 +76,7 @@ class TestDrainPendingImages(unittest.TestCase):
 
     def test_image_precedes_the_text(self) -> None:
         sess, _ = _session()
-        sess._pending_images.append(_fake_image())
+        _queue(sess, _fake_image())
         out = sess._drain_pending_images("what is this?")
         self.assertIsInstance(out, list)
         self.assertEqual(out[0]["type"], "image")
@@ -79,7 +87,7 @@ class TestDrainPendingImages(unittest.TestCase):
     def test_resized_image_carries_scale_metadata(self) -> None:
         """A downsampled screenshot needs the scale factor or coordinates lie."""
         sess, _ = _session()
-        sess._pending_images.append(_fake_image(resized=True))
+        _queue(sess, _fake_image(resized=True))
         out = sess._drain_pending_images("click the button")
         texts = [b["text"] for b in out if b["type"] == "text"]
         self.assertTrue(
@@ -89,14 +97,14 @@ class TestDrainPendingImages(unittest.TestCase):
 
     def test_unresized_clipboard_image_has_no_metadata_noise(self) -> None:
         sess, _ = _session()
-        sess._pending_images.append(_fake_image(resized=False))
+        _queue(sess, _fake_image(resized=False))
         out = sess._drain_pending_images("hi")
         self.assertEqual([b["type"] for b in out], ["image", "text"])
 
     def test_drain_is_destructive(self) -> None:
         """A resend must not duplicate the image."""
         sess, _ = _session()
-        sess._pending_images.append(_fake_image())
+        _queue(sess, _fake_image())
         first = sess._drain_pending_images("a")
         self.assertIsInstance(first, list)
         self.assertEqual(sess._pending_images, [])
@@ -104,13 +112,13 @@ class TestDrainPendingImages(unittest.TestCase):
 
     def test_empty_text_yields_no_empty_text_block(self) -> None:
         sess, _ = _session()
-        sess._pending_images.append(_fake_image())
+        _queue(sess, _fake_image())
         out = sess._drain_pending_images("")
         self.assertEqual([b["type"] for b in out], ["image"])
 
     def test_existing_blocks_are_preserved(self) -> None:
         sess, _ = _session()
-        sess._pending_images.append(_fake_image())
+        _queue(sess, _fake_image())
         existing = [{"type": "text", "text": "hi"}]
         out = sess._drain_pending_images(existing)
         self.assertEqual(out[0]["type"], "image")
@@ -118,7 +126,7 @@ class TestDrainPendingImages(unittest.TestCase):
 
     def test_multiple_images_all_ride_along(self) -> None:
         sess, _ = _session()
-        sess._pending_images.extend([_fake_image(), _fake_image()])
+        _queue(sess, _fake_image(), _fake_image())
         out = sess._drain_pending_images("two")
         self.assertEqual(sum(1 for b in out if b["type"] == "image"), 2)
 
@@ -282,7 +290,7 @@ class TestPendingImagesLifecycle(unittest.TestCase):
         """The whole point: an attached image reaches the model with the prompt."""
 
         sess, _ = _session()
-        sess._pending_images.append(_fake_image())
+        _queue(sess, _fake_image())
         put: list = []
         sess._inbox = mock.Mock(put=put.append)
 
@@ -316,7 +324,7 @@ class TestPendingImagesLifecycle(unittest.TestCase):
         earlier version of this test asserted the opposite and pinned the bug.
         """
         sess, _ = _session()
-        sess._pending_images.append(_fake_image())
+        _queue(sess, _fake_image())
         put: list = []
         sess._inbox = mock.Mock(put=put.append)
 
@@ -360,7 +368,7 @@ class TestClearDropsPendingImages(unittest.TestCase):
     def test_clear_empties_the_queue(self) -> None:
 
         sess, emitted = _session()
-        sess._pending_images.append(_fake_image())
+        _queue(sess, _fake_image())
 
         asyncio.run(
             sess._handle_control_request({"request_id": "c1", "request": {"subtype": "clear"}})
@@ -372,7 +380,7 @@ class TestClearDropsPendingImages(unittest.TestCase):
         """A refused clear must not have side effects."""
 
         sess, emitted = _session()
-        sess._pending_images.append(_fake_image())
+        _queue(sess, _fake_image())
         sess._current_abort = object()  # an active turn
 
         asyncio.run(
@@ -395,7 +403,7 @@ class TestBlockOrderConsumers(unittest.TestCase):
 
     def test_metadata_trails_the_user_text(self) -> None:
         sess, _ = _session()
-        sess._pending_images.append(_fake_image(resized=True, source="/tmp/shot.png"))
+        _queue(sess, _fake_image(resized=True, source="/tmp/shot.png"))
         out = sess._drain_pending_images("+500k refactor this")
         texts = [b["text"] for b in out if b["type"] == "text"]
         self.assertEqual(texts[0], "+500k refactor this")
@@ -406,7 +414,7 @@ class TestBlockOrderConsumers(unittest.TestCase):
         from src.server.agent_server import _extract_prompt_text
 
         sess, _ = _session()
-        sess._pending_images.append(_fake_image(resized=True, source="/tmp/shot.png"))
+        _queue(sess, _fake_image(resized=True, source="/tmp/shot.png"))
         out = sess._drain_pending_images("+500k do the thing")
         flat = _extract_prompt_text({"message": {"role": "user", "content": out}})
         self.assertTrue(
@@ -419,7 +427,7 @@ class TestBlockOrderConsumers(unittest.TestCase):
         from src.types.messages import create_user_message
 
         sess, _ = _session()
-        sess._pending_images.append(_fake_image(resized=True, source="/tmp/shot.png"))
+        _queue(sess, _fake_image(resized=True, source="/tmp/shot.png"))
         out = sess._drain_pending_images("what is in this screenshot?")
         preview = _first_prompt_preview([create_user_message(out)])
         self.assertIsNotNone(preview)
@@ -461,6 +469,168 @@ class TestPendingImageCap(unittest.TestCase):
         asyncio.run(sess._do_detect_file_drop("r1", str(p)))
         self.assertEqual(len(sess._pending_images), sess.MAX_PENDING_IMAGES)
         self.assertIn("error", _reply_of(emitted))
+
+
+class TestImageRefParsing(unittest.TestCase):
+    def test_finds_every_chip(self) -> None:
+        from src.server.agent_server import _parse_image_refs
+
+        self.assertEqual(
+            _parse_image_refs("a [Image #1] b [Image #12] c"), {1, 12}
+        )
+
+    def test_id_zero_is_never_real(self) -> None:
+        from src.server.agent_server import _parse_image_refs
+
+        self.assertEqual(_parse_image_refs("[Image #0]"), set())
+
+    def test_no_chips_is_empty(self) -> None:
+        from src.server.agent_server import _parse_image_refs
+
+        self.assertEqual(_parse_image_refs("just a prompt"), set())
+        self.assertEqual(_parse_image_refs("[Image] [Image #] [Pasted text #1]"), set())
+
+    def test_scans_text_blocks_of_a_content_list(self) -> None:
+        from src.server.agent_server import _content_text
+
+        blocks = [
+            {"type": "image", "source": {"data": "x"}},
+            {"type": "text", "text": "see [Image #4]"},
+        ]
+        self.assertIn("[Image #4]", _content_text(blocks))
+
+
+class TestChipIsAuthoritative(unittest.TestCase):
+    """The `[Image #N]` chip doubles as un-attach.
+
+    Deleting it from the composer must drop the image, mirroring the reference
+    ("Images are only sent if their [Image #N] placeholder is still in the
+    text", handlePromptSubmit.ts:225).
+    """
+
+    def test_ids_increment_across_the_session(self) -> None:
+        sess, _ = _session()
+        self.assertEqual(_queue(sess, _fake_image(), _fake_image(), _fake_image()), [1, 2, 3])
+
+    def test_kept_chip_sends_its_image(self) -> None:
+        sess, _ = _session()
+        _queue(sess, _fake_image(), placeholder=True)
+        out = sess._drain_pending_images("what is this? [Image #1]")
+        self.assertEqual(sum(1 for b in out if b["type"] == "image"), 1)
+
+    def test_deleted_chip_drops_its_image(self) -> None:
+        sess, _ = _session()
+        _queue(sess, _fake_image(), placeholder=True)
+        self.assertEqual(
+            sess._drain_pending_images("changed my mind"), "changed my mind"
+        )
+
+    def test_only_the_deleted_one_is_dropped(self) -> None:
+        sess, _ = _session()
+        # Distinguishable bytes, so this can show WHICH image survived.
+        _queue(
+            sess,
+            _fake_image(data="Zmlyc3Q="),   # "first"
+            _fake_image(data="c2Vjb25k"),   # "second"
+            placeholder=True,
+        )
+        out = sess._drain_pending_images("keeping [Image #2] only")
+        images = [b for b in out if b["type"] == "image"]
+        self.assertEqual(len(images), 1)
+        self.assertEqual(
+            images[0]["source"]["data"], "c2Vjb25k", "kept the wrong image"
+        )
+
+    def test_chip_text_stays_in_the_prompt(self) -> None:
+        """The reference leaves image refs inline (history.ts:79)."""
+        sess, _ = _session()
+        _queue(sess, _fake_image(), placeholder=True)
+        out = sess._drain_pending_images("look at [Image #1]")
+        texts = [b["text"] for b in out if b["type"] == "text"]
+        self.assertIn("look at [Image #1]", texts)
+
+    def test_queue_is_drained_even_when_everything_was_unattached(self) -> None:
+        """A dropped image must not linger and land on the NEXT prompt."""
+        sess, _ = _session()
+        _queue(sess, _fake_image(), placeholder=True)
+        sess._drain_pending_images("no chip")
+        self.assertEqual(sess._pending_images, [])
+
+    def test_client_without_chips_is_unaffected(self) -> None:
+        """headless -p and the VS Code bridge render no chip, so never filter."""
+        sess, _ = _session()
+        _queue(sess, _fake_image(), placeholder=False)
+        out = sess._drain_pending_images("no chip anywhere")
+        self.assertEqual(sum(1 for b in out if b["type"] == "image"), 1)
+
+    def test_reply_carries_the_id_under_both_names(self) -> None:
+        """ImageAttachResponse readers want `id`; ClipboardPasteResponse `count`."""
+        import shutil
+        import tempfile
+
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
+        p = d / "a.png"
+        p.write_bytes(_png())
+        sess, emitted = _session()
+        asyncio.run(sess._do_attach_image("r1", str(p), expects_placeholder=True))
+        reply = _reply_of(emitted)
+        self.assertEqual(reply["id"], 1)
+        self.assertEqual(reply["count"], 1)
+        self.assertTrue(reply["attached"])
+
+
+class TestClipboardRouteHonorsPlaceholder(unittest.TestCase):
+    """The clipboard route is Ctrl+V *and* Cmd+V — the whole point of the chip.
+
+    ``_do_clipboard_image`` accepted ``expects_placeholder`` and dropped it on the
+    floor, so the chip was decoration there: deleting it did not un-attach. 47
+    green tests missed it because none drove this handler with the flag set.
+    """
+
+    def _clipboard(self, sess, *, flag: bool) -> None:
+        with mock.patch(
+            "src.utils.image_paste.get_image_from_clipboard", return_value=_fake_image()
+        ), mock.patch(
+            "src.utils.image_paste.clipboard_tooling_available", return_value=True
+        ):
+            asyncio.run(sess._do_clipboard_image("r1", expects_placeholder=flag))
+
+    def test_flag_reaches_the_queue(self) -> None:
+        sess, _ = _session()
+        self._clipboard(sess, flag=True)
+        self.assertEqual([p for _, _, p in sess._pending_images], [True])
+
+    def test_deleting_the_chip_un_attaches(self) -> None:
+        sess, _ = _session()
+        self._clipboard(sess, flag=True)
+        self.assertEqual(sess._drain_pending_images("never mind"), "never mind")
+
+    def test_keeping_the_chip_sends_it(self) -> None:
+        sess, _ = _session()
+        self._clipboard(sess, flag=True)
+        out = sess._drain_pending_images("what is [Image #1]")
+        self.assertEqual(sum(1 for b in out if b["type"] == "image"), 1)
+
+    def test_unflagged_caller_always_sends(self) -> None:
+        """A client that renders no chip must not have its image filtered."""
+        sess, _ = _session()
+        self._clipboard(sess, flag=False)
+        out = sess._drain_pending_images("no chip anywhere")
+        self.assertEqual(sum(1 for b in out if b["type"] == "image"), 1)
+
+    def test_dropped_path_route_honors_the_flag_too(self) -> None:
+        import shutil
+        import tempfile
+
+        d = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: shutil.rmtree(d, ignore_errors=True))
+        p = d / "shot.png"
+        p.write_bytes(_png())
+        sess, _ = _session()
+        asyncio.run(sess._do_detect_file_drop("r1", str(p), expects_placeholder=True))
+        self.assertEqual([q for _, _, q in sess._pending_images], [True])
+        self.assertEqual(sess._drain_pending_images("nope"), "nope")
 
 
 if __name__ == "__main__":

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -840,6 +840,69 @@ describe('GatewayClient NDJSON adapter', () => {
     })
   })
 
+  // The macOS Cmd+V route. Apple Terminal/iTerm handle Cmd+V themselves and
+  // deliver the clipboard as a bracketed paste, so with an image on the
+  // clipboard an EMPTY paste arrives and lands in the composer's
+  // empty-bracketed branch → onClipboardPaste → this RPC. Unwired it resolved
+  // {} and Cmd+V did nothing, silently (the call passes quiet=true).
+  it('maps clipboard.paste to the clipboard_image control', async () => {
+    const p = gw.request('clipboard.paste', { session_id: 's1' })
+    await replyToControl('clipboard_image', {
+      attached: true, count: 3, height: 220, name: 'clipboard image', width: 760
+    })
+    await expect(p).resolves.toMatchObject({ attached: true, count: 3 })
+  })
+
+  it('gives clipboard.paste a message when the clipboard has no image', async () => {
+    // The caller shows this only on an explicit paste (quiet=false).
+    const p = gw.request('clipboard.paste', {})
+    await replyToControl('clipboard_image', {})
+    await expect(p).resolves.toMatchObject({ message: 'No image found in clipboard' })
+  })
+
+  it('does not overwrite a real failure with the not-found message', async () => {
+    const p = gw.request('clipboard.paste', {})
+    await replyToControl('clipboard_image', { unavailable: true })
+    const r = (await p) as { message?: string; unavailable?: boolean }
+    expect(r.unavailable).toBe(true)
+  })
+
+  // `placeholder` says "this caller renders an `[Image #N]` chip", which makes the
+  // chip authoritative — the backend DROPS a pending image whose chip is gone at
+  // submit. It must therefore come from the CALLER, never be hardcoded per-RPC:
+  // six sites reach these RPCs and only three insert a chip. Hardcoding `true`
+  // made `/image`, the startup image, and typed-path submit silently lose their
+  // images *after* their UI had confirmed success. Default false is fail-open.
+  it('forwards placeholder:true from a chip-rendering caller', async () => {
+    void gw.request('image.clipboard', { placeholder: true })
+    await vi.waitFor(() => {
+      seen.push(...stdinFrames())
+      const req = seen.find(f => f.request?.subtype === 'clipboard_image')
+      expect(req?.request?.placeholder).toBe(true)
+    })
+  })
+
+  it('sends placeholder:false when the caller renders no chip', async () => {
+    // `/image`, the startup image and typed-path submit all land here. If this
+    // ever flips to true their images are dropped at submit.
+    void gw.request('image.attach', { path: '/tmp/a.png' })
+    await vi.waitFor(() => {
+      seen.push(...stdinFrames())
+      const req = seen.find(f => f.request?.subtype === 'attach_image')
+      expect(req?.request?.placeholder).toBe(false)
+    })
+  })
+
+  it('never invents placeholder:true from a truthy-ish value', async () => {
+    // Strict === true, so a stray string/1 cannot make a chip authoritative.
+    void gw.request('input.detect_drop', { placeholder: 'yes', text: '/tmp/a.png' })
+    await vi.waitFor(() => {
+      seen.push(...stdinFrames())
+      const req = seen.find(f => f.request?.subtype === 'detect_file_drop')
+      expect(req?.request?.placeholder).toBe(false)
+    })
+  })
+
   it('never resolves an image RPC to undefined', async () => {
     // The composer does `attached?.name`, but `input.detect_drop`'s caller reads
     // `dropped.matched` after a truthiness check — a bare undefined from a

--- a/ui-tui/src/__tests__/imageRef.test.ts
+++ b/ui-tui/src/__tests__/imageRef.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatImageRef, IMAGE_REF_RE, parseImageRefs } from '../protocol/imageRef.js'
+
+describe('formatImageRef', () => {
+  it('renders the chip the composer shows', () => {
+    expect(formatImageRef(1)).toBe('[Image #1]')
+    expect(formatImageRef(12)).toBe('[Image #12]')
+  })
+})
+
+describe('parseImageRefs', () => {
+  it('finds every chip in order', () => {
+    expect(parseImageRefs('a [Image #1] b [Image #12] c')).toEqual([1, 12])
+  })
+
+  it('ignores id 0 — ids start at 1', () => {
+    expect(parseImageRefs('[Image #0]')).toEqual([])
+  })
+
+  it('does not match near-misses', () => {
+    expect(parseImageRefs('[Image] [Image #] [Pasted text #1] [image #1]')).toEqual([])
+  })
+
+  it('returns nothing for an ordinary prompt', () => {
+    expect(parseImageRefs('what is this about?')).toEqual([])
+  })
+
+  it('is stateless across calls despite the /g flag', () => {
+    // A module-level /g regex carries lastIndex; matchAll resets it, but pin it
+    // so a refactor to .exec() cannot introduce an every-other-call bug.
+    const text = 'x [Image #3] y'
+    expect(parseImageRefs(text)).toEqual([3])
+    expect(parseImageRefs(text)).toEqual([3])
+    expect(IMAGE_REF_RE.lastIndex).toBe(0)
+  })
+})
+
+/** The backend mirrors this pattern (`_IMAGE_REF_RE` in agent_server.py) and
+ *  drops any pending image whose chip is absent from the submitted text. These
+ *  cases are the contract both sides have to agree on. */
+describe('chip round-trip against the backend contract', () => {
+  it('a formatted chip is parseable back to its id', () => {
+    for (const id of [1, 2, 9, 10, 99, 1000]) {
+      expect(parseImageRefs(`prompt ${formatImageRef(id)} more`)).toEqual([id])
+    }
+  })
+
+  it('survives being embedded on its own line, which is how it is inserted', () => {
+    expect(parseImageRefs(`what is this?\n${formatImageRef(2)}`)).toEqual([2])
+  })
+})
+
+describe('appendImageChip — composer placement', () => {
+  it('puts the chip on its own line under existing text', async () => {
+    const { appendImageChip } = await import('../app/useComposerState.js')
+
+    expect(appendImageChip('what this image is about?', 2).value).toBe(
+      'what this image is about?\n[Image #2] '
+    )
+  })
+
+  it('is the only content in an empty composer', async () => {
+    const { appendImageChip } = await import('../app/useComposerState.js')
+
+    expect(appendImageChip('', 1).value).toBe('[Image #1] ')
+  })
+
+  it('does not double the newline', async () => {
+    const { appendImageChip } = await import('../app/useComposerState.js')
+
+    expect(appendImageChip('line\n', 3).value).toBe('line\n[Image #3] ')
+  })
+
+  it('leaves the cursor after the chip', async () => {
+    const { appendImageChip } = await import('../app/useComposerState.js')
+    const out = appendImageChip('hi', 4)
+
+    expect(out.cursor).toBe(out.value.length)
+  })
+
+  it('keeps a dropped-path remainder after the chip', async () => {
+    const { appendImageChip } = await import('../app/useComposerState.js')
+
+    // No trailing space before a newline — it would be invisible whitespace.
+    expect(appendImageChip('look:', 5, 'and this too').value).toBe(
+      'look:\n[Image #5]\nand this too'
+    )
+  })
+
+  it('stacks multiple attachments, each parseable', async () => {
+    const { appendImageChip } = await import('../app/useComposerState.js')
+    const one = appendImageChip('compare these', 1).value
+    const two = appendImageChip(one, 2).value
+
+    expect(parseImageRefs(two)).toEqual([1, 2])
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -230,6 +230,8 @@ export interface ComposerActions {
   replaceQueue: (index: number, text: string) => void
   setCompIdx: StateSetter<number>
   setHistoryIdx: StateSetter<null | number>
+  /** Insert an `[Image #N]` chip for a just-attached image. */
+  insertImageRef: (id: number) => void
   setInput: StateSetter<string>
   setPasteSnips: StateSetter<PasteSnippet[]>
   setQueueEdit: (index: null | number) => void

--- a/ui-tui/src/app/useComposerState.ts
+++ b/ui-tui/src/app/useComposerState.ts
@@ -17,6 +17,7 @@ import { resolveEditor } from '../lib/editor.js'
 import { readOsc52Clipboard } from '../lib/osc52.js'
 import { isRemoteShellSession } from '../lib/terminalSetup.js'
 import { pasteTokenLabel, stripTrailingPasteNewlines } from '../lib/text.js'
+import { formatImageRef } from '../protocol/imageRef.js'
 
 import type { MaybePromise, PasteSnippet, UseComposerStateOptions, UseComposerStateResult } from './interfaces.js'
 import { $isBlocked } from './overlayStore.js'
@@ -42,6 +43,26 @@ const trimSnips = (snips: PasteSnippet[]): PasteSnippet[] => {
   }
 
   return out.length === snips.length ? snips : out
+}
+
+/** Append an `[Image #N]` chip on its own line at the end of the composer.
+ *
+ *  Block-level rather than at-cursor on purpose: the chip is a standing
+ *  attachment indicator, not pasted prose, and putting it on its own line keeps
+ *  it visible and easy to delete (deleting it un-attaches the image). All three
+ *  attach routes — Ctrl+V hotkey, Cmd+V empty-paste, dropped path — use this so
+ *  the chip lands in the same place regardless of how the image arrived. */
+export function appendImageChip(value: string, id: number, extra = ''): { cursor: number; value: string } {
+  // Trailing space ONLY when the chip is last, so paste-then-type does not
+  // fuse into `[Image #1]what`. The reference does this lazily
+  // (pendingSpaceAfterPillRef); an eager space is the same benefit for a
+  // fraction of the machinery. Skipped before a newline, where it would just
+  // be invisible trailing whitespace.
+  const chip = formatImageRef(id)
+  const body = extra ? `${chip}\n${extra}` : `${chip} `
+  const next = !value ? body : value.endsWith('\n') ? `${value}${body}` : `${value}\n${body}`
+
+  return { cursor: next.length, value: next }
 }
 
 /** Insert text at the cursor position, adding spacing to separate from adjacent non-whitespace. */
@@ -208,24 +229,41 @@ export function useComposerState({
         try {
           const attached = await gw.request<ImageAttachResponse>('image.attach', {
             path: cleanedText,
+            // This route inserts an `[Image #N]` chip below, so the chip is
+            // authoritative: deleting it un-attaches the image.
+            placeholder: true,
             session_id: sid
           })
 
           if (attached?.name) {
-            onImageAttached?.(attached)
-            const remainder = attached.remainder?.trim() ?? ''
-
-            if (!remainder) {
-              return { cursor, value }
+            // Insert the chip by RETURNING it, not via setInput: the caller
+            // applies this {cursor, value} to the composer, so a separate
+            // setInput would race it and the chip could be clobbered.
+            // Guard the id rather than defaulting to 0: `[Image #0]` is
+            // filtered by the backend's ref parser, so it would render as
+            // visible garbage AND guarantee the image is dropped.
+            if (attached.id) {
+              return appendImageChip(value, attached.id, attached.remainder?.trim() ?? '')
             }
 
-            return insertAtCursor(value, cursor, remainder)
+            onImageAttached?.(attached)
+
+            return null
+          }
+
+          if (attached?.error || attached?.unavailable) {
+            onImageAttached?.(attached)
+
+            return null
           }
         } catch {
           // Fall back to generic file-drop detection below.
         }
 
         try {
+          // No chip on this route (it inserts the returned text instead), so
+          // no `placeholder` — the backend must not make a chip authoritative
+          // for an image whose chip never gets rendered.
           const dropped = await gw.request<InputDetectDropResponse>('input.detect_drop', {
             session_id: sid,
             text: cleanedText
@@ -305,7 +343,7 @@ export function useComposerState({
         return readPreferredText.then(async preferredText => {
           const decision = await resolveHotkeyPaste({
             probeClipboardImage: () =>
-              gw.request<ImageAttachResponse>('image.clipboard', {}).catch(() => null),
+              gw.request<ImageAttachResponse>('image.clipboard', { placeholder: true }).catch(() => null),
             text: preferredText
           })
 
@@ -316,9 +354,18 @@ export function useComposerState({
           }
 
           if (decision.kind === 'image') {
-            // The backend holds the bytes and attaches them to the next prompt;
-            // nothing goes into the composer text.
-            onImageAttached?.(decision.image)
+            const { image } = decision
+
+            // The backend holds the bytes; the composer shows an `[Image #N]`
+            // chip, which is both the "attached" indicator and the un-attach
+            // control (delete it and the backend drops the image at submit).
+            // Returned rather than set, so the caller's value application is the
+            // single writer.
+            if (image.id) {
+              return appendImageChip(value, image.id)
+            }
+
+            onImageAttached?.(image)
 
             return null
           }
@@ -333,6 +380,20 @@ export function useComposerState({
     },
     [gw, handleResolvedPaste, onClipboardPaste, onImageAttached, querier]
   )
+
+  /** Insert an `[Image #N]` chip for a just-attached image.
+   *
+   *  The chip is the whole UI for an attachment: it shows one is pending, and
+   *  deleting it un-attaches (the backend drops any image whose chip is absent
+   *  from the submitted text). Placed on its own line when the composer already
+   *  has content, which is how the reference renders it. */
+  const insertImageRef = useCallback((id: number) => {
+    if (!Number.isFinite(id) || id <= 0) {
+      return
+    }
+
+    setInput(prev => appendImageChip(prev, id).value)
+  }, [])
 
   const openEditor = useCallback(async () => {
     const dir = mkdtempSync(join(tmpdir(), 'clawcodex-'))
@@ -372,6 +433,7 @@ export function useComposerState({
       dismissCompletions,
       enqueue,
       handleTextPaste,
+      insertImageRef,
       openEditor,
       pushHistory,
       removeQueue: removeQ,
@@ -389,6 +451,7 @@ export function useComposerState({
       dismissCompletions,
       enqueue,
       handleTextPaste,
+      insertImageRef,
       openEditor,
       pushHistory,
       removeQ,

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -14,7 +14,7 @@ import { STARTUP_RESUME_ID, TRANSCRIPT_COLOR } from '../config/env.js'
 import { MAX_HISTORY, WHEEL_SCROLL_STEP } from '../config/limits.js'
 import { hasLeadGap, prevRenderedMsg, showsInterTurnSeparator } from '../domain/blockLayout.js'
 import { SECTION_NAMES, sectionMode } from '../domain/details.js'
-import { attachedImageNotice, imageTokenMeta } from '../domain/messages.js'
+import { attachedImageNotice } from '../domain/messages.js'
 import { composeTabTitle, fmtCwdBranch, shortCwd } from '../domain/paths.js'
 import { type GatewayClient } from '../gatewayClient.js'
 import type {
@@ -221,6 +221,7 @@ export function useMainApp(gw: GatewayClient) {
   const scrollRef = useRef<null | ScrollBoxHandle>(null)
   const onEventRef = useRef<(ev: GatewayEvent) => void>(() => {})
   const clipboardPasteRef = useRef<(quiet?: boolean) => Promise<void> | void>(() => {})
+  const insertImageRefRef = useRef<(id: number) => void>(() => {})
   const submitRef = useRef<(value: string) => void>(() => {})
   const terminalHintsShownRef = useRef(new Set<string>())
   const historyItemsRef = useRef(historyItems)
@@ -286,6 +287,9 @@ export function useMainApp(gw: GatewayClient) {
   const composer = useComposerState({
     gw,
     onClipboardPaste: quiet => clipboardPasteRef.current(quiet),
+    // Success renders as an `[Image #N]` chip in the composer (see
+    // insertImageRef), so this fires only for failures — an undecodable
+    // image, or a box with no xclip/wl-clipboard.
     onImageAttached: info => {
       sys(attachedImageNotice(info))
     },
@@ -796,15 +800,25 @@ export function useMainApp(gw: GatewayClient) {
 
   const paste = useCallback(
     (quiet = false) =>
-      rpc<ClipboardPasteResponse>('clipboard.paste', { session_id: getUiState().sid }).then(r => {
+      rpc<ClipboardPasteResponse>('clipboard.paste', {
+        // Inserts an `[Image #N]` chip below, so the chip is authoritative.
+        placeholder: true,
+        session_id: getUiState().sid
+      }).then(r => {
         if (!r) {
           return
         }
 
         if (r.attached) {
-          const meta = imageTokenMeta(r)
+          // The chip in the composer IS the feedback — matching the reference,
+          // which shows `[Image #N]` inline and prints nothing to the transcript.
+          // It also doubles as un-attach: delete the chip and the backend drops
+          // the image at submit.
+          return insertImageRefRef.current(r.count ?? 0)
+        }
 
-          return sys(`📎 Image #${r.count} attached from clipboard${meta ? ` · ${meta}` : ''}`)
+        if (r.error || r.unavailable) {
+          return sys(attachedImageNotice(r))
         }
 
         if (!quiet) {
@@ -815,6 +829,9 @@ export function useMainApp(gw: GatewayClient) {
   )
 
   clipboardPasteRef.current = paste
+  // `paste` is declared above the composer, so it reaches insertImageRef through
+  // this ref (same pattern as clipboardPasteRef itself).
+  insertImageRefRef.current = composerActions.insertImageRef
 
   const { dispatchSubmission, send, sendQueued, submit } = useSubmission({
     appendMessage,

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -1024,21 +1024,61 @@ export class GatewayClient extends EventEmitter {
       case 'image.attach':
         // Longer deadline than a normal RPC: reading + downsampling a large
         // screenshot is Pillow work, and osascript alone is ~1.5s.
+        //
+        // `placeholder` must come from the CALLER, not be hardcoded here:
+        // whether an `[Image #N]` chip gets rendered is a property of the call
+        // site, not of the RPC. Six sites reach these four RPCs and only three
+        // insert a chip — hardcoding `true` made the backend drop the images of
+        // the other three (`/image`, the startup image, and typed-path submit)
+        // at submit time, after their UI had already confirmed success.
+        // Default false is fail-open: an unmarked caller keeps its image.
         return this.controlQuery(
           'attach_image',
-          { path: String(p.path ?? '') },
+          { path: String(p.path ?? ''), placeholder: p.placeholder === true },
           IMAGE_RPC_TIMEOUT_MS
         ).then(r => (r ?? {}) as T)
 
       case 'image.clipboard':
-        return this.controlQuery('clipboard_image', {}, IMAGE_RPC_TIMEOUT_MS).then(
-          r => (r ?? {}) as T
-        )
+        return this.controlQuery(
+          'clipboard_image',
+          { placeholder: p.placeholder === true },
+          IMAGE_RPC_TIMEOUT_MS
+        ).then(r => (r ?? {}) as T)
+
+      // The macOS Cmd+V route, and the one users actually reach first. Apple
+      // Terminal and iTerm handle Cmd+V themselves and deliver the clipboard as
+      // a BRACKETED PASTE, so the app never sees a Cmd+V keypress — and with an
+      // image on the clipboard there is no text, so what arrives is an EMPTY
+      // bracketed paste. That lands in handleResolvedPaste's empty branch, which
+      // calls onClipboardPaste → this RPC. Unwired, it resolved `{}` and Cmd+V
+      // did nothing at all, silently (the call passes quiet=true).
+      case 'clipboard.paste':
+        return this.controlQuery(
+          'clipboard_image',
+          { placeholder: p.placeholder === true },
+          IMAGE_RPC_TIMEOUT_MS
+        ).then(r => {
+          const res = (r ?? {}) as {
+            attached?: boolean
+            error?: string
+            message?: string
+            unavailable?: boolean
+          }
+
+          // Only synthesize for a genuinely empty clipboard. Adding it to an
+          // error/unavailable reply would have it claim "no image found"
+          // alongside a real failure.
+          if (res.attached || res.error || res.unavailable) {
+            return res as T
+          }
+
+          return { ...res, message: 'No image found in clipboard' } as T
+        })
 
       case 'input.detect_drop':
         return this.controlQuery(
           'detect_file_drop',
-          { text: String(p.text ?? '') },
+          { text: String(p.text ?? ''), placeholder: p.placeholder === true },
           IMAGE_RPC_TIMEOUT_MS
         ).then(r => (r ?? {}) as T)
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -475,10 +475,15 @@ export interface ShellExecResponse {
 
 export interface ClipboardPasteResponse {
   attached?: boolean
+  /** The N in the `[Image #N]` chip the composer inserts. */
   count?: number
+  /** Set when the image could not be read; `attached` is then absent. */
+  error?: string
   height?: number
   message?: string
   token_estimate?: number
+  /** Set when the platform has no clipboard-image tooling. */
+  unavailable?: boolean
   width?: number
 }
 
@@ -502,6 +507,8 @@ export interface ImageAttachResponse {
   /** Set when the image could not be read; `name` is then absent. */
   error?: string
   height?: number
+  /** The N in the `[Image #N]` chip the composer inserts. */
+  id?: number
   name?: string
   remainder?: string
   token_estimate?: number

--- a/ui-tui/src/protocol/imageRef.ts
+++ b/ui-tui/src/protocol/imageRef.ts
@@ -1,0 +1,24 @@
+/** The `[Image #N]` chip shown in the composer for a pending image attachment.
+ *
+ *  Port of `formatImageRef` / the image half of `parseReferences` in
+ *  `typescript/src/history.ts`. The backend mirrors the same pattern
+ *  (`_IMAGE_REF_RE` in `agent_server.py`) because the chip is the contract, not
+ *  decoration: at submit the backend drops any pending image whose chip is no
+ *  longer in the text, which is what makes deleting the chip un-attach the
+ *  image. Keep the two patterns in sync.
+ *
+ *  The chip stays in the prompt text that reaches the model — the reference
+ *  leaves image refs inline and sends the bytes as separate content blocks
+ *  (history.ts:79), so the model sees where in the message the image belongs. */
+export const IMAGE_REF_RE = /\[Image #(\d+)\]/g
+
+export function formatImageRef(id: number): string {
+  return `[Image #${id}]`
+}
+
+/** Image ids still referenced by a chip in `text`. */
+export function parseImageRefs(text: string): number[] {
+  return [...text.matchAll(IMAGE_REF_RE)]
+    .map(m => Number.parseInt(m[1] ?? '0', 10))
+    .filter(id => id > 0)
+}


### PR DESCRIPTION
Follow-up to #761, from two user-reported gaps.

## 1. A pasted image left no trace in the input box

The composer now shows the reference's chip:

```
> what this image is about?
  [Image #2]
```

**The chip is not decoration.** The backend assigns the id, and at submit it **drops any pending image whose `[Image #N]` is no longer in the text** — so deleting the chip un-attaches the image. That's the reference's rule (`handlePromptSubmit.ts:225`), and it closes the gap #761 shipped with: previously the only way to undo an accidental attach was `/clear`, which destroys the conversation.

The chip text stays in the prompt the model sees — the reference leaves image refs inline and sends the bytes as separate blocks (`history.ts:79`).

`_pending_images` entries become `(image_id, PastedImage, expects_placeholder)` behind the existing `_queue_image` choke point, with a monotonic per-session `_image_seq`. Session-wide rather than per-prompt **on purpose**: ids are never reused and the drain is destructive, so a stale chip recalled from history or `/resume` matches nothing. A per-prompt reset would be *worse* than the reference — a recalled `[Image #1]` would keep a freshly-pasted image #1 alive after its real chip was deleted.

## 2. Cmd+V did nothing on macOS

A **third** unwired RPC: `clipboard.paste`. macOS terminals own Cmd+V and, with an image-only clipboard, deliver an **empty** bracketed paste — which lands in the composer's empty-paste branch, calls `onClipboardPaste`, and hit `gatewayClient`'s "Unhandled RPC (Phase 2)" default. Resolved `{}`, silently, because that call passes `quiet=true`.

**The keybinding was never the missing piece.** I checked three references and they disagree:

| project | Cmd+V bound? | how |
|---|---|---|
| **hermes** (clawcodex's ui-tui ancestor) | **yes** | `isMac && isActionMod(k) && inp === 'v'` in `textInput.tsx`; `super+v` reserved in `platform.ts` |
| openclaude | no — reserved, severity `error` | image paste is `ctrl+v`; ships a tip *"use control+v (not cmd+v!)"* |
| opencode | no | `ctrl+v` only (though it uses `super+z`/`super+a`), plus a re-dispatch on an empty bracketed paste |

clawcodex already inherited hermes' binding, so Cmd+V works as a keypress wherever the terminal reports Cmd, and through the empty-paste route where it doesn't (Apple Terminal). Ctrl+V works everywhere.

## ⚠️ `placeholder` is a call-site property, not an RPC property

Whether an `[Image #N]` chip gets rendered depends on the **caller**, so the flag has to come from one. Six sites reach these four RPCs and only three render a chip. Hardcoding `placeholder: true` at the RPC layer made the backend drop the images of the other three — **`/image`, the `CLAWCODEX_TUI_IMAGE` startup image, and typed-path submit** — at submit time, *after* their UI had already printed "📎 Attached image". Both of those worked when #761 shipped.

Default `false` is fail-open, so headless `-p` and the VS Code bridge keep sending their images. **If a new image entry point is added, it must opt in only if it renders a chip.**

## Testing

Tests pin the cross-layer invariant in both directions — that's what was missing when a green suite hid the above:

- RPC forwards `true` from a chip-rendering caller, defaults to `false`, and refuses a truthy-ish `'yes'`.
- The real `_do_clipboard_image` / `_do_detect_file_drop` honour the flag and drop on a deleted chip (`TestClipboardRouteHonorsPlaceholder`).
- `TestChipIsAuthoritative`: kept chip sends, deleted chip drops, partial drop keeps the *right* image (distinguishable bytes, so it can actually tell), chip text stays inline, queue drained even when everything was un-attached, no-placeholder client unaffected.

**Live:** clipboard image → `[Image #1]` → `claude-opus-5` read `**PURPLE-ELEPHANT-42**` (`finish_reason: end_turn`); with the chip deleted the prompt went out as plain text with the queue drained.

**Python 9007 passed / 3 skipped / 0 failed.** ui-tui 1545 passed, same 8 pre-existing baseline failures. `tsc --noEmit` clean; 0 lint errors.

One flake worth naming: an earlier full run failed `test_sigterm_triggers_drain`. It passes in isolation and 5/5 runs of its file, has zero overlap with anything here, and fires SIGTERM 200ms into a subprocess expecting the handler to be installed — load-sensitive. A clean re-run of identical code confirmed it.

## Follow-ups (not in this change)

- **Atomic chip** — one backspace should delete the whole pill (`Cursor.ts:346-370`). Today it takes 10, and a partial `[Image #1` silently un-attaches.
- **Chip for `/image`** — it currently prints a notice instead, which also leaves `session.ts:162`'s remainder-replaces-composer behavior unaddressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)