### PR TITLE
fix(harness): stop the loop guard and plan mode from killing headless runs

### DIFF
--- a/src/context_system/plan_mode.py
+++ b/src/context_system/plan_mode.py
@@ -371,10 +371,22 @@ def _attachments_since_last_exit(messages: list[Any]) -> int:
 # ---------------------------------------------------------------------------
 
 
+NON_INTERACTIVE_PLAN_ADDENDUM = (
+    "NOTE — non-interactive session: the AskUserQuestion and ExitPlanMode "
+    "tools are NOT available here, so ignore every instruction above to end "
+    "your turn by calling them. There is no user to answer a question or "
+    "approve a plan. Instead: write the finished plan to the plan file and "
+    "then end your turn normally. Do not attempt to call either tool — they "
+    "are not registered, and the call will fail."
+)
+
+
 def build_plan_mode_attachments(
     messages: list[Any],
     permission_mode: str,
     agent_id: str | None = None,
+    *,
+    interactive: bool = True,
 ) -> list[str]:
     """Return the plan-mode attachment TEXTS due this turn (possibly empty).
 
@@ -420,6 +432,17 @@ def build_plan_mode_attachments(
         )
     else:
         attachments.append(build_plan_mode_sparse_text(plan_file_path))
+
+    if not interactive:
+        # The ported texts above are verbatim TS and name AskUserQuestion /
+        # ExitPlanMode as the only two ways to end a turn. Headless
+        # unregisters both (there is no surface to answer a question or
+        # approve a plan), so on that surface the instructions point at tools
+        # the model cannot call. Appended rather than edited into the prompt
+        # so the port stays verbatim and the correction is visible as its own
+        # statement. Reached only via ``--permission-mode plan`` headlessly,
+        # since nothing else puts a non-interactive session in plan mode.
+        attachments.append(NON_INTERACTIVE_PLAN_ADDENDUM)
 
     return attachments
 

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -246,6 +246,46 @@ def run_headless(options: HeadlessOptions) -> int:
     # headlessly. ``_noop_ask_user`` stays as a backstop for any path that
     # still reaches the context hook.
     tool_registry.remove_tool("AskUserQuestion")
+    # The plan-mode pair goes for the SAME reason, and this is the reference
+    # behavior rather than a divergence. ExitPlanMode is the other
+    # ``requires_user_interaction`` tool, which makes it bypass-immune
+    # (permissions/check.py) — so its ask always resolves to a DENY here:
+    # under bypass the handler is None and ``handle_permission_ask`` denies
+    # with the ask's own message, and otherwise ``_auto_deny_permission_handler``
+    # denies outright. On the bypass path (what the benchmarks run) that
+    # message is the raw dialog question, "Exit plan mode?", handed to the
+    # model as a tool error it cannot possibly act on. The model then cannot leave plan
+    # mode, so every subsequent write is refused: EnterPlanMode auto-allows
+    # (plan_mode.py — TS Tool.ts default), and the exit is unreachable.
+    #
+    # Upstream hit exactly this and fixed it the same way. ExitPlanModeV2Tool
+    # .ts:167-178 disables the tool when the user is not watching the TUI
+    # ("The plan-approval dialog would hang. Paired with the same gate on
+    # EnterPlanMode so plan mode isn't a trap."), and EnterPlanModeTool.ts:
+    # 52-63 disables entry "so plan mode isn't a trap the model can enter but
+    # never leave." Headless is that condition in its strongest form: there is
+    # no terminal at all. Their gate keys off ``--channels``; ours keys off
+    # being headless.
+    #
+    # Measured on terminal-bench 2.1 (2026-08-01): 41 ExitPlanMode calls, a
+    # 100% error rate, across 16 of 32 trials — 5.7% of the entire tool budget
+    # spent on a round trip that could never complete. Model-agnostic by
+    # construction: it removes an unusable tool rather than special-casing any
+    # model, and a model that never calls the pair is unaffected.
+    #
+    # ``--permission-mode plan`` headlessly still works: the mode is set from
+    # options, not by the tool, so a plan-only run starts in plan mode, writes
+    # its plan, and ends the turn. It simply cannot exit plan mode and start
+    # executing — the point of asking for plan mode non-interactively.
+    #
+    # That holds only BECAUSE of ``NON_INTERACTIVE_PLAN_ADDENDUM``
+    # (context_system/plan_mode.py): the ported plan-mode reminder names
+    # AskUserQuestion and ExitPlanMode as the only two ways to end a turn, so
+    # without the addendum this removal would leave the model instructed to
+    # call tools that are not registered. Delete one and the other stops
+    # making sense.
+    tool_registry.remove_tool("ExitPlanMode")
+    tool_registry.remove_tool("EnterPlanMode")
     # Canonicalize BOTH sets up front (before either filter runs) so an alias
     # form (e.g. --disallowed-tools KillShell) resolves while its tool is still
     # registered.

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -591,8 +591,31 @@ async def run_query_as_agent_loop(
             pc = getattr(tool_context, "permission_context", None)
             mode = str(getattr(pc, "mode", "default")) if pc is not None else "default"
             agent_id = getattr(tool_context, "agent_id", None)
+            # Whether the plan-mode reminder may tell the model to end its
+            # turn via AskUserQuestion / ExitPlanMode. Headless unregisters
+            # both, so on that surface the ported instructions would point at
+            # tools that are not callable; read off the live registry rather
+            # than a mode flag so it tracks whatever this surface actually
+            # registered (an explicit --disallowed-tools too).
+            #
+            # Read from ``tool_registry``, NOT ``tool_context.options.tools``:
+            # the latter defaults to [] and is not populated until query()
+            # assigns it (query.py:1529) from this same registry — which
+            # happens BELOW, at the run_query call. Reading options.tools here
+            # returns [] on the FIRST query of every session, so the TUI would
+            # get the non-interactive addendum on exactly the turn that
+            # carries the full plan text, then silently correct itself from
+            # turn 2. tool_registry is populated now and is what becomes
+            # params.tools, so the two can never disagree.
+            from src.tool_system.build_tool import find_tool_by_name
+
+            _interactive = (
+                find_tool_by_name(tool_registry.list_tools(), "ExitPlanMode")
+                is not None
+            )
             texts = build_plan_mode_attachments(
                 messages_for_query, mode, agent_id=agent_id,
+                interactive=_interactive,
             )
             texts += build_plan_mode_exit_attachment(mode, agent_id=agent_id)
             for text in texts:

--- a/src/query/tool_failure_loop_guard.py
+++ b/src/query/tool_failure_loop_guard.py
@@ -11,6 +11,32 @@ patterns recognize this runtime's native error strings —
 ``NoSuchTool`` bucket TS assigns its "No such tool available" text, and
 ``No such file or directory`` (Python ``OSError`` phrasing, no ENOENT
 literal) maps to ``NotFound``. All other patterns are verbatim TS.
+
+Second divergence (intentional): counters increment once per BATCH per
+distinct key. TS iterates its ``failures`` array and increments once per
+failing BLOCK (toolFailureLoopGuard.ts:137,173,201), so a single assistant
+turn that issues ``threshold`` parallel calls which all fail the same way
+trips the guard immediately -- on the model's FIRST mistake, with no chance
+to correct. Measured on terminal-bench 2.1: that ended two runs after 3 and
+4 turns (31s / 38s), each on a plain ``python3: command not found`` the
+model would have recovered from, while a serially-calling model on the same
+task images hit the same missing interpreter and was never stopped. The
+penalty landed purely on HOW a model batches its calls, not on whether it
+was actually looping, so the guard was measuring the wrong thing. Per-batch
+counting matches this module's own stated contract ("consecutive tool
+batches").
+
+The change is strictly permissive: every counter is pointwise <= its old
+value at every step (all reset paths are untouched) and every trip predicate
+is monotone in the counters, so it can only DELAY a trip, never cause one
+that would not have happened. How much later, measured by differential fuzz
+against the old behavior at threshold 3: a homogeneous loop trips at most
+``threshold - 1`` batches later; once failures vary or successes interleave
+-- which clear ``signature_counts`` / ``category_counts`` -- the delay grows
+(observed up to ~20 batches at a 25% interleaved success rate). The trip is
+always eventually reached, never suppressed, and ``max_turns`` bounds the
+worst case. Deliberate: a model succeeding a quarter of the time is making
+progress, not looping.
 """
 from __future__ import annotations
 
