### PR TITLE
feat(models): register moonshot kimi-k3 (1M window, real pricing, effort vocabulary)

### DIFF
--- a/eval/harbor/clawcodex_agent.py
+++ b/eval/harbor/clawcodex_agent.py
@@ -200,6 +200,18 @@ _PROVIDER_ENV_VARS: dict[str, tuple[str, ...]] = {
     "zai": ("ZAI_API_KEY", "Z_AI_API_KEY"),
     "minimax": ("MINIMAX_API_KEY",),
     "gemini": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+    # Mirrors the moonshot ProviderSpec's env_vars. Absent, an advisor at
+    # ``moonshot:kimi-k3`` fell back to _ALL_PROVIDER_ENV_VARS — which does not
+    # contain MOONSHOT_API_KEY — and reached the container with no credentials
+    # at all, producing exactly the silent degradation _advisor_env_vars warns
+    # about below: the run LOOKS clean because the worker carries on.
+    #
+    # Note every row added here also WIDENS _ALL_PROVIDER_ENV_VARS, which is
+    # the fallback for providers absent from this table — so an advisor at an
+    # unlisted provider now also carries the Moonshot vars into its container.
+    # Net still narrowing: a moonshot advisor goes from 9 forwarded keys to 2.
+    # Providers already listed take the exact-match branch and are unaffected.
+    "moonshot": ("MOONSHOT_API_KEY", "KIMI_API_KEY"),
 }
 _ALL_PROVIDER_ENV_VARS: tuple[str, ...] = tuple(
     dict.fromkeys(key for keys in _PROVIDER_ENV_VARS.values() for key in keys)

--- a/src/models/configs.py
+++ b/src/models/configs.py
@@ -398,6 +398,203 @@ MODEL_CONFIGS: dict[str, ModelConfig] = {
         max_output_tokens=8_192,
         supports_cache=True,
     ),
+    # Moonshot / Kimi (api.moonshot.ai, OpenAI-compatible). Windows and vision
+    # flags below are read off the vendor's own ``GET /v1/models`` catalog
+    # (probed 2026-08-05), which publishes ``context_length`` and
+    # ``supports_image_in`` per model. Pricing lives in ``services/pricing.py``
+    # (single source), so the cost_* fields stay unset.
+    #
+    # ORDER IS LOAD-BEARING — the k2.x rows MUST stay above ``kimi-k3``.
+    # ``get_model_config`` falls back to ``key.rsplit("-", 1)[0]``, under which
+    # "kimi-k3" reduces to the broad "kimi" and claims EVERY ``kimi*`` id. Exact
+    # match protects only the four ids named here; anything else — a dated
+    # variant like ``kimi-k2.7-code-0801``, an alias like ``kimi-latest`` —
+    # falls into the prefix loop, which returns the FIRST matching row in
+    # insertion order. With kimi-k3 first, a 262K model silently inherits a
+    # 1,048,576 window: the WIDENING direction, which overflows the request
+    # with a context-length 400 instead of merely compacting early. With the
+    # k2.x rows first, unknown ``kimi*`` ids get the conservative 262,144.
+    # This is the same guard the ``claude-opus-4-20250514`` and ``gpt-oss``
+    # rows exist for. It is reachable, not hypothetical: the moonshot spec now
+    # discovers its catalog from the endpoint, so unenumerated ids are
+    # selectable.
+    #
+    # ``supports_vision`` is stated explicitly rather than left to default:
+    # ``capabilities.supports_vision`` trusts a verdict only from an exact
+    # MODEL_CONFIGS hit, so adding these rows turns "unknown -> permissive"
+    # into an asserted claim that the fusion validator will believe. All four
+    # report ``supports_image_in: true``, so True is probed, not assumed.
+    #
+    # ``max_output_tokens`` is ADVISORY here, as on every OpenAI-compatible row
+    # above: nothing sends a wire ``max_tokens`` for this provider. Its only
+    # live consumer is the auto-compact reservation, itself clamped to
+    # MAX_OUTPUT_TOKENS_FOR_SUMMARY (20_000) — so any value above that behaves
+    # identically. kimi-k3's 131_072 is Moonshot's documented default cap
+    # (raisable to 1_048_576 via ``max_completion_tokens``).
+    #
+    # NOTE these rows now OUTRANK a user's own ``modelLimits`` setting:
+    # ``get_context_window_for_model`` consults ``get_model_config`` first and
+    # only falls through to the setting when it returns None.
+    #
+    # For the four Moonshot ids named here that is corrective. It is NOT
+    # corrective for the rest of the namespace this prefix claims. A
+    # self-hosted ``kimi-*`` on ollama/vLLM — exactly the case ``_settings_limit``
+    # exists to serve — now resolves to 262,144 no matter what the user set:
+    # an explicit ``modelLimits`` of 8,192 becomes a guessed 262,144, a 32x
+    # OVER-estimate, which is the direction this block calls dangerous above.
+    #
+    # Not fixed here because the fix is not kimi-shaped: ``glm``, ``gpt`` and
+    # ``MiniMax`` are already single-token bases with the identical hole, and
+    # correcting it means reordering ``get_context_window_for_model`` to
+    # exact-hit -> settings -> prefix for every model family at once. That is
+    # its own change with its own sweep. Recorded so the next person does not
+    # rediscover it from a bug report.
+    "kimi-k2.6": ModelConfig(
+        model_id="kimi-k2.6",
+        display_name="Kimi K2.6",
+        context_window=262_144,
+        max_output_tokens=32_768,
+        supports_vision=True,
+        supports_cache=True,
+    ),
+    "kimi-k2.7-code": ModelConfig(
+        model_id="kimi-k2.7-code",
+        display_name="Kimi K2.7 Code",
+        context_window=262_144,
+        max_output_tokens=32_768,
+        supports_vision=True,
+        supports_cache=True,
+    ),
+    "kimi-k2.7-code-highspeed": ModelConfig(
+        model_id="kimi-k2.7-code-highspeed",
+        display_name="Kimi K2.7 Code Highspeed",
+        context_window=262_144,
+        max_output_tokens=32_768,
+        supports_vision=True,
+        supports_cache=True,
+    ),
+    "kimi-k3": ModelConfig(
+        model_id="kimi-k3",
+        display_name="Kimi K3",
+        context_window=1_048_576,
+        max_output_tokens=131_072,
+        supports_vision=True,
+        supports_cache=True,
+    ),
+    # Vendor-qualified Kimi ids, as served by the gateways in this registry.
+    # ``get_model_config`` deliberately does NOT strip a leading ``<vendor>/``
+    # (see its docstring), so these need explicit rows — the same treatment
+    # ``openai/gpt-5.6-luna`` gets. Without them ``moonshotai/Kimi-K3``, which
+    # this repo ships in Baseten's curated ``available_models``, resolved to
+    # the 200,000 default: the exact bug the bare kimi-k3 row above fixes,
+    # one ``/model`` selection away.
+    #
+    # ORDER IS LOAD-BEARING HERE TOO, and more sharply than above: these ids
+    # contain a single hyphen, so ``key.rsplit("-", 1)[0]`` reduces
+    # ``moonshotai/kimi-k2``, ``moonshotai/kimi-k2.6`` AND ``moonshotai/kimi-k3``
+    # all to the same base ``moonshotai/kimi``. Whichever lands first claims
+    # every unenumerated ``moonshotai/kimi*`` id, so the SMALLEST window must
+    # lead. Windows read off OpenRouter's live catalogue 2026-08-05:
+    # kimi-k2 131,072; k2-0905 / k2-thinking / k2.5 / k2.6 / k2.7-code 262,144;
+    # k3 1,048,576.
+    #
+    # Left UNPRICED on purpose. ``get_pricing`` strips the vendor prefix, so
+    # the lowercase ids already reach the Moonshot tier — consistent with the
+    # module's stated policy of pricing a proxied model at its upstream rate.
+    # Baseten's capitalised ``Kimi-K3`` misses that strip (case-sensitive
+    # lookup) and stays unpriced, which is correct: Baseten sets its own rates.
+    "moonshotai/kimi-k2": ModelConfig(
+        model_id="moonshotai/kimi-k2",
+        display_name="Kimi K2",
+        context_window=131_072,
+        max_output_tokens=32_768,
+        supports_vision=True,
+        supports_cache=True,
+    ),
+    "moonshotai/kimi-k2-0905": ModelConfig(
+        model_id="moonshotai/kimi-k2-0905",
+        display_name="Kimi K2 (0905)",
+        context_window=262_144,
+        max_output_tokens=32_768,
+        supports_vision=True,
+        supports_cache=True,
+    ),
+    "moonshotai/kimi-k2-thinking": ModelConfig(
+        model_id="moonshotai/kimi-k2-thinking",
+        display_name="Kimi K2 Thinking",
+        context_window=262_144,
+        max_output_tokens=32_768,
+        supports_vision=True,
+        supports_cache=True,
+    ),
+    "moonshotai/kimi-k2.5": ModelConfig(
+        model_id="moonshotai/kimi-k2.5",
+        display_name="Kimi K2.5",
+        context_window=262_144,
+        max_output_tokens=32_768,
+        supports_vision=True,
+        supports_cache=True,
+    ),
+    "moonshotai/kimi-k2.6": ModelConfig(
+        model_id="moonshotai/kimi-k2.6",
+        display_name="Kimi K2.6",
+        context_window=262_144,
+        max_output_tokens=32_768,
+        supports_vision=True,
+        supports_cache=True,
+    ),
+    "moonshotai/kimi-k2.7-code": ModelConfig(
+        model_id="moonshotai/kimi-k2.7-code",
+        display_name="Kimi K2.7 Code",
+        context_window=262_144,
+        max_output_tokens=32_768,
+        supports_vision=True,
+        supports_cache=True,
+    ),
+    "moonshotai/kimi-k3": ModelConfig(
+        model_id="moonshotai/kimi-k3",
+        display_name="Kimi K3",
+        context_window=1_048_576,
+        max_output_tokens=131_072,
+        supports_vision=True,
+        supports_cache=True,
+    ),
+    # The capitalised spelling is a SECOND namespace, not a one-off: the
+    # fallback's ``startswith`` is case-sensitive, so ``moonshotai/Kimi-*``
+    # shares no base with the lowercase rows above and needs its own guard.
+    # It is also more populated than "the id Baseten ships" suggests —
+    # ``moonshotai/`` is the HuggingFace org namespace and capitalised
+    # ``Kimi-*`` is the conventional repo-id spelling under it, so any
+    # HF-backed gateway emits ids of this shape (Kimi-K2-Instruct,
+    # Kimi-VL-A3B-Thinking, Kimi-Dev-72B …). ``--model`` is free text with no
+    # availability check, so reaching one takes nothing but typing it.
+    #
+    # Hence the same smallest-window-first discipline: without this row,
+    # ``moonshotai/Kimi-K3`` would be the only claimant of base
+    # ``moonshotai/Kimi`` AND carry the largest window in the table, handing
+    # every other capitalised id 1,048,576 — worse than the 200,000 default
+    # they had before these rows existed. 131_072 is not a Baseten-specific
+    # guess: it is the figure already pinned for the lowercase
+    # ``moonshotai/kimi-k2`` above, and the capitalisation does not change the
+    # weights. If a gateway never serves this id the row is inert except as
+    # the guard, which is exactly its job — same as ``kimi-k2.6`` above.
+    "moonshotai/Kimi-K2": ModelConfig(
+        model_id="moonshotai/Kimi-K2",
+        display_name="Kimi K2",
+        context_window=131_072,
+        max_output_tokens=32_768,
+        supports_vision=True,
+        supports_cache=True,
+    ),
+    # Baseten's spelling, shipped in its curated ``available_models``.
+    "moonshotai/Kimi-K3": ModelConfig(
+        model_id="moonshotai/Kimi-K3",
+        display_name="Kimi K3",
+        context_window=1_048_576,
+        max_output_tokens=131_072,
+        supports_vision=True,
+        supports_cache=True,
+    ),
     # Meta Muse Spark 1.1 (api.meta.ai, OpenAI-compatible). Muse Spark is a
     # server-side reasoning model (usage reports ``reasoning_tokens``); like
     # DeepSeek/GLM it exposes no Anthropic-style thinking blocks (the

--- a/src/providers/openai_compatible_specs.py
+++ b/src/providers/openai_compatible_specs.py
@@ -81,6 +81,26 @@ class ProviderSpec:
     #: ``hybrid`` by hand for exactly this reason; this field lets a spec row
     #: say the same thing.
     catalog_mode: str = "dynamic"
+    #: Reasoning-effort levels this provider's API actually accepts, or ``None``
+    #: for "the whole clawcodex ladder passes through untouched". Feeds
+    #: ``BaseProvider.supported_reasoning_efforts``; see
+    #: ``BaseProvider.normalize_reasoning_effort`` for why a provider that
+    #: silently IGNORES an unknown level still needs this — the user gets the
+    #: API's default rather than what they asked for, with no diagnostic.
+    #:
+    #: SCOPE CAVEAT: this is provider-scoped but describes a MODEL-scoped fact.
+    #: That is fine while a provider's models share one vocabulary (deepseek,
+    #: moonshot today), but a spec row with ``dynamic_catalog`` set can grow
+    #: models that disagree. Split to a per-model table if that happens rather
+    #: than widening the tuple to the union, which would re-admit the levels
+    #: this exists to translate away.
+    reasoning_efforts: tuple[str, ...] | None = None
+    #: Maps a clawcodex level this provider does NOT accept onto the nearest one
+    #: it does, as ``(level, replacement)`` pairs. A tuple rather than a dict so
+    #: the frozen dataclass stays hashable; ``build_provider_class`` converts it
+    #: to the dict ``BaseProvider.reasoning_effort_aliases`` expects. Only
+    #: consulted for levels absent from ``reasoning_efforts``.
+    reasoning_effort_aliases: tuple[tuple[str, str], ...] = ()
     #: Generated subclass name (for repr / debugging). Derived from ``id`` when
     #: omitted.
     class_name: str = ""
@@ -229,14 +249,54 @@ _SPECS: tuple[ProviderSpec, ...] = (
         env_vars=("ARCEE_API_KEY",),
         aliases=("arcee-ai", "arcee_ai"),
     ),
+    # Moonshot / Kimi. ``kimi-k3`` is the current flagship: a 1,048,576-token
+    # window, native image+video input, and reasoning that cannot be turned off
+    # (the catalog reports ``supports_thinking_type: "only"``).
+    #
+    # ``hybrid`` discovery, not ``dynamic``: the curated list below leads the
+    # picker, and ``GET /models`` appends the rest of the catalog (kimi-k2.6,
+    # kimi-k2.7-code-highspeed, and whatever ships next). Moonshot's endpoint
+    # serves only chat models — no embedding/speech rows to filter out — so
+    # appending it wholesale is safe. Failure falls back to the static list.
+    #
+    # Efforts are Moonshot's own published vocabulary, read off the catalog's
+    # ``reasoning_efforts.valid_efforts`` for kimi-k3: low | high | max, with
+    # ``max`` as the API default.
+    #
+    # SCOPE: that is a kimi-k3 fact applied provider-wide. Only the kimi-k3
+    # catalog row carries a ``reasoning_efforts`` block at all — the k2.x rows
+    # report ``supports_reasoning: true`` and nothing further — so the correct
+    # vocabulary for those is simply unpublished. Applying k3's is the safe
+    # reading: the levels below are a SUBSET of clawcodex's ladder, so a model
+    # that in fact accepts more receives a level it understands, just possibly
+    # a coarser one. If a future Moonshot model publishes a different ladder,
+    # split this to a per-model table rather than widening the tuple to the
+    # union — the union would re-admit the very levels this translates away.
+    #
+    # Sending a level outside it does NOT 400 —
+    # probed 2026-08-05, ``medium``, ``xhigh`` and even ``bogus`` all return
+    # 200 — the field is simply ignored, so the request lands on ``max``.
+    #
+    # That makes the aliases below matter in a way DeepSeek's do not. DeepSeek
+    # maps medium->high onto an API whose default already IS high, so the
+    # mapping only makes existing behaviour explicit. Here the ignored-value
+    # default is ``max``, the TOP of the ladder: without ``medium -> high``, a
+    # user asking for medium silently gets maximum reasoning and pays $15/Mtok
+    # of output for it. The translation is what makes the setting real.
     ProviderSpec(
         id="moonshot",
         label="Moonshot / Kimi",
         default_base_url="https://api.moonshot.ai/v1",
-        default_model="kimi-k2.7-code",
-        available_models=("kimi-k2.7-code",),
+        default_model="kimi-k3",
+        available_models=("kimi-k3", "kimi-k2.7-code"),
+        dynamic_catalog="openai-compatible",
+        catalog_mode="hybrid",
         env_vars=("MOONSHOT_API_KEY", "KIMI_API_KEY"),
         aliases=("moonshot-ai", "kimi", "kimi-k2"),
+        reasoning_efforts=("low", "high", "max"),
+        # ``minimal`` is deliberately absent: it is not on clawcodex's ladder
+        # (query.VALID_THINKING_EFFORT_LEVELS), so it can never arrive here.
+        reasoning_effort_aliases=(("medium", "high"), ("xhigh", "max")),
     ),
     ProviderSpec(
         id="sglang",
@@ -515,6 +575,12 @@ def build_provider_class(provider_id: str) -> type[_SpecOpenAICompatibleProvider
             "SPEC": spec,
             "DEFAULT_BASE_URL": spec.default_base_url,
             "DEFAULT_MODEL": spec.default_model,
+            "supported_reasoning_efforts": spec.reasoning_efforts,
+            # Fresh dict PER CLASS. ``BaseProvider.reasoning_effort_aliases`` is
+            # a mutable class-level default; handing several generated classes
+            # one shared object would let a mutation through any of them leak
+            # into every other provider.
+            "reasoning_effort_aliases": dict(spec.reasoning_effort_aliases),
             "__doc__": (
                 f"{spec.label} provider (OpenAI-compatible). Generated from "
                 "ProviderSpec; see src/providers/openai_compatible_specs.py."

--- a/src/services/pricing.py
+++ b/src/services/pricing.py
@@ -130,6 +130,37 @@ _TIER_MUSE_SPARK = {
     "cache_creation": 1.25 / 1_000_000,
     "cache_read": 0.15 / 1_000_000,
 }
+# Moonshot kimi-k3 (api.moonshot.ai, OpenAI-compatible). Moonshot's published
+# LIST rates, read off the vendor's own pricing page
+# (platform.kimi.ai/docs/pricing/chat-k3) on 2026-08-05: cache-miss input
+# $3.00/M, cache-hit input $0.30/M, output $15.00/M. Single tier — the page
+# states no context-length or time-of-day tiering, unlike the Luna row below.
+#
+# Sourced from the VENDOR, deliberately, per the post-mortem on that Luna row:
+# rates taken from a gateway can be a promotional discount that rots into
+# silent under-reporting the day it ends. Only an external number catches
+# that, so ``TestKimiK3PublishedRates`` pins these absolutes.
+#
+# ``cache_read`` is LIVE: the generic OpenAI-compat usage builder maps
+# ``prompt_tokens_details.cached_tokens`` onto ``cache_read_input_tokens``,
+# and Moonshot populates it (measured: a 1303-token prompt replayed with 1280
+# cached). That is a 10x discount on the cached portion, so the split is worth
+# real money on long agentic sessions.
+#
+# ``cache_creation`` mirrors ``input`` following _TIER_MUSE_SPARK: OpenAI-style
+# caching has no separate write charge. It is also UNREACHABLE on this wire —
+# ``openai_compatible.py`` hard-sets ``cache_creation_input_tokens = 0`` — so
+# it exists for shape only, and a test must not pin it as though a request
+# could exercise it.
+#
+# Only kimi-k3 is registered: Moonshot publishes no rates for the k2.x models,
+# and guessing one would be worse than the $0.00 they report today.
+_TIER_KIMI_K3 = {
+    "input": 3.00 / 1_000_000,
+    "output": 15.00 / 1_000_000,
+    "cache_creation": 3.00 / 1_000_000,
+    "cache_read": 0.30 / 1_000_000,
+}
 # OpenAI GPT-5.6 Luna / Luna Pro, as proxied by OpenRouter (both variants
 # publish identical rates). Read off OpenRouter's /models pricing record
 # 2026-07-31: prompt $0.10/M, completion $0.60/M, input_cache_write
@@ -226,6 +257,15 @@ PRICING: dict[str, dict[str, float]] = {
     "MiniMax-M2.7": _TIER_MINIMAX_M27,
     # Meta Muse Spark (api.meta.ai)
     "muse-spark-1.1": _TIER_MUSE_SPARK,
+    # Moonshot Kimi K3 (api.moonshot.ai). Exact-match only — this adds no
+    # family prefix, so the k2.x ids stay unpriced rather than inheriting K3's
+    # rates. Baseten serves its own ``moonshotai/Kimi-K3`` (see the spec
+    # registry); get_pricing's vendor-prefix strip reduces that to ``Kimi-K3``,
+    # which misses this key because the lookup is case-sensitive. That is the
+    # right outcome — Baseten's rates are not Moonshot's — but it survives on
+    # capitalization alone, so a future id-normalization pass must add an
+    # explicit Baseten row rather than let it fall through to here.
+    "kimi-k3": _TIER_KIMI_K3,
     # OpenAI GPT-5.6 Luna. Reached from OpenRouter's ``openai/gpt-5.6-luna``
     # via get_pricing's vendor-prefix strip, same as the DeepSeek rows.
     # VALUES UNUSED — these two rows act only as membership gates for

--- a/tests/test_kimi_k3_registration.py
+++ b/tests/test_kimi_k3_registration.py
@@ -1,0 +1,308 @@
+"""Moonshot ``kimi-k3`` registration: window, pricing, effort vocabulary.
+
+The model worked end-to-end before it was registered, which is precisely why
+the gaps were invisible: a 1M-window model silently resolved to the 200,000
+default, and a run that cost $0.078 reported $0.00. Nothing failed loudly.
+
+Every number pinned here was read off Moonshot's own surfaces on 2026-08-05 —
+``GET https://api.moonshot.ai/v1/models`` for windows and capability flags,
+platform.kimi.ai/docs/pricing/chat-k3 for rates — not inferred from the
+neighbouring rows.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import unittest
+
+from src.models.capabilities import supports_vision
+from src.models.configs import get_model_config
+from src.models.context import (
+    get_context_window_for_model,
+    get_model_max_output_tokens,
+)
+from src.providers import get_provider_class
+from src.providers.openai_compatible_specs import SPECS_BY_ID
+from src.services.pricing import compute_cost, get_pricing
+
+
+class TestKimiK3ModelConfig(unittest.TestCase):
+    """The window is the load-bearing number — it sizes auto-compaction."""
+
+    def test_context_window_is_the_published_1m(self) -> None:
+        self.assertEqual(get_context_window_for_model("kimi-k3"), 1_048_576)
+
+    def test_max_output_tokens(self) -> None:
+        self.assertEqual(get_model_max_output_tokens("kimi-k3"), 131_072)
+
+    def test_vision_is_asserted_not_merely_permitted(self) -> None:
+        # ``capabilities.supports_vision`` trusts a verdict only from an exact
+        # MODEL_CONFIGS hit, so this must come from a real row rather than the
+        # unknown-model default.
+        self.assertIsNotNone(get_model_config("kimi-k3"))
+        self.assertTrue(supports_vision("kimi-k3"))
+
+    def test_k2_models_keep_their_smaller_window(self) -> None:
+        for model in ("kimi-k2.6", "kimi-k2.7-code", "kimi-k2.7-code-highspeed"):
+            with self.subTest(model=model):
+                self.assertEqual(get_context_window_for_model(model), 262_144)
+
+
+class TestKimiPrefixCaptureGuard(unittest.TestCase):
+    """The regression this file exists for.
+
+    ``get_model_config`` falls back to ``key.rsplit("-", 1)[0]``, so the
+    ``kimi-k3`` key claims the broad prefix ``kimi`` and captures every
+    unenumerated ``kimi*`` id. Ordered with kimi-k3 first, a 262K model
+    inherits a 1,048,576 window — the WIDENING direction, which overflows the
+    request with a context-length 400 instead of merely compacting early.
+
+    The k2.x rows are placed above kimi-k3 so the prefix loop reaches the
+    conservative window first. This is reachable rather than hypothetical: the
+    moonshot spec discovers its catalog from the endpoint, so ids nobody
+    enumerated here are selectable via ``/model``.
+    """
+
+    UNENUMERATED = (
+        "kimi-latest",
+        "kimi-k2-turbo-preview",
+        "kimi-k2.7-code-0801",
+        "kimi-k3-0801",
+    )
+
+    def test_unenumerated_kimi_ids_never_inherit_the_1m_window(self) -> None:
+        for model in self.UNENUMERATED:
+            with self.subTest(model=model):
+                self.assertEqual(
+                    get_context_window_for_model(model),
+                    262_144,
+                    f"{model} must not inherit kimi-k3's 1M window — check that "
+                    "the kimi-k2.* rows still precede kimi-k3 in MODEL_CONFIGS",
+                )
+
+
+class TestVendorQualifiedKimiIds(unittest.TestCase):
+    """``get_model_config`` does not strip a leading ``<vendor>/``.
+
+    So the gateways that proxy Kimi need explicit rows, exactly as
+    ``openai/gpt-5.6-luna`` does. Baseten's ``moonshotai/Kimi-K3`` is shipped
+    in this repo's own curated list, and before these rows it reproduced the
+    bug being fixed — 200,000 against a real 1,048,576 — one ``/model``
+    selection away from the id that was fixed.
+
+    These ids carry a single hyphen, so ``moonshotai/kimi-k2``,
+    ``moonshotai/kimi-k2.6`` and ``moonshotai/kimi-k3`` all reduce to the SAME
+    base ``moonshotai/kimi``. The smallest window must therefore lead. Windows
+    for the lowercase ids come from OpenRouter's live catalogue (2026-08-05);
+    the capitalised rows are the HuggingFace-style spelling the same weights
+    are served under, and share the lowercase figures.
+    """
+
+    def test_each_proxied_id_gets_its_real_window(self) -> None:
+        # Exact matches only — this pins values. Ordering is the sibling
+        # test's job; do not delete that one thinking this covers it.
+        for model, window in (
+            ("moonshotai/kimi-k2", 131_072),
+            ("moonshotai/kimi-k2-0905", 262_144),
+            ("moonshotai/kimi-k2-thinking", 262_144),
+            ("moonshotai/kimi-k2.5", 262_144),
+            ("moonshotai/kimi-k2.6", 262_144),
+            ("moonshotai/kimi-k2.7-code", 262_144),
+            ("moonshotai/kimi-k3", 1_048_576),
+            ("moonshotai/Kimi-K3", 1_048_576),
+        ):
+            with self.subTest(model=model):
+                self.assertEqual(get_context_window_for_model(model), window)
+
+    def test_unenumerated_proxied_ids_fall_to_the_smallest_window(self) -> None:
+        # Both namespaces. A future ``moonshotai/kimi-*`` or ``moonshotai/Kimi-*``
+        # must not inherit k3's 1M — under-estimating compacts early,
+        # over-estimating dies on a context-length 400.
+        #
+        # The capitalised cases are a REGRESSION guard, not a hypothetical:
+        # registering moonshotai/Kimi-K3 without a capital-K guard moved every
+        # HF-spelled id from the 200,000 default to 1,048,576.
+        for model in (
+            "moonshotai/kimi-unknown-future",
+            "moonshotai/Kimi-K2-Instruct",
+            "moonshotai/Kimi-VL-A3B-Thinking",
+            "moonshotai/Kimi-Dev-72B",
+            "moonshotai/Kimi-Unknown",
+        ):
+            with self.subTest(model=model):
+                self.assertEqual(
+                    get_context_window_for_model(model),
+                    131_072,
+                    f"{model}: the -k2/-K2 rows must remain FIRST in their "
+                    "respective moonshotai/ namespaces",
+                )
+
+    def test_baseten_id_has_a_window_but_no_price(self) -> None:
+        # Window and price are separate questions: Baseten sets its own rates
+        # (so no pricing row) but serves the same 1M-context weights.
+        self.assertEqual(get_context_window_for_model("moonshotai/Kimi-K3"), 1_048_576)
+        self.assertIsNone(get_pricing("moonshotai/Kimi-K3"))
+
+    def test_openrouter_id_is_both_windowed_and_priced(self) -> None:
+        # The asymmetry this class closes: get_pricing strips the vendor
+        # prefix and get_model_config does not, so registering the tier
+        # without a row left this id priced at Moonshot's rate while still
+        # sized to the 200,000 default.
+        self.assertEqual(get_context_window_for_model("moonshotai/kimi-k3"), 1_048_576)
+        self.assertIsNotNone(get_pricing("moonshotai/kimi-k3"))
+
+
+class TestKimiK3PublishedRates(unittest.TestCase):
+    """Pin kimi-k3's ABSOLUTE rates, following the gpt-5.6-luna post-mortem.
+
+    That row sat at exactly half its published price for its whole registered
+    life because the internal ratios were self-consistent and only an external
+    number could contradict them. Source for these:
+    platform.kimi.ai/docs/pricing/chat-k3 (2026-08-05).
+    """
+
+    def test_rates_match_the_vendor_pricing_page(self) -> None:
+        p = get_pricing("kimi-k3")
+        self.assertIsNotNone(p)
+        self.assertAlmostEqual(p["input"] * 1e6, 3.00, places=6)
+        self.assertAlmostEqual(p["output"] * 1e6, 15.00, places=6)
+        self.assertAlmostEqual(p["cache_read"] * 1e6, 0.30, places=6)
+
+    def test_any_vendor_prefix_strips_to_the_same_tier(self) -> None:
+        # get_pricing strips a leading ``<vendor>/`` whatever the vendor is.
+        # NOT OpenRouter coverage — OpenRouter emits ``moonshotai/kimi-k3``,
+        # which TestVendorQualifiedKimiIds covers for both price AND window.
+        # This id is priced but unwindowed; no gateway emits it.
+        self.assertEqual(get_pricing("moonshot/kimi-k3"), get_pricing("kimi-k3"))
+
+    def test_baseten_capitalised_id_stays_unpriced(self) -> None:
+        # Baseten serves its own ``moonshotai/Kimi-K3`` at its own rates. The
+        # vendor-prefix strip reduces it to ``Kimi-K3``, which misses the
+        # case-sensitive key — the right outcome, pinned because it currently
+        # survives on capitalization alone.
+        self.assertIsNone(get_pricing("moonshotai/Kimi-K3"))
+
+    def test_k2_models_are_deliberately_unpriced(self) -> None:
+        # Moonshot publishes no rates for these; guessing would be worse than
+        # reporting nothing.
+        for model in ("kimi-k2.6", "kimi-k2.7-code", "kimi-k2.7-code-highspeed"):
+            with self.subTest(model=model):
+                self.assertIsNone(get_pricing(model))
+
+    def test_cost_of_a_real_measured_run(self) -> None:
+        # Usage record from an actual 4-turn agentic run against kimi-k3.
+        # Before registration this returned 0.0.
+        usage = {
+            "input_tokens": 19_031,
+            "output_tokens": 296,
+            "cache_read_input_tokens": 55_552,
+            "cache_creation_input_tokens": 0,
+        }
+        expected = 19_031 * 3.0e-6 + 296 * 15.0e-6 + 55_552 * 0.30e-6
+        self.assertAlmostEqual(compute_cost("kimi-k3", usage), expected, places=9)
+        self.assertGreater(compute_cost("kimi-k3", usage), 0.0)
+
+
+class TestMoonshotSpec(unittest.TestCase):
+    def test_kimi_k3_is_selectable(self) -> None:
+        # Asserted against the SPEC, not ``get_available_models()``: the spec
+        # is now a hybrid dynamic catalog, and that call fires a live
+        # ``GET /models`` whenever the discovery cache is cold — which, under
+        # the per-test config dir, it always is.
+        # The one fact not pinned elsewhere: kimi-k3 is in the picker at all,
+        # so ``/model kimi-k3`` passes the membership check that used to
+        # reject it. default_model is pinned by VENDOR_DEFAULTS in
+        # test_provider_registry.py; behavioural discovery coverage is carried
+        # by the parameterized guards in test_opencode_compat_providers.py,
+        # which moonshot now joins.
+        self.assertIn("kimi-k3", SPECS_BY_ID["moonshot"].available_models)
+
+
+class TestMoonshotEffortVocabulary(unittest.TestCase):
+    """Moonshot accepts low | high | max and IGNORES anything else.
+
+    An out-of-vocabulary level does not 400 (probed: ``medium``, ``xhigh`` and
+    ``bogus`` all return 200) — the field is dropped and the request lands on
+    the API default, which for kimi-k3 is ``max``. So an untranslated
+    ``medium`` silently buys maximum reasoning at $15/Mtok of output.
+    """
+
+    def setUp(self) -> None:
+        cls = get_provider_class("moonshot")
+        self.provider = cls(
+            api_key="k", base_url="https://api.moonshot.ai/v1", model="kimi-k3"
+        )
+
+    def test_supported_levels_pass_through_untouched(self) -> None:
+        for level in ("low", "high", "max"):
+            with self.subTest(level=level):
+                self.assertEqual(
+                    self.provider.normalize_reasoning_effort(level), level
+                )
+
+    def test_unsupported_levels_map_to_the_nearest_supported_one(self) -> None:
+        self.assertEqual(self.provider.normalize_reasoning_effort("medium"), "high")
+        self.assertEqual(self.provider.normalize_reasoning_effort("xhigh"), "max")
+
+    def test_none_stays_none(self) -> None:
+        self.assertIsNone(self.provider.normalize_reasoning_effort(None))
+
+    def test_alias_dict_is_not_shared_between_generated_classes(self) -> None:
+        # ``BaseProvider.reasoning_effort_aliases`` is a mutable class-level
+        # default; one shared object across generated classes would let a
+        # mutation through any provider leak into every other.
+        other = get_provider_class("cerebras")
+        moonshot = get_provider_class("moonshot")
+        self.assertIsNot(
+            other.reasoning_effort_aliases, moonshot.reasoning_effort_aliases
+        )
+        self.assertEqual(other.reasoning_effort_aliases, {})
+
+    def test_providers_without_a_declared_vocabulary_still_pass_through(self) -> None:
+        cls = get_provider_class("cerebras")
+        provider = cls(api_key="k")
+        self.assertIsNone(cls.supported_reasoning_efforts)
+        for level in ("low", "medium", "high", "xhigh", "max"):
+            with self.subTest(level=level):
+                self.assertEqual(provider.normalize_reasoning_effort(level), level)
+
+
+class TestHarborAdvisorCredentials(unittest.TestCase):
+    """The advisor forwards its OWN provider's key, and moonshot was missing.
+
+    Parsed rather than imported: ``clawcodex_agent`` runs inside Harbor's venv
+    and uses ``typing.override`` (3.12+), so importing it here would couple
+    this suite to the interpreter version.
+
+    Without the entry, ``_advisor_env_vars`` falls back to the union of all
+    known vars — which does not contain MOONSHOT_API_KEY — and a
+    ``moonshot:kimi-k3`` advisor reaches the container with no credentials.
+    It then fails quietly: the worker carries on and the task can still score
+    1.0, so the reward alone never reveals it.
+    """
+
+    def test_moonshot_keys_are_forwarded_to_the_container(self) -> None:
+        path = (
+            pathlib.Path(__file__).resolve().parents[1]
+            / "eval"
+            / "harbor"
+            / "clawcodex_agent.py"
+        )
+        tree = ast.parse(path.read_text())
+        table = None
+        for node in ast.walk(tree):
+            target = node.target if isinstance(node, ast.AnnAssign) else None
+            if isinstance(target, ast.Name) and target.id == "_PROVIDER_ENV_VARS":
+                table = ast.literal_eval(node.value)
+                break
+        self.assertIsNotNone(table, "_PROVIDER_ENV_VARS not found in the adapter")
+        self.assertEqual(table["moonshot"], ("MOONSHOT_API_KEY", "KIMI_API_KEY"))
+
+    def test_the_adapter_map_matches_the_provider_spec(self) -> None:
+        self.assertEqual(
+            SPECS_BY_ID["moonshot"].env_vars, ("MOONSHOT_API_KEY", "KIMI_API_KEY")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_opencode_compat_providers.py
+++ b/tests/test_opencode_compat_providers.py
@@ -24,7 +24,11 @@ import pytest
 from src.providers import PROVIDER_INFO, get_provider_class
 from src.providers.openai_compatible_specs import SPECS_BY_ID, _SPECS
 
-PORTED = ("groq", "cerebras", "baseten", "xai")
+# ``moonshot`` is not an OpenCode port, but it became a hosted hybrid row when
+# kimi-k3 was registered, so it belongs to exactly the population these
+# parameterized guards describe — curated list leads, discovery appends,
+# vendor env var sources the key.
+PORTED = ("groq", "cerebras", "baseten", "xai", "moonshot")
 
 
 @pytest.mark.parametrize("provider_id", PORTED)
@@ -97,6 +101,7 @@ def test_the_key_is_sourced_from_the_vendor_env_var(provider_id: str) -> None:
         "cerebras": "CEREBRAS_API_KEY",
         "baseten": "BASETEN_API_KEY",
         "xai": "XAI_API_KEY",
+        "moonshot": "MOONSHOT_API_KEY",
     }[provider_id]
     assert expected in SPECS_BY_ID[provider_id].env_vars
 

--- a/tests/test_provider_registry.py
+++ b/tests/test_provider_registry.py
@@ -60,7 +60,7 @@ EXPECTED_NEW_PROVIDERS = {
 VENDOR_DEFAULTS = {
     "nvidia-nim": ("https://integrate.api.nvidia.com/v1", "deepseek-ai/deepseek-v4-pro"),
     "together": ("https://api.together.xyz/v1", "deepseek-ai/DeepSeek-V4-Pro"),
-    "moonshot": ("https://api.moonshot.ai/v1", "kimi-k2.7-code"),
+    "moonshot": ("https://api.moonshot.ai/v1", "kimi-k3"),
     "ollama": ("http://localhost:11434/v1", "deepseek-coder:1.3b"),
     "deepinfra": ("https://api.deepinfra.com/v1/openai", "deepseek-ai/DeepSeek-V4-Pro"),
     "stepfun": ("https://api.stepfun.ai/v1", "step-3.7-flash"),
@@ -167,7 +167,7 @@ class TestProviderResolution(unittest.TestCase):
 
     def test_get_provider_info_via_alias(self):
         info = get_provider_info("kimi")
-        self.assertEqual(info["default_model"], "kimi-k2.7-code")
+        self.assertEqual(info["default_model"], "kimi-k3")
 
 
 class TestApiKeyResolution(unittest.TestCase):


### PR DESCRIPTION
## What

`kimi-k3` **already worked** end-to-end — a 4-turn agentic run with Write/Read/Bash completes fine, prompt caching registers. It was simply never registered, so it resolved to defaults that were wrong in ways nothing failed loudly about:

| | before | after | consequence of "before" |
|---|---|---|---|
| context window | 200,000 | **1,048,576** | compaction fired at 20% of the real window |
| max output | 8,192 | **131,072** | undersized auto-compact reservation |
| pricing | *none* → $0.00 | **$3.00 / $15.00 / $0.30 cached** | a run that cost $0.078 reported $0.00 |
| `/model kimi-k3` | **rejected** | accepted | absent from `available_models` |
| effort vocabulary | pass-through | **low \| high \| max** | `medium`/`xhigh` silently ignored |

Every figure is probed, not inferred: `GET /v1/models` for windows and capability flags, the vendor pricing page for rates, direct wire probes for parameter acceptance.

## Why the effort vocabulary needs a new mechanism

`ProviderSpec` gains `reasoning_efforts` / `reasoning_effort_aliases` so a *generated* provider can declare a vocabulary — previously only expressible on a hand-written class.

Moonshot needs one. An out-of-vocabulary `reasoning_effort` does **not** 400 — probed, `medium`, `xhigh` and even `bogus` all return 200. The field is dropped and the request lands on the API default, which for kimi-k3 is `max`. Untranslated, a user asking for `medium` buys maximum reasoning at $15/Mtok of output.

Aliases are a tuple of pairs so the frozen dataclass stays hashable, converted to a **per-class** dict to avoid sharing `BaseProvider`'s mutable class-level default.

## Order is load-bearing in MODEL_CONFIGS

The prefix fallback reduces a key to `key.rsplit("-", 1)[0]`, so `"kimi-k3"` claims the broad base `kimi` and captures every unenumerated `kimi*` id. Left unguarded a 262K model inherits 1,048,576 — the **widening** direction, which overflows the request with a context-length 400 instead of merely compacting early.

Three namespaces, each with a guard row carrying the smallest window, placed first:

| guard | window | protects |
|---|---|---|
| `kimi-k2.6` | 262,144 | `kimi-*` |
| `moonshotai/kimi-k2` | 131,072 | `moonshotai/kimi-*` |
| `moonshotai/Kimi-K2` | 131,072 | `moonshotai/Kimi-*` |

The vendor-qualified rows are not incidental. `get_model_config` deliberately does not strip a leading `<vendor>/`, so **`moonshotai/Kimi-K3` — which this repo already ships in Baseten's curated list — reproduced the exact bug being fixed**, one `/model` selection away. OpenRouter's live catalogue also shows `moonshotai/kimi-k2` at **131,072**, not the 262,144 the family suggests, so a k3-only row would have widened that id 8×. `moonshotai/` is the HuggingFace org namespace, so capitalised `Kimi-*` is a populated convention rather than one Baseten row — and `--model` is free text with no availability check.

## Harbor adapter

`moonshot` added to `_PROVIDER_ENV_VARS`. Without it an advisor at `moonshot:kimi-k3` fell through to the union of all known vars — which does not contain `MOONSHOT_API_KEY` — and reached the container with **no credentials**. It fails quietly: the worker carries on and the task can still score 1.0, so reward alone never reveals it.

## Known, documented, not fixed here

These rows outrank a user's `modelLimits`, because `get_context_window_for_model` consults `get_model_config` first. Corrective for the enumerated ids; an over-estimate for a self-hosted `kimi-*` on ollama/vLLM. The fix is reordering to exact-hit → settings → prefix, which touches `glm`/`gpt`/`MiniMax` alike and needs its own sweep. Recorded in-code so it is not rediscovered from a bug report.

The `default_model` flip to `kimi-k3` is **inert for existing installs** — `get_default_config()` materializes `default_model` into every provider block and on-disk wins the merge. Fresh configs only.

## Verification

- Full suite **9762 passed / 10 skipped / 0 failed**.
- **All three ordering guards mutation-tested** — hoisting or deleting a guard row fails the corresponding subtests, so none of them is a test that cannot fail.
- Live re-run against the API reports **$0.063** where it previously reported **$0.00**.
- Reviewed by the `critic` subagent across three rounds; it caught a real regression I had introduced in the capital-K namespace (200,000 → 1,048,576) before the final APPROVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)