### PR TITLE
fix(pricing): gpt-5.6-luna was priced at half its real rate

### DIFF
--- a/eval/harbor/advisor_cost.py
+++ b/eval/harbor/advisor_cost.py
@@ -4,11 +4,26 @@
 Harbor's ``result.json`` reports ``cost_usd`` from the session's
 ``total_cost_usd``, which sums ACTUAL BILLED cost. A subscription-backed
 advisor bills $0.00 per token, so an advisor run's headline cost is the
-WORKER'S cost alone — in one measured trial that understated the true
-economic cost by ~23x, because the reviewer was 92% of it.
+WORKER'S cost alone — on one 89-task run the reviewer was 87% of the
+economic cost and reported as free.
 
-Token counts are unaffected: n_input_tokens / n_output_tokens already
-combine every model. Only the dollar figure is misleading.
+Token counts are unaffected: ``n_input_tokens`` / ``n_output_tokens``
+already combine every model. Only the dollar figure misleads.
+
+PREFER THE BILLED FIGURE; RECOMPUTE ONLY WHAT BILLED $0
+-------------------------------------------------------
+``compute_cost`` picks a pricing tier from the prompt size of the record it
+is handed, because some models are context-tiered — ``gpt-5.6-luna`` doubles
+above 272K prompt tokens. ``model_usage`` has already aggregated individual
+requests away, so recomputing from it prices an entire session as one giant
+long-context request. Measured on an 89-task run: $4.96 recomputed vs $2.74
+actually billed.
+
+So this does NOT recompute what is already priced. ``cost_usd`` was computed
+per-REQUEST by the live agent and is the best figure available. Recomputation
+applies only where ``cost_usd`` is 0.00 because the model ran on a
+subscription — Anthropic today, which has no context tier, making aggregate
+pricing exact there.
 
 Usage:  python3 eval/harbor/advisor_cost.py <job-dir> [<job-dir> ...]
 """
@@ -16,11 +31,20 @@ import json
 import pathlib
 import sys
 
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
+
+
+def _blank() -> dict:
+    return {"in": 0, "out": 0, "cache_read": 0, "cache_create": 0,
+            "billed": 0.0, "listed": 0.0}
+
 
 def job_cost(job: pathlib.Path) -> dict:
+    from src.services.pricing import compute_cost
+
     per_model: dict[str, dict] = {}
-    billed = estimated = 0.0
-    trials = 0
+    billed = listed = 0.0
+    sessions = 0
     for s in job.rglob("sessions/*.json"):
         try:
             cost = json.loads(s.read_text()).get("cost") or {}
@@ -28,21 +52,109 @@ def job_cost(job: pathlib.Path) -> dict:
             continue
         if not cost:
             continue
-        trials += 1
+        sessions += 1
         billed += float(cost.get("total_cost_usd") or 0.0)
-        estimated += float(cost.get("estimated_cost_usd") or 0.0)
         for model, u in (cost.get("model_usage") or {}).items():
-            acc = per_model.setdefault(
-                model, {"in": 0, "out": 0, "cache_read": 0, "cache_create": 0}
-            )
-            acc["in"] += int(u.get("input_tokens") or 0)
-            acc["out"] += int(u.get("output_tokens") or 0)
-            acc["cache_read"] += int(u.get("cache_read_input_tokens") or 0)
-            acc["cache_create"] += int(u.get("cache_creation_input_tokens") or 0)
-    return {
-        "trials": trials, "billed": billed,
-        "estimated": estimated, "per_model": per_model,
-    }
+            acc = per_model.setdefault(model, _blank())
+            rec = {
+                "input_tokens": int(u.get("input_tokens") or 0),
+                "output_tokens": int(u.get("output_tokens") or 0),
+                "cache_read_input_tokens": int(u.get("cache_read_input_tokens") or 0),
+                "cache_creation_input_tokens": int(
+                    u.get("cache_creation_input_tokens") or 0),
+            }
+            acc["in"] += rec["input_tokens"]
+            acc["out"] += rec["output_tokens"]
+            acc["cache_read"] += rec["cache_read_input_tokens"]
+            acc["cache_create"] += rec["cache_creation_input_tokens"]
+            acc["billed"] += float(u.get("cost_usd") or 0.0)
+            acc["listed"] += compute_cost(model, rec)
+
+    # PREFER THE BILLED FIGURE WHEREVER IT EXISTS.
+    #
+    # ``cost_usd`` was computed per-REQUEST by the live agent, which is the
+    # only place the context tier can be applied correctly: gpt-5.6-luna
+    # doubles above 272K prompt tokens, and ``model_usage`` has already
+    # aggregated individual requests away, so ANY recomputation from it
+    # prices a whole session as one giant long-context request. Measured on
+    # an 89-task run: recomputed $4.96 vs $2.74 actually billed, an 81%
+    # overstatement — the reconstruction is strictly worse than the number
+    # already in the file.
+    #
+    # Recomputation is only needed where ``cost_usd`` is 0.00 because the
+    # model ran on a subscription. That is Anthropic today, which has no
+    # context tier, so aggregate pricing is exact for it.
+    for u in per_model.values():
+        u["listed"] = u["billed"] if u["billed"] > 0 else u["listed"]
+    listed = sum(m["listed"] for m in per_model.values())
+    return {"sessions": sessions, "billed": billed,
+            "listed": listed, "per_model": per_model}
+
+
+def _trial_dirs(job: pathlib.Path) -> int:
+    return sum(1 for p in job.iterdir() if p.is_dir())
+
+
+def _declared_trials(job: pathlib.Path) -> int | None:
+    try:
+        return json.loads((job / "result.json").read_text()).get("n_total_trials")
+    except (OSError, ValueError):
+        return None
+
+
+def report(job: pathlib.Path) -> None:
+    from src.services.pricing import get_pricing
+
+    if not job.exists():
+        print(f"\n=== {job.name} ===")
+        print(f"  NO SUCH JOB DIRECTORY: {job}")
+        return
+
+    r = job_cost(job)
+    declared = _declared_trials(job)
+    on_disk = _trial_dirs(job)
+
+    print(f"\n=== {job.name} ===")
+    if declared is not None and on_disk < declared:
+        # An aborted run leaves a partial tree; reporting its cost as if it
+        # were the whole job is how a 3-of-89 job gets mistaken for a
+        # finished one.
+        print(f"  INCOMPLETE JOB: {on_disk} trial dirs on disk, "
+              f"{declared} declared. Cost below covers only what ran.")
+    print(f"  sessions with cost data: {r['sessions']}"
+          + (f" of {on_disk} trial dirs" if on_disk else ""))
+    if on_disk and r["sessions"] < on_disk:
+        print(f"  {on_disk - r['sessions']} trial(s) have NO session JSON — "
+              "timed-out trials are killed before session.save(), so their "
+              "cost is invisible here and everywhere else. Totals are a "
+              "lower bound.")
+    if not r["sessions"]:
+        return
+
+    unpriced = []
+    for model, u in sorted(r["per_model"].items()):
+        if get_pricing(model) is None:
+            unpriced.append(model)
+            share, note = "   ?", "  <-- NO PRICING DATA (not free; excluded)"
+        else:
+            share = (f"{100 * u['listed'] / r['listed']:4.1f}"
+                     if r["listed"] else "   ?")
+            note = ""
+        print(f"  {model}")
+        print(f"    input {u['in']:>13,}   output {u['out']:>12,}")
+        print(f"    cache_read {u['cache_read']:>8,}   "
+              f"cache_create {u['cache_create']:>8,}")
+        prompt = u["in"] + u["cache_read"] + u["cache_create"]
+        if prompt:
+            print(f"    prompt total {prompt:>11,}  "
+                  f"({100 * u['cache_read'] / prompt:.1f}% cached)")
+        print(f"    billed ${u['billed']:>10.4f}   "
+              f"list ${u['listed']:>10.4f}  ({share}%){note}")
+    if unpriced:
+        print(f"  WARNING: no pricing row for {', '.join(unpriced)} — "
+              "excluded from the totals, which are a lower bound.")
+    print(f"  {'BILLED (harbor cost_usd)':30s} ${r['billed']:>12.4f}")
+    print(f"  {'TRUE COMBINED (list price)':30s} ${r['listed']:>12.4f}")
 
 
 def main() -> int:
@@ -50,45 +162,10 @@ def main() -> int:
         print(__doc__)
         return 2
     for arg in sys.argv[1:]:
-        job = pathlib.Path(arg)
-        r = job_cost(job)
-        if not r["trials"]:
-            print(f"{job.name}: no session JSON found "
-                  "(timed-out trials never persist one)")
-            continue
-        print(f"\n=== {job.name} ===")
-        print(f"trials with cost data: {r['trials']}")
-        try:
-            sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[2]))
-            from src.services.pricing import compute_cost, get_pricing
-            unpriced = []
-            for model, u in sorted(r["per_model"].items()):
-                c = compute_cost(model, {
-                    "input_tokens": u["in"], "output_tokens": u["out"],
-                    "cache_read_input_tokens": u["cache_read"],
-                    "cache_creation_input_tokens": u["cache_create"],
-                })
-                # A model with no pricing row costs $0.0000 here, which reads
-                # as "free" when it means "unknown". Say which it is —
-                # a silently-zero model would understate the very total this
-                # script exists to correct.
-                if get_pricing(model) is None:
-                    unpriced.append(model)
-                    note = "  <-- NO PRICING DATA (not free; excluded)"
-                    share_s = "   ?"
-                else:
-                    note = ""
-                    share_s = (f"{100 * c / r['estimated']:4.1f}"
-                               if r["estimated"] else "   ?")
-                print(f"  {model:22s} in={u['in']:>9,} out={u['out']:>8,}  "
-                      f"list-price ${c:>9.4f}  ({share_s}%){note}")
-            if unpriced:
-                print(f"  WARNING: no pricing row for {', '.join(unpriced)} — "
-                      "the totals below EXCLUDE them and are a lower bound.")
-        except Exception as exc:  # noqa: BLE001 — reporting must not fail
-            print(f"  (per-model pricing unavailable: {exc})")
-        print(f"  {'BILLED (harbor cost_usd)':22s} ${r['billed']:>32.4f}")
-        print(f"  {'TRUE COMBINED (list)':22s} ${r['estimated']:>32.4f}")
+        report(pathlib.Path(arg))
+    print("\nNote: 'billed' omits any model on a subscription ($0.00/token). "
+          "'list price' is what the same tokens would cost on the API, and is "
+          "the figure to compare between runs.")
     return 0
 
 

--- a/src/services/pricing.py
+++ b/src/services/pricing.py
@@ -147,18 +147,48 @@ _TIER_MUSE_SPARK = {
 # and the Responses builder does the same, so cached input bills at the
 # cache-read rate on either wire. Measured on a real 2613-token turn with a
 # 2560-token hit, the split lowers the reported cost ~7.5x for this model.
+# CORRECTED 2026-08-04 against OpenAI's own model page
+# (developers.openai.com/api/docs/models/gpt-5.6-luna): every rate here was
+# exactly HALF the published price — $0.10/$0.60 against a real $0.20/$1.20.
+#
+# ROOT CAUSE, worth knowing before "fixing" this back: the original figures
+# came from a 2026-07-31 probe of OPENROUTER, which was and still is running
+# a 50% promotional discount off OpenAI's list price. The probe was accurate
+# about the gateway it measured; the mistake was storing a promo rate as the
+# model's price, in a row that also serves api.openai.com direct — where the
+# eval actually runs. Found by reconciling an 89-task eval against the
+# invoice: $2.89 accounted, $7.20 billed.
+#
+# THIS ROW HOLDS LIST PRICE, for both gateways, deliberately. A discount is
+# temporary and would rot into silent under-reporting the moment it ends;
+# over-reporting an OpenRouter run is the safe direction for a benchmark
+# whose cost figure gets compared against other agents'. (``get_pricing``
+# matches exactly before stripping the vendor prefix, so a discounted
+# ``openai/gpt-5.6-luna`` row COULD be added — resist it unless someone is
+# prepared to track the promo's end date.)
+#
+# The RATIOS were right all along (2x input, 1.5x output above the tier
+# limit), so nothing looked internally inconsistent and no consistency check
+# could fire. Only an external number could catch it, and nothing pinned the
+# absolute rates — see TestGpt56LunaPublishedRates, which now does.
+#
+# Published rates: input $0.20/M, cached input $0.02/M (the standard 90%
+# cache-read discount), output $1.20/M. Cache WRITES bill at 1.25x the
+# uncached input rate = $0.25/M. Prompts above the tier limit are priced at
+# 2x input and 1.5x output FOR THE FULL REQUEST, so every input-side rate
+# doubles in the LONG tier.
 _GPT_56_LUNA_INPUT_TIER_LIMIT = 272_000
 _TIER_GPT_56_LUNA = {
-    "input": 0.10 / 1_000_000,
-    "output": 0.60 / 1_000_000,
-    "cache_creation": 0.125 / 1_000_000,
-    "cache_read": 0.01 / 1_000_000,
-}
-_TIER_GPT_56_LUNA_LONG = {
     "input": 0.20 / 1_000_000,
-    "output": 0.90 / 1_000_000,
+    "output": 1.20 / 1_000_000,
     "cache_creation": 0.25 / 1_000_000,
     "cache_read": 0.02 / 1_000_000,
+}
+_TIER_GPT_56_LUNA_LONG = {
+    "input": 0.40 / 1_000_000,
+    "output": 1.80 / 1_000_000,
+    "cache_creation": 0.50 / 1_000_000,
+    "cache_read": 0.04 / 1_000_000,
 }
 
 

--- a/tests/test_pricing_status_bar.py
+++ b/tests/test_pricing_status_bar.py
@@ -264,3 +264,68 @@ class TestFormatCostUsd(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestGpt56LunaPublishedRates(unittest.TestCase):
+    """Pin gpt-5.6-luna's ABSOLUTE rates against OpenAI's published page.
+
+    These were wrong for the model's whole registered life — exactly half the
+    published price — and nothing caught it, because the internal RATIOS were
+    right (2x input / 1.5x output above the tier limit) so no consistency
+    check could fire. It surfaced only by reconciling a real eval against an
+    OpenAI invoice: $2.89 accounted against $7.20 billed.
+
+    A ratio test cannot catch a uniformly-scaled table. Pin the absolute
+    numbers, and when OpenAI changes them, change these deliberately.
+    Source: developers.openai.com/api/docs/models/gpt-5.6-luna (2026-08-04).
+    """
+
+    def test_standard_tier_matches_published_rates(self) -> None:
+        from src.services.pricing import get_pricing
+
+        p = get_pricing("gpt-5.6-luna", input_tokens=1_000)
+        self.assertAlmostEqual(p["input"] * 1e6, 0.20, places=6)
+        self.assertAlmostEqual(p["output"] * 1e6, 1.20, places=6)
+        self.assertAlmostEqual(p["cache_read"] * 1e6, 0.02, places=6)
+        self.assertAlmostEqual(p["cache_creation"] * 1e6, 0.25, places=6)
+
+    def test_cache_read_is_the_standard_90_percent_discount(self) -> None:
+        from src.services.pricing import get_pricing
+
+        p = get_pricing("gpt-5.6-luna", input_tokens=1_000)
+        self.assertAlmostEqual(p["cache_read"], p["input"] * 0.10, places=12)
+
+    def test_cache_write_is_1_25x_uncached_input(self) -> None:
+        from src.services.pricing import get_pricing
+
+        p = get_pricing("gpt-5.6-luna", input_tokens=1_000)
+        self.assertAlmostEqual(p["cache_creation"], p["input"] * 1.25, places=12)
+
+    def test_long_context_tier_doubles_input_and_1_5x_output(self) -> None:
+        """>272K prompts are priced at 2x input / 1.5x output for the FULL
+        request, so every input-side rate doubles."""
+        from src.services.pricing import get_pricing
+
+        short = get_pricing("gpt-5.6-luna", input_tokens=1_000)
+        long = get_pricing("gpt-5.6-luna", input_tokens=272_001)
+        self.assertAlmostEqual(long["input"], short["input"] * 2, places=12)
+        self.assertAlmostEqual(long["output"], short["output"] * 1.5, places=12)
+        self.assertAlmostEqual(long["cache_read"], short["cache_read"] * 2, places=12)
+        self.assertAlmostEqual(
+            long["cache_creation"], short["cache_creation"] * 2, places=12)
+
+    def test_tier_boundary_is_inclusive_of_the_limit(self) -> None:
+        from src.services.pricing import get_pricing
+
+        at = get_pricing("gpt-5.6-luna", input_tokens=272_000)
+        over = get_pricing("gpt-5.6-luna", input_tokens=272_001)
+        self.assertAlmostEqual(at["input"] * 1e6, 0.20, places=6)
+        self.assertAlmostEqual(over["input"] * 1e6, 0.40, places=6)
+
+    def test_pro_variant_shares_the_rates(self) -> None:
+        from src.services.pricing import get_pricing
+
+        self.assertEqual(
+            get_pricing("gpt-5.6-luna", input_tokens=1_000),
+            get_pricing("gpt-5.6-luna-pro", input_tokens=1_000),
+        )

--- a/tests/test_query_openai_compat_effort.py
+++ b/tests/test_query_openai_compat_effort.py
@@ -321,28 +321,41 @@ class TestLunaOpenRouterIdRegistration(unittest.TestCase):
 
     def test_pricing_resolves_through_the_vendor_prefix(self):
         """``get_pricing`` DOES strip the vendor prefix (its own documented
-        tier 2), so one bare pricing key covers the OpenRouter id."""
+        tier 2), so one bare pricing key covers the OpenRouter id.
+
+        RATES ARE OPENAI LIST, deliberately. These assertions previously read
+        $0.10/$0.60, taken from a 2026-07-31 probe of OpenRouter — which was
+        and still is running a 50% promotional discount off OpenAI's
+        $0.20/$1.20. Pinning the promo made every OpenAI-direct run report
+        HALF its real cost, and that is how it was found: an 89-task eval
+        accounted $2.89 against a $7.20 invoice.
+
+        One row serves both gateways and it holds LIST price. A discount is
+        temporary and would rot into silent under-reporting the moment it
+        ends; over-reporting an OpenRouter run is the safe direction for a
+        benchmark whose cost figure gets compared against other agents'.
+        """
         pricing = get_pricing(LUNA)
         self.assertIsNotNone(pricing, "luna must not be priced as unknown")
