### PR TITLE
fix(tui): drop the abandoned ScrollBox remount key

### DIFF
--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -104,27 +104,6 @@ const TranscriptPane = memo(function TranscriptPane({
         flexDirection="column"
         flexGrow={1}
         flexShrink={1}
-        // Remount on width change — inline mode only.
-        //
-        // Inline mode has no constrained-height root (ink lays the tree out
-        // with `calculateLayout(columns)`, height undefined), so the ScrollBox
-        // sizes to its content. Widening the terminal re-wraps every row
-        // shorter, but the box does NOT shrink with them: it keeps its
-        // pre-resize height and pads the difference with blank rows. Those
-        // blanks push the transcript above the terminal viewport, and the
-        // resize repaint's ERASE_SCROLLBACK (log-update fullReset →
-        // clearTerminal) wipes it from scrollback — so the whole transcript
-        // reads as gone, with only the composer left on screen.
-        //
-        // A fresh Yoga node has no prior layout to keep, so remounting is what
-        // actually re-measures. Marking the tree dirty is NOT enough (tested).
-        // Every transcript row already remounts on a width change (useMainApp
-        // keys virtualRows on `cols`), so this adds no new render cost.
-        //
-        // Fullscreen pins the root to terminalRows, so its ScrollBox can never
-        // drift — and keying there would throw away the user's scroll position
-        // on every resize.
-        key={INLINE_MODE ? composer.cols : undefined}
         onClick={(e: { cellIsBlank?: boolean }) => {
           if (e.cellIsBlank) {
             actions.clearSelection()


### PR DESCRIPTION
Follow-up to #775. Removes a dead-end fix of mine that reached `main` by accident.

## What happened

My first attempt at the resize-blanking bug keyed the transcript ScrollBox on `cols`, to force a fresh Yoga node on every width change. It worked on the repro, but the diagnosis behind it was wrong — the real cause is `TranscriptScrollbar` stretching the flex row from a stale `viewportHeight`, which #775 fixes at the source.

I abandoned the key, but it had already been swept into #774's `d350b1a9`, and that merged. So `main` currently carries both the real fix and the abandoned one.

## Why it has to go

It isn't just redundant:

- **Orphaned subscriptions.** Remounting the ScrollBox builds a new `listenersRef` Set behind `useImperativeHandle(..., [])`, while the three `useSyncExternalStore` subscribers (`useVirtualHistory`, `useViewportSnapshot`, `useScrollbarSnapshot`) have stable deps and never resubscribe. Every subscription ends up on the dead handle — on every resize. #775 added comments at those three call sites saying exactly this.
- **Cold start.** The remount resets the handle, so `getViewportHeight()` returns 0 and `useVirtualHistory` takes its `vp <= 0` branch: last 30 items only, behind a large blank `topSpacer`. On a long transcript that is worse than the bug being fixed.
- **The comment was wrong**, which is worse than no comment — it told the next reader the vendored Yoga port fails to re-measure and that marking the tree dirty is insufficient. Neither is true; both were tested and ruled out.

## Verification

- **PTY at 60 → 110 columns with the key removed:** blank rows 7/30 before, 7/30 after — matching #775's numbers. The guard alone is sufficient.
- **Suite:** 8 failed / 1681 passed across three runs, identical to `main`'s baseline (same 8 pre-existing failures). The resize regression test from #775 stays green.
- `tsc --noEmit` clean. The one eslint error in `appLayout.tsx` is a pre-existing import-order issue, present on pristine `main` and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)