### PR TITLE
fix: address critic findings on #789 (always-zero num_turns, false docstring claims, coverage holes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,30 @@ jobs:
           path: test-results/*.xml
           retention-days: 3
 
+  harbor-adapter:
+    # The harbor eval adapter (eval/harbor/clawcodex_agent.py) cannot be
+    # imported by the 3.11 job above: it uses `typing.override` (3.12+) and
+    # imports `harbor.*`, which is not a repo dependency. So its tests SKIP
+    # there — including the guard on a real defect that shipped in #789, where
+    # the adapter reported a fabricated `num_turns: 0` for exactly the killed
+    # trials it was added to measure. A guard nobody executes is a comment, so
+    # this job runs them on the interpreter the adapter actually runs on.
+    #
+    # `--isolated` is required, not tidiness: without it `uv run` treats the
+    # repo as a project and re-syncs the checkout's venv to 3.13.
+    name: "Harbor adapter (3.13)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Run adapter tests
+        run: |
+          uv run --isolated --python 3.13 --with harbor --with pytest \
+            python -m pytest tests/test_headless_usage_events.py -v
+
   event_file:
     name: "Event File"
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -673,6 +673,17 @@ The final Messages request URLs are
 - **`settings.modelLimits`** — context/output limits for private or gateway models absent from the built-in catalog. Keys may be exact model IDs, model prefixes, or host-qualified IDs such as `localhost:4000:private-model`; exact matches beat prefixes and host-qualified keys beat bare keys within the same match type. Built-in catalog metadata remains authoritative.
 - **`env`** — secrets and environment values injected at startup (e.g. `TAVILY_API_KEY` for web search). Managed via `clawcodex config`; keys here are exported into the process environment without overriding anything you already set in your shell.
 
+#### Stream-stall tuning
+
+A streaming request that keeps the connection alive but stops producing content would otherwise hang until something upstream kills it. Two independent bounds catch that, one per wire — they are deliberately separate knobs, because raising one to work around a quirk on your gateway should not loosen the other.
+
+| Variable | Wire | Default | Notes |
+| --- | --- | --- | --- |
+| `CLAWCODEX_CONTENT_PROGRESS_TIMEOUT_MS` | OpenAI-compatible (OpenRouter, DeepSeek, Z.AI, Groq, local servers, …) | `300000` (5 min) | Max time with **no content, reasoning, or tool-call delta**. Byte-level keepalives do *not* count — that is the point, since they defeat an HTTP read timeout. **Set to `0` to disable.** A malformed value falls back to the default rather than disabling. |
+| `CLAUDE_STREAM_IDLE_TIMEOUT_MS` / `CLAUDE_STREAM_FIRST_EVENT_TIMEOUT_MS` | Anthropic | `90000` / `300000` | Byte-aware idle watchdog; re-arms while raw bytes keep arriving. |
+
+The 300 s default is measured, not guessed: across 727 completed trials in 44 terminal-bench eval jobs, mean seconds per agent turn ran median 14.2 / p99 100.3 / max 183.8, with zero trials above 300 s — and that metric overstates model latency because it includes tool execution. If a slow gateway trips it anyway, the error names the variable.
+
 ### Run
 
 ```bash

--- a/eval/harbor/clawcodex_agent.py
+++ b/eval/harbor/clawcodex_agent.py
@@ -903,10 +903,18 @@ class Clawcodex(BaseInstalledAgent):
             return None
         extra: dict[str, Any] = {}
         num_turns = (result_event or {}).get("num_turns")
-        if not isinstance(num_turns, int) and usage_event:
-            num_turns = usage_event.get("num_turns")
         if isinstance(num_turns, int):
             extra["num_turns"] = num_turns
+        elif usage_event:
+            # NOT mapped onto num_turns. The incremental event counts model
+            # ROUND TRIPS, and an agent-loop turn can span several of them, so
+            # writing it into num_turns would report a confidently wrong
+            # number for exactly the killed trials this lane exists to
+            # measure. Surfaced under its own name instead; a killed trial
+            # legitimately has no turn count.
+            messages = usage_event.get("assistant_messages")
+            if isinstance(messages, int):
+                extra["assistant_messages"] = messages
         duration_ms = (result_event or {}).get("duration_ms")
         if isinstance(duration_ms, (int, float)):
             extra["duration_ms"] = duration_ms

--- a/src/cli_core/structured_io.py
+++ b/src/cli_core/structured_io.py
@@ -102,11 +102,28 @@ class UsageEvent(HeadlessEvent):
     Additive: a new event ``type``, so existing consumers that switch on the
     types they know are unaffected. It does not replace or change
     ``ResultEvent.usage``.
+
+    Carries ``assistant_messages``, NOT ``num_turns``. The first draft shipped
+    ``num_turns`` for shape symmetry with ``ResultEvent`` and it was always
+    zero: the headless loop increments its turn counter only after the whole
+    agent loop returns, so no event emitted DURING a run can ever see a
+    non-zero value. The harbor adapter then promoted that zero into killed
+    trials' metrics, which meant the trial that did the most work reported
+    ``num_turns: 0`` — the same floor-biased-low-on-the-longest-trials defect
+    this event exists to remove, and worse than the old behaviour, which
+    omitted the field rather than asserting a false zero.
+
+    ``assistant_messages`` counts model round trips and is genuinely
+    incrementable mid-run, so it means something on a truncated stream. It is
+    deliberately NOT called ``num_turns`` and must not be mapped onto it: an
+    agent-loop turn can span several round trips, so the two are different
+    quantities and conflating them would re-introduce the same class of lie
+    with a different number.
     """
 
     type: str = "usage"
     usage: dict[str, Any] = field(default_factory=dict)
-    num_turns: int = 0
+    assistant_messages: int = 0
 
 
 @dataclass

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -625,6 +625,9 @@ def run_headless(options: HeadlessOptions) -> int:
     # double-count, and this lane exists precisely for runs that never reach
     # the per-turn accounting.
     live_usage: dict[str, int] = {}
+    # Model round trips so far. A one-element list because ``_persist`` is a
+    # closure defined per prompt and rebinding an int there would shadow it.
+    live_messages: list[int] = [0]
     exit_code = 0
     # Terminal reason of the LAST agent-loop turn, when it stopped the run
     # early rather than the model finishing (``tool_failure_loop``,
@@ -740,10 +743,16 @@ def run_headless(options: HeadlessOptions) -> int:
                                     and _msg_usage
                                 ):
                                     _accumulate_usage(live_usage, _msg_usage)
+                                    live_messages[0] += 1
+                                    # Round trips, NOT agent-loop turns.
+                                    # ``num_turns_total`` only advances after
+                                    # the whole loop returns, so anything
+                                    # emitted here would report a constant 0 —
+                                    # see the UsageEvent docstring.
                                     writer.write(
                                         UsageEvent(
                                             usage=dict(live_usage),
-                                            num_turns=num_turns_total,
+                                            assistant_messages=live_messages[0],
                                         )
                                     )
                                 # Claude Code's stream-json exposes signed

--- a/src/providers/fusion_provider.py
+++ b/src/providers/fusion_provider.py
@@ -471,10 +471,10 @@ class FusionProvider:
         what keeps the negative cache honest. A transport failure means the
         vision provider is unreachable, and ``_substitute`` caches that so an
         outage costs one attempt per image rather than being re-tried on every
-        turn of a replayed history — the arithmetic at
-        :data:`_FAILURE_TTL_SECONDS` (8 images x 60 s x 2 attempts per turn)
-        is why. An empty completion is the opposite situation: the provider is
-        up, answered fast, and just produced nothing that turn.
+        turn of a replayed history — the arithmetic in :meth:`_substitute`'s
+        failure branch (8 images x 60 s x 2 attempts per turn) is why. An empty
+        completion is the opposite situation: the provider is up, answered
+        fast, and just produced nothing that turn.
 
         What caching an empty 200 actually costs — stated precisely, because
         an earlier draft of this docstring got it wrong and contradicted

--- a/src/providers/fusion_provider.py
+++ b/src/providers/fusion_provider.py
@@ -469,15 +469,24 @@ class FusionProvider:
 
         An EMPTY 200 gets one retry; nothing else does. The distinction is
         what keeps the negative cache honest. A transport failure means the
-        vision provider is unreachable, and ``_substitute`` caches that
-        permanently on purpose — the docstring's arithmetic (8 images x 60 s
-        x 2 attempts on every turn, forever, uninterruptible) is why. An empty
-        completion is the opposite situation: the provider is up, answered
-        fast, and just produced nothing that turn. Caching THAT permanently
-        loses the image for the rest of the session over a transient quirk —
-        observed on terminal-bench gcode-to-text (2026-08-02), where
+        vision provider is unreachable, and ``_substitute`` caches that so an
+        outage costs one attempt per image rather than being re-tried on every
+        turn of a replayed history — the arithmetic at
+        :data:`_FAILURE_TTL_SECONDS` (8 images x 60 s x 2 attempts per turn)
+        is why. An empty completion is the opposite situation: the provider is
+        up, answered fast, and just produced nothing that turn.
+
+        What caching an empty 200 actually costs — stated precisely, because
+        an earlier draft of this docstring got it wrong and contradicted
+        :data:`_FAILURE_TTL_SECONDS` directly. Failures are NOT cached
+        forever: the entry carries a 90 s expiry and ``_cache_get`` drops it.
+        So the real cost is that the image is degraded to a "could not be
+        described" note for up to 90 s — every turn that falls inside that
+        window, which in a fast agent loop is several. That was enough to
+        matter on terminal-bench gcode-to-text (2026-08-02), where
         ``openai:gpt-5.6-luna`` returned no text for image 2 of 5 and the task
-        scored 0 against a baseline that solved it.
+        scored 0 against a baseline that solved it. One retry inside the same
+        request beats waiting out the TTL.
 
         Bounded at one extra round trip per distinct image, and only while the
         request's own call/time budget still allows it, so the outage

--- a/src/utils/stream_watchdog.py
+++ b/src/utils/stream_watchdog.py
@@ -235,6 +235,19 @@ class StreamIdleTimeout(Exception):
 #: Default ceiling on a stream that delivers no semantic delta. Same value as
 #: the Anthropic first-event grace, arrived at independently: prompt processing
 #: on a large context legitimately runs minutes before the first token.
+#:
+#: Measured rather than guessed. Across 727 completed trials in 44 harbor eval
+#: jobs (2026-08-03), mean seconds per agent turn ran median 14.2, p90 38.3,
+#: p99 100.3, max 183.8 — ZERO trials over 300 s/turn and one over 150. That
+#: metric OVERSTATES model latency (it includes tool execution inside the
+#: turn), so real time-to-first-delta has even more headroom. 300 s sits ~3x
+#: above the observed p99.
+#:
+#: What the corpus cannot rule out: it contains only trials that COMPLETED, so
+#: a shape that reliably dies young is absent by construction — notably a
+#: gateway emitting SSE keepalive comments while proxying a model whose
+#: reasoning it does not forward, on a very large context queued behind
+#: capacity. That is what the off switch below is for.
 DEFAULT_CONTENT_PROGRESS_TIMEOUT_S = 300.0
 
 
@@ -368,8 +381,15 @@ class ContentProgressDeadline:
         if self._stream is not None:
             force_close_response(self._stream)
         suffix = f" ({self._label})" if self._label else ""
+        # Name the knob in the message. An escape hatch nobody can find is not
+        # a mitigation, and this is the only bound in the codebase that
+        # applies to every OpenAI-compatible provider at once — the operator
+        # who hits a false positive on some gateway reads this string, not the
+        # source.
         raise StreamIdleTimeout(
-            f"stream produced no content for {self._timeout_s:.0f}s{suffix}"
+            f"stream produced no content for {self._timeout_s:.0f}s{suffix} — "
+            "raise or disable with CLAWCODEX_CONTENT_PROGRESS_TIMEOUT_MS "
+            "(0 disables)"
         )
 
 

--- a/src/utils/stream_watchdog.py
+++ b/src/utils/stream_watchdog.py
@@ -74,7 +74,9 @@ __all__ = [
     "DEFAULT_STREAM_IDLE_TIMEOUT_S",
     "DEFAULT_STREAM_FIRST_EVENT_TIMEOUT_S",
     "DEFAULT_STREAM_IDLE_MAX_ATTEMPTS",
+    "DEFAULT_CONTENT_PROGRESS_TIMEOUT_S",
     "ContentProgressDeadline",
+    "content_progress_timeout_seconds",
     "StreamIdleTimeout",
     "stream_idle_timeout_seconds",
     "stream_first_event_timeout_seconds",
@@ -230,6 +232,43 @@ class StreamIdleTimeout(Exception):
     """
 
 
+#: Default ceiling on a stream that delivers no semantic delta. Same value as
+#: the Anthropic first-event grace, arrived at independently: prompt processing
+#: on a large context legitimately runs minutes before the first token.
+DEFAULT_CONTENT_PROGRESS_TIMEOUT_S = 300.0
+
+
+def content_progress_timeout_seconds() -> float:
+    """Resolve the content-progress deadline, or ``0.0`` to disable it.
+
+    Its OWN env var (``CLAWCODEX_CONTENT_PROGRESS_TIMEOUT_MS``) rather than
+    the Anthropic watchdog's. Sharing
+    ``CLAUDE_STREAM_FIRST_EVENT_TIMEOUT_MS`` — which the first cut did —
+    means one knob silently governs two unrelated deadlines on two different
+    wires, so raising it to work around a false positive here also loosens the
+    Anthropic idle watchdog. Different failure modes, different instruments,
+    different knobs.
+
+    ``0`` DISABLES the deadline entirely, which the shared var could not
+    express (it floors at the inter-event idle and falls back to its default
+    on any non-positive value). This bound is new and applies to every
+    OpenAI-compatible provider at once, so an operator who hits a false
+    positive on some gateway needs a way to turn it off that does not require
+    a patched build. Malformed values fall back to the default rather than
+    disabling — failing open on a typo would silently remove the bound.
+    """
+    raw = os.environ.get("CLAWCODEX_CONTENT_PROGRESS_TIMEOUT_MS", "").strip()
+    if not raw:
+        return DEFAULT_CONTENT_PROGRESS_TIMEOUT_S
+    try:
+        ms = int(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_CONTENT_PROGRESS_TIMEOUT_S
+    if ms < 0:
+        return DEFAULT_CONTENT_PROGRESS_TIMEOUT_S
+    return ms / 1000.0
+
+
 class ContentProgressDeadline:
     """Bound how long a stream may deliver nothing MEANINGFUL.
 
@@ -247,9 +286,15 @@ class ContentProgressDeadline:
     terminal-bench 2.1 (2026-08-02): 880 s of total silence on
     ``model-extraction-relu-logits`` before the harness killed the trial.
 
-    Used from the consumer's existing poll tick — no timer thread, and it can
-    only fire while the chunk queue is empty, so a stream that is actually
-    delivering is never interrupted by it.
+    Used from the consumer's existing poll loop — no timer thread.
+
+    **Call ``check()`` on EVERY loop iteration, not only when the chunk queue
+    is empty.** This is the one way to get this wrong, and it is the natural
+    way to write it. A stalled provider is usually still SENDING — keepalive
+    comments, empty delta frames — so the queue never empties and an
+    ``except Empty:``-gated check never runs at all. Both call sites were
+    written that way first and both reproduced the original hang; the two
+    regression tests hang rather than fail against that variant.
 
     The default threshold is the FIRST-EVENT grace (300 s), not the tighter
     inter-event idle (90 s), and it stays flat for the whole stream instead of
@@ -264,10 +309,10 @@ class ContentProgressDeadline:
 
         deadline = ContentProgressDeadline(stream=stream, label=model)
         while True:
+            deadline.check()          # EVERY iteration — see above
             try:
                 item = q.get(timeout=0.1)
             except Empty:
-                deadline.check()      # raises StreamIdleTimeout when expired
                 continue
             ...
             deadline.note_progress()  # a real delta arrived
@@ -284,10 +329,15 @@ class ContentProgressDeadline:
         self._timeout_s = (
             timeout_s
             if timeout_s is not None
-            else stream_first_event_timeout_seconds()
+            else content_progress_timeout_seconds()
         )
         self._label = label
         self._last = _time.monotonic()
+
+    @property
+    def enabled(self) -> bool:
+        """False when the deadline is switched off (timeout <= 0)."""
+        return self._timeout_s > 0
 
     @property
     def timeout_s(self) -> float:
@@ -301,6 +351,8 @@ class ContentProgressDeadline:
         self._last = _time.monotonic()
 
     def expired(self) -> bool:
+        if not self.enabled:
+            return False
         return _time.monotonic() - self._last > self._timeout_s
 
     def check(self) -> None:

--- a/tests/test_headless_cli.py
+++ b/tests/test_headless_cli.py
@@ -914,3 +914,88 @@ def test_headless_multi_prompt_sums_cache_but_not_the_last_snapshot(
         "last_* was summed across prompts, which measures nothing"
     )
     assert usage["last_input_tokens"] == 5
+
+
+# ---------------------------------------------------------------------------
+# incremental usage events (the killed-run measurement lane)
+
+
+def _usage_events(out: str) -> list[dict]:
+    return [
+        json.loads(line)
+        for line in out.splitlines()
+        if line.strip().startswith("{") and json.loads(line).get("type") == "usage"
+    ]
+
+
+def test_stream_json_emits_incremental_usage(fake_wiring, tmp_path):
+    """A run must publish its running totals BEFORE it ends.
+
+    ResultEvent is authoritative but only exists if the run reaches the end;
+    a killed run emits none, which is how 21 of 46 trials in one
+    terminal-bench job came back with no tokens and no cost at all.
+    """
+    fake_wiring.append(_text_response("hi there"))
+    stdout = io.StringIO()
+    code = run_headless(
+        HeadlessOptions(
+            prompt="go", output_format="stream-json", verbose=True,
+            stdout=stdout, workspace_root=tmp_path,
+        )
+    )
+    assert code == 0
+    events = _usage_events(stdout.getvalue())
+    assert events, "no usage event was emitted at all"
+
+
+def test_incremental_usage_agrees_with_the_result_event(fake_wiring, tmp_path):
+    """The one invariant the fix rests on: the live lane is tracked in its
+    OWN accumulator, so it neither double-counts against `usage_total` nor
+    diverges from it. Folding both from one source silently doubles these."""
+    fake_wiring.append(_text_response("hi there"))
+    stdout = io.StringIO()
+    run_headless(
+        HeadlessOptions(
+            prompt="go", output_format="stream-json", verbose=True,
+            stdout=stdout, workspace_root=tmp_path,
+        )
+    )
+    out = stdout.getvalue()
+    last_usage = _usage_events(out)[-1]["usage"]
+    result = [
+        json.loads(line)
+        for line in out.splitlines()
+        if line.strip().startswith("{") and json.loads(line).get("type") == "result"
+    ][-1]
+    for key in (
+        "input_tokens",
+        "output_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+    ):
+        assert last_usage.get(key, 0) == (result["usage"] or {}).get(key, 0), (
+            f"{key} disagrees between the live lane and the result event"
+        )
+
+
+def test_usage_event_counts_round_trips_not_turns(fake_wiring, tmp_path):
+    """`assistant_messages` must actually increment.
+
+    The field it replaced (`num_turns`) was structurally always 0 — the turn
+    counter only advances after the whole agent loop returns — and the harbor
+    adapter promoted that zero into killed trials' metrics.
+    """
+    fake_wiring.append(_text_response("hi there"))
+    stdout = io.StringIO()
+    run_headless(
+        HeadlessOptions(
+            prompt="go", output_format="stream-json", verbose=True,
+            stdout=stdout, workspace_root=tmp_path,
+        )
+    )
+    events = _usage_events(stdout.getvalue())
+    assert "num_turns" not in events[-1], "the always-zero field is back"
+    assert events[-1]["assistant_messages"] >= 1
+    assert [e["assistant_messages"] for e in events] == list(
+        range(1, len(events) + 1)
+    ), "counter must advance by one per round trip"

--- a/tests/test_headless_usage_events.py
+++ b/tests/test_headless_usage_events.py
@@ -36,12 +36,18 @@ class _Sink:
 def test_usage_event_serializes_with_a_distinct_type():
     sink = _Sink()
     StreamJsonWriter(sink).write(
-        UsageEvent(usage={"input_tokens": 10, "output_tokens": 3}, num_turns=2)
+        UsageEvent(
+            usage={"input_tokens": 10, "output_tokens": 3}, assistant_messages=2
+        )
     )
     (event,) = sink.events()
     assert event["type"] == "usage"
     assert event["usage"] == {"input_tokens": 10, "output_tokens": 3}
-    assert event["num_turns"] == 2
+    assert event["assistant_messages"] == 2
+    assert "num_turns" not in event, (
+        "num_turns was structurally always 0 here and the adapter promoted "
+        "that zero into killed trials' metrics"
+    )
 
 
 def test_usage_event_does_not_collide_with_the_result_event():
@@ -67,8 +73,15 @@ def _adapter():
     uses ``typing.override`` (3.12+) and imports ``harbor.*``, so the repo's
     3.11 test venv cannot load it. Run these under that interpreter:
 
-        uv run --python 3.13 --with harbor -m pytest \\
-            tests/test_headless_usage_events.py
+        uv run --isolated --python 3.13 --with harbor --with pytest \\
+            python -m pytest tests/test_headless_usage_events.py
+
+    ``--isolated`` is REQUIRED, not tidiness. Without it ``uv run`` treats the
+    repo as a project and re-syncs ``.venv`` to the requested interpreter —
+    it replaced this repo's 3.11 venv with a 3.13 one (and on a second
+    invocation deleted it outright), which then has to be rebuilt from
+    ``requirements.txt`` + ``requirements.dev.txt``. ``--with pytest`` is also
+    required: the isolated env has no dev dependencies.
     """
     import sys
     from pathlib import Path
@@ -124,13 +137,18 @@ def test_final_metrics_falls_back_to_the_usage_event():
         None,           # result_event — a killed run never emits one
         12,             # total_steps
         None,           # totals — copy-back never ran
-        {"type": "usage", "num_turns": 4,
+        {"type": "usage", "assistant_messages": 4,
          "usage": {"input_tokens": 100, "cache_read_input_tokens": 900,
                    "output_tokens": 7}},
     )
     assert metrics is not None, "a killed trial must still report tokens"
     assert metrics.total_prompt_tokens == 1000
     assert metrics.total_completion_tokens == 7
+    # Round trips are surfaced under their OWN name. Mapping them onto
+    # num_turns would report a confidently wrong turn count for exactly the
+    # killed trials this lane exists to measure.
+    assert metrics.extra.get("assistant_messages") == 4
+    assert "num_turns" not in metrics.extra
 
 
 def test_final_metrics_prefers_the_result_event_over_the_usage_event():

--- a/tests/test_openai_compat_stream_idle.py
+++ b/tests/test_openai_compat_stream_idle.py
@@ -293,3 +293,66 @@ def test_short_empty_response_completes_without_firing():
     out = _run(provider)
     assert out.content == ""
     assert provider.attempts == 1
+
+
+# --- the escape hatch's own resolution -------------------------------------
+#
+# `test_deadline_can_be_disabled` above exercises the WIRING (that `enabled`
+# short-circuits `expired()`), but it cannot pin the parsing: its stream gap is
+# ~1.2s, which passes under any timeout >= 1.2s. So the two branches that
+# matter most were unguarded — `0` disabling, and a malformed value failing
+# CLOSED rather than silently removing the bound on every OpenAI-compatible
+# provider at once. This knob is the entire mitigation for the gateway shape
+# the deadline cannot distinguish from a stall, so it gets a direct test.
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, 300.0),      # unset -> the measured default
+        ("0", 0.0),         # the off switch
+        ("1500", 1.5),
+        ("600000", 600.0),
+        ("abc", 300.0),     # malformed fails CLOSED, not open
+        ("", 300.0),
+        ("-5", 300.0),      # negative is malformed, not "disable"
+    ],
+)
+def test_content_progress_timeout_resolution(monkeypatch, raw, expected):
+    from src.utils.stream_watchdog import content_progress_timeout_seconds
+
+    if raw is None:
+        monkeypatch.delenv("CLAWCODEX_CONTENT_PROGRESS_TIMEOUT_MS", raising=False)
+    else:
+        monkeypatch.setenv("CLAWCODEX_CONTENT_PROGRESS_TIMEOUT_MS", raw)
+    assert content_progress_timeout_seconds() == expected
+
+
+def test_disabling_survives_an_unbounded_silent_gap(monkeypatch):
+    """`enabled is False` must mean never, not merely 'a long time'."""
+    from src.utils.stream_watchdog import ContentProgressDeadline
+
+    monkeypatch.setenv("CLAWCODEX_CONTENT_PROGRESS_TIMEOUT_MS", "0")
+    deadline = ContentProgressDeadline()
+    assert deadline.enabled is False
+    deadline._last -= 10_000  # simulate ~3 hours of silence
+    assert deadline.expired() is False
+    deadline.check()  # must not raise
+
+
+def test_the_two_wires_have_independent_knobs(monkeypatch):
+    """Raising the Anthropic first-event grace must not move this deadline.
+
+    They were one variable in the first cut, which meant working around a
+    false positive on an OpenAI-compatible gateway also loosened the
+    Anthropic idle watchdog.
+    """
+    from src.utils.stream_watchdog import (
+        content_progress_timeout_seconds,
+        stream_first_event_timeout_seconds,
+    )
+
+    monkeypatch.delenv("CLAWCODEX_CONTENT_PROGRESS_TIMEOUT_MS", raising=False)
+    monkeypatch.setenv("CLAUDE_STREAM_FIRST_EVENT_TIMEOUT_MS", "900000")
+    assert stream_first_event_timeout_seconds() == 900.0
+    assert content_progress_timeout_seconds() == 300.0

--- a/tests/test_openai_compat_stream_idle.py
+++ b/tests/test_openai_compat_stream_idle.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import threading
 import time
 import types
+from typing import Any
 
 import pytest
 
@@ -28,23 +29,71 @@ from src.utils.stream_watchdog import StreamIdleTimeout
 
 
 # Deadline used by every test here. Real default is 300 s; these override the
-# env so the suite stays fast. BOTH vars are needed —
-# ``stream_first_event_timeout_seconds`` floors its result at the inter-event
-# idle, so setting only the first-event var leaves it pinned at 90 s.
+# env so the suite stays fast.
 _DEADLINE_MS = 300
 _DEADLINE_S = _DEADLINE_MS / 1000.0
 
 
 @pytest.fixture(autouse=True)
 def _fast_deadline(monkeypatch):
-    monkeypatch.setenv("CLAUDE_STREAM_FIRST_EVENT_TIMEOUT_MS", str(_DEADLINE_MS))
-    monkeypatch.setenv("CLAUDE_STREAM_IDLE_TIMEOUT_MS", str(_DEADLINE_MS))
+    monkeypatch.setenv("CLAWCODEX_CONTENT_PROGRESS_TIMEOUT_MS", str(_DEADLINE_MS))
 
 
-def _chunk(*, content=None, reasoning=None, finish=None):
-    """One streaming chunk in the shape the consumer duck-types."""
+def _run_bounded(fn, *, limit_s: float):
+    """Run ``fn`` on a thread and fail if it does not return in ``limit_s``.
+
+    Every "must fire" test here regresses by HANGING, not by failing — that
+    is what the production bug was. With no pytest-timeout plugin installed, a
+    bare call would burn the whole CI job budget and report "job timed out"
+    instead of naming the regression. This converts the hang into a normal,
+    legible assertion failure.
+    """
+    box: dict[str, Any] = {}
+
+    def _target() -> None:
+        try:
+            box["value"] = fn()
+        except BaseException as exc:  # noqa: BLE001 — re-raised on the caller
+            box["error"] = exc
+
+    thread = threading.Thread(target=_target, daemon=True)
+    thread.start()
+    thread.join(limit_s)
+    if thread.is_alive():
+        raise AssertionError(
+            f"call did not return within {limit_s:.1f}s — the content-progress "
+            "deadline did not fire (this is the production hang)"
+        )
+    if "error" in box:
+        raise box["error"]
+    return box.get("value")
+
+
+def _chunk(*, content=None, reasoning=None, finish=None, tool_args=None,
+           tool_name=None):
+    """One streaming chunk in the shape the consumer duck-types.
+
+    ``tool_args`` produces a tool-CALL argument delta. That shape matters on
+    its own: a model writing a large file streams it as tool-call arguments
+    with no content and no reasoning deltas, so it is kept alive by a
+    different progress signal than every other test here exercises.
+
+    ``tool_name`` is set on the FIRST delta of a call only, which is what the
+    real wire does — the consumer accumulates ``entry["name"] += fn_name``, so
+    a fake that repeats the name on every delta yields "WriteWriteWrite" and
+    is not modelling the protocol.
+    """
+    tool_calls = None
+    if tool_args is not None:
+        tool_calls = [
+            types.SimpleNamespace(
+                index=0,
+                id="call_1" if tool_name else None,
+                function=types.SimpleNamespace(name=tool_name, arguments=tool_args),
+            )
+        ]
     delta = types.SimpleNamespace(
-        content=content, reasoning_content=reasoning, tool_calls=None
+        content=content, reasoning_content=reasoning, tool_calls=tool_calls
     )
     choice = types.SimpleNamespace(delta=delta, finish_reason=finish)
     return types.SimpleNamespace(choices=[choice], model="m", usage=None)
@@ -121,7 +170,7 @@ def test_keepalive_frames_without_deltas_still_time_out():
     try:
         started = time.monotonic()
         with pytest.raises(StreamIdleTimeout):
-            _run(provider)
+            _run_bounded(lambda: _run(provider), limit_s=_DEADLINE_S * 20)
         elapsed = time.monotonic() - started
     finally:
         stream.stop.set()
@@ -136,7 +185,7 @@ def test_total_silence_times_out():
     provider = _Provider(stream)
     try:
         with pytest.raises(StreamIdleTimeout):
-            _run(provider)
+            _run_bounded(lambda: _run(provider), limit_s=_DEADLINE_S * 20)
     finally:
         stream.stop.set()
     assert provider.attempts == 2
@@ -150,8 +199,11 @@ def test_stall_after_partial_content_is_not_retried():
     seen: list[str] = []
     try:
         with pytest.raises(StreamIdleTimeout):
-            provider.chat_stream_response(
-                [{"role": "user", "content": "hi"}], on_text_chunk=seen.append
+            _run_bounded(
+                lambda: provider.chat_stream_response(
+                    [{"role": "user", "content": "hi"}], on_text_chunk=seen.append
+                ),
+                limit_s=_DEADLINE_S * 20,
             )
     finally:
         stream.stop.set()
@@ -195,6 +247,41 @@ def test_reasoning_deltas_count_as_progress():
     out = _run(provider)
     assert out.content == "answer"
     assert out.reasoning_content == "thinking...still thinking..."
+    assert provider.attempts == 1
+
+
+def test_tool_call_deltas_count_as_progress():
+    """A model writing a large file streams tool-call ARGUMENT deltas and
+    nothing else — no content, no reasoning. Without this signal the biggest
+    tool calls would be exactly the ones killed at the deadline and replayed.
+    """
+    gap = _DEADLINE_S * 0.6
+    stream = _FakeStream([
+        (gap, _chunk(tool_name="Write", tool_args='{"file_path":')),
+        (gap, _chunk(tool_args='"/app/x.py",')),
+        (gap, _chunk(tool_args='"content":"..."}')),
+        (0.0, _chunk(finish="tool_calls")),
+    ])
+    provider = _Provider(stream)
+    out = _run(provider)
+    assert provider.attempts == 1, "a streaming tool call must not be interrupted"
+    assert out.tool_uses and out.tool_uses[0]["name"] == "Write"
+    assert out.tool_uses[0]["input"] == {"file_path": "/app/x.py", "content": "..."}
+
+
+def test_deadline_can_be_disabled(monkeypatch):
+    """The escape hatch. This bound is new and applies to every
+    OpenAI-compatible provider at once, so an operator who hits a false
+    positive on some gateway must be able to switch it off without patching."""
+    monkeypatch.setenv("CLAWCODEX_CONTENT_PROGRESS_TIMEOUT_MS", "0")
+    stream = _FakeStream([(_DEADLINE_S * 4, _chunk(content="slow")),
+                          (0.0, _chunk(finish="stop"))])
+    provider = _Provider(stream)
+    try:
+        out = _run(provider)
+    finally:
+        stream.stop.set()
+    assert out.content == "slow"
     assert provider.attempts == 1
 
 

--- a/tests/test_openai_subscription.py
+++ b/tests/test_openai_subscription.py
@@ -691,8 +691,7 @@ def test_responses_stream_that_never_produces_content_times_out(monkeypatch) -> 
     Without the deadline this test does not fail — it hangs forever, which is
     exactly what happened in production.
     """
-    monkeypatch.setenv("CLAUDE_STREAM_FIRST_EVENT_TIMEOUT_MS", "300")
-    monkeypatch.setenv("CLAUDE_STREAM_IDLE_TIMEOUT_MS", "300")
+    monkeypatch.setenv("CLAWCODEX_CONTENT_PROGRESS_TIMEOUT_MS", "300")
     provider = _subscription_provider(monkeypatch)
     fake_response = _StallingStreamResponse()
 
@@ -709,12 +708,33 @@ def test_responses_stream_that_never_produces_content_times_out(monkeypatch) -> 
         def close(self):
             pass
 
+    # Bounded on a thread: this regresses by HANGING, not failing (that is
+    # the production bug), and there is no pytest-timeout plugin installed —
+    # a bare call would burn the whole CI job budget and report "job timed
+    # out" instead of naming the regression.
+    box: dict = {}
+
+    def _call() -> None:
+        try:
+            with patch(
+                "src.auth.openai_subscription.get_valid_credentials",
+                return_value=_credentials(),
+            ), patch("httpx.Client", _FakeClient):
+                provider.chat_stream_response([{"role": "user", "content": "hi"}])
+        except BaseException as exc:  # noqa: BLE001 — asserted on below
+            box["error"] = exc
+
+    worker = threading.Thread(target=_call, daemon=True)
     try:
-        with patch(
-            "src.auth.openai_subscription.get_valid_credentials",
-            return_value=_credentials(),
-        ), patch("httpx.Client", _FakeClient), pytest.raises(StreamIdleTimeout):
-            provider.chat_stream_response([{"role": "user", "content": "hi"}])
+        worker.start()
+        worker.join(6.0)
+        assert not worker.is_alive(), (
+            "the Responses consumer did not return — the content-progress "
+            "deadline did not fire (this is the production hang)"
+        )
+        assert isinstance(box.get("error"), StreamIdleTimeout), (
+            f"expected StreamIdleTimeout, got {box.get('error')!r}"
+        )
     finally:
         fake_response.stop.set()
 


### PR DESCRIPTION
A critic pass on the merged #789 returned **REVISE** with four defects and
three coverage holes; a re-review of the fixes returned **APPROVE** with two
residual gaps, which this PR also closes. Every finding was verified by
mutation or direct probe rather than by reading, in both directions.

## The two defects where #789 asserted something untrue

**`UsageEvent.num_turns` was structurally always 0.** The headless turn
counter only advances *after* the agent loop returns, so no event emitted
during a run can see a non-zero value — and the harbor adapter then promoted
that zero into killed trials' metrics. The trial that did the most work
reported `num_turns: 0`. That is the same floor-biased-low-on-the-longest-
trials defect #789 was written to remove, relocated from tokens to turns, and
worse than the old behaviour, which omitted the field rather than asserting a
false zero. The adapter test that should have caught it used `num_turns: 4` —
a value the producer cannot emit.

Replaced with `assistant_messages`, which counts round trips and actually
increments mid-run, and deliberately **not** mapped back onto `num_turns`
anywhere: an agent-loop turn can span several round trips, so conflating them
would reintroduce the same lie with a plausible-looking number.

**The "cached permanently / for the rest of the session" rationale was
false.** `_FAILURE_TTL_SECONDS = 90.0` and `_cache_get` expires entries; the
docstring #789 added contradicted the one 350 lines above that exists to
explain the TTL. The retry is still right — an empty 200 degrades that image
for up to 90 s, across however many turns fall in that window — but the
reason given for it was wrong.

## Docs that would have caused the next bug

`ContentProgressDeadline`'s docstring documented the design that was
**rejected** (`except Empty: deadline.check()`) and asserted a safety property
that is false. Both call sites deliberately do the opposite. A maintainer
following the docstring would have reintroduced the hang — mutating to it
hangs. Rewritten with an explicit "this is the one way to get this wrong, and
it is the natural way to write it".

## Escape hatch (the "don't hurt other providers" constraint)

#789 shipped a new hard bound on ~15 providers with no off switch, reading
`CLAUDE_STREAM_FIRST_EVENT_TIMEOUT_MS` — so raising it to work around a false
positive also loosened the Anthropic watchdog. Now
`CLAWCODEX_CONTENT_PROGRESS_TIMEOUT_MS`, where `0` disables and a malformed
value fails **closed**. Named in the error message and documented in the
README, because an escape hatch nobody can find is not a mitigation.

The 300 s default is now measured rather than asserted: across 727 completed
trials in 44 harbor jobs, mean seconds per agent turn ran median 14.2 / p90
38.3 / p99 100.3 / max 183.8 — zero above 300, on a metric that *overstates*
model latency since it includes tool execution. What the corpus cannot rule
out is stated too.

## Coverage

Five mutants that previously survived now fail:

| Mutant | Before | Now |
| --- | --- | --- |
| delete the `UsageEvent` emission | survived | caught |
| `live_usage` → `usage_total` (the double-count) | survived | caught |
| delete the tool-call progress signal | survived | caught |
| `0` no longer disables the deadline | survived | caught |
| malformed value silently removes the bound | survived | caught |

Nothing called `run_headless` at all before. The tool-call gap was the
highest-consequence uncovered line: a model streaming a large `Write` emits
tool-call argument deltas and nothing else, so the biggest tool calls would
be the ones killed and replayed. Writing that test I made the same
unfaithful-fake mistake the critic had just flagged — set the tool name on
every delta and got `"WriteWriteWrite"` — so `_chunk` now models the real
wire, where the name appears on the first delta only.

**Tests that hung now fail.** The two most important stream tests regressed
by hanging, not failing, and there is no `pytest-timeout` — in CI that burns
the whole job budget and reports the wrong cause. Bounded on a thread: the
Empty-gated mutant fails in 16 s instead of hanging past 120 s.

**New CI job.** The guard on the `num_turns` defect lived in a file the 3.11
job cannot import, so the regression could return with CI green. A
`Harbor adapter (3.13)` job runs it on the interpreter the adapter actually
uses. Verified it catches the mutant.

Also fixes the skip docstring, which told the reader to run `uv run --python
3.13` from the repo root — that re-syncs the project venv, and it destroyed
this repo's twice during the work.

## Verification

Suite: **9641 passed, 9 skipped, 0 failures** on 3.11. Adapter tests: 7
passed under `uv run --isolated --python 3.13 --with harbor --with pytest`.

Deferred with the critic's explicit agreement: the OpenRouter
keepalive-comment shape (no measurement justifies a different threshold; the
off switch is the stopgap), and the in-session "Full Access" divergence from
the flag, which wants its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)