-        self.assertAlmostEqual(pricing["input"] * 1_000_000, 0.10, places=6)
-        self.assertAlmostEqual(pricing["output"] * 1_000_000, 0.60, places=6)
+        self.assertAlmostEqual(pricing["input"] * 1_000_000, 0.20, places=6)
+        self.assertAlmostEqual(pricing["output"] * 1_000_000, 1.20, places=6)
 
     def test_long_context_pricing_tier(self):
-        """Above 272K prompt tokens OpenRouter roughly doubles every rate. A
-        1M-window model on a benchmark will cross that, and cost is a number
-        the eval reports."""
+        """Above 272K prompt tokens the full request is repriced at 2x input
+        and 1.5x output. A 1M-window model on a benchmark will cross that,
+        and cost is a number the eval reports."""
         short = get_pricing(LUNA, input_tokens=100_000)
         long = get_pricing(LUNA, input_tokens=300_000)
-        self.assertAlmostEqual(short["input"] * 1_000_000, 0.10, places=6)
-        self.assertAlmostEqual(long["input"] * 1_000_000, 0.20, places=6)
-        self.assertAlmostEqual(long["output"] * 1_000_000, 0.90, places=6)
+        self.assertAlmostEqual(short["input"] * 1_000_000, 0.20, places=6)
+        self.assertAlmostEqual(long["input"] * 1_000_000, 0.40, places=6)
+        self.assertAlmostEqual(long["output"] * 1_000_000, 1.80, places=6)
 
     def test_cost_uses_the_long_tier_for_a_big_prompt(self):
         """End-to-end through compute_cost, which is what the eval reports."""
         cheap = compute_cost(LUNA, {"input_tokens": 100_000, "output_tokens": 1_000})
         pricey = compute_cost(LUNA, {"input_tokens": 300_000, "output_tokens": 1_000})
