### PR TITLE
fix(deps): cap mcp below 2.0 — 2.0.0 removed mcp.client.websocket

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,20 @@ dependencies = [
     # Official Model Context Protocol SDK used by ``src.services.mcp`` for
     # stdio, SSE, Streamable HTTP, WebSocket, OAuth discovery, and JSON-RPC
     # message models.
-    "mcp>=1.27.0",
+    #
+    # Capped below 2.0 deliberately. mcp 2.0.0 (2026-07-28) is a restructure
+    # that REMOVED ``mcp.client.websocket`` — the module
+    # ``src/services/mcp/transport.py:30`` imports ``websocket_client`` from.
+    # Because the old bound was open-ended, CI began resolving 2.0.0 the day it
+    # published and every PR died with 26 collection errors
+    # (``ModuleNotFoundError: No module named 'mcp.client.websocket'``) in files
+    # nobody had touched. 1.29.0 still ships the module.
+    #
+    # Lifting the cap is a real migration, not a version bump: 2.0 also renames
+    # the client internals (``_transport``, ``caching``, ``subscriptions`` are
+    # new; ``experimental`` is gone). Do that on its own branch, with the
+    # websocket transport either ported or explicitly dropped.
+    "mcp>=1.27.0,<2",
     # Image decode/resize/encode for the FileReadTool image pipeline (port
     # of TS imageResizer.ts which uses sharp). Pillow has pure-Python wheels
     # for all platforms and covers PNG/JPEG/GIF/WebP and palette quantization.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,11 @@ PyYAML>=6.0
 pathspec>=0.11
 websockets>=14.0
 httpx-sse>=0.4
-mcp>=1.27.0
+# Capped below 2.0: mcp 2.0.0 removed ``mcp.client.websocket``, which
+# src/services/mcp/transport.py imports. See the longer note in pyproject.toml.
+# THIS is the file CI installs from (ci.yml -> requirements.dev.txt -> here);
+# pyproject.toml is packaging metadata only, so both need the cap.
+mcp>=1.27.0,<2
 Pillow>=10.0
 markdownify>=0.11
 pydantic>=2.0


### PR DESCRIPTION
**Every PR opened since 2026-07-28T13:45 fails CI**, in files the PR never touched:

```
ModuleNotFoundError: No module named 'mcp.client.websocket'
ERROR tests/test_mcp_transport.py
ERROR tests/test_mcp_auth.py
… 24 more
Interrupted: 26 errors during collection
```

## Cause

The bound was open-ended — `mcp>=1.27.0` — so CI resolved `mcp 2.0.0` the day it published. 2.0.0 is a restructure that **removed `mcp.client.websocket`**, which `src/services/mcp/transport.py:30` imports `websocket_client` from.

| when | what | mcp |
|---|---|---|
| 2026-07-28T08:12 | PR #761 CI **passes** | 1.28.1 |
| 2026-07-28T13:45 | **`mcp 2.0.0` published** | — |
| 2026-07-29T05:06 | PR #762 CI **fails**, 26 collection errors | 2.0.0 |

Nothing in the failing PR touched MCP or any dependency file. A no-op PR opened right now would fail identically.

## Verified in clean venvs

```
mcp 2.0.0  -> submodules: _input_required _memory _probe _transport auth caching
                          client context extension session session_group sse
                          stdio streamable_http subscriptions
              websocket_client GONE: ModuleNotFoundError

mcp>=1.27.0,<2 -> resolves 1.29.0, websocket_client imports OK
                  (against the already-declared websockets>=14.0)
```

Note `experimental` is also gone and `_transport`/`caching`/`subscriptions` are new — this is a genuine 2.x restructure, not a rename or two.

## Why a cap and not a migration

Lifting the cap means porting the client internals *and* deciding the fate of the websocket transport. That's its own branch with its own review. This change unblocks CI with a one-line bound and a comment recording why, so the next person doesn't just widen it again.

`tests/test_mcp_transport.py` + `tests/test_mcp_string_utils.py`: 29 passed locally on the pinned resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)