### PR TITLE
fix(headless): stop reporting a cut-short run as a success

### DIFF
--- a/eval/harbor/clawcodex_agent.py
+++ b/eval/harbor/clawcodex_agent.py
@@ -641,6 +641,33 @@ class Clawcodex(BaseInstalledAgent):
         events = self._parse_stream_events()
         result_event = self._last_result_event(events)
 
+        # Surface an EARLY STOP where a human reading the trial will see it.
+        # clawcodex now marks a run the agent loop cut short with a non-success
+        # result subtype (``error_during_execution`` when the tool-failure-loop
+        # guard trips, ``error_max_turns`` on the turn ceiling) instead of
+        # reporting success. Nothing here read ``subtype``, so without this the
+        # stream log became honest while the trial output stayed silent — the
+        # exact workflow that let 31-second guard kills pass as clean runs
+        # scoring zero.
+        #
+        # Deliberately NOT raised as an exception: Harbor would record an
+        # ``exception.txt``, and compare_trajectories.py excludes those trials
+        # as "killed by harness", censoring the runs this is meant to reveal.
+        # A log line plus a metadata field keeps the trial in the dataset AND
+        # visible.
+        stop_subtype = (result_event or {}).get("subtype")
+        if isinstance(stop_subtype, str) and stop_subtype not in ("", "success"):
+            self.logger.warning(
+                f"clawcodex ended this trial early: {stop_subtype} "
+                f"(the model did not finish the task)"
+            )
+            # Also machine-readable, so a sweep can count early stops without
+            # re-parsing every stream log. Lands in the trial's result.json.
+            context.metadata = {
+                **(context.metadata or {}),
+                "clawcodex_stop_subtype": stop_subtype,
+            }
+
         try:
             trajectory, totals = self._build_trajectory(events, result_event)
         except Exception as exc:  # noqa: BLE001 — never fail a trial over this

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -60,7 +60,34 @@ from src.query.agent_loop_compat import (
 )
 from src.tool_system.context import ToolContext
 from src.tool_system.defaults import build_default_registry
+from src.query.transitions import EARLY_STOP_SUBTYPES
 from src.utils.abort_controller import AbortController, AbortError
+
+
+def _json_result_subtype(
+    exit_code: int, early_stop_subtype: str | None
+) -> tuple[str, bool]:
+    """``(subtype, is_error)`` for a headless result event.
+
+    One function so the two can never disagree. They did once: ``is_error``
+    was computed from its own expression, which let ``cancelled`` come back
+    flagged as an error — contradicting the deliberate pairing (a user
+    interrupt is not a failure). Precedence: a cancel or a hard error beats an
+    early stop, because those already carry a non-zero exit code and the
+    caller needs the stronger signal.
+
+    Pure and total, so the cross product is pinned by a table test rather
+    than by constructing each runtime state — the ``cancelled`` + early-stop
+    row in particular is otherwise reachable only through a /goal
+    continuation.
+    """
+    if exit_code == 130:
+        subtype = "cancelled"
+    elif exit_code != 0:
+        subtype = "error"
+    else:
+        subtype = early_stop_subtype or "success"
+    return subtype, subtype not in ("success", "cancelled")
 
 
 OUTPUT_FORMATS = ("text", "json", "stream-json")
@@ -548,6 +575,12 @@ def run_headless(options: HeadlessOptions) -> int:
     num_turns_total = 0
     usage_total: dict[str, int] = {}
     exit_code = 0
+    # Terminal reason of the LAST agent-loop turn, when it stopped the run
+    # early rather than the model finishing (``tool_failure_loop``,
+    # ``max_turns``). Drives the result event's subtype below so a run the
+    # harness cut short is distinguishable from a completed one. ``None``
+    # for a normal completion.
+    early_stop_reason: str | None = None
     start = time.monotonic()
 
     # Two-mode SIGINT handler:
@@ -730,6 +763,34 @@ def run_headless(options: HeadlessOptions) -> int:
                             ),
                             num_turns=compat_result.num_turns,
                         )
