### PR TITLE
docs(readme): add Terminal-Bench 2.1 headline banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@
 
 <div align="center">
 
+# 🏆 Terminal-Bench 2.1
+
+# **80.9%** on Claude Opus 5 — a top-tier open-source result
+
+### 72 of 89 tasks solved (pass@1) on the verified 89-task suite. On the [public leaderboard](https://www.tbench.ai/leaderboard/terminal-bench/2.1) that slots **around 3rd** — behind Claude Code / Fable 5 (83.8%) and Codex / GPT-5.5 (83.1%), **ahead of Claude Code on Opus 4.8 (78.9%)**.
+
+ClawCodex — the open-source Python rebuild of Claude Code — run headless on `claude-opus-5` at `effort=xhigh`.
+A single run (k=1) against the board's k=5 averages; benchmarked on `main` at #756. Fully reproducible from the
+open-source [Harbor adapter](eval/harbor/). **[Read the full breakdown ↓](#-news)**
+
+</div>
+
+***
+
+<div align="center">
+
 # 🌿✂️ /eco Token Compression
 
 # Same session, **80% fewer** Bash-output tokens

--- a/docs/i18n/README_ZH.md
+++ b/docs/i18n/README_ZH.md
@@ -94,6 +94,22 @@ clawcodex --dangerously-skip-permissions   # 启动 REPL
 
 ***
 
+## 🏆 Terminal-Bench 2.1 —— Opus 5 上 **80.9%**，顶尖开源成绩
+
+在经过验证的 89 任务 **Terminal-Bench 2.1** 套件上，ClawCodex 以 `claude-opus-5`（`effort=xhigh`）无头运行，解决了 **72 / 89** 个任务（**80.9% pass@1**，单次运行）。在[公开排行榜](https://www.tbench.ai/leaderboard/terminal-bench/2.1)（k=5 平均）上这大约排在**第 3 左右**：
+
+| Agent | 模型 | 准确率 |
+|---|---|---:|
+| Claude Code | Fable 5 | 83.8% |
+| Codex | GPT-5.5 | 83.1% |
+| **ClawCodex** | **Opus 5** | **80.9%** |
+| Terminus 2 | Fable 5 | 80.4% |
+| Claude Code | Opus 4.8 | 78.9% |
+
+落后于 Claude Code / Fable 5 与 Codex / GPT-5.5，**领先 Claude Code 搭配 Opus 4.8（78.9%）**。单次 k=1 对照榜单的 k=5 平均值，基准运行在 v1.3.0 打标签前的 `main`（#756），完整可由开源 [Harbor 适配器](../../eval/harbor/) 复现。
+
+***
+
 ## 🏆 SWE-bench Verified —— 相同模型下 `clawcodex` 超越 `openclaude`
 
 ![SWE-bench Verified —— clawcodex vs openclaude on Gemini 2.5 Pro](../../assets/swebench-verified-gemini.png)


### PR DESCRIPTION
Leads the README with a centered **Terminal-Bench 2.1** headline banner (80.9% on `claude-opus-5`, would slot around 3rd on the [public board](https://www.tbench.ai/leaderboard/terminal-bench/2.1), ahead of Claude Code on Opus 4.8), in the same style as the existing `/eco` and DeepSeek banners. Adds a matching headline section to the ZH README.

Framing matches the v1.3.0 news item: honest k=1-vs-k=5 caveat, benchmarked-commit note (#756), and the accurate "ahead of Claude Code on Opus 4.8" comparison (the #1 board entry is Claude Code / Fable 5, acknowledged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)