### PR TITLE
fix(advisor): 16.6% of consultations echoed the transcript instead of advising

### DIFF
--- a/eval/harbor/clawcodex_agent.py
+++ b/eval/harbor/clawcodex_agent.py
@@ -1126,22 +1126,36 @@ class Clawcodex(BaseInstalledAgent):
             prompt += inp + cread + ccreate
             cached += cread
             completion += usage.get("output_tokens") or 0
-        # Cost: prefer the billed ``total_cost_usd``; when it's 0 (a
-        # subscription run consumes plan allowance, not metered credits, so
-        # the billed cost is $0) fall back to ``estimated_cost_usd`` — the
-        # always-computed list-price figure — so the leaderboard/trajectory
-        # cost column is populated and comparable with the claude-code
-        # agent, which reports a list-price cost on subscription runs too.
+        # Cost: report the LARGER of billed and estimated.
+        #
+        # ``estimated_cost_usd`` is list price across EVERY model; ``billed``
+        # is metered charges only, so a model on a subscription contributes
+        # $0 to it. This used to read "billed if billed > 0, else estimated",
+        # which is right for an all-subscription run and WRONG for a MIXED
+        # one — and the advisor creates exactly that: an API worker plus a
+        # subscription reviewer. Billed was non-zero (the worker's cost), so
+        # it won, and the reviewer's entire cost was dropped.
+        #
+        # Measured on db-wal-recovery from the 89-task advisor run: the
+        # trajectory reported $0.0373 against a true $0.7839 — a 21x
+        # understatement in the field the leaderboard reads, on the exact
+        # comparison the advisor exists to justify. Token totals were never
+        # affected; they already summed both models.
+        #
+        # ``max`` is safe in the other directions too: for an all-API run the
+        # two agree, and estimated can never be below billed because both
+        # price the same tokens and estimated ignores the $0 subscription
+        # discount rather than applying it.
         billed = cost.get("total_cost_usd")
         estimated = cost.get("estimated_cost_usd")
-        if isinstance(billed, (int, float)) and billed > 0:
-            cost_usd: float | None = float(billed)
-        elif isinstance(estimated, (int, float)) and estimated > 0:
-            cost_usd = float(estimated)
-        elif isinstance(billed, (int, float)):
-            cost_usd = float(billed)
+        _billed = float(billed) if isinstance(billed, (int, float)) else None
+        _est = float(estimated) if isinstance(estimated, (int, float)) else None
+        if _billed is not None and _est is not None:
+            cost_usd: float | None = max(_billed, _est)
+        elif _est is not None and _est > 0:
+            cost_usd = _est
         else:
-            cost_usd = None
+            cost_usd = _billed
         return {
             "prompt": prompt,
             "completion": completion,

--- a/src/utils/advisor.py
+++ b/src/utils/advisor.py
@@ -1136,7 +1136,34 @@ def execute_client_advisor(
 
     text = getattr(response, "content", None) or ""
     if not isinstance(text, str) or not text.strip():
-        return (False, "Advisor returned no text content.", usage)
+        # An empty reply is usually the reviewer DECLINING, not a glitch.
+        # Measured across an 89-task terminal-bench run: every empty response
+        # came from one of three security-flavoured tasks
+        # (break-filter-js-from-html, crack-7z-hash, vulnerable-secret), the
+        # model emitted 2-3 tokens, and 100% of consultations on those tasks
+        # failed. The old text — "Advisor returned no text content." — told
+        # the worker nothing about why, so it simply called again and got the
+        # same non-answer, spending a turn and a full cache-write each time.
+        #
+        # Carry the stop reason (ChatResponse.finish_reason is the provider's
+        # ``stop_reason``) and say plainly that retrying is unlikely to help,
+        # so the worker proceeds instead of looping. NOT routed through the
+        # retry lane: this is a considered response, not a transient error,
+        # and re-issuing it costs a fresh consultation to reach the same
+        # place.
+        reason = str(getattr(response, "finish_reason", "") or "").strip()
+        detail = f" (stop reason: {reason})" if reason else ""
+        logging.getLogger(__name__).info(
+            "advisor returned no text%s; continuing without advice", detail
+        )
+        return (
+            False,
+            f"Advisor returned no advice{detail} — the reviewer model "
+            "declined or produced no text for this conversation. Calling it "
+            "again on this task is unlikely to help; proceed on your own "
+            "judgment.",
+            usage,
+        )
     return (True, text, usage)
 
 

--- a/src/utils/advisor.py
+++ b/src/utils/advisor.py
@@ -657,10 +657,40 @@ def build_advisor_forwarded_messages(
             continue
         flattened.append({"role": role, "content": text})
 
-    # Ensure the conversation ends with a user message. Vertex-fronted
-    # Anthropic (and most proxies) reject assistant-prefill.
+    # TWO requirements, and conflating them was a real defect:
+    #
+    #   (a) the forwarded conversation must END WITH A USER TURN — Vertex-
+    #       fronted Anthropic and most proxies reject assistant-prefill; and
+    #   (b) that final turn must actually ASK FOR ADVICE, or the reviewer is
+    #       handed a bare transcript with no request in it.
+    #
+    # This used to append the request ONLY when the tail was not already a
+    # user turn, which silently made (b) conditional on (a). The worker
+    # usually calls the advisor mid-tool-round, so after flattening the tail
+    # IS a user turn (a ``[Tool result: ...]`` line) — no request was added,
+    # and the reviewer did the natural thing with an unterminated transcript:
+    # it CONTINUED it, replying in the worker's own voice with narration and
+    # further tool calls instead of a review.
+    #
+    # Measured on an 89-task terminal-bench run: 54 of 326 answered
+    # consultations (16.6%), spread over 45 of 89 tasks, came back as echoed
+    # transcript. Each cost a full reviewer call and returned the worker its
+    # own words as advice — worse than no advisor at all, because the model
+    # is told to weight advice heavily.
+    #
+    # Appended to the EXISTING user turn rather than added as a second one:
+    # consecutive same-role messages are rejected on some wires, and the
+    # request belongs with the transcript it refers to.
     if not flattened or flattened[-1].get("role") != "user":
         flattened.append({"role": "user", "content": CLIENT_ADVISOR_PROMPT_SUFFIX})
+    elif CLIENT_ADVISOR_PROMPT_SUFFIX not in str(flattened[-1].get("content") or ""):
+        tail = dict(flattened[-1])
+        existing = str(tail.get("content") or "").rstrip()
+        tail["content"] = (
+            f"{existing}\n\n{CLIENT_ADVISOR_PROMPT_SUFFIX}" if existing
+            else CLIENT_ADVISOR_PROMPT_SUFFIX
+        )
+        flattened[-1] = tail
     return flattened
 
 

--- a/tests/test_advisor_effort_wiring.py
+++ b/tests/test_advisor_effort_wiring.py
@@ -598,3 +598,67 @@ class TestBuildAnthropicThinkingKwargs(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAdvisorEmptyResponse(unittest.TestCase):
+    """An empty reply is usually the reviewer DECLINING, not a glitch.
+
+    Across an 89-task terminal-bench run every empty response came from a
+    security-flavoured task, the model emitted 2-3 tokens, and 100% of
+    consultations on those tasks failed — so the worker called again and got
+    the same non-answer, spending a turn and a full cache-write each time.
+    """
+
+    def _empty_response_recorder(self, finish_reason: str = "") -> _Recorder:
+        class _Empty:
+            content = "   "
+            usage = {"input_tokens": 5, "output_tokens": 2}
+            model = "claude-opus-5"
+
+        _Empty.finish_reason = finish_reason
+        rec = _Recorder()
+        rec_cls_response = _Empty()
+
+        def chat_stream_response(messages, **kwargs):
+            rec.calls += 1
+            rec.kwargs = kwargs
+            return rec_cls_response
+
+        rec.chat_stream_response = chat_stream_response
+        return rec
+
+    def test_empty_reply_explains_itself_and_says_not_to_retry(self) -> None:
+        rec = self._empty_response_recorder("refusal")
+        (ok, text, _usage), rec = _run_advisor(
+            "claude-opus-5", anthropic_wire=True, recorder=rec,
+        )
+        self.assertFalse(ok)
+        self.assertIn("refusal", text, msg="the stop reason must be carried")
+        self.assertIn("declined", text.lower())
+        self.assertIn("unlikely to help", text.lower())
+
+    def test_empty_reply_is_not_retried(self) -> None:
+        """A considered non-answer is not transient; re-issuing costs a fresh
+        consultation to reach the same place."""
+        rec = self._empty_response_recorder("end_turn")
+        (_ok, _text, _u), rec = _run_advisor(
+            "claude-opus-5", anthropic_wire=True, recorder=rec,
+        )
+        self.assertEqual(rec.calls, 1)
+
+    def test_usage_is_still_reported_for_an_empty_reply(self) -> None:
+        """The call still cost tokens; dropping them would hide the spend."""
+        rec = self._empty_response_recorder("refusal")
+        (_ok, _text, usage), _rec = _run_advisor(
+            "claude-opus-5", anthropic_wire=True, recorder=rec,
+        )
+        self.assertEqual(usage["input_tokens"], 5)
+        self.assertEqual(usage["output_tokens"], 2)
+
+    def test_missing_stop_reason_still_produces_actionable_text(self) -> None:
+        rec = self._empty_response_recorder("")
+        (_ok, text, _u), _rec = _run_advisor(
+            "claude-opus-5", anthropic_wire=True, recorder=rec,
+        )
+        self.assertIn("declined", text.lower())
+        self.assertNotIn("stop reason:", text.lower())

--- a/tests/test_advisor_effort_wiring.py
+++ b/tests/test_advisor_effort_wiring.py
@@ -662,3 +662,112 @@ class TestAdvisorEmptyResponse(unittest.TestCase):
         )
         self.assertIn("declined", text.lower())
         self.assertNotIn("stop reason:", text.lower())
+
+
+class TestAdvisorAlwaysAsksForAdvice(unittest.TestCase):
+    """The forwarded conversation must always END WITH A REQUEST.
+
+    The tail-is-user case is the COMMON one — the worker calls the advisor
+    mid-tool-round, so after flattening the last turn is a `[Tool result:
+    ...]` line. The request used to be appended only when the tail was NOT
+    already a user turn, so in the common case the reviewer got a bare
+    unterminated transcript and CONTINUED it, replying in the worker's voice
+    with narration and tool calls instead of a review.
+
+    Measured on an 89-task run: 54 of 326 answered consultations (16.6%),
+    across 45 of 89 tasks.
+    """
+
+    def _fwd(self, history):
+        from src.utils.advisor import build_advisor_forwarded_messages
+
+        return build_advisor_forwarded_messages(history)
+
+    def _suffix(self) -> str:
+        from src.utils.advisor import CLIENT_ADVISOR_PROMPT_SUFFIX
+
+        return CLIENT_ADVISOR_PROMPT_SUFFIX
+
+    def test_tail_is_a_user_tool_result_still_asks(self) -> None:
+        """THE regression. This shape produced 16.6% junk consultations."""
+        history = [
+            {"role": "user", "content": "do the task"},
+            {"role": "assistant", "content": [
+                {"type": "text", "text": "waiting on the build"},
+                {"type": "tool_use", "id": "t1", "name": "Bash",
+                 "input": {"command": "ls"}},
+            ]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "file.txt"},
+            ]},
+        ]
+        fwd = self._fwd(history)
+        self.assertEqual(fwd[-1]["role"], "user")
+        self.assertIn(
+            self._suffix(), fwd[-1]["content"],
+            msg="reviewer received a transcript with no request — it will "
+                "continue the transcript instead of reviewing",
+        )
+
+    def test_the_original_tool_result_text_is_preserved(self) -> None:
+        history = [
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "IMPORTANT"}]},
+        ]
+        fwd = self._fwd(history)
+        self.assertIn("IMPORTANT", fwd[-1]["content"])
+        self.assertIn(self._suffix(), fwd[-1]["content"])
+
+    def test_tail_is_assistant_appends_a_user_turn(self) -> None:
+        """The original behaviour, unchanged."""
+        history = [
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": [
+                {"type": "text", "text": "my plan is X"}]},
+        ]
+        fwd = self._fwd(history)
+        self.assertEqual(fwd[-1]["role"], "user")
+        self.assertEqual(fwd[-1]["content"], self._suffix())
+
+    def test_no_two_consecutive_user_turns(self) -> None:
+        """Some wires reject consecutive same-role messages, so the request
+        is folded into the existing turn rather than added after it."""
+        history = [
+            {"role": "user", "content": "task"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "t1", "name": "Bash", "input": {}}]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "out"}]},
+        ]
+        fwd = self._fwd(history)
+        roles = [m["role"] for m in fwd]
+        for a, b in zip(roles, roles[1:]):
+            self.assertNotEqual(a, b, msg=f"consecutive {a} turns: {roles}")
+
+    def test_request_is_not_duplicated(self) -> None:
+        history = [{"role": "user", "content": "task"}]
+        once = self._fwd(history)
+        self.assertEqual(once[-1]["content"].count(self._suffix()), 1)
+
+    def test_every_shape_ends_with_a_user_request(self) -> None:
+        shapes = {
+            "empty": [],
+            "user only": [{"role": "user", "content": "task"}],
+            "assistant tail": [
+                {"role": "user", "content": "t"},
+                {"role": "assistant", "content": [{"type": "text", "text": "plan"}]}],
+            "tool-result tail": [
+                {"role": "user", "content": "t"},
+                {"role": "assistant", "content": [
+                    {"type": "tool_use", "id": "x", "name": "Bash", "input": {}}]},
+                {"role": "user", "content": [
+                    {"type": "tool_result", "tool_use_id": "x", "content": "o"}]}],
+        }
+        for name, hist in shapes.items():
+            with self.subTest(shape=name):
+                fwd = self._fwd(hist)
+                self.assertEqual(fwd[-1]["role"], "user")
+                self.assertIn(self._suffix(), fwd[-1]["content"])