@@ -124,10 +150,32 @@ def update_tool_failure_loop_guard(
             if key.startswith(prefix):
                 del state.persistent_signature_counts[key]
 
+    # One increment per BATCH per distinct key, not one per failing block.
+    # See the "Divergence vs TS" note in the module docstring: an assistant
+    # turn that issues N parallel calls which all fail the same way is ONE
+    # unsuccessful batch, not N consecutive ones.
+    bumped_this_batch: set[tuple[str, str]] = set()
+
+    def _bump(counts: dict[str, int], key: str, kind: str) -> tuple[int, bool]:
+        """Increment ``counts[key]`` at most once per batch.
+
+        Returns ``(count, first_in_batch)``. For a repeat the CURRENT count
+        comes back, so a duplicate can never push a counter over the
+        threshold, while a first occurrence that legitimately reaches it
+        still trips on this batch. ``first_in_batch`` lets the caller emit
+        one advisory per key rather than one per failing block.
+        """
+        if (kind, key) in bumped_this_batch:
+            return counts.get(key, 0), False
+        bumped_this_batch.add((kind, key))
+        return _increment_counter(counts, key), True
+
     advisories: list[str] = []
     for tool_name, error_category, _path in failures:
-        count = _increment_counter(
-            state.persistent_signature_counts, f"{tool_name}\0{error_category}"
+        count, first = _bump(
+            state.persistent_signature_counts,
+            f"{tool_name}\0{error_category}",
+            "persistent",
         )
         if count >= resolved_threshold:
             return ToolFailureLoopGuardDecision(
@@ -141,7 +189,7 @@ def update_tool_failure_loop_guard(
                     tool_name=tool_name, error_category=error_category,
                 ),
             )
-        if resolved_threshold > 1 and count == resolved_threshold - 1:
+        if first and resolved_threshold > 1 and count == resolved_threshold - 1:
             advisories.append(_create_advisory_message(
                 threshold=resolved_threshold,
                 tool_name=tool_name,
@@ -151,7 +199,7 @@ def update_tool_failure_loop_guard(
     for tool_name, error_category, path in failures:
         if not path or path in successful_mutation_paths:
             continue
-        path_count = _increment_counter(state.path_counts, path)
+        path_count, _ = _bump(state.path_counts, path, "path")
         if path_count >= resolved_threshold:
             return ToolFailureLoopGuardDecision(
                 tripped=True, kind="path", threshold=resolved_threshold,
@@ -171,10 +219,12 @@ def update_tool_failure_loop_guard(
         )
 
     for tool_name, error_category, path in failures:
-        signature_count = _increment_counter(
-            state.signature_counts, f"{tool_name}\0{error_category}"
+        signature_count, _ = _bump(
+            state.signature_counts, f"{tool_name}\0{error_category}", "signature"
         )
-        category_count = _increment_counter(state.category_counts, error_category)
+        category_count, _ = _bump(
+            state.category_counts, error_category, "category"
+        )
         if signature_count >= resolved_threshold:
             return ToolFailureLoopGuardDecision(
                 tripped=True,

--- a/src/services/tool_execution/tool_execution.py
+++ b/src/services/tool_execution/tool_execution.py
@@ -57,16 +57,37 @@ async def run_tool_use(
     tool = find_tool_by_name(tool_use_context.options.tools, tool_name)
 
     if tool is None:
-        # Old-transcript names and pool-hidden tools resolve through the
-        # FULL base-tool list (TS toolExecution.ts:335-341:
-        # findToolByName(getAllBaseTools(), toolName)). Not a permission
-        # bypass: resolution still runs downstream for the resolved tool.
+        # DEPRECATED ALIASES ONLY. TS resolves the fallback from the full
+        # base-tool list but then accepts it only when the called name is one
+        # of that tool's ``aliases`` (toolExecution.ts:415-426, "Only fall
+        # back for tools where the name matches an alias, not the primary
+        # name") — e.g. an old transcript calling ``KillShell``, now an alias
+        # for ``TaskStop``.
+        #
+        # The port dropped that second half, so ANY unregistered tool
+        # resolved by primary name and executed. That silently un-did every
+        # deliberate removal: ``--disallowed-tools`` / ``--allowed-tools``
+        # dropped a tool from the advertised schema while leaving it fully
+        # callable, and headless's ``remove_tool`` calls for the tools that
+        # cannot work without a user (AskUserQuestion, and the plan-mode pair
+        # below) hid them without disabling them. That mattered because the
+        # plan-mode reminder NAMES ExitPlanMode, so the model was prompted
+        # into calling a tool the harness had removed, and got the raw
+        # "Exit plan mode?" dialog question back as a tool error.
+        #
+        # Restoring the guard makes removal mean removal. A genuinely unknown
+        # or removed name now falls through to the "No such tool available"
+        # branch below, which is a message the model can act on.
         try:
             from src.tool_system.defaults import build_default_registry
 
-            tool = find_tool_by_name(
+            fallback = find_tool_by_name(
                 build_default_registry().list_tools(), tool_name
             )
+            if fallback is not None and tool_name in (
+                getattr(fallback, "aliases", None) or ()
+            ):
+                tool = fallback
         except Exception:
             pass
 

--- a/tests/test_headless_tool_filter.py
+++ b/tests/test_headless_tool_filter.py
@@ -177,3 +177,162 @@ def test_remove_tool_is_idempotent_for_ask_user_question():
     assert registry.remove_tool("AskUserQuestion") is True
     assert registry.remove_tool("AskUserQuestion") is False
     assert "AskUserQuestion" not in _names(registry)
+
+
+def test_headless_unregisters_the_plan_mode_pair_source():
+    """Headless must unregister BOTH plan-mode tools, not just ExitPlanMode.
+
+    ExitPlanMode is the other ``requires_user_interaction`` tool, which makes
+    it bypass-immune, so headlessly its ask reaches ``handle_permission_ask``
+    with no handler and returns a DENY carrying the raw dialog question,
+    "Exit plan mode?", as a tool error. EnterPlanMode auto-allows. The pair
+    is therefore a one-way door: the model enters plan mode and can never
+    leave, so every following write is refused.
+
+    Upstream fixed this the same way — ExitPlanModeV2Tool.ts:167-178 and
+    EnterPlanModeTool.ts:52-63 both disable when the user is not watching the
+    TUI, explicitly "so plan mode isn't a trap the model can enter but never
+    leave." Removing only the exit would leave entry reachable and make the
+    trap worse, which is why both are asserted here.
+
+    Measured on terminal-bench 2.1 (2026-08-01): 41 ExitPlanMode calls, a
+    100% error rate, across 16 of 32 trials.
+    """
+    import inspect
+
+    src = inspect.getsource(headless_mod.run_headless)
+    for name in ("ExitPlanMode", "EnterPlanMode"):
+        assert f'remove_tool("{name}")' in src, (
+            f"headless must unregister {name}: plan mode cannot complete "
+            "without an interactive approval surface"
+        )
+        assert src.index(f'remove_tool("{name}")') < src.index("_filter_registry"), (
+            f"unregister {name} before the allow/deny filters run"
+        )
+
+
+def test_plan_mode_pair_removal_is_idempotent():
+    registry = build_default_registry(provider="anthropic")
+    for name in ("ExitPlanMode", "EnterPlanMode"):
+        assert registry.remove_tool(name) is True
+        assert registry.remove_tool(name) is False
+        assert name not in _names(registry)
+
+
+def test_default_registry_keeps_plan_mode():
+    """The removal is headless-only, applied to the registry run_headless
+    builds. The DEFAULT registry — what the TUI/agent-server path starts
+    from, and that path installs a real round-trip approval handler — must
+    still carry both. This is the guard against 'fixing' the trap by
+    deleting plan mode everywhere."""
+    registry = build_default_registry(provider="anthropic")
+    names = _names(registry)
+    assert "EnterPlanMode" in names
+    assert "ExitPlanMode" in names
+
+
+def test_removed_tool_is_not_resurrected_by_the_execution_fallback():
+    """Removal must mean UNREACHABLE, not merely unadvertised.
+
+    ``run_tool_use`` falls back to the full base-tool list when a called name
+    is absent from the session's tools. TS accepts that fallback only when the
+    name is one of the tool's deprecated ``aliases`` (toolExecution.ts:415-426,
+    "Only fall back for tools where the name matches an alias, not the primary
+    name"); the port had dropped that guard, so any removed tool resolved by
+    primary name and executed anyway.
+
+    That silently un-did every deliberate removal — ``--disallowed-tools``,
+    and headless's unregistering of the tools that cannot work without a user.
+    It mattered most for ExitPlanMode, which the plan-mode reminder explicitly
+    tells the model to call.
+    """
+    import inspect
+
+    from src.services.tool_execution import tool_execution as te
+
+    src = inspect.getsource(te)
+    assert 'getattr(fallback, "aliases", None)' in src, (
+        "the base-tool fallback must be gated on the called name being a "
+        "deprecated ALIAS, or removing a tool does not disable it"
+    )
+
+
+def test_alias_fallback_still_resolves_deprecated_names():
+    """The guard must not break the case the fallback exists for.
+
+    Drives the REAL fallback: TaskStop is removed from the active pool, so
+    resolving its deprecated alias ``KillShell`` can only succeed through the
+    base-list fallback. Behavioural rather than a source string-match, and it
+    fails if the guard is over-tightened to reject aliases too.
+    """
+    from src.tool_system.build_tool import find_tool_by_name
+
+    registry = build_default_registry(provider="anthropic")
+    registry.remove_tool("TaskStop")
+    assert find_tool_by_name(registry.list_tools(), "KillShell") is None, (
+        "precondition: the alias must be gone from the active pool"
+    )
+    base = find_tool_by_name(build_default_registry().list_tools(), "KillShell")
+    assert base is not None
+    assert "KillShell" in (getattr(base, "aliases", None) or ()), (
+        "the fallback guard keys off the called name being in .aliases"
+    )
+    # A removed PRIMARY name has no alias entry, so the same guard rejects it.
+    plan = find_tool_by_name(build_default_registry().list_tools(), "ExitPlanMode")
+    assert "ExitPlanMode" not in (getattr(plan, "aliases", None) or ())
+
+
+def test_plan_addendum_reads_the_registry_not_options_tools():
+    """The non-interactive plan addendum must key off ``tool_registry``.
+
+    ``ToolContext.options.tools`` defaults to ``[]`` and is not populated
+    until ``query()`` assigns it (query.py) from this same registry — which
+    happens AFTER the attachment block runs. Reading it there returns ``[]``
+    on the FIRST query of every session, so the interactive TUI would be told
+    "the AskUserQuestion and ExitPlanMode tools are NOT available here" on
+    exactly the turn that carries the full plan text, then silently correct
+    itself from turn 2 on. Intermittent, order-dependent, and aimed at the
+    surface where plan mode actually works.
+    """
+    import inspect
+
+    from src.query import agent_loop_compat
+
+    src = inspect.getsource(agent_loop_compat)
+    marker = '_interactive = ('
+    assert marker in src
+    window = src[src.index(marker): src.index(marker) + 300]
+    assert "tool_registry.list_tools()" in window, (
+        "read availability from tool_registry (populated now), not from "
+        "options.tools (empty until query() assigns it)"
+    )
+    assert "options" not in window, (
+        "options.tools is empty on the first query — it must not be the source"
+    )
+
+
+def test_plan_addendum_absent_for_a_full_registry():
+    """Behavioural companion: a full (interactive) registry must not get the
+    non-interactive correction, and a headless one must."""
+    from src.context_system.plan_mode import (
+        NON_INTERACTIVE_PLAN_ADDENDUM,
+        build_plan_mode_attachments,
+    )
+    from src.tool_system.build_tool import find_tool_by_name
+    from src.types.messages import create_user_message
+
+    msgs = [create_user_message(content="hi")]
+    full = build_default_registry(provider="anthropic")
+    headless = build_default_registry(provider="anthropic")
+    for name in ("AskUserQuestion", "ExitPlanMode", "EnterPlanMode"):
+        headless.remove_tool(name)
+
+    def addendum_for(registry):
+        interactive = (
+            find_tool_by_name(registry.list_tools(), "ExitPlanMode") is not None
+        )
+        texts = build_plan_mode_attachments(msgs, "plan", interactive=interactive)
+        return any(NON_INTERACTIVE_PLAN_ADDENDUM in t for t in texts)
+
+    assert addendum_for(full) is False, "the TUI must not get the correction"
+    assert addendum_for(headless) is True, "headless must get the correction"

--- a/tests/test_tool_failure_loop_guard.py
+++ b/tests/test_tool_failure_loop_guard.py
@@ -128,9 +128,18 @@ class TestSuccessReset(unittest.TestCase):
                 _update(state, blocks, [_result("t1", "same err")]).tripped
             )
 
-    def test_within_batch_failures_accumulate_per_failure(self):
-        """Counters increment per FAILURE, not per batch (guard:96-107):
-        2 identical failures in one batch + 1 in the next → trips at 3."""
+    def test_within_batch_failures_accumulate_per_batch(self):
+        """Counters increment per BATCH, not per failure.
+
+        REVERSED deliberately. This test previously asserted the TS behavior
+        (increment per failing block: 2 identical failures in one batch put
+        the counter at 2, so one more failure tripped it). That is what let a
+        model issuing parallel calls trip the guard on its first mistake —
+        see the divergence note in the guard's module docstring and
+        TestPerBatchCounting below. Two identical failures in ONE batch are
+        now one unsuccessful batch, so the counter reads 1 and it takes two
+        further failing batches to trip.
+        """
         state = create_tool_failure_loop_guard_state()
         first_batch_blocks = [_tool_use("t1", "Bash"), _tool_use("t2", "Bash")]
         decision = _update(
@@ -139,9 +148,13 @@ class TestSuccessReset(unittest.TestCase):
             [_result("t1", "same err"), _result("t2", "same err")],
         )
         self.assertFalse(decision.tripped)
-        self.assertEqual(state.signature_counts["Bash\0same err"], 2)
+        self.assertEqual(state.signature_counts["Bash\0same err"], 1)
         decision = _update(
             state, [_tool_use("t3", "Bash")], [_result("t3", "same err")]
+        )
+        self.assertFalse(decision.tripped, "second failing batch is still under 3")
+        decision = _update(
+            state, [_tool_use("t4", "Bash")], [_result("t4", "same err")]
         )
         self.assertTrue(decision.tripped)
         self.assertEqual(decision.kind, "signature")
@@ -403,3 +416,150 @@ class TestHarvest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPerBatchCounting(unittest.TestCase):
+    """A single assistant turn is ONE batch, however many calls it contains.
+
+    Documented divergence from TS (see the module docstring): TS increments
+    once per failing BLOCK, so ``threshold`` parallel calls that all fail the
+    same way trip the guard inside a single turn — punishing the model's first
+    mistake, and punishing it only because the calls were issued in parallel
+    rather than one at a time. Measured on terminal-bench 2.1: two runs ended
+    after 3 and 4 turns (31s / 38s) on a plain ``python3: command not found``,
+    while a serially-calling model hit the same missing interpreter on the same
+    task images and was never stopped.
+    """
+
+    def test_parallel_batch_of_threshold_failures_does_not_trip(self):
+        """THE regression guard. Three identical failures in ONE turn."""
+        state = create_tool_failure_loop_guard_state()
+        blocks = [_tool_use(f"t{i}", "Bash") for i in range(3)]
+        results = [
+            _result(f"t{i}", "bash: line 1: python3: command not found")
+            for i in range(3)
+        ]
+        decision = _update(state, blocks, results, threshold=3)
+        self.assertFalse(
+            decision.tripped,
+            "one batch of parallel failures is one unsuccessful batch, not three",
+        )
+
+    def test_still_trips_across_consecutive_batches(self):
+        """The guard's actual purpose must survive: a real loop is caught."""
+        state = create_tool_failure_loop_guard_state()
+        for i in range(2):
+            d = _update(
+                state,
+                [_tool_use(f"a{i}", "Bash")],
+                [_result(f"a{i}", "bash: python3: command not found")],
+                threshold=3,
+            )
+            self.assertFalse(d.tripped, f"batch {i} should not trip yet")
+        d = _update(
+            state,
+            [_tool_use("a2", "Bash")],
+            [_result("a2", "bash: python3: command not found")],
+            threshold=3,
+        )
+        self.assertTrue(d.tripped, "third consecutive failing batch must trip")
+        self.assertEqual(d.kind, "signature")
+
+    def test_parallel_batches_still_trip_one_batch_later(self):
+        """Batching delays a real loop by at most the batch count, never
+        prevents it — the change is permissive, not disabling."""
+        state = create_tool_failure_loop_guard_state()
+        tripped_on = None
+        for batch in range(5):
+            blocks = [_tool_use(f"b{batch}_{i}", "Bash") for i in range(3)]
+            results = [
+                _result(f"b{batch}_{i}", "bash: python3: command not found")
+                for i in range(3)
+            ]
+            if _update(state, blocks, results, threshold=3).tripped:
+                tripped_on = batch
+                break
+        self.assertEqual(tripped_on, 2, "should trip on the 3rd failing batch")
+
+    def test_distinct_signatures_in_one_batch_each_count_once(self):
+        """Dedupe is per KEY, not per batch: different tools failing
+        differently must still each accrue their own count."""
+        state = create_tool_failure_loop_guard_state()
+        blocks = [_tool_use("x1", "Bash"), _tool_use("x2", "Read")]
+        results = [
+            _result("x1", "bash: python3: command not found"),
+            _result("x2", "No such file or directory"),
+        ]
+        _update(state, blocks, results, threshold=3)
+        self.assertEqual(len(state.persistent_signature_counts), 2)
+        self.assertTrue(
+            all(v == 1 for v in state.persistent_signature_counts.values()),
+            f"each distinct signature counts once: {state.persistent_signature_counts}",
+        )
+
+    def test_advisory_not_duplicated_within_a_batch(self):
+        """One advisory per key per batch, not one per failing block."""
+        state = create_tool_failure_loop_guard_state()
+        _update(
+            state,
+            [_tool_use("p0", "Bash")],
+            [_result("p0", "bash: python3: command not found")],
+            threshold=3,
+        )
+        blocks = [_tool_use(f"p1_{i}", "Bash") for i in range(3)]
+        results = [
+            _result(f"p1_{i}", "bash: python3: command not found") for i in range(3)
+        ]
+        d = _update(state, blocks, results, threshold=3)
+        self.assertFalse(d.tripped)
+        self.assertEqual(len(d.advisories), 1, f"got {d.advisories}")
+
+    def test_success_in_the_same_batch_still_resets(self):
+        """Unrelated pre-existing behavior must be untouched."""
+        state = create_tool_failure_loop_guard_state()
+        _update(
+            state,
+            [_tool_use("s0", "Bash")],
+            [_result("s0", "bash: python3: command not found")],
+            threshold=3,
+        )
+        d = _update(
+            state,
+            [_tool_use("s1", "Bash"), _tool_use("s2", "Bash")],
+            [
+                _result("s1", "bash: python3: command not found"),
+                _result("s2", "ok", is_error=False),
+            ],
+            threshold=3,
+        )
+        self.assertFalse(d.tripped)
+        self.assertEqual(state.signature_counts, {})
+
+
+class TestCounterKindsAreIndependent(unittest.TestCase):
+    """The per-batch dedupe namespaces its key by counter KIND.
+
+    Without that, a path and an error category that stringify the same would
+    share one dedupe slot and the second would be silently skipped. It is
+    constructible: an ``Edit`` whose ``file_path`` is literally "NotFound"
+    failing with an ENOENT-shaped error yields path key "NotFound" and
+    category key "NotFound".
+    """
+
+    def test_same_string_as_path_and_category_counts_separately(self):
+        state = create_tool_failure_loop_guard_state()
+        blocks = [_tool_use("k1", "Edit", {"file_path": "NotFound"})]
+        results = [_result("k1", "No such file or directory")]
+        _update(state, blocks, results, threshold=3)
+        self.assertEqual(
+            list(state.path_counts.values()), [1], state.path_counts
+        )
+        self.assertTrue(
+            state.persistent_signature_counts,
+            "the signature counter must have advanced too, not been deduped "
+            "away by the path counter sharing its key string",
+        )
+        # THE assertion that catches the collision: the path loop claims the
+        # "NotFound" slot first, so a category bump sharing one namespace
+        # would return without incrementing and leave this dict empty.
+        self.assertEqual(state.category_counts, {"NotFound": 1})

--- a/tests/test_tool_pipeline_round3.py
+++ b/tests/test_tool_pipeline_round3.py
@@ -39,7 +39,9 @@ class _ToolUse:
 _SCHEMA = {"type": "object", "properties": {}, "additionalProperties": True}
 
 
-def _stub_tool(name: str, call_fn, *, max_chars: float = 30_000, backfill=None):
+def _stub_tool(
+    name: str, call_fn, *, max_chars: float = 30_000, backfill=None, aliases=()
+):
     return build_tool(
         name=name,
         input_schema=_SCHEMA,
@@ -48,6 +50,7 @@ def _stub_tool(name: str, call_fn, *, max_chars: float = 30_000, backfill=None):
         description="stub",
         max_result_size_chars=max_chars,
         backfill_observable_input=backfill,
+        aliases=aliases,
     )
 
 
@@ -315,25 +318,62 @@ class TestCallInputDiscipline(_Base):
 
 
 class TestBaseToolFallback(_Base):
-    def test_pool_hidden_tool_resolves_via_base_list(self):
+    def test_base_list_fallback_resolves_a_deprecated_ALIAS(self):
+        """The fallback exists for old transcripts calling a renamed tool."""
         ran: list = []
 
         def call(_inp, _ctx):
             ran.append(True)
-            return ToolResult(name="HiddenTool", output="ran")
+            return ToolResult(name="NewName", output="ran")
 
-        hidden = _stub_tool("HiddenTool", call)
-        fake_registry = SimpleNamespace(list_tools=lambda: [hidden])
+        renamed = _stub_tool("NewName", call, aliases=("OldName",))
+        fake_registry = SimpleNamespace(list_tools=lambda: [renamed])
 
         ctx = self._context([])  # NOT in the active pool
         with mock.patch(
             "src.tool_system.defaults.build_default_registry",
             return_value=fake_registry,
         ):
-            updates = self._execute(ctx, _ToolUse("HiddenTool", {}))
-        self.assertTrue(ran)
+            updates = self._execute(ctx, _ToolUse("OldName", {}))
+        self.assertTrue(ran, "a deprecated alias must still resolve")
         blocks = self._result_blocks(updates)
         self.assertFalse(blocks[0].get("is_error", False))
+
+    def test_base_list_fallback_REJECTS_a_removed_primary_name(self):
+        """REVERSED deliberately — this test previously asserted that a tool
+        absent from the active pool still resolved by its PRIMARY name.
+
+        TS accepts the fallback only when the called name is one of the
+        tool's aliases (toolExecution.ts:415-426, "Only fall back for tools
+        where the name matches an alias, not the primary name"); the port had
+        dropped that half. The old premise -- that tools can be "hidden" from
+        the pool and need rescuing -- is false: ``options.tools`` is the full
+        registry (agent_loop_compat.py sets it from ``tool_registry
+        .list_tools()``), so deferred tools are present and resolve at the
+        primary lookup. What the loose fallback actually did was silently
+        undo every deliberate removal: ``--disallowed-tools``, headless's
+        unregistering of tools that need a user, and the
+        ALL_AGENT_DISALLOWED_TOOLS subagent containment list.
+        """
+        ran: list = []
+
+        def call(_inp, _ctx):
+            ran.append(True)
+            return ToolResult(name="RemovedTool", output="ran")
+
+        removed = _stub_tool("RemovedTool", call)
+        fake_registry = SimpleNamespace(list_tools=lambda: [removed])
+
+        ctx = self._context([])  # removed from the active pool
+        with mock.patch(
+            "src.tool_system.defaults.build_default_registry",
+            return_value=fake_registry,
+        ):
+            updates = self._execute(ctx, _ToolUse("RemovedTool", {}))
+        self.assertFalse(ran, "a removed tool must not execute via fallback")
+        blocks = self._result_blocks(updates)
+        self.assertTrue(blocks[0].get("is_error"))
+        self.assertIn("No such tool available", str(blocks[0].get("content", "")))
 
     def test_unknown_name_still_errors(self):
         ctx = self._context([])
@@ -353,7 +393,7 @@ class TestBaseToolFallback(_Base):
             ran.append(True)
             return ToolResult(name="HiddenTool", output="ran")
 
-        hidden = _stub_tool("HiddenTool", call)
+        hidden = _stub_tool("HiddenTool", call, aliases=("HiddenAlias",))
         fake_registry = SimpleNamespace(list_tools=lambda: [hidden])
 
         def deny_all(*_a, **_k):
@@ -367,7 +407,7 @@ class TestBaseToolFallback(_Base):
             async def drive():
                 updates = []
                 async for update in run_tool_use(
-                    _ToolUse("HiddenTool", {}),
+                    _ToolUse("HiddenAlias", {}),
                     AssistantMessage(content="using a tool"),
                     deny_all,
                     ctx,


### PR DESCRIPTION
Two model-agnostic harness defects found by comparing terminal-bench 2.1 trajectories between a parallel-calling model and a serial one. Both punished a model for **how** it called tools rather than for whether it was making progress.

## 1. The loop guard counted per failing block, not per batch

`update_tool_failure_loop_guard` built its `failures` list from every result in one batch, then incremented counters **once per failure**. An assistant turn issuing `threshold` (3) parallel calls that all failed the same way tripped the guard *inside that single turn* — on the model's first mistake, with no turn in which to correct it.

Live: two runs ended after 3 and 4 turns (**31s / 38s**) on a plain `python3: command not found`. A serially-calling model hit the same missing interpreter on the same task images at a similar rate (20 occurrences/13 trials vs 17/8) and was **never stopped once in 88 trials**. The differentiator was purely batching — 13.8% of turns issued ≥3 parallel calls versus 0.7%.

Counters now increment at most once per batch per distinct key, which is what the module's own docstring always claimed ("consecutive tool batches").

**Strictly permissive**: every counter is pointwise ≤ its old value and every trip predicate is monotone, so it can only delay a trip, never cause one. Verified by differential fuzz against the old behavior — 4000 randomized trials, zero cases tripping earlier. A real loop still trips.

Deliberate divergence from TS (`toolFailureLoopGuard.ts:137,173,201` increments per block), documented in the module docstring with measured delay bounds.

## 2. Plan mode was a one-way door headlessly

`ExitPlanMode` is `requires_user_interaction`, hence bypass-immune, so headlessly its ask always resolves to a deny — under bypass carrying the raw dialog question, **`"Exit plan mode?"`**, handed to the model as a tool error it cannot act on. `EnterPlanMode` auto-allows. The model could enter plan mode and never leave, after which every write was refused.

Live: **41 ExitPlanMode calls, 100% error rate, across 16 of 32 trials** — 5.7% of the entire tool budget on a round trip that could not complete.

Headless now unregisters both, beside the existing `AskUserQuestion` removal. This is **parity-faithful, not a divergence**: `ExitPlanModeV2Tool.ts:167-178` and `EnterPlanModeTool.ts:52-63` both disable when the user isn't watching the TUI, explicitly *"so plan mode isn't a trap the model can enter but never leave."*

## 3. Removal did not mean removal (required for #2 to work)

`remove_tool()` only unadvertises. `run_tool_use` falls back to the full base-tool list, and the port had dropped TS's guard accepting that fallback only when the called name is a deprecated **alias** (`toolExecution.ts:415-426`). So any removed tool resolved by primary name and executed — which would have made fix 2 cosmetic, since the plan-mode reminder *names* ExitPlanMode.

Restoring the guard also closes two holes that predate this change:
- `--allowed-tools` / `--disallowed-tools` dropped tools from the advertised schema while leaving them **callable**.
- Subagents could call the `ALL_AGENT_DISALLOWED_TOOLS` set (`Agent`, `Workflow`, `TaskStop`, …) by primary name, defeating the explicit *"prevent recursive workflow execution inside subagents"* containment.

Plus `NON_INTERACTIVE_PLAN_ADDENDUM`, since the ported plan text names AskUserQuestion/ExitPlanMode as the only ways to end a turn — appended rather than edited in, so the port stays byte-comparable against `typescript/`.

## Model-agnostic by construction

Serial callers are **bit-identical** under the guard change. No model is named anywhere. The plan-mode removal drops tools that cannot function on that surface for anyone.

Availability is read from `tool_registry`, not `tool_context.options.tools` — the latter is empty until `query()` populates it, which would have mislabelled the **first query of every interactive session** as non-interactive, on exactly the turn carrying the full plan text.

## Verification

- Both fixes and every new guard **mutation-tested**: disabling each fails the intended tests, restoring passes.
- Behavioural end-to-end: a removed primary name now yields `Error: No such tool available`, an actionable message; a genuine deprecated alias still resolves and executes.
- On the wire: headless advertises 38 tools, none of the three interactive ones.
- Two existing tests were **deliberately reversed** — they codified the per-block increment and the loose primary-name fallback. Both replacements state what changed and why.
- Full suite green. The 27 MCP-auth failures in a fresh worktree venv reproduce identically on pristine `main` with these changes stashed — an `mcp` version-resolution issue in that env, not code.

Reviewed by the `critic` subagent across three rounds. It caught that my first cut of fix 2 was non-enforcing (issue 3 above), and that my availability check misfired on the TUI's first query.

## Not included, deliberately

A guard trip still returns `subtype: "success", is_error: false`, so batch runners record a clean run with reward 0 — which is why this took a benchmark analysis to find. That changes headless exit semantics for every model and every eval adapter, so it lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
