### PR TITLE
fix(providers): bill cached tokens as cache reads, and stop dropping OpenRouter reasoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,10 +352,11 @@ providers = [
     # OpenAI-compatible vendors
     "nvidia-nim", "atlascloud", "wanjie-ark", "volcengine", "xiaomi-mimo",
     "novita", "fireworks", "siliconflow", "siliconflow-cn", "arcee", "moonshot",
-    "huggingface", "together", "stepfun", "deepinfra",
+    "huggingface", "together", "stepfun", "deepinfra", "meta",
+    "groq", "cerebras", "baseten", "xai",
     # Local servers (no API key required)
     "ollama", "vllm", "sglang",
-]  # 25 providers; aliases like `nim`, `kimi`, `hf` resolve automatically
+]  # 30 providers; aliases like `nim`, `kimi`, `hf`, `grok` resolve automatically
 ```
 
 Any new OpenAI-compatible vendor is a one-row addition to

--- a/src/providers/deepseek_provider.py
+++ b/src/providers/deepseek_provider.py
@@ -70,9 +70,10 @@ class DeepSeekProvider(OpenAICompatibleProvider):
         ``prompt_cache_miss_tokens`` (DeepSeek's native shape) or, on some
         OpenAI-compatible gateways, nested under
         ``prompt_tokens_details.cached_tokens``. The base
-        :meth:`OpenAICompatibleProvider._build_usage_dict` reports
-        ``input_tokens`` as the FULL prompt (hit + miss) and drops the cache
-        split, so cache hit-rate is invisible and cost cannot credit the hit.
+        :meth:`OpenAICompatibleProvider._build_usage_dict` now performs the
+        nested-``cached_tokens`` split itself for every OpenAI-compatible
+        provider; this override remains for DeepSeek's NATIVE top-level
+        fields, which the base does not know about.
 
         When a cache hit is present we re-map onto the **Anthropic
         convention** that ``cost_tracker.record_api_usage`` /
@@ -117,7 +118,14 @@ class DeepSeekProvider(OpenAICompatibleProvider):
             except (TypeError, ValueError):
                 hit = 0
 
-        prompt_tokens = int(result.get("input_tokens", 0) or 0)
+        # The FULL prompt (hit + miss). The base builder now performs the
+        # generic nested-``cached_tokens`` re-map itself, so ``input_tokens``
+        # may already be miss-only; adding back whatever it split off
+        # recovers the original total. Without this the subtraction below
+        # runs twice and drives the miss count to zero, under-reporting cost.
+        prompt_tokens = int(result.get("input_tokens", 0) or 0) + int(
+            result.get("cache_read_input_tokens", 0) or 0
+        )
         if hit > 0:
             # Only an explicit/derivable cache hit triggers the re-map; with no
             # hit, the base dict (input_tokens = full prompt) is already correct.

--- a/src/providers/gemini_provider.py
+++ b/src/providers/gemini_provider.py
@@ -208,8 +208,30 @@ class GeminiProvider(BaseProvider):
     def _convert_messages(
         self, messages: list[MessageInput]
     ) -> tuple[list[Any], Optional[str]]:
-        """Convert Anthropic-style messages → (gemini contents, system_instruction)."""
+        """Convert Anthropic-style messages → (gemini contents, system_instruction).
+
+        ``openai_responses_item`` blocks are stripped first, matching
+        ``AnthropicProvider`` and ``MinimaxProvider``. A mid-session
+        ``/model`` switch away from the ChatGPT-subscription path leaves
+        those reasoning-replay blocks in assistant history.
+
+        This is defence in depth, NOT a bug fix: today the if/elif chain
+        below has no ``else``, so an unknown block contributes no part, and
+        the ``if parts:`` guard then drops a message left with none — the
+        same outcome the strip produces. The reason to strip explicitly is
+        that the current behaviour is accidental. It depends on two separate
+        implicit fallthroughs, and adding an ``else`` branch or a
+        placeholder part (the natural way to handle some future block type)
+        would silently start forwarding ChatGPT replay items to Gemini.
+        Being the one converter of four that relies on that is the actual
+        defect.
+        """
         _ensure_sdk()
+        from .openai_responses import strip_responses_item_blocks
+
+        messages = strip_responses_item_blocks(
+            [m if isinstance(m, dict) else m.to_dict() for m in messages]
+        )
         contents: list[Any] = []
         system_parts: list[str] = []
 

--- a/src/providers/openai_compatible.py
+++ b/src/providers/openai_compatible.py
@@ -569,6 +569,25 @@ def _parse_tool_call_arguments(raw: str | None) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def _extract_reasoning(source: Any) -> Optional[str]:
+    """Reasoning text from a message or delta, across both field names.
+
+    ``reasoning_content`` is the DeepSeek/GLM convention. OpenRouter uses a
+    bare ``reasoning`` instead — verified live 2026-08-02, where a streamed
+    gpt-5.6-luna turn carried ``delta.reasoning`` and ``delta.reasoning_details``
+    but no ``reasoning_content`` at all. Reading only the first name dropped
+    every token of reasoning from the provider this repo's benchmarks run on.
+
+    ``reasoning_details`` (a structured summary list) is deliberately not
+    read: it duplicates the same text in a shape nothing downstream consumes.
+    """
+    for name in ("reasoning_content", "reasoning"):
+        value = getattr(source, name, None)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
 class OpenAICompatibleProvider(BaseProvider):
     """Base class for providers using OpenAI-style chat completions API.
 
@@ -624,13 +643,74 @@ class OpenAICompatibleProvider(BaseProvider):
         return _convert_anthropic_messages_to_openai(base)
 
     def _build_usage_dict(self, usage: Any) -> dict[str, Any]:
+        """Provider usage → the Anthropic-convention dict the cost layer reads.
+
+        ``prompt_tokens`` on this wire INCLUDES tokens served from the prompt
+        cache, with the cached count reported separately under
+        ``prompt_tokens_details.cached_tokens``. Reporting only the total
+        billed every cached token at the full input rate — for OpenRouter's
+        gpt-5.6-luna that is $1.25/M against a real $0.15/M, an ~8x
+        over-estimate on the cached portion, and it made cache hit-rate
+        invisible. Every pricing tier already carries a ``cache_read`` rate;
+        two of them (``_TIER_MUSE_SPARK``, ``_TIER_GPT_56_LUNA``) say in
+        comments that the rate is inert "for when that lands". This is that.
+
+        The split follows the convention ``services.pricing.compute_cost``
+        already understands, which is also how DeepSeek's override has
+        reported for some time and how OpenCode maps usage for every
+        OpenAI-compatible provider (openai-chat.ts):
+
+        * ``input_tokens``               → cache MISS, at the input rate
+        * ``cache_read_input_tokens``    → cache HIT, at the cache-read rate
+        * ``cache_creation_input_tokens`` → 0; this wire has no cache-write
+          charge, so there is nothing to bill for populating the cache.
+
+        With no cache hit the dict is byte-identical to the previous one, so
+        providers that never report the field are unaffected.
+        """
         if usage is None:
             return {}
-        return {
+        result: dict[str, Any] = {
             "input_tokens": getattr(usage, "prompt_tokens", 0),
             "output_tokens": getattr(usage, "completion_tokens", 0),
             "total_tokens": getattr(usage, "total_tokens", 0),
         }
+
+        # Gateways differ on whether details arrive as an object or a mapping.
+        details = getattr(usage, "prompt_tokens_details", None)
+        cached = None
+        if isinstance(details, dict):
+            cached = details.get("cached_tokens")
+        elif details is not None:
+            cached = getattr(details, "cached_tokens", None)
+        # Only a genuine number counts. ``int()`` alone is too permissive:
+        # any object defining ``__int__`` converts, and a ``MagicMock`` usage
+        # stub — which auto-creates ``prompt_tokens_details.cached_tokens`` —
+        # yields 1, inventing a one-token cache hit out of a fixture that
+        # never meant to describe one. ``bool`` is excluded because it is an
+        # ``int`` subclass and ``True`` would read as a single cached token.
+        if isinstance(cached, bool) or not isinstance(cached, (int, float, str)):
+            hit = 0
+        else:
+            try:
+                hit = int(cached)
+            except (TypeError, ValueError, OverflowError):
+                # OverflowError descends from ArithmeticError, not
+                # ValueError, so it escapes the other two and would kill the
+                # turn. Reachable: stdlib ``json.loads`` accepts a bare
+                # ``Infinity`` literal, so any vendor emitting one crashes
+                # the session rather than losing a usage number.
+                hit = 0
+
+        if hit > 0:
+            try:
+                prompt_tokens = int(result.get("input_tokens", 0) or 0)
+            except (TypeError, ValueError):
+                prompt_tokens = 0
+            result["input_tokens"] = max(prompt_tokens - hit, 0)
+            result["cache_read_input_tokens"] = hit
+            result["cache_creation_input_tokens"] = 0
+        return result
 
     @staticmethod
     def _with_system_prompt(
@@ -719,13 +799,8 @@ class OpenAICompatibleProvider(BaseProvider):
         # Extract content
         choice = response.choices[0]
 
-        # Handle reasoning content (GLM specific, but harmless for others)
-        reasoning_content: Optional[str] = None
-        if (
-            hasattr(choice.message, "reasoning_content")
-            and choice.message.reasoning_content
-        ):
-            reasoning_content = choice.message.reasoning_content
+        # Reasoning text, under either provider's field name.
+        reasoning_content: Optional[str] = _extract_reasoning(choice.message)
 
         # Extract tool calls (OpenAI format -> Anthropic format)
         tool_uses: Optional[list[dict[str, Any]]] = None
@@ -1040,7 +1115,7 @@ class OpenAICompatibleProvider(BaseProvider):
                             if on_text_chunk is not None:
                                 on_text_chunk(piece)
 
-                        reasoning_piece = getattr(delta, "reasoning_content", None)
+                        reasoning_piece = _extract_reasoning(delta)
                         if reasoning_piece:
                             reasoning_parts.append(str(reasoning_piece))
                             if on_thinking_chunk is not None:

--- a/src/providers/openai_responses.py
+++ b/src/providers/openai_responses.py
@@ -531,8 +531,27 @@ def build_usage_dict(
     if subscription:
         result["billing_mode"] = "subscription"
     cached = input_details.get("cached_tokens")
-    if cached:
-        result["cache_read_input_tokens"] = int(cached)
+    if isinstance(cached, bool) or not isinstance(cached, (int, float, str)):
+        cached = 0
+    try:
+        hit = int(cached or 0)
+    except (TypeError, ValueError, OverflowError):
+        # See the matching guard in ``OpenAICompatibleProvider``:
+        # ``int(float('inf'))`` raises OverflowError, which is an
+        # ArithmeticError and so slips past a ValueError-only except.
+        hit = 0
+    if hit > 0:
+        # Subtract, don't just annotate. ``input_tokens`` on this wire
+        # already INCLUDES the cached prefix, so recording the hit alongside
+        # the untouched total made the two double-count: every consumer sums
+        # input + cache_creation + cache_read, so a 2613-token prompt with a
+        # 2560-token hit reported 5173. That billed the cached portion at
+        # BOTH the input and the cache-read rate, and inflated the prompt
+        # size that ``get_pricing`` uses to select a tier — which for
+        # gpt-5.6-luna can cross the 272K boundary and pick the wrong one.
+        result["input_tokens"] = max(result["input_tokens"] - hit, 0)
+        result["cache_read_input_tokens"] = hit
+        result["cache_creation_input_tokens"] = 0
     return result
 
 

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -3583,12 +3583,21 @@ class _AgentSession:
 
     @staticmethod
     def _usage_token_total(snapshot: dict) -> int:
-        """Total input+output tokens across the cost snapshot's model_usage."""
+        """Total tokens across the cost snapshot's model_usage.
+
+        Includes the cache fields. ``input_tokens`` counts only the UNCACHED
+        prompt — providers report the cached prefix separately, and the
+        snapshot already carries both — so summing input+output alone
+        under-reported every cached turn, by 98% of the prompt on a warm
+        prefix cache.
+        """
         total = 0
         try:
             for usage in (snapshot.get("model_usage") or {}).values():
                 total += int(usage.get("input_tokens", 0) or 0)
                 total += int(usage.get("output_tokens", 0) or 0)
+                total += int(usage.get("cache_read_input_tokens", 0) or 0)
+                total += int(usage.get("cache_creation_input_tokens", 0) or 0)
         except Exception:  # noqa: BLE001
             return 0
         return total

--- a/src/services/pricing.py
+++ b/src/services/pricing.py
@@ -120,15 +120,10 @@ _TIER_MINIMAX_M27 = {
 # Meta Muse Spark 1.1 (api.meta.ai, OpenAI-compatible). Meta's published rates:
 # $1.25/M input, $4.25/M output, $0.15/M cached input. OpenAI-style caching has
 # no separate cache-write charge, so ``cache_creation`` mirrors ``input``.
-# NOTE: the generic OpenAI-compat usage builder does not (yet) map
-# ``prompt_tokens_details.cached_tokens`` onto ``cache_read_input_tokens`` —
-# only the hand-written DeepSeek provider does — so today ``cache_read`` is
-# inert for Meta: cached input is billed at the full input rate in the cost
-# display, an over-estimate on the cached portion ($1.25 vs $0.15/M, ~8x).
-# The displayed cost is thus a safe upper bound, consistent with the other
-# registry providers; wiring the mapping into ``_build_usage_dict`` is a
-# separate change (it would affect all OpenAI-compat providers). The real
-# cache-read rate is recorded here for when that lands.
+# ``cache_read`` is LIVE: the generic OpenAI-compat usage builder maps
+# ``prompt_tokens_details.cached_tokens`` onto ``cache_read_input_tokens``,
+# so cached input bills at $0.15/M rather than the full $1.25/M. Before that
+# mapping the displayed cost over-estimated the cached portion by ~8x.
 _TIER_MUSE_SPARK = {
     "input": 1.25 / 1_000_000,
     "output": 4.25 / 1_000_000,
@@ -147,10 +142,11 @@ _TIER_MUSE_SPARK = {
 # against other agents' — under-reporting the expensive half of a run by ~2x
 # would corrupt exactly the number the eval exists to produce.
 #
-# Cache rates remain inert in practice: the generic OpenAI-compat usage
-# builder does not map ``prompt_tokens_details.cached_tokens`` onto
-# ``cache_read_input_tokens`` (only the hand-written DeepSeek provider does),
-# so cached input bills at the full input rate. Recorded for when that lands.
+# Cache rates are LIVE: the generic OpenAI-compat usage builder maps
+# ``prompt_tokens_details.cached_tokens`` onto ``cache_read_input_tokens``,
+# and the Responses builder does the same, so cached input bills at the
+# cache-read rate on either wire. Measured on a real 2613-token turn with a
+# 2560-token hit, the split lowers the reported cost ~7.5x for this model.
 _GPT_56_LUNA_INPUT_TIER_LIMIT = 272_000
 _TIER_GPT_56_LUNA = {
     "input": 0.10 / 1_000_000,
@@ -410,8 +406,16 @@ def compute_session_cost(
 
     Worker cache token counts default to zero — callers that don't
     track cache separately (most of them, today) just get input+output
-    pricing. Advisor cache is ignored entirely; the advisor's separate
-    API call doesn't get cache hits across runs.
+    pricing. Advisor cache is ignored entirely: the advisor branch below
+    passes no cache keys, and ``utils.advisor`` projects the provider dict
+    down to input+output before it gets here.
+
+    That is a known under-count, NOT a claim that the advisor misses the
+    cache. The original rationale — "the advisor's separate API call doesn't
+    get cache hits across runs" — is unsafe: OpenAI-compatible prefix caching
+    is automatic and does hit across calls that share a system prompt, which
+    advisor calls do. Threading the cache keys through both sites is a
+    separate change.
     """
     worker_cost = 0.0
     if worker_model and (worker_input_tokens or worker_output_tokens):

--- a/tests/test_openai_subscription.py
+++ b/tests/test_openai_subscription.py
@@ -287,14 +287,27 @@ def test_chat_completions_converter_strips_passthrough_blocks() -> None:
 
 
 def test_usage_dict_marks_subscription_billing() -> None:
+    """Subscription flag, and the cache split that rides alongside it.
+
+    The expectation used to be ``input_tokens: 10`` WITH
+    ``cache_read_input_tokens: 4`` — 14 tokens for a 10-token prompt.
+    ``input_tokens`` on this wire already includes the cached prefix, and
+    every consumer sums input + cache_creation + cache_read, so recording
+    the hit without subtracting double-counted it. That is invisible in the
+    cost here (``billing_mode: subscription`` zeroes it), but the same
+    inflated numbers drive the context-left display.
+    """
     usage = build_usage_dict({
         "input_tokens": 10, "output_tokens": 5, "total_tokens": 15,
         "input_tokens_details": {"cached_tokens": 4},
     })
     assert usage == {
-        "input_tokens": 10, "output_tokens": 5, "total_tokens": 15,
+        "input_tokens": 6, "output_tokens": 5, "total_tokens": 15,
         "billing_mode": "subscription", "cache_read_input_tokens": 4,
+        "cache_creation_input_tokens": 0,
     }
+    # the parts still reconstruct the prompt the model actually saw
+    assert usage["input_tokens"] + usage["cache_read_input_tokens"] == 10
 
 
 # --- provider ---------------------------------------------------------------

--- a/tests/test_provider_usage_and_reasoning.py
+++ b/tests/test_provider_usage_and_reasoning.py
@@ -1,0 +1,434 @@
+"""Cross-provider follow-ups: cache-read accounting, reasoning field names,
+foreign-block stripping, and the README provider list.
+
+Each of these was a silent gap — nothing errored, the numbers and the
+transcript were just quietly wrong — so the tests assert the observable
+consequence rather than the shape of the code.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.providers import PROVIDER_INFO, get_provider_class
+from src.providers.deepseek_provider import DeepSeekProvider
+from src.providers.openai_compatible import _extract_reasoning
+from src.services.pricing import compute_cost
+
+
+def _usage(prompt: int, cached: int | None = None, *, as_dict: bool = False):
+    details = None
+    if cached is not None:
+        details = {"cached_tokens": cached} if as_dict else type(
+            "D", (), {"cached_tokens": cached}
+        )()
+    return type(
+        "U",
+        (),
+        {
+            "prompt_tokens": prompt,
+            "completion_tokens": 50,
+            "total_tokens": prompt + 50,
+            "prompt_tokens_details": details,
+            "completion_tokens_details": None,
+        },
+    )()
+
+
+# --- cache-read accounting ------------------------------------------------
+
+
+def test_cached_prompt_tokens_are_split_out_of_billable_input() -> None:
+    """`prompt_tokens` INCLUDES cache hits, so reporting it whole over-bills.
+
+    Every pricing tier carries a `cache_read` rate, and two of them say in
+    comments that the rate is inert until this mapping lands.
+    """
+    provider = get_provider_class("groq")(api_key="sk-test")
+    usage = provider._build_usage_dict(_usage(1000, cached=900))
+    assert usage["input_tokens"] == 100
+    assert usage["cache_read_input_tokens"] == 900
+    assert usage["cache_creation_input_tokens"] == 0
+    # the full prompt is still recoverable
+    assert usage["input_tokens"] + usage["cache_read_input_tokens"] == 1000
+
+
+def test_the_cache_split_actually_lowers_the_reported_cost() -> None:
+    """The point of the split is money, so assert money.
+
+    Numbers are a real turn measured against DeepSeek (2613-token prompt,
+    2560 of it served from the prefix cache).
+    """
+    mapped = {
+        "input_tokens": 53,
+        "output_tokens": 8,
+        "cache_read_input_tokens": 2560,
+        "cache_creation_input_tokens": 0,
+    }
+    unmapped = {"input_tokens": 2613, "output_tokens": 8}
+    for model in ("deepseek-v4-pro", "openai/gpt-5.6-luna"):
+        cheap = compute_cost(model, mapped)
+        dear = compute_cost(model, unmapped)
+        assert cheap > 0, model
+        assert dear > cheap * 2, f"{model}: cache split had no material effect"
+
+
+def test_providers_that_report_no_cache_are_unchanged() -> None:
+    """No cache hit must produce byte-identical output to before the change."""
+    provider = get_provider_class("groq")(api_key="sk-test")
+    for usage in (_usage(1000), _usage(1000, cached=0)):
+        assert provider._build_usage_dict(usage) == {
+            "input_tokens": 1000,
+            "output_tokens": 50,
+            "total_tokens": 1050,
+        }
+
+
+def test_details_are_read_whether_object_or_mapping() -> None:
+    """Gateways differ on the shape; both must map."""
+    provider = get_provider_class("groq")(api_key="sk-test")
+    as_obj = provider._build_usage_dict(_usage(100, cached=40))
+    as_map = provider._build_usage_dict(_usage(100, cached=40, as_dict=True))
+    assert as_obj == as_map
+    assert as_obj["cache_read_input_tokens"] == 40
+
+
+def test_a_cache_count_larger_than_the_prompt_cannot_go_negative() -> None:
+    provider = get_provider_class("groq")(api_key="sk-test")
+    usage = provider._build_usage_dict(_usage(10, cached=999))
+    assert usage["input_tokens"] == 0
+
+
+@pytest.mark.parametrize(
+    "native,nested",
+    [
+        ({"prompt_cache_hit_tokens": 900, "prompt_cache_miss_tokens": 100}, None),
+        (None, 900),
+        ({"prompt_cache_hit_tokens": 900, "prompt_cache_miss_tokens": 100}, 900),
+    ],
+)
+def test_deepseek_agrees_with_the_base_on_every_usage_shape(native, nested) -> None:
+    """DeepSeek's override runs AFTER the base now performs the same split.
+
+    Without compensating, its `prompt_tokens - hit` subtraction ran twice and
+    drove billable input to zero — under-reporting cost on the provider whose
+    prefix cache makes this fire on nearly every turn.
+    """
+    attrs = {
+        "prompt_tokens": 1000,
+        "completion_tokens": 50,
+        "total_tokens": 1050,
+        "completion_tokens_details": None,
+        "prompt_tokens_details": type("D", (), {"cached_tokens": nested})()
+        if nested
+        else None,
+    }
+    if native:
+        attrs.update(native)
+    usage = DeepSeekProvider(api_key="sk-test")._build_usage_dict(
+        type("U", (), attrs)()
+    )
+    assert usage["input_tokens"] == 100
+    assert usage["cache_read_input_tokens"] == 900
+
+
+# --- reasoning field names ------------------------------------------------
+
+
+def test_reasoning_is_read_under_either_provider_field_name() -> None:
+    """OpenRouter streams `reasoning`; DeepSeek/GLM stream `reasoning_content`.
+
+    Verified live 2026-08-02: a streamed gpt-5.6-luna turn over OpenRouter
+    carried `delta.reasoning` and `delta.reasoning_details` and NO
+    `reasoning_content` key at all, so reading only the latter dropped every
+    reasoning token from the provider this repo's benchmarks run on.
+    """
+    make = lambda **kw: type("X", (), kw)()  # noqa: E731
+    assert _extract_reasoning(make(reasoning_content="rc")) == "rc"
+    assert _extract_reasoning(make(reasoning="r")) == "r"
+    # the established name wins when a provider somehow sends both
+    assert _extract_reasoning(make(reasoning_content="rc", reasoning="r")) == "rc"
+
+
+def test_absent_empty_and_non_string_reasoning_are_ignored() -> None:
+    """OpenRouter sends `reasoning: None` when the trace is encrypted."""
+    make = lambda **kw: type("X", (), kw)()  # noqa: E731
+    assert _extract_reasoning(make(content="hi")) is None
+    assert _extract_reasoning(make(reasoning="")) is None
+    assert _extract_reasoning(make(reasoning=None)) is None
+    assert _extract_reasoning(make(reasoning=["structured"])) is None
+
+
+# --- foreign-block stripping ---------------------------------------------
+
+
+def test_gemini_drops_responses_item_blocks_from_history() -> None:
+    """Gemini strips ChatGPT replay blocks explicitly, like the other three.
+
+    This pins consistency, not a live bug: the converter's `if parts:` guard
+    already drops a message whose blocks all fell through the if/elif chain,
+    so today the observable result is identical either way. What the strip
+    buys is that the outcome stops depending on two implicit fallthroughs —
+    adding an `else` branch or a placeholder part would otherwise start
+    forwarding replay items to Gemini silently.
+
+    Because the behaviours coincide, the assertion below is on the shared
+    helper's contract plus the converter's output shape; removing the strip
+    call does NOT fail this test, and that is expected rather than a gap.
+    """
+    from src.providers.openai_responses import strip_responses_item_blocks
+
+    history = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": [{"type": "openai_responses_item", "item": {}}]},
+        {
+            "role": "assistant",
+            "content": [
+                {"type": "openai_responses_item", "item": {}},
+                {"type": "text", "text": "kept"},
+            ],
+        },
+    ]
+    stripped = strip_responses_item_blocks(history)
+    assert len(stripped) == 2, "reasoning-only turn should be dropped entirely"
+    assert stripped[-1]["content"] == [{"type": "text", "text": "kept"}]
+
+    # Driven through the converter, not grepped for. A source check would
+    # pass on any mention of the helper, including an unreached one.
+    import sys
+    from unittest.mock import MagicMock
+
+    sys.modules.setdefault("google", MagicMock())
+    sys.modules.setdefault("google.genai", MagicMock())
+    import src.providers.gemini_provider as gemini
+
+    with patch.object(gemini, "_ensure_sdk", lambda: None), patch.object(
+        gemini, "genai_types", MagicMock()
+    ) as fake_types:
+        fake_types.Part.from_text = lambda text: {"text": text}
+        seen: list[list] = []
+        fake_types.Content = lambda role, parts: seen.append(parts) or {"parts": parts}
+        provider = gemini.GeminiProvider.__new__(gemini.GeminiProvider)
+        contents, _ = provider._convert_messages(history)
+
+    assert len(contents) == 2, (
+        "the reasoning-only assistant turn should be gone, not present-but-empty"
+    )
+    assert all(parts for parts in seen), "no message may convert to empty parts"
+
+
+# --- README ---------------------------------------------------------------
+
+
+def test_the_readme_provider_list_matches_the_registry() -> None:
+    """The list drifted by five providers before this was pinned."""
+    readme = Path("README.md").read_text(encoding="utf-8")
+    block = re.search(r"providers = \[(.*?)\]  # (\d+) providers", readme, re.S)
+    assert block, "provider list block not found in README.md"
+
+    listed = set(re.findall(r'"([a-z0-9\-]+)"', block.group(1)))
+    assert listed == set(PROVIDER_INFO), (
+        f"README missing {sorted(set(PROVIDER_INFO) - listed)}, "
+        f"extra {sorted(listed - set(PROVIDER_INFO))}"
+    )
+    assert int(block.group(2)) == len(PROVIDER_INFO)
+
+
+def test_context_accounting_still_sees_the_whole_prompt() -> None:
+    """Splitting input must not shrink what the context display counts.
+
+    `input_tokens` no longer means "the whole prompt", so anything treating
+    it that way would under-count context and delay auto-compaction until
+    after the real limit. The consumers sum all three parts
+    (`context_analyzer`, `tasks/progress`, `cost_tracker`), which is the
+    Anthropic convention the codebase was already built around — this pins
+    that the parts still reconstruct the total.
+    """
+    provider = get_provider_class("groq")(api_key="sk-test")
+    usage = provider._build_usage_dict(_usage(2613, cached=2560))
+
+    context_total = (
+        usage.get("input_tokens", 0)
+        + usage.get("cache_creation_input_tokens", 0)
+        + usage.get("cache_read_input_tokens", 0)
+    )
+    assert context_total == 2613
+
+
+def test_the_cost_tracker_records_the_cache_split_rather_than_flattening_it() -> None:
+    from src.bootstrap import state as bootstrap_state
+
+    provider = get_provider_class("groq")(api_key="sk-test")
+    usage = provider._build_usage_dict(_usage(2613, cached=2560))
+
+    assert hasattr(bootstrap_state.ModelUsage(), "cache_read_input_tokens")
+    recorded = bootstrap_state.ModelUsage(
+        input_tokens=usage["input_tokens"],
+        cache_read_input_tokens=usage["cache_read_input_tokens"],
+    )
+    assert recorded.input_tokens == 53
+    assert recorded.cache_read_input_tokens == 2560
+
+
+# --- the reasoning CALL SITES, not just the helper ------------------------
+
+
+def _openrouter_message(text: str, reasoning: str | None):
+    """A Chat Completions message shaped the way OpenRouter sends one.
+
+    A plain object, not a MagicMock: a mock auto-creates
+    ``reasoning_content``, which would let a call site reading only that name
+    pass.
+    """
+    msg = type(
+        "M",
+        (),
+        {"content": text, "role": "assistant", "tool_calls": None, "reasoning": reasoning},
+    )()
+    return type("C", (), {"message": msg, "finish_reason": "stop", "index": 0})()
+
+
+def test_non_streaming_reasoning_reaches_the_response() -> None:
+    """The helper being right is not enough — the call site must use it."""
+    from unittest.mock import MagicMock
+
+    client = MagicMock()
+    response = MagicMock()
+    response.choices = [_openrouter_message("hi", "BECAUSE_REASONS")]
+    response.model = "openai/gpt-5.6-luna"
+    response.usage = None
+    client.chat.completions.create.return_value = response
+
+    provider = get_provider_class("groq")(api_key="sk-test")
+    # The SDK is imported lazily inside `_create_client`, so there is no
+    # module-level symbol to patch; the client property is the seam.
+    with patch.object(type(provider), "client", property(lambda self: client)):
+        result = provider.chat([{"role": "user", "content": "hi"}])
+
+    assert result.reasoning_content == "BECAUSE_REASONS"
+
+
+def test_streaming_reasoning_reaches_the_thinking_callback() -> None:
+    """Streamed `delta.reasoning` must drive on_thinking_chunk."""
+    from unittest.mock import MagicMock
+
+    def chunk(reasoning=None, content=None):
+        delta = type(
+            "D", (), {"content": content, "reasoning": reasoning, "tool_calls": None}
+        )()
+        choice = type("C", (), {"delta": delta, "finish_reason": None, "index": 0})()
+        return type("K", (), {"choices": [choice], "usage": None, "model": "m"})()
+
+    client = MagicMock()
+    client.chat.completions.create.return_value = iter(
+        [chunk(reasoning="STEP_ONE"), chunk(content="answer")]
+    )
+
+    provider = get_provider_class("groq")(api_key="sk-test")
+    thinking: list[str] = []
+    with patch.object(type(provider), "client", property(lambda self: client)):
+        result = provider.chat_stream_response(
+            [{"role": "user", "content": "hi"}], on_thinking_chunk=thinking.append
+        )
+
+    assert "STEP_ONE" in "".join(thinking), "delta.reasoning never reached the callback"
+    assert result.reasoning_content == "STEP_ONE"
+
+
+# --- the Responses wire, which reports the same numbers differently -------
+
+
+def test_responses_usage_parts_reconstruct_the_prompt() -> None:
+    """`input_tokens` on the Responses wire also INCLUDES the cached prefix.
+
+    It recorded the hit alongside the untouched total, so the two
+    double-counted: every consumer sums input + cache_creation + cache_read,
+    and a 2613-token prompt with a 2560-token hit reported 5173. That billed
+    the cached portion at BOTH rates and inflated the prompt size
+    `get_pricing` uses to pick a tier — which for gpt-5.6-luna can cross the
+    272K boundary and select the wrong one.
+
+    Since #783 routes by model, one OpenAIProvider can use either wire, so
+    the two must agree on what the numbers mean.
+    """
+    from src.providers.openai_responses import build_usage_dict
+
+    usage = build_usage_dict(
+        {
+            "input_tokens": 2613,
+            "output_tokens": 8,
+            "total_tokens": 2621,
+            "input_tokens_details": {"cached_tokens": 2560},
+        },
+        subscription=False,
+    )
+    assert usage["input_tokens"] == 53
+    assert usage["cache_read_input_tokens"] == 2560
+    parts = (
+        usage["input_tokens"]
+        + usage.get("cache_creation_input_tokens", 0)
+        + usage["cache_read_input_tokens"]
+    )
+    assert parts == 2613, f"parts sum to {parts}, not the real prompt"
+
+
+def test_both_wires_report_the_same_split_for_the_same_turn() -> None:
+    """Chat Completions and Responses must not disagree about one turn."""
+    from src.providers.openai_responses import build_usage_dict
+
+    chat = get_provider_class("groq")(api_key="sk-test")._build_usage_dict(
+        _usage(2613, cached=2560)
+    )
+    responses = build_usage_dict(
+        {
+            "input_tokens": 2613,
+            "output_tokens": 50,
+            "total_tokens": 2663,
+            "input_tokens_details": {"cached_tokens": 2560},
+        },
+        subscription=False,
+    )
+    for key in ("input_tokens", "cache_read_input_tokens", "cache_creation_input_tokens"):
+        assert chat[key] == responses[key], key
+
+
+def test_responses_usage_without_a_cache_hit_is_unchanged() -> None:
+    from src.providers.openai_responses import build_usage_dict
+
+    assert build_usage_dict(
+        {"input_tokens": 100, "output_tokens": 5, "total_tokens": 105},
+        subscription=False,
+    ) == {"input_tokens": 100, "output_tokens": 5, "total_tokens": 105}
+
+
+@pytest.mark.parametrize("bad", [float("inf"), float("-inf"), float("nan")])
+def test_a_non_finite_cache_count_cannot_kill_the_turn(bad: float) -> None:
+    """`int(float('inf'))` raises OverflowError, an ArithmeticError.
+
+    It therefore slipped past a `ValueError`-only except and escaped both
+    usage builders, ending the turn. Reachable rather than theoretical:
+    stdlib `json.loads` accepts a bare `Infinity` literal, so a vendor
+    emitting one would take the session down over a usage number.
+    """
+    from src.providers.openai_responses import build_usage_dict
+
+    base = get_provider_class("groq")(api_key="sk-test")._build_usage_dict(
+        _usage(100, cached=bad, as_dict=True)
+    )
+    responses = build_usage_dict(
+        {
+            "input_tokens": 100,
+            "output_tokens": 1,
+            "total_tokens": 101,
+            "input_tokens_details": {"cached_tokens": bad},
+        },
+        subscription=False,
+    )
+    # survives, and claims no cache rather than inventing one
+    for usage in (base, responses):
+        assert usage["input_tokens"] == 100
+        assert "cache_read_input_tokens" not in usage


### PR DESCRIPTION
Four cross-provider follow-ups deferred from #783 and #784. All were **silent** — nothing errored, the numbers and the transcript were just wrong.

## Cached prompt tokens were billed at the full input rate

`prompt_tokens` on the OpenAI-compatible wire **includes** tokens served from the prompt cache, with the cached count reported separately under `prompt_tokens_details.cached_tokens`. The base usage builder read only the total, so every cached token was priced as fresh input and cache hit-rate was invisible.

Both builders now split onto the convention `compute_cost` already understands: `input_tokens` = miss, `cache_read_input_tokens` = hit, `cache_creation_input_tokens` = 0. Every pricing tier already carried a `cache_read` rate, and two of them said in comments that the rate was inert *"for when that lands"*. This is that.

**Measured live against DeepSeek**: a 2613-token prompt returned as 53 miss / 2560 hit. Pricing that turn without the split over-reports it **7.5x** for `openai/gpt-5.6-luna` and **29x** for `deepseek-v4-pro`.

Three interactions had to be fixed alongside it:

- **DeepSeek double-subtracted.** Its override calls `super()` then does its own `prompt_tokens - hit`. With the base splitting first, that ran twice and drove billable input to **zero** — under-reporting cost on the provider whose prefix cache fires nearly every turn.
- **The Responses wire double-counted.** It recorded the hit alongside an untouched `input_tokens`, so a 2613-token prompt reported **5173**. That billed the cached portion at *both* rates and inflated the prompt size `get_pricing` uses to pick a tier — which for gpt-5.6-luna can cross the 272K boundary. Since #783 routes by model, one `OpenAIProvider` can take either wire, so the two agreeing is now a tested invariant.
- **`agent_server._usage_token_total`** ignored the cache fields already present in the snapshot it reads — an under-count of 98% of the prompt on a warm cache.

Both builders reject a non-numeric `cached_tokens` rather than coercing it: `int()` accepts anything with `__int__`, so a `MagicMock` usage stub yielded `1` and invented a one-token cache hit. `bool` is excluded because it's an `int` subclass and `True` would read as a cached token. They also catch `OverflowError`, which descends from `ArithmeticError` and slipped past a `ValueError`-only guard — stdlib `json.loads` accepts a bare `Infinity`, so a vendor emitting one ended the turn.

## OpenRouter reasoning was discarded entirely

Verified live: a streamed `openai/gpt-5.6-luna` turn over OpenRouter carries `delta.reasoning` and `delta.reasoning_details`, and **no `reasoning_content` key at all**. Both extraction sites read only `reasoning_content`, so every reasoning token from the provider this repo's benchmarks run on was dropped. Reading either name recovers it — 336 characters across 71 thinking chunks on the same prompt.

`reasoning_details` is deliberately not read: it repeats the same text in a shape nothing downstream consumes, and arrives as `reasoning: None` when the trace is encrypted.

## Gemini strips ChatGPT replay blocks explicitly

**This is defence in depth, not a bug fix.** The converter's `if parts:` guard already drops a message whose blocks all fell through its if/elif chain, so the observable result is identical — I checked, after initially believing otherwise. The point is that the correctness stops depending on two implicit fallthroughs: adding an `else` branch or a placeholder part would otherwise start forwarding replay items to Gemini silently. The test says outright that removing the strip does not fail it, and why that's expected.

## README provider list

Listed 25 against an actual 30. A test now asserts the list equals `PROVIDER_INFO` so it can't drift again.

## Deferred, and why

`agent_loop_compat.py`'s cumulative `result.usage` aggregator drops the cache keys, and `compute_session_cost`'s advisor branch passes none. Both are **pre-existing and documented as such in the code** — they were already wrong for Anthropic and DeepSeek, whose wires are natively split. This change widens their blast radius to OpenAI-compatible providers rather than creating the defect, and fixing the aggregator is a contract change to stream-json. `logging.py`'s `NonNullableUsage.total_tokens` and `status_line_command`'s context bar share the gap with no production caller today.

## Verification

- Full suite **9572 passed, 0 failed**.
- Live: DeepSeek cache split, OpenRouter reasoning capture, OpenRouter's raw stream shape.
- Mutation-tested throughout. Three mutants that survived a first pass drove real fixes — both reasoning **call sites** were untested (the helper was tested, the wire between wasn't), and the Responses fix was itself untested.
- `test_usage_dict_marks_subscription_billing` was **asserting the bug** (10 + 4 for a 10-token prompt); corrected to pin the invariant that the parts reconstruct the prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)