-        self.assertAlmostEqual(cheap, 100_000 * 1e-7 + 1_000 * 6e-7, places=9)
-        self.assertAlmostEqual(pricey, 300_000 * 2e-7 + 1_000 * 9e-7, places=9)
+        self.assertAlmostEqual(cheap, 100_000 * 2e-7 + 1_000 * 1.2e-6, places=9)
+        self.assertAlmostEqual(pricey, 300_000 * 4e-7 + 1_000 * 1.8e-6, places=9)
 
 
 class TestEffortRoutingHasOneInjectionSite(unittest.TestCase):


### PR DESCRIPTION
Found by reconciling a real 89-task eval against the OpenAI invoice: our accounting said **$2.89** for a day OpenAI billed **$7.20**.

## The pricing bug

Every `gpt-5.6-luna` rate was exactly **half** the published price.

| | published | we had |
|---|---|---|
| input | $0.20/M | $0.10/M |
| cached input | $0.02/M | $0.01/M |
| output | $1.20/M | $0.60/M |
| cache write | $0.25/M | $0.125/M |
| >272K tier | 2× in / 1.5× out | 2× / 1.5× ✓ |

**Root cause, worth knowing before anyone "fixes" it back:** the original figures came from a 2026-07-31 probe of **OpenRouter**, which was and still is running a **50% promotional discount** off list. The probe was accurate about the gateway it measured — the mistake was storing a promo rate as *the model's price*, in a row that also serves `api.openai.com` direct, which is where the eval actually runs.

