### PR TITLE
fix(errors): recover from "too many images" instead of dying on it

### DIFF
--- a/src/services/api/errors.py
+++ b/src/services/api/errors.py
@@ -207,10 +207,43 @@ def is_transport_error(error: BaseException) -> bool:
 
 
 def is_media_size_error(raw: str) -> bool:
+    """Provider errors meaning "there is too much media in this request".
+
+    The name says SIZE but the category is really "the request carries more
+    media than the endpoint accepts", which the recovery lane treats
+    identically: the message is withheld (``_is_withheld_media_size``), one
+    reactive compaction runs, and compaction's ``strip_images_from_messages``
+    removes the media before the retry. Too-big and too-many both get fixed
+    by dropping media, so both belong here.
+
+    Case-insensitive: providers paraphrase casing inconsistently, and the
+    first two patterns previously required exact lowercase.
+
+    COUNT limits are the fourth pattern. An agent that reads image files in a
+    loop — video frames, a screenshot series, a page-by-page scan — accumulates
+    one image block per Read in the conversation, and every block rides along
+    on every later request. Nothing bounds that: compaction is the only thing
+    that strips images and it is triggered by the TOKEN budget, so on a
+    million-token model it may never fire before the image cap is hit.
+    Observed on terminal-bench 2.1 (video-processing, 2026-08-01): 82 image
+    Reads, then ``Exceeded maximum number of images (50) allowed in the
+    request.`` — unclassified, so it fell through to the generic handler and
+    killed a 22-minute run outright instead of compacting and retrying.
+
+    Patterns cover the observed OpenAI/Azure wording plus the likely
+    paraphrases, since the same gap already had to be patched once for a
+    different provider's phrasing (see ``is_image_unsupported_error``).
+    """
+    low = raw.lower()
     return (
-        ("image exceeds" in raw and "maximum" in raw)
-        or ("image dimensions exceed" in raw and "many-image" in raw)
-        or bool(re.search(r"maximum of \d+ PDF pages", raw))
+        ("image exceeds" in low and "maximum" in low)
+        or ("image dimensions exceed" in low and "many-image" in low)
+        or bool(re.search(r"maximum of \d+ pdf pages", low))
+        # Too MANY images, as opposed to too large.
+        or bool(re.search(r"maximum number of images", low))
+        or bool(re.search(r"too many images", low))
+        or bool(re.search(r"exceeds? the maximum of \d+ images", low))
+        or bool(re.search(r"at most \d+ images", low))
     )
 
 

