### PR TITLE
feat(eval): let harbor runs use a fusion model, and fix the dead forward_keys opt-out

### DIFF
--- a/eval/harbor/clawcodex_agent.py
+++ b/eval/harbor/clawcodex_agent.py
@@ -49,6 +49,16 @@ API keys reach the container two ways, either is sufficient:
 
 Agent kwargs (``--ak key=value``):
 
+* ``fusion`` — run a FUSION model: a text-only base plus a borrowed
+  vision model, as ``<base>+<vision>`` with each side ``provider:model``
+  (e.g. ``fusion=deepseek:deepseek-v4-flash+openai:gpt-5.6-luna``). Pair
+  it with ``--model <fusion-name>``; the seeded record is named after that
+  so clawcodex can resolve the selector. Needed because a fusion model
+  lives in the user's global config rather than being addressable as
+  ``provider/model``, so a fresh container cannot resolve one otherwise.
+  The name carries no ``/``, which leaves the env allowlist on its
+  all-providers fallback — required here, since a fusion run legitimately
+  needs two vendors' keys at once.
 * ``max_turns`` — clawcodex ``--max-turns`` (default 300 here; the CLI's
   own default of 50 is too low for terminal-bench tasks). The
   ``CLAWCODEX_MAX_TURNS`` host env var works as a fallback.
@@ -322,6 +332,8 @@ class Clawcodex(BaseInstalledAgent):
         logs_dir: Path,
         subscription: bool | str = False,
         source: str | None = None,
+        fusion: str | None = None,
+        forward_keys: bool | str = True,
         *args,
         **kwargs,
     ):
@@ -329,6 +341,20 @@ class Clawcodex(BaseInstalledAgent):
 
         self._subscription = parse_bool_env_value(subscription, name="subscription")
         self._source = source