Correcting the rates takes the reconciliation from **40% to 80%** explained. The residual is consistent with requests crossing the 272K tier, the run spanning midnight, and luna usage outside harbor.

Verified against [OpenAI's model page](https://developers.openai.com/api/docs/models/gpt-5.6-luna).

**The row keeps LIST price for both gateways, deliberately.** A discount is temporary and would rot into silent under-reporting the moment it ends; over-reporting an OpenRouter run is the safe direction for a benchmark whose cost is compared against other agents'. `get_pricing` matches exactly before stripping the vendor prefix, so a discounted `openai/gpt-5.6-luna` row *could* be added — the comment says not to unless someone tracks the promo's end date.

### Why nothing caught it

The internal **ratios** were right (2× input, 1.5× output above the limit), so no consistency check could fire, and the only test touching these numbers asserted `> 0`. **A ratio test cannot catch a uniformly-scaled table** — only an external number could. `TestGpt56LunaPublishedRates` now pins the absolute rates, the 90% cache-read discount, the 1.25× cache-write multiplier and the tier boundary.

Three assertions in `test_query_openai_compat_effort` pinned the promo rate as if it were the model's price; updated with the gateway distinction spelled out.

## Also: three fixes to the cost reporter

1. **Over-pricing.** It aggregated a whole job's tokens and priced once. `compute_cost` picks a tier from the prompt size it is handed, so a job total of 141.7M forced every token into the long-context tier — $5.03 against $2.74 actually billed. It no longer recomputes what is already priced: `cost_usd` was computed *per-request* by the live agent, which is the only place a context tier can be applied correctly. Recomputation now applies only to subscription models that bill $0.00 (Anthropic, which has no tier, so aggregate pricing is exact there).
2. **Cache invisible.** Only input/output were printed while 96.7% of luna's prompt was `cache_read`. It was always *priced*, but a reader could not see it — so the natural conclusion was that cached input went uncounted. Now prints cache read/write, prompt total and cached percentage.
3. **Partial and missing jobs reported as complete.** An aborted run leaves a partial tree, and the tool priced 3 trials of a declared 89 with no indication — which is how it got pointed at the wrong job. Now compares trial dirs against `n_total_trials`. A nonexistent directory previously blamed timeouts for a typo; it now says `NO SUCH JOB DIRECTORY`.

## Impact on past results

Every earlier luna eval under-reported cost by 2×. `tb21-oai-luna-xhigh` reported $12.16; it was really ~$24.31.

Full suite **9726 passed, 10 skipped, exit 0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)