+                        # Why the loop stopped, for the result event below.
+                        # ``AgentLoopResult`` deliberately keeps its legacy
+                        # shape, so the reason is read off ``compat_result``
+                        # here rather than widening that type (which the TUI
+                        # also consumes).
+                        #
+                        # STICKY, and only for reasons we actually report: one
+                        # terminal result event covers the WHOLE run (there is
+                        # no per-turn result path), and every other field on it
+                        # — num_turns_total, usage_total, aggregate_text — is
+                        # cumulative. Overwriting each iteration would let a
+                        # normal completion on prompt N+1 erase an early stop
+                        # on prompt N, which is the same silent success this
+                        # code exists to remove, just harder to see: with
+                        # ``--input-format stream-json`` the explanation stays
+                        # in ``result`` while ``subtype`` claims success.
+                        # Among mapped reasons this is LAST-wins, not
+                        # first-wins ("sticky" reads as first-wins to most
+                        # people): two early stops in one run report the
+                        # later one. Immaterial — both are early stops and
+                        # ``is_error`` is True either way.
+                        _reason = (
+                            compat_result.terminal.reason
+                            if compat_result.terminal is not None
+                            else None
+                        )
+                        if _reason in EARLY_STOP_SUBTYPES:
+                            early_stop_reason = _reason
                     finally:
                         # Flip BEFORE the outer except block can run so a
                         # SIGINT landing between ``run_agent_loop`` returning
@@ -848,17 +909,59 @@ def run_headless(options: HeadlessOptions) -> int:
     duration_ms = int((time.monotonic() - start) * 1000)
     final_text = "\n\n".join(t for t in aggregate_text if t).strip()
 
+    # An early stop is NOT a success. The agent loop can end a run itself —
+    # the tool-failure-loop guard tripping, or max_turns — and in both cases
+    # the model never finished the task. Both used to report
+    # ``subtype: "success", is_error: false``, so a batch runner recorded a
+    # clean completion that merely happened to score zero. That is how the
+    # guard's 31-second kills went unnoticed until someone read the raw
+    # trajectories: the harness said the run was fine.
+    #
+    # Subtypes are the reference's (QueryEngine.ts:891 ``error_max_turns``,
+    # :1142 ``error_during_execution``), and like the reference the event
+    # keeps its full metrics block — usage, num_turns, the stop explanation
+    # as ``result``. Eval adapters read token counts off this event
+    # (eval/harbor/clawcodex_agent.py), so SUPPRESSING it or replacing it
+    # with a bare error would trade a silent-success bug for a missing-data
+    # bug.
+    #
+    # The process EXIT CODE deliberately stays 0 — a documented divergence
+    # from the reference, which exits ``is_error ? 1 : 0``
+    # (typescript/src/cli/print.ts:1069-1070). Not an ordering constraint:
+    # the emission gate could be moved and the code bumped afterwards. The
+    # reason is what a non-zero code means downstream. Harbor raises
+    # ``NonZeroAgentExitCodeError`` on it, the trial records an
+    # ``exception.txt``, and ``eval/harbor/compare_trajectories.py`` then
+    # treats that trial as "killed by harness" and EXCLUDES it from the step
+    # means. Flipping the code would right-censor every guard trip and every
+    # max_turns run straight out of the comparison — deleting precisely the
+    # trials this change exists to make visible, and reintroducing the
+    # denominator corruption that once inverted a whole iteration's metrics.
+    #
+    # So the signal lives in the event (subtype + is_error), which callers
+    # can act on without any run disappearing from the dataset. Anyone
+    # tempted to "finish the job" by bumping the exit code should re-read
+    # this paragraph first.
+    early_stop_subtype = EARLY_STOP_SUBTYPES.get(early_stop_reason or "")
+
     if options.output_format == "text":
         if final_text:
             stdout.write(final_text + "\n")
             stdout.flush()
+        if early_stop_subtype is not None:
+            # The default format has no structured field to carry this, and
+            # it is what a plain shell caller sees. The reference prints an
+            # equivalent line (print.ts:1041-1047). stderr so it never
+            # pollutes piped stdout.
+            stderr.write(
+                f"[clawcodex] run stopped early ({early_stop_reason}); "
+                "the task was not completed\n"
+            )
+            stderr.flush()
     elif options.output_format == "json":