+        # Explicit constructor kwargs, NOT CLI_FLAGS entries: both are config
+        # inputs with no clawcodex flag behind them, and every CLI_FLAGS entry
+        # is emitted into the command by ``build_cli_flags()``. Declaring them
+        # there would pass ``--fusion ...`` to clawcodex, which rejects it.
+        #
+        # ``forward_keys`` was previously read from ``_resolved_flags`` while
+        # being declared nowhere. ``_resolve_flag_values`` only walks
+        # ``CLI_FLAGS``, so the value never arrived and the documented
+        # ``--ak forward_keys=false`` opt-out silently did nothing — keys were
+        # forwarded regardless. Same silent-drop that made ``fusion=`` a no-op
+        # on its first run: an undeclared ``--ak`` key is accepted without
+        # complaint and discarded.
+        self._fusion = fusion
+        self._forward_keys = parse_bool_env_value(forward_keys, name="forward_keys")
         super().__init__(logs_dir, *args, **kwargs)
         if self._source and self._version:
             raise ValueError(
@@ -498,11 +524,7 @@ class Clawcodex(BaseInstalledAgent):
         Values travel to the container through the exec ENV, never the command
         string, so they stay out of process listings and Harbor's logs.
         """
-        if str(self._resolved_flags.get("forward_keys", "true")).lower() in (
-            "false",
-            "0",
-            "no",
-        ):
+        if not self._forward_keys:
             return {}
         path = Path.home() / ".clawcodex" / "config.json"
         try:
@@ -516,6 +538,47 @@ class Clawcodex(BaseInstalledAgent):
             for k, v in block.items()
             if isinstance(v, (str, int, float)) and str(v).strip()
         }
+
+    def _fusion_record(self) -> dict[str, str] | None:
+        """The ``fusionModels`` entry for a ``fusion=`` run, or None.
+
+        A fusion model is a text-only base plus a borrowed vision model, and
+        it lives in the user's GLOBAL config rather than being addressable as
+        ``provider/model`` — so a fresh container cannot resolve one no matter
+        what ``--model`` says. Seeding the record is what makes
+        ``--model <fusion-name>`` mean anything in there.
+
+        Named after ``--model`` so the two cannot drift: the record's name IS
+        the selector clawcodex looks up.
+
+        Note the key forwarding this relies on. ``--model <fusion-name>`` has
+        no ``provider/`` prefix, so ``_parsed_model_provider`` is empty and
+        the env allowlist falls back to ALL providers — which is required
+        here and only here, because a fusion run legitimately needs two
+        vendors' keys at once (the base's and the vision model's).
+        """
+        raw = str(self._fusion or "").strip()
+        if not raw:
+            return None
+        name = (self._parsed_model_name or "").strip()
+        if not name:
+            raise ValueError(
+                "fusion= requires --model <fusion-name>; the seeded record is "
+                "named after it so clawcodex can resolve the selector"
+            )
+        base, sep, vision = raw.partition("+")
+        if not sep or not base.strip() or not vision.strip():
+            raise ValueError(
+                "fusion= must be '<base>+<vision>', each as <provider>:<model> "
+                "(e.g. fusion=deepseek:deepseek-v4-flash+openai:gpt-5.6-luna); "
+                f"got {raw!r}"
+            )
+        for part in (base, vision):
+            if ":" not in part:
+                raise ValueError(
+                    f"fusion= selector {part.strip()!r} must be <provider>:<model>"
+                )
+        return {"name": name, "base": base.strip(), "vision": vision.strip()}
 
     async def _seed_container_settings(
         self,
@@ -552,6 +615,16 @@ class Clawcodex(BaseInstalledAgent):
         env_block = self._host_env_keys()
         if env_block:
             config["env"] = env_block
+        fusion = self._fusion_record()
+        if fusion:
+            config["fusionModels"] = [fusion]
+            # The fusion's BASE provider also becomes the session default.
+            # Provider resolution runs BEFORE the fusion name is looked up:
+            # with no default configured, clawcodex falls back to anthropic
+            # and dies on its missing key without ever reaching the fusion
+            # record. Seeding the base provider is also semantically right —
+            # the base model is the one that runs the loop.
+            config["default_provider"] = fusion["base"].split(":", 1)[0]
         if not config:
             return
         payload = json.dumps(config)

--- a/tests/test_harbor_adapter_fusion.py
+++ b/tests/test_harbor_adapter_fusion.py
@@ -1,0 +1,130 @@
+"""Fusion-model wiring in the harbor eval adapter.
+
+SKIPPED IN CI. ``eval/harbor/clawcodex_agent.py`` imports ``harbor`` at
+module scope, and harbor is not a dev dependency — it is installed as a
+separate uv tool by the people who run evals. So these assertions run for
+them and nowhere else, which is worth knowing before treating a green CI as
+coverage of this file. The adapter had no tests at all before this.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("harbor", reason="harbor is an eval-only tool dependency")
+
+_ADAPTER_DIR = Path(__file__).resolve().parents[1] / "eval" / "harbor"
+if str(_ADAPTER_DIR) not in sys.path:
+    sys.path.insert(0, str(_ADAPTER_DIR))
+
+from clawcodex_agent import Clawcodex  # noqa: E402
+
+
+def _agent(fusion: str | None, model: str = "deepseek-v4-flash-luna") -> Clawcodex:
+    """An adapter instance with just the fields the record builder reads."""
+    agent = Clawcodex.__new__(Clawcodex)
+    agent._fusion = fusion
+    agent._parsed_model_name = model
+    return agent
+
+
+def test_a_valid_pairing_becomes_a_seedable_record() -> None:
+    record = _agent("deepseek:deepseek-v4-flash+openai:gpt-5.6-luna")._fusion_record()
+    assert record == {
+        "name": "deepseek-v4-flash-luna",
+        "base": "deepseek:deepseek-v4-flash",
+        "vision": "openai:gpt-5.6-luna",
+    }
+
+
+def test_the_record_is_what_clawcodex_can_actually_load() -> None:
+    """The seeded JSON must satisfy clawcodex's own parser.
+
+    The adapter writes this straight into the container's global config; if
+    the shape drifts, the container silently resolves no fusion model and
+    falls back to the default provider — which is how this first failed.
+    """
+    from src.providers.fusion_models import fusion_model_from_json
+
+    record = _agent("deepseek:deepseek-v4-flash+openai:gpt-5.6-luna")._fusion_record()
+    model = fusion_model_from_json(record)
+    assert model is not None
+    assert model.base.selector == "deepseek:deepseek-v4-flash"
+    assert model.vision.selector == "openai:gpt-5.6-luna"
+
+
+def test_no_fusion_kwarg_seeds_nothing() -> None:
+    assert _agent(None)._fusion_record() is None
+    assert _agent("")._fusion_record() is None
+
+
+def test_the_record_is_named_after_the_model_flag() -> None:
+    """`--model <name>` IS the selector clawcodex looks up, so they must match."""
+    record = _agent(
+        "deepseek:deepseek-v4-flash+openai:gpt-5.6-luna", model="my-fusion"
+    )._fusion_record()
+    assert record["name"] == "my-fusion"
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "deepseek:deepseek-v4-flash",  # no +vision
+        "+openai:gpt-5.6-luna",  # no base
+        "deepseek:deepseek-v4-flash+",  # no vision
+        "deepseek-v4-flash+openai:gpt-5.6-luna",  # base missing provider:
+        "deepseek:deepseek-v4-flash+gpt-5.6-luna",  # vision missing provider:
+    ],
+)
+def test_a_malformed_pairing_fails_loudly(bad: str) -> None:
+    """Loudly, because the alternative is a silent fallback.
+
+    An undeclared or unparsed value here does not error at the container —
+    it just leaves no fusion record, and the run proceeds against the
+    default provider looking superficially fine.
+    """
+    with pytest.raises(ValueError):
+        _agent(bad)._fusion_record()
+
+
+def test_the_two_malformed_shapes_report_different_causes() -> None:
+    """A wrong SHAPE and a wrong SELECTOR need different messages.
+
+    Both are rejected either way — the `":" in part` check alone catches
+    every malformed case — so the shape check earns its place purely by
+    telling the operator which mistake they made. Without this assertion it
+    is an equivalent mutant and reads as dead code.
+    """
+    with pytest.raises(ValueError, match=r"<base>\+<vision>"):
+        _agent("deepseek:deepseek-v4-flash")._fusion_record()
+
+    with pytest.raises(ValueError, match=r"must be <provider>:<model>"):
+        _agent("deepseek-v4-flash+openai:gpt-5.6-luna")._fusion_record()
+
+
+def test_fusion_without_a_model_flag_fails_loudly() -> None:
+    with pytest.raises(ValueError, match="requires --model"):
+        _agent("deepseek:deepseek-v4-flash+openai:gpt-5.6-luna", model="")._fusion_record()
+
+
+def test_fusion_and_forward_keys_are_declared_constructor_kwargs() -> None:
+    """Not CLI_FLAGS entries — that distinction is load-bearing.
+
+    `_resolve_flag_values` only walks `CLI_FLAGS`, so an undeclared `--ak`
+    key is accepted and discarded without complaint. `forward_keys` was read
+    from `_resolved_flags` while declared nowhere, which made the documented
+    `--ak forward_keys=false` opt-out a no-op. Declaring them in `CLI_FLAGS`
+    instead is not the fix: `build_cli_flags()` emits every entry, so
+    clawcodex would be passed a `--fusion` flag it rejects.
+    """
+    import inspect
+
+    params = inspect.signature(Clawcodex.__init__).parameters
+    assert "fusion" in params
+    assert "forward_keys" in params
+    assert not any(
+        flag.kwarg in {"fusion", "forward_keys"} for flag in Clawcodex.CLI_FLAGS
+    )


