### PR TITLE
fix(goal): stop cancels and errors from re-running the goal, drop a stray edit

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -3949,8 +3949,31 @@ class _AgentSession:
             # ``turns_used`` and lets the goal's own cap decide. Short-
             # circuiting it would let a turn that keeps stopping early retry
             # forever.
+            # WHICH non-success outcomes continue the goal, and which end it.
+            #
+            # Only the ones the AGENT LOOP itself produced — the values in
+            # EARLY_STOP_SUBTYPES. Those mean "the model did not finish", so
+            # retrying is right and matches what happened before the subtype
+            # was derived at all (the turn arrived as "success", was judged
+            # not-done, and the loop retried).
+            #
+            # ``cancelled`` and ``error`` are NOT those. ``_run_turn`` returns
+            # ``cancelled`` on AbortError and ``error`` on an exception, so a
+            # blanket ``!= "success"`` made ESC during a /goal loop re-enqueue
+            # the work the user just killed, and made a provider 5xx retry up
+            # to the goal's whole turn budget. Same category as the hook stops
+            # deliberately excluded from the map: the USER or the PROVIDER
+            # ended the turn, not the harness cutting it short.
+            from src.query.transitions import EARLY_STOP_SUBTYPES
+
+            _loop_early_stops = frozenset(EARLY_STOP_SUBTYPES.values())
             early_stop_subtype = str(outcome.get("subtype") or "")
-            early_stop = early_stop_subtype not in ("", "success")
+            if (
+                early_stop_subtype != "success"
+                and early_stop_subtype not in _loop_early_stops
+            ):
+                return
+            early_stop = early_stop_subtype in _loop_early_stops
             response_text = str(outcome.get("response_text") or "")
             if not early_stop and not response_text.strip():
                 return
@@ -4021,9 +4044,6 @@ class _AgentSession:
                 )
                 should_continue = bool(decision.get("should_continue"))
                 continuation = decision.get("continuation_prompt") or ""
-                if early_stop:  # MUTANT: short-circuit the budget tick
-                    should_continue = True
-                    continuation = continuation or "[Continuing toward your standing goal]"
                 if should_continue and continuation and self._inbox.empty():
                     # Internal-turn semantics downstream: no UserPromptSubmit
                     # hooks, no ultracode reminder, no memory recall, no

--- a/tests/server/test_agent_server_workflows.py
+++ b/tests/server/test_agent_server_workflows.py
@@ -776,3 +776,148 @@ def test_a_normal_turn_still_reaches_the_goal_judge():
         sess, {"subtype": "success", "response_text": "I fixed the tests."}
     )
     assert judged, "a completed turn must still be judged"
+
+
+def _bare_goal_session(max_turns: int = 3):
+    """A session with only the I/O collaborators stubbed.
+
+    NOT the ``_spawned`` harness: that runs a live worker which CONSUMES
+    ``_inbox``, so queue assertions race it.
+    """
+    import queue
+    import threading
+
+    from src.goals import GoalManager
+    from src.server import agent_server as srv
+
+    sess = object.__new__(srv._AgentSession)
+    sess._lock = threading.RLock()
+    sess._inbox = queue.Queue()
+    sess.session_id = "s"
+    sess.provider = None
+    sess.session = None
+    sess._emit = lambda *a, **k: None
+    sess._save_session = lambda: None
+    sess._goal_snapshot_locked = lambda: (None, 0)
+    sess._goal_mgr = GoalManager("s", judge=None, default_max_turns=max_turns)
+    sess._goal_mgr.set("make the tests pass")
+    sess._goal_manager = lambda: sess._goal_mgr
+    return sess, srv
+
+
+def test_early_stop_continuations_are_bounded_by_the_goal_cap():
+    """A turn that keeps stopping early must NOT retry forever.
+
+    THE safety property of the auto-continue design, and the one my own
+    mutation testing missed: forcing ``should_continue = True`` after
+    ``apply_verdict`` (bypassing the ``turns_used`` tick) passed every other
+    test in this file, because they assert only that *something* was enqueued
+    — which a direct enqueue satisfies just as well.
+
+    This drives the real ``_maybe_continue_goal`` repeatedly against a cap of
+    3 and asserts the continuations actually STOP. It fails if the budget tick
+    is bypassed.
+    """
+    sess, srv = _bare_goal_session(max_turns=3)
+    outcome = {
+        "subtype": "error_during_execution",
+        "response_text": "[Stopped: repeated tool failures detected]",
+    }
+
+    continuations = 0
+    for _ in range(10):
+        srv._AgentSession._maybe_continue_goal(sess, outcome)
+        drained = 0
+        while not sess._inbox.empty():
+            sess._inbox.get_nowait()
+            drained += 1
+        if not drained:
+            break
+        continuations += 1
+
+    assert continuations >= 1, "an early stop must continue the goal at least once"
+    assert continuations < 10, (
+        f"the goal cap must bound early-stop retries; got {continuations} "
+        "continuations — the budget tick is being bypassed"
+    )
+    assert not sess._goal_mgr.is_active(), (
+        "the goal must end once its turn budget is spent"
+    )
+
+
+def test_user_cancel_and_provider_error_do_not_continue_the_goal():
+    """``cancelled`` / ``error`` are the USER or the PROVIDER ending the turn,
+    not the harness cutting it short — so they must END the goal loop, not
+    retry it. A blanket ``!= "success"`` made ESC during a /goal loop
+    re-enqueue the work the user had just killed, and made a provider 5xx
+    retry up to the whole turn budget.
+
+    Paired with a POSITIVE control below, because this harness swallows
+    exceptions: a "nothing was enqueued" assertion would otherwise pass for
+    the wrong reason if a stub were missing.
+    """
+    for subtype in ("cancelled", "error"):
+        sess, srv = _bare_goal_session()
+        srv._AgentSession._maybe_continue_goal(
+            sess, {"subtype": subtype, "response_text": ""}
+        )
+        assert sess._inbox.empty(), f"{subtype} must not continue the goal"
+
+    # POSITIVE CONTROL: the same harness DOES enqueue for a loop early stop,
+    # so the assertions above are meaningful rather than vacuous.
+    sess, srv = _bare_goal_session()
+    srv._AgentSession._maybe_continue_goal(
+        sess,
+        {"subtype": "error_during_execution", "response_text": "[Stopped: x]"},
+    )
+    assert not sess._inbox.empty(), (
+        "control failed — the harness enqueues nothing at all, so the "
+        "negative assertions above prove nothing"
+    )
+
+
+def test_early_stop_respects_the_verdict_decision():
+    """The continuation must come FROM ``apply_verdict``, not around it.
+
+    THE test the shipped defect needed. A stray
+
+        if early_stop:
+            should_continue = True
+
+    after ``apply_verdict`` was committed by accident and reached main. It is
+    not a runaway — ``apply_verdict`` still runs before it, so ``turns_used``
+    still ticks and the goal still deactivates at its cap (measured: 3
+    continuations instead of 2 at cap=3). That is exactly why a cap test does
+    NOT catch it, and why asserting "something was enqueued" does not either.
+
+    What it does break is authority: the goal's own decision to stop is
+    overridden, buying one extra model turn past the budget. So assert the
+    negative directly — when the verdict says stop, nothing is enqueued.
+    """
+    sess, srv = _bare_goal_session()
+
+    real_apply = sess._goal_mgr.apply_verdict
+
+    def _stop(*a, **k):
+        decision = dict(real_apply(*a, **k))
+        decision["should_continue"] = False
+        return decision
+
+    sess._goal_mgr.apply_verdict = _stop
+    srv._AgentSession._maybe_continue_goal(
+        sess,
+        {"subtype": "error_during_execution", "response_text": "[Stopped: x]"},
+    )
+    assert sess._inbox.empty(), (
+        "a continuation was enqueued despite apply_verdict saying stop — the "
+        "verdict is being overridden rather than honoured"
+    )
+
+    # POSITIVE CONTROL: the same harness DOES enqueue when the verdict allows,
+    # so the assertion above cannot pass vacuously.
+    sess2, _ = _bare_goal_session()
+    srv._AgentSession._maybe_continue_goal(
+        sess2,
+        {"subtype": "error_during_execution", "response_text": "[Stopped: x]"},
+    )
+    assert not sess2._inbox.empty(), "control failed — nothing ever enqueues"