-        if exit_code == 0:
-            json_subtype = "success"
-        elif exit_code == 130:
-            json_subtype = "cancelled"
-        else:
-            json_subtype = "error"
+        json_subtype, json_is_error = _json_result_subtype(
+            exit_code, early_stop_subtype
+        )
         payload = {
             "type": "result",
             "subtype": json_subtype,
@@ -870,14 +973,15 @@ def run_headless(options: HeadlessOptions) -> int:
             "duration_ms": duration_ms,
             "usage": usage_total or None,
             "tool_events": aggregate_tool_events,
-            "is_error": exit_code not in (0, 130),
+            "is_error": json_is_error,
         }
         stdout.write(ndjson_safe_dumps(payload) + "\n")
         stdout.flush()
     elif options.output_format == "stream-json" and writer is not None and exit_code == 0:
         writer.write(
             ResultEvent(
-                subtype="success",
+                subtype=early_stop_subtype or "success",
+                is_error=early_stop_subtype is not None,
                 session_id=session.session_id,
                 num_turns=num_turns_total,
                 result=final_text,

--- a/src/query/transitions.py
+++ b/src/query/transitions.py
@@ -34,6 +34,41 @@ TerminalReason = Literal[
 ]
 
 
+# Terminal reasons where the AGENT LOOP ended the run rather than the model
+# finishing, mapped to the reference's result subtypes (QueryEngine.ts:891
+# ``error_max_turns``, :1142 ``error_during_execution``). Every one of these
+# used to be reported as ``subtype: "success", is_error: false`` by headless,
+# so a batch runner recorded a clean completion that merely scored zero.
+#
+# Lives here, beside the taxonomy it is keyed on, rather than in an
+# entrypoint: more than one surface has to agree on it (headless today, the
+# agent-server's turn outcome next), and importing an entrypoint for one dict
+# would invert the layering.
+#
+# Accounts for the WHOLE taxonomy above. Not mapped, deliberately:
+#   * ``completed``                     — the normal path;
+#   * ``aborted_streaming`` / ``aborted_tools`` / ``model_error`` — re-raised
+#     by agent_loop_compat, so they already reach exit 130 / 1 and the
+#     cancelled / error subtypes;
+#   * ``hook_stopped`` / ``stop_hook_prevented`` — a hook refusing to continue
+#     is the operator's own policy working as configured, not the harness
+#     cutting a run short. Neither can fire without an installed hook that
+#     emits those signals. Listed rather than omitted so the exclusion reads
+#     as a decision.
+#
+# ``blocking_limit`` and ``prompt_too_long`` are the worst of the set: their
+# explanation goes to ``last_api_error_text``, which agent_loop_compat only
+# surfaces as response_text for ``tool_failure_loop``, so those runs reported
+# success with an EMPTY result — a clean completion with no evidence at all.
+EARLY_STOP_SUBTYPES: dict[str, str] = {
+    "tool_failure_loop": "error_during_execution",
+    "blocking_limit": "error_during_execution",
+    "prompt_too_long": "error_during_execution",
+    "image_error": "error_during_execution",
+    "max_turns": "error_max_turns",
+}
+
+
 @dataclass(frozen=True)
 class Transition:
     reason: ContinueReason

--- a/tests/test_headless_cli.py
+++ b/tests/test_headless_cli.py
@@ -464,3 +464,328 @@ def test_headless_passes_provider_is_explicit_when_provider_flagged(
         )
     )
     assert calls and calls[0]["provider_is_explicit"] is True
+
+
+# ---------------------------------------------------------------------------
+# early-stop visibility — a run the harness cut short is not a "success"
+
+
+def _stub_loop(monkeypatch, *, reason, text="stopped", turns=3):
+    """Make the agent loop return a Terminal instead of a normal completion.
+
+    Patches the seam headless actually consumes. Driving a real guard trip
+    would need a tool registry with failing tools; what is under test here is
+    the mapping from terminal reason to result subtype, not the guard.
+    """
+    from src.query.agent_loop_compat import AgentLoopRunResult
+    from src.query.transitions import Terminal
+
+    async def fake_loop(*_a, **_k):
+        return AgentLoopRunResult(
+            response_text=text,
+            usage={"input_tokens": 100, "output_tokens": 20},
+            num_turns=turns,
+            terminal=Terminal(reason=reason) if reason else None,
+        )
+
+    monkeypatch.setattr(headless_mod, "run_query_as_agent_loop", fake_loop)
+
+
+def _result_event(raw: str) -> dict:
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        if obj.get("type") == "result":
+            return obj
+    raise AssertionError(f"no result event in output: {raw!r}")
+
+
+@pytest.mark.parametrize(
+    "reason,expected_subtype",
+    [
+        ("tool_failure_loop", "error_during_execution"),
+        ("max_turns", "error_max_turns"),
+        # blocking_limit / prompt_too_long are the worst of the set: their
+        # explanation never reaches response_text, so they reported success
+        # with an EMPTY result — a clean completion with no evidence at all.
+        ("blocking_limit", "error_during_execution"),
+        ("prompt_too_long", "error_during_execution"),
+        ("image_error", "error_during_execution"),
+    ],
+)
+def test_early_stop_is_not_reported_as_success_stream_json(
+    fake_wiring, tmp_path, monkeypatch, reason, expected_subtype
+):
+    """THE regression guard.
+
+    A tool-failure-loop trip or a max_turns stop used to emit
+    ``subtype: "success", is_error: false``, so a batch runner recorded a
+    clean completion that merely scored zero — which is how 31-second guard
+    kills went unnoticed on terminal-bench until the raw trajectories were
+    read. Subtypes mirror the reference (QueryEngine.ts:891, :1142).
+    """
+    _stub_loop(monkeypatch, reason=reason)
+    stdout = io.StringIO()
+    run_headless(
+        HeadlessOptions(
+            prompt="hi",
+            output_format="stream-json",
+            stdout=stdout,
+            stderr=io.StringIO(),
+            workspace_root=tmp_path,
+        )
+    )
+    event = _result_event(stdout.getvalue())
+    assert event["subtype"] == expected_subtype
+    assert event["is_error"] is True
+
+
+@pytest.mark.parametrize(
+    "reason,expected_subtype",
+    [
+        ("tool_failure_loop", "error_during_execution"),
+        ("max_turns", "error_max_turns"),
+    ],
+)
+def test_early_stop_subtype_in_json_output(
+    fake_wiring, tmp_path, monkeypatch, reason, expected_subtype
+):
+    _stub_loop(monkeypatch, reason=reason)
+    stdout = io.StringIO()
+    run_headless(
+        HeadlessOptions(
+            prompt="hi",
+            output_format="json",
+            stdout=stdout,
+            stderr=io.StringIO(),
+            workspace_root=tmp_path,
+        )
+    )
+    event = _result_event(stdout.getvalue())
+    assert event["subtype"] == expected_subtype
+    assert event["is_error"] is True
+
+
+def test_early_stop_keeps_the_full_metrics_block(
+    fake_wiring, tmp_path, monkeypatch
+):
+    """Eval adapters read tokens/cost off this event.
+
+    Suppressing it, or replacing it with a bare error, would trade a
+    silent-success bug for a missing-data bug — the reference keeps usage and
+    num_turns on error_during_execution too (QueryEngine.ts:1142-1153).
+    """
+    _stub_loop(monkeypatch, reason="tool_failure_loop", text="Stopped: repeated tool failures detected.", turns=4)
+    stdout = io.StringIO()
+    run_headless(
+        HeadlessOptions(
+            prompt="hi",
+            output_format="stream-json",
+            stdout=stdout,
+            stderr=io.StringIO(),
+            workspace_root=tmp_path,
+        )
+    )
+    event = _result_event(stdout.getvalue())
+    assert event["usage"], "usage must survive — adapters read tokens from here"
+    assert event["num_turns"] == 4
+    assert "repeated tool failures" in event["result"], (
+        "the stop explanation must still reach the caller"
+    )
+
+
+def test_normal_completion_still_reports_success(
+    fake_wiring, tmp_path, monkeypatch
+):
+    """The default path must be untouched: no terminal, no early-stop flag."""
+    _stub_loop(monkeypatch, reason=None, text="all done")
+    stdout = io.StringIO()
+    code = run_headless(
+        HeadlessOptions(
+            prompt="hi",
+            output_format="stream-json",
+            stdout=stdout,
+            stderr=io.StringIO(),
+            workspace_root=tmp_path,
+        )
+    )
+    event = _result_event(stdout.getvalue())
+    assert event["subtype"] == "success"
+    assert event["is_error"] is False
+    assert code == 0
+
+
+def test_early_stop_does_not_change_the_exit_code(
+    fake_wiring, tmp_path, monkeypatch
+):
+    """Deliberate: the process exit code stays 0.
+
+    NOT because the emission is gated on ``exit_code == 0`` — that gate is
+    movable. Because Harbor raises ``NonZeroAgentExitCodeError`` on a
+    non-zero code, the trial then records an ``exception.txt``, and
+    ``eval/harbor/compare_trajectories.py`` treats such trials as "killed by
+    harness" and EXCLUDES them from the step means. Flipping the code would
+    right-censor every guard trip out of the very comparison this change
+    exists to make honest.
+
+    A documented divergence from the reference, which exits
+    ``is_error ? 1 : 0`` (print.ts:1069-1070). The trade: a shell caller
+    doing ``clawcodex -p ...; echo $?`` cannot detect an early stop, and must
+    read the result event's subtype instead.
+    """
+    _stub_loop(monkeypatch, reason="tool_failure_loop")
+    stdout = io.StringIO()
+    code = run_headless(
+        HeadlessOptions(
+            prompt="hi",
+            output_format="stream-json",
+            stdout=stdout,
+            stderr=io.StringIO(),
+            workspace_root=tmp_path,
+        )
+    )
+    assert code == 0
+    assert _result_event(stdout.getvalue())["subtype"] == "error_during_execution"
+
+
+@pytest.mark.parametrize("reason", ["hook_stopped", "stop_hook_prevented", "completed"])
+def test_deliberately_unmapped_terminals_stay_success(
+    fake_wiring, tmp_path, monkeypatch, reason
+):
+    """Hook stops are the operator's own policy working as configured, not the
+    harness cutting a run short. Pinned so the exclusion reads as a decision
+    rather than an oversight — and so widening the map is a conscious act."""
+    _stub_loop(monkeypatch, reason=reason)
+    stdout = io.StringIO()
+    run_headless(
+        HeadlessOptions(
+            prompt="hi",
+            output_format="stream-json",
+            stdout=stdout,
+            stderr=io.StringIO(),
+            workspace_root=tmp_path,
+        )
+    )
+    assert _result_event(stdout.getvalue())["subtype"] == "success"
+
+
+def test_early_stop_survives_a_later_normal_prompt(fake_wiring, tmp_path, monkeypatch):
+    """Multi-prompt stream-json: ONE result event covers the whole run.
+
+    Every other field on it is cumulative (num_turns, usage, text), so an
+    early stop on prompt N must not be erased by prompt N+1 completing
+    normally — otherwise the explanation sits in ``result`` while ``subtype``
+    claims success, which is the original bug wearing a disguise.
+    """
+    from src.query.agent_loop_compat import AgentLoopRunResult
+    from src.query.transitions import Terminal
+
+    calls = {"n": 0}
+
+    async def fake_loop(*_a, **_k):
+        calls["n"] += 1
+        first = calls["n"] == 1
+        return AgentLoopRunResult(
+            response_text="[Stopped: repeated tool failures detected]" if first else "ok",
+            usage={"input_tokens": 10, "output_tokens": 2},
+            num_turns=2,
+            terminal=Terminal(reason="tool_failure_loop") if first else Terminal(reason="completed"),
+        )
+
+    monkeypatch.setattr(headless_mod, "run_query_as_agent_loop", fake_loop)
+    stdin = io.StringIO(
+        json.dumps({"type": "user", "message": {"role": "user", "content": "one"}}) + "\n"
+        + json.dumps({"type": "user", "message": {"role": "user", "content": "two"}}) + "\n"
+    )
+    stdout = io.StringIO()
+    run_headless(
+        HeadlessOptions(
+            prompt=None,
+            input_format="stream-json",
+            output_format="stream-json",
+            stdin=stdin,
+            stdout=stdout,
+            stderr=io.StringIO(),
+            workspace_root=tmp_path,
+        )
+    )
+    assert calls["n"] == 2, "both prompts must have run"
+    event = _result_event(stdout.getvalue())
+    assert event["subtype"] == "error_during_execution", (
+        "an early stop anywhere in the run must survive to the result event"
+    )
+    assert event["is_error"] is True
+
+
+def test_cancelled_is_not_flagged_as_an_error(fake_wiring, tmp_path, monkeypatch):
+    """Exit-code precedence: 130 must still win, and cancelled must NOT be
+    flagged is_error — the pairing is deliberate."""
+    from src.query.agent_loop_compat import AgentLoopRunResult
+    from src.query.transitions import Terminal
+    from src.utils.abort_controller import AbortError
+
+    async def fake_loop(*_a, **_k):
+        raise AbortError("user_interrupt")
+
+    monkeypatch.setattr(headless_mod, "run_query_as_agent_loop", fake_loop)
+    stdout = io.StringIO()
+    code = run_headless(
+        HeadlessOptions(
+            prompt="hi",
+            output_format="json",
+            stdout=stdout,
+            stderr=io.StringIO(),
+            workspace_root=tmp_path,
+        )
+    )
+    event = _result_event(stdout.getvalue())
+    assert code == 130
+    assert event["subtype"] == "cancelled"
+    assert event["is_error"] is False, "cancelled is not an error"
+
+
+def test_text_format_reports_the_early_stop_on_stderr(
+    fake_wiring, tmp_path, monkeypatch
+):
+    """The default format has no structured field, and it is what a plain
+    shell caller sees."""
+    _stub_loop(monkeypatch, reason="tool_failure_loop", text="stopped")
+    stderr = io.StringIO()
+    run_headless(
+        HeadlessOptions(
+            prompt="hi",
+            output_format="text",
+            stdout=io.StringIO(),
+            stderr=stderr,
+            workspace_root=tmp_path,
+        )
+    )
+    assert "stopped early" in stderr.getvalue()
+    assert "tool_failure_loop" in stderr.getvalue()
+
+
+@pytest.mark.parametrize(
+    "exit_code,early,expected",
+    [
+        (0, None, ("success", False)),
+        (0, "error_during_execution", ("error_during_execution", True)),
+        (0, "error_max_turns", ("error_max_turns", True)),
+        (130, None, ("cancelled", False)),
+        # THE collision: an early stop earlier in the run, then a cancel.
+        # Reachable at runtime only via a /goal continuation, which is why
+        # the derivation is pinned as a pure function instead.
+        (130, "error_during_execution", ("cancelled", False)),
+        (1, None, ("error", True)),
+        (1, "error_during_execution", ("error", True)),
+    ],
+)
+def test_subtype_and_is_error_never_disagree(exit_code, early, expected):
+    """``is_error`` must be derived from the subtype, never recomputed.
+
+    An independent expression let ``cancelled`` come back flagged as an
+    error, contradicting the deliberate pairing that a user interrupt is not
+    a failure.
+    """
+    assert headless_mod._json_result_subtype(exit_code, early) == expected


### PR DESCRIPTION
When the agent loop ends a run **itself**, the model never finished the task. Headless reported `subtype: "success", is_error: false` anyway — so a batch runner recorded a clean completion that merely happened to score zero.

That is why the tool-failure-loop guard's 31-second kills (fixed in #777) went unnoticed on terminal-bench until someone read the raw trajectories: **the harness said the runs were fine.** The eval data wasn't just missing a signal, it carried a wrong one.

## What changes

Every terminal reason where the loop cut the run short now maps to the reference's result subtypes (`QueryEngine.ts:891` `error_max_turns`, `:1142` `error_during_execution`), on both `json` and `stream-json`, with `is_error: true`:

| terminal reason | subtype |
|---|---|
| `tool_failure_loop` | `error_during_execution` |
| `blocking_limit` | `error_during_execution` |
| `prompt_too_long` | `error_during_execution` |
| `image_error` | `error_during_execution` |
| `max_turns` | `error_max_turns` |

`blocking_limit` and `prompt_too_long` were the worst of the set: their explanation goes to `last_api_error_text`, which the compat layer only surfaces for `tool_failure_loop` — so those runs reported success with an **empty** result. A clean completion carrying no evidence at all.

`hook_stopped` / `stop_hook_prevented` are **deliberately left as success**: a hook refusing to continue is the operator's own policy working as configured, not the harness cutting a run short. Neither can fire without an installed hook emitting those signals. Both are named in the map's docstring and pinned by a test, so the exclusion reads as a decision rather than an oversight.

Like the reference, the event keeps its **full metrics block** — usage, num_turns, and the stop explanation as `result`. Eval adapters read token counts off it, so suppressing the event would have traded a silent-success bug for a missing-data bug.

## ⚠️ The exit code deliberately stays 0

A documented divergence from the reference, which exits `is_error ? 1 : 0` (`print.ts:1069-1070`).

Not an ordering constraint — the emission gate is movable. The reason is what a non-zero code means downstream: Harbor raises `NonZeroAgentExitCodeError`, the trial records an `exception.txt`, and `eval/harbor/compare_trajectories.py` then treats that trial as *"killed by harness"* and **excludes it from the step means**.

Flipping the code would right-censor every guard trip and every max_turns run straight out of the comparison — deleting precisely the trials this change exists to reveal, and reintroducing the denominator corruption that once inverted a whole iteration's metrics.

The trade: `clawcodex -p ...; echo $?` cannot detect an early stop and must read the result event instead. The `text` format gets a stderr line so it isn't silent either.

## Sticky across multi-prompt runs

One terminal result event covers a whole `stream-json` run and every other field on it is cumulative, so an early stop on prompt N must not be erased by prompt N+1 completing normally — otherwise the explanation sits in `result` while `subtype` claims success. The original bug wearing a disguise.

## Placement

`EARLY_STOP_SUBTYPES` lives in `query/transitions.py` beside the `TerminalReason` literal it's keyed on, not in the entrypoint — more than one surface has to agree on it, and importing an entrypoint for one dict would invert the layering.

## The adapter now reads it

`eval/harbor/clawcodex_agent.py` previously read only usage/cost, so without this the stream log would have become honest while the **trial output stayed silent** — the exact workflow that failed. It now logs a warning and records `metadata["clawcodex_stop_subtype"]`, which lands in the trial's `result.json`. Deliberately not raised as an exception, for the censoring reason above.

## Verification

- Unit tests over both output formats and every mapped reason.
- A multi-prompt case asserting **both prompts ran** before checking the subtype, so it can't pass vacuously.
- The subtype/`is_error` derivation extracted as a pure function and pinned as a cross-product table — the `cancelled` + early-stop collision is otherwise reachable only through a `/goal` continuation.
- A **real end-to-end guard trip** against a local SSE server: `error_during_execution`, `is_error: true`, usage intact, explanation in `result`; and the text format printing `[clawcodex] run stopped early (tool_failure_loop)`.
- All mutation-tested.

Reviewed by the `critic` subagent across two rounds. It caught the multi-prompt erasure and the five unmapped terminals with runtime probes, and corrected my stated rationale for the exit code — my reason was a self-imposed ordering artifact; the real one (censoring) is much stronger and is now recorded in the code so nobody "finishes the job" and silently drops the data.

## Follow-ups, deliberately not bundled

- The `empty assistant turn -> re-prompting (3/3)` path also ends in `Terminal(completed)` and reports success. Needs a **new** terminal reason, touching a taxonomy the TUI and agent-server both read.
- `agent_server.py` hardcodes `subtype="success"` regardless of terminal reason, so on the TUI path a guard-killed turn is fed to the `/goal` judge as a successful one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