### PR DESCRIPTION
A **fusion model** — a text-only base plus a borrowed vision model — lives in the user's *global* config and is selected by name. It is not addressable as `provider/model`, so a fresh eval container could not resolve one no matter what `--model` said, and vision tasks were unrunnable on a text-only base.

```bash
--model deepseek-v4-flash-luna \
--ak fusion=deepseek:deepseek-v4-flash+openai:gpt-5.6-luna
```

The record is seeded into the container's global config, named after `--model` so the two cannot drift: that name **is** the selector clawcodex looks up.

## Two things beyond the record itself

**`default_provider` is seeded from the fusion's BASE provider.** Provider resolution runs *before* the fusion name is looked up, so with no default configured clawcodex fell back to anthropic and died on its missing key without ever reaching the record — the run looked like a credentials problem rather than a routing one. Seeding the base is also semantically right: the base model runs the loop.

**Key forwarding already works, but by an accident worth recording.** A fusion name carries no `provider/` prefix, so `_parsed_model_provider` is empty and the env allowlist falls back to *all* providers — required here and only here, because a fusion run legitimately needs two vendors' keys at once.

## The `CLI_FLAGS` distinction is load-bearing in both directions

`fusion` and `forward_keys` are explicit constructor kwargs, **not** `CLI_FLAGS` entries:

- `_resolve_flag_values` only walks `CLI_FLAGS`, so an undeclared `--ak` key is accepted and **silently discarded**. That is why the first run of this feature was a no-op — and why **`--ak forward_keys=false` has been doing nothing since it was documented**: it was read from `_resolved_flags` while declared nowhere, so keys were forwarded regardless of the opt-out. Fixed here.
- Declaring them in `CLI_FLAGS` is not the fix either: `build_cli_flags()` emits every entry, so clawcodex would be handed a `--fusion` flag it rejects.

## Verified end to end

terminal-bench 2.1 `code-from-image` — transcribe handwritten pseudocode from a PNG and reproduce its output:

- **reward 1.0** with `deepseek-v4-flash` + `openai:gpt-5.6-luna`, matching the opus-5 baseline on that task.
- Attributable to the fusion path, not the base coping: `deepseek-v4-flash` alone returns `400 unknown variant image_url` on the same image.
- The trajectory is `Read /app/code.png` → `Bash python3 …SALT = b'0000TBENCH-SALT'…` → `Write output.txt`, with the salt transcribed **verbatim** and no OCR tool involved.
- The vision leg is first-party OpenAI on an API key (`subscription_active: False`, `api.openai.com/v1/responses`) — not OpenRouter, not the ChatGPT plan.

## Tests are SKIPPED IN CI

`clawcodex_agent.py` imports `harbor` at module scope, and harbor is not a dev dependency — it is a separate uv tool installed by whoever runs evals. So these assertions run for them and nowhere else, which is worth knowing before reading a green CI as coverage of this file. **The adapter had no tests at all before this.** Verified passing under harbor's environment (12 tests), and mutation-tested against the two defects actually hit — the silent `--ak` drop and the record name drifting from `--model` — plus the shape-validation and `forward_keys` paths.

Full suite: **9587 passed, 0 failed** (the 4th skip is this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)