--- a/tests/test_query_loop.py
+++ b/tests/test_query_loop.py
@@ -347,3 +347,141 @@ class TestQueryLoopImageSizeError(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestQueryLoopImageCountError(unittest.TestCase):
+    """A "too MANY images" provider error must enter the media-recovery lane.
+
+    An agent that reads image files in a loop — video frames, a screenshot
+    series, a page-by-page scan — accumulates one image block per Read, and
+    every block rides along on every later request. Nothing bounds that:
+    compaction is the only thing that strips images, and it is triggered by
+    the TOKEN budget, so on a million-token model it may never fire before the
+    provider's image cap is hit.
+
+    Observed on terminal-bench 2.1 (video-processing, 2026-08-01): 82 image
+    Reads, then ``Exceeded maximum number of images (50) allowed in the
+    request.`` The classifier did not recognise the wording, so it fell
+    through to the generic handler and killed a 22-minute run outright
+    instead of compacting once and retrying.
+
+    The recovery machinery already existed and was tested — only the
+    classifier's pattern set was missing this phrasing.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.temp_dir.name)
+        self.registry = build_default_registry()
+        self.context = ToolContext(workspace_root=self.workspace)
+        self.abort = AbortController()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _run_with_error(self, error_text: str):
+        provider = MagicMock()
+        exc = Exception(error_text)
+        provider.chat_stream_response.side_effect = exc
+        provider.chat.side_effect = exc
+        params = QueryParams(
+            messages=[UserMessage(content="describe the frames")],
+            system_prompt="You are helpful.",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=10,
+        )
+        collected = []
+
+        async def run():
+            async for msg in query(params):
+                collected.append(msg)
+
+        _run(run())
+        return collected
+
+    def test_image_count_error_is_classified_as_media_size(self):
+        """THE regression guard — the exact string that killed the trial."""
+        collected = self._run_with_error(
+            "Exceeded maximum number of images (50) allowed in the request."
+        )
+        assistants = [m for m in collected if isinstance(m, AssistantMessage)]
+        self.assertTrue(assistants, "expected an assistant error message")
+        tagged = [
+            m for m in assistants
+            if getattr(m, "_api_error", None) == "media_size"
+        ]
+        self.assertTrue(
+            tagged,
+            "the image-COUNT error must carry the media_size tag so the "
+            "reactive-compact lane (which strips images) can recover; "
+            f"got tags {[getattr(m, '_api_error', None) for m in assistants]}",
+        )
+
+    def test_image_count_error_does_not_end_as_a_plain_model_error(self):
+        """Unclassified, it reached ``Terminal(model_error)`` and the run died.
+
+        Classified, an exhausted recovery lands on ``image_error`` instead —
+        which ``EARLY_STOP_SUBTYPES`` maps to a non-success result subtype, so
+        the caller can tell a media problem from an arbitrary crash.
+        """
+        from src.query.query import run_query
+        from src.query.transitions import EARLY_STOP_SUBTYPES
+
+        provider = MagicMock()
+        exc = Exception("Exceeded maximum number of images (50) allowed in the request.")
+        provider.chat_stream_response.side_effect = exc
+        provider.chat.side_effect = exc
+        params = QueryParams(
+            messages=[UserMessage(content="describe the frames")],
+            system_prompt="s",
+            tools=self.registry.list_tools(),
+            tool_registry=self.registry,
+            tool_use_context=self.context,
+            provider=provider,
+            abort_controller=self.abort,
+            max_turns=10,
+        )
+        _msgs, terminal = _run(run_query(params))
+        self.assertNotEqual(
+            terminal.reason, "model_error",
+            "a recognised media error must not exit as a generic model_error",
+        )
+        self.assertEqual(terminal.reason, "image_error")
+        self.assertIn(
+            "image_error", EARLY_STOP_SUBTYPES,
+            "image_error must map to a non-success subtype so the caller can "
+            "distinguish it from a clean completion",
+        )
+
+    def test_size_errors_still_recognised(self):
+        """The pre-existing SIZE patterns must keep working."""
+        collected = self._run_with_error("image exceeds the maximum allowed size")
+        tagged = [
+            m for m in collected
+            if isinstance(m, AssistantMessage)
+            and getattr(m, "_api_error", None) == "media_size"
+        ]
+        self.assertTrue(tagged)
+
+    def test_unrelated_errors_are_not_swept_in(self):
+        """Widening the pattern set must not capture other failures — a
+        prompt-too-long has its own recovery, and a generic server error has
+        none, so mislabelling either would route it wrongly."""
+        for text, expect_tag in (
+            ("prompt is too long: 137500 tokens > 135000 maximum", "prompt_too_long"),
+            ("The server had an error processing your request", None),
+        ):
+            with self.subTest(text=text):
+                collected = self._run_with_error(text)
+                tags = {
+                    getattr(m, "_api_error", None)
+                    for m in collected
+                    if isinstance(m, AssistantMessage)
+                }
+                self.assertNotIn("media_size", tags, f"{text!r} misclassified")
+                if expect_tag:
+                    self.assertIn(expect_tag, tags)


### PR DESCRIPTION
An agent that reads image files in a loop — video frames, a screenshot series, a page-by-page scan — accumulates **one image block per Read** in the conversation, and every block rides along on every later request.

Nothing bounds that. Compaction is the only thing that strips images, and it's triggered by the **token** budget — so on a million-token model it may never fire before the provider's **image** cap is reached. The two limits are on different axes and only one was tracked.

Observed on terminal-bench 2.1 (`video-processing`, 2026-08-01): 82 image Reads, then

```
Exceeded maximum number of images (50) allowed in the request.
```

## Why it was fatal

`is_media_size_error` matched only three patterns — `"image exceeds"+"maximum"`, `"image dimensions exceed"+"many-image"`, and `"maximum of N PDF pages"`. The **count** wording matches none, so the error fell through to the generic handler, became `Terminal(model_error)`, and killed a 22-minute run outright.

**The recovery lane already existed and was already tested:**

```
classify media_size → withhold (_is_withheld_media_size) → one reactive compaction
→ strip_images_from_messages drops the media → retry
```

Only the classifier's pattern set was missing the phrasing. Same gap class as `is_image_unsupported_error`, which had to be added separately for a different provider's wording.

## The change

Adds count patterns, and makes the whole predicate **case-insensitive** — the first two patterns silently required exact lowercase.

## Scope — what this does and doesn't buy

It converts a fatal crash into one compaction + retry, and a legible `Terminal(image_error)` if the cap is hit again (`EARLY_STOP_SUBTYPES` maps that to a non-success result subtype rather than a silent success).

It is **not** a full fix. `has_attempted_reactive_compact` is one-shot per turn-chain, so an agent that keeps reading images will hit the cap a second time and stop.

**Nor would it have won that trial.** On the same task, in the same container, with the same tools, `claude-opus-5` used **15** image reads to luna's **82** (18 of which were re-reads of frames already seen) and never came close to the cap. Hitting the cap at all is a model-behaviour difference — only the **crash** is the harness's fault.

The root cause — unbounded image accumulation with no per-request bound — is deliberately left for a separate change: a proactive cap changes what the model sees on every image task, and the limit differs per provider (50 OpenAI/Azure, 100 Anthropic). That's a design decision worth making explicitly rather than as a side effect of a bug fix.

## Verification

- Tests drive the **real query loop** with the exact failing string, asserting it reaches the `media_size` tag and exits as `image_error` rather than `model_error`.
- **Negative controls**: `prompt_too_long` keeps its own tag (it has a different recovery), a generic server error stays untagged (it has none) — so the widened patterns can't sweep in errors that would be routed wrongly.
- 13-case classifier table covering the observed wording, likely paraphrases, and the pre-existing size/PDF patterns.
- **Mutation-tested**: removing the count patterns reproduces the shipped failure.
- Full suite at the local baseline; no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