--- a/tests/test_harbor_adapter_advisor.py
+++ b/tests/test_harbor_adapter_advisor.py
@@ -332,3 +332,52 @@ def test_half_empty_advisor_is_rejected(bad: str) -> None:
     advisor that is silently inert at run time."""
     with pytest.raises(ValueError, match="both halves non-empty"):
         _construct(advisor=bad)
+
+
+# --------------------------------------------------------------------------
+# Trajectory cost (what the leaderboard reads)
+# --------------------------------------------------------------------------
+
+def _cost_of(cost_block: dict) -> float | None:
+    """Fold a session cost block the way the trajectory builder does.
+
+    ``model_usage`` must be present: the helper returns None without it, so a
+    block lacking one exercises the guard rather than the cost logic.
+    """
+    import clawcodex_agent as mod
+
+    block = {"model_usage": {"m": {"input_tokens": 1, "output_tokens": 1}}}
+    block.update(cost_block)
+    # staticmethod — call on the class, not an instance.
+    return mod.Clawcodex._billing_totals_from_cost_block(block)["cost"]
+
+
+def test_mixed_api_and_subscription_run_reports_the_full_cost() -> None:
+    """THE advisor case: an API worker (bills > 0) plus a subscription
+    reviewer (bills $0).
+
+    The old rule was "billed if billed > 0, else estimated" — correct for an
+    all-subscription run, wrong for a mixed one. Billed won because the
+    worker's cost is non-zero, and the reviewer's entire cost was dropped.
+    Measured on a real trial: $0.0373 reported against $0.7839 true, a 21x
+    understatement in the field the leaderboard reads.
+    """
+    assert _cost_of({"total_cost_usd": 0.0373, "estimated_cost_usd": 0.7839}) == 0.7839
+
+
+def test_all_subscription_run_still_uses_the_estimate() -> None:
+    assert _cost_of({"total_cost_usd": 0.0, "estimated_cost_usd": 0.51}) == 0.51
+
+
+def test_all_api_run_is_unchanged() -> None:
+    """Both figures agree when nothing ran on a subscription."""
+    assert _cost_of({"total_cost_usd": 0.42, "estimated_cost_usd": 0.42}) == 0.42
+
+
+def test_a_genuinely_free_run_reports_zero_not_none() -> None:
+    assert _cost_of({"total_cost_usd": 0.0, "estimated_cost_usd": 0.0}) == 0.0
+
+
+def test_missing_estimate_falls_back_to_billed() -> None:
+    """Older sessions predate estimated_cost_usd."""
+    assert _cost_of({"total_cost_usd": 0.19}) == 0.19


### PR DESCRIPTION
Three defects found by analysing an 89-task advisor run against its control. The first is the serious one.

## 1. The advisor returned the worker's own transcript — 16.6% of the time

The forwarded conversation only asked for advice when its last turn was **not** already a user message:

```python
if not flattened or flattened[-1].get("role") != "user":
    flattened.append({"role": "user", "content": CLIENT_ADVISOR_PROMPT_SUFFIX})
```

That guard exists for a different reason — the conversation must end with a user turn because proxies reject assistant-prefill — and it silently made the **request** conditional on the **shape**. The worker usually calls the advisor mid-tool-round, so after flattening the tail *is* a user turn (a `[Tool result: ...]` line). No request was appended, and the reviewer did the natural thing with an unterminated transcript: **it continued it**, replying in the worker's own voice with narration and further tool calls.

**54 of 326 answered consultations (16.6%), across 45 of 89 tasks.** Each cost a full opus-5 call and handed the worker its own words back as advice — worse than having no advisor, because the tool's instructions tell the model to give advice serious weight.

It hid because it looked like success: HTTP 200, tokens billed, `is_error=false`. The content is only visibly wrong if you *read* it.

The request is now folded into the existing user turn rather than added as a second one — consecutive same-role messages are rejected on some wires, and the request belongs with the transcript it refers to.

## 2. The trajectory under-reported cost by 21×

`_billing_totals_from_cost_block` read *"billed if billed > 0, else estimated"* — right for an **all**-subscription run, wrong for the **mixed** run an advisor creates (API worker + subscription reviewer). Billed was non-zero, so it won, and the reviewer's entire cost was dropped: `$0.0373` reported against `$0.7839` true, in the field the leaderboard reads. Now `max(billed, estimated)`.

Token totals were never affected — they already summed both models (2,134,895 = 2,032,164 worker + 102,731 advisor, verified).

## 3. An empty consultation explained nothing

*"Advisor returned no text content."* gave no reason, so the worker called again and got the same non-answer. Every empty response came from one of three security-flavoured tasks — `break-filter-js-from-html`, `crack-7z-hash`, `vulnerable-secret` — with 2-3 tokens emitted and 100% of consultations failing on each. That is the reviewer **declining**. Now carries the provider's stop reason and says retrying is unlikely to help. Deliberately not retried: a considered non-answer is not transient.

## Hypotheses tested and falsified

Recorded so nobody re-runs them: the empty replies were **not** token starvation (5 output tokens across 2 calls, not 32,000), and the advisor does **not** repeat itself despite being blind to its own prior advice (mean consecutive similarity 0.083 over 240 pairs).

## Verification

- Full suite **9736 passed, 10 skipped, exit 0**
- Both fixes mutation-tested (revert the fix → red; restore → green)
- **Live**: the exact echoing shape now returns proper `**Gaps:**` advice, 901 tokens, substantive
- **Container**: 3 tb2.1 tasks incl. two that previously echoed — **8 consultations, 0 echoed**, 3/3 reward 1.0, 0 exceptions

## Known gap, deliberately not fixed here

Subagents inherit the advisor tool (`ALL_AGENT_DISALLOWED_TOOLS` doesn't list it) — 7 consultations came from `Explore`/`general-purpose` subagents. Whether an Explore subagent should get expert review of a file listing is a behaviour decision, not a bug fix, so it is left for a separate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)