### PR DESCRIPTION
**`main` is red.** CI on #779: `1 failed, 9474 passed` — `tests/server/test_goal_control.py::TestMaybeContinueGoal::test_cancelled_and_error_turns_skip_judging`. Two defects, both introduced by #779.

## 1. A user cancel or provider error restarted the goal loop

#779 made `/goal` auto-continue past a turn the agent loop cut short, keyed on `subtype not in ("", "success")`. But `_run_turn` also returns `cancelled` on `AbortError` and `error` on an exception — both got swept in.

So **pressing ESC during a `/goal` loop re-enqueued the work you had just killed** (the `_inbox.empty()` preflight doesn't help — an interrupt leaves it empty), and a provider 5xx/auth failure retried up to the goal's whole turn budget.

It contradicted the function's own docstring (*"Skips when: … the turn was cancelled/errored"*) and `_after_wakeup_turn`'s rationale, which cites the goal loop's no-continuation-on-error guard as its precedent. A test already pinned this; #779 broke it.

Narrowed to `EARLY_STOP_SUBTYPES.values()` — the stops the **agent loop** produced. Those mean "the model did not finish", so retrying is right and matches pre-#779 behaviour (the turn arrived as "success", was judged not-done, and the loop retried). `cancelled`/`error` are the same category as the hook stops deliberately excluded from that map: the **user** or the **provider** ended the turn, not the harness cutting it short.

## 2. A stray edit reached main

`agent_server.py` carried, verbatim:

```python
if early_stop:  # MUTANT: short-circuit the budget tick
    should_continue = True
    continuation = continuation or "[Continuing toward your standing goal]"
```

Mutation-testing scaffolding committed by accident in #779 — the tree was mutated in place while the commit was taken, and the staged diff wasn't read.

**Measured impact, because the comment overstates it:** `apply_verdict` still runs *before* this block, so `turns_used` still ticks and the goal still deactivates at its cap. At `max_turns=3` it yields **3 continuations instead of 2** — one extra model turn past budget, bounded, not a runaway. Still wrong: it overrides the goal's own decision to stop.

## Tests

The cap test added in #779 **cannot** catch (2) — the cap genuinely holds under it, which is exactly why it slipped through. So the new test asserts **authority** instead: patch `apply_verdict` to say stop, assert nothing is enqueued. It fails against the exact code that shipped.

Also adds a cancel/error guard test in this file — the pre-existing one lives in `test_goal_control.py`, which is why the targeted runs during #779 never saw it.

Both new tests carry **positive controls**: this harness swallows exceptions, so a bare "nothing was enqueued" assertion would otherwise pass for the wrong reason if a stub were missing.

## Verification

- Full suite back to the local MCP-only baseline; `test_goal_control.py` no longer among the failures.
- `tests/server`: 469 passed.
- Both defects mutation-tested by re-introducing the exact shipped code.
- Staged diff read before committing, and `git show HEAD` confirmed free of scaffolding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
