### PR TITLE
fix(advisor): let the reviewer approve a plan, and make it hand over the check

### DIFF
--- a/src/utils/advisor.py
+++ b/src/utils/advisor.py
@@ -279,6 +279,46 @@ ADVISOR_MODE_CLIENT_SIDE = "client_side"
 # provider as the system message. Kept short — the conversation we
 # forward is the substantive context, and the prompt's role is just to
 # orient the advisor model on what kind of feedback to produce.
+#
+# THIS PROMPT IS OURS, not a port. The TypeScript reference has no
+# equivalent: upstream's advisor is server-side only, so the reviewer's
+# behaviour is defined by the API and never appears in client code
+# (`typescript/src/utils/advisor.ts` declares the schema and the
+# WHEN-to-call policy, and nothing else). Client-side mode is a Python
+# extension that made non-Anthropic advisors possible, and it obliged us
+# to author the reviewer's mandate ourselves. Treat this as a design
+# surface we own — there is no upstream fidelity argument for any line
+# of it.
+#
+# REBALANCED after an 89-task terminal-bench differential. The first
+# version told the reviewer "your only value is the gap" and gave it an
+# output format demanding 1-3 Gaps and 1-3 Risks. A strong model asked to
+# find problems always finds real ones, and every one became work: the
+# "Nothing material missing" escape hatch fired essentially never across
+# 300+ consultations. Measured against the same worker with no advisor:
+#
+#     cancel-async-tasks   11 steps / reward 0.0   vs   7 steps / 1.0
+#     headless-terminal    52 steps / reward 0.0   vs  19 steps / 1.0
+#     sam-cell-seg         73 steps / reward 0.0   vs  18 steps / 1.0
+#
+# The advice was expert-grade in every case — it was also 1.6x, 2.7x and
+# 4.1x the work, for a worse outcome. A reviewer that can only add is
+# half a reviewer; the floor is not zero, it is negative whenever the
+# simpler path would have succeeded.
+#
+# So: `proceed` is a first-class verdict, "None." is the expected answer
+# for a sound plan, and scope must be justified by the user's goal rather
+# than by best practice. Rule 6 additionally makes the RECONCILE protocol
+# fire from this side. The worker-side policy
+# (ADVISOR_TOOL_INSTRUCTIONS) already tells the worker to surface a
+# conflict rather than silently switch, but that text is a byte-for-byte
+# port we must not edit — and it was not firing. Requiring the reviewer
+# to hand over a verifying command when its claim is checkable achieves
+# the same protocol without touching ported text. This is not
+# hypothetical: on `raman-fitting` the reviewer asserted a peak
+# assignment, told the worker to reject the competing reading, and was
+# WRONG — the grader expected exactly the reading it rejected, and one
+# command against data the worker already had would have settled it.
 CLIENT_ADVISOR_SYSTEM_PROMPT = """You are a senior reviewer being consulted by a junior worker model that has paused mid-task to get your judgment. The conversation below is everything the worker has seen and done so far: the user's task, every tool call the worker made, every result.
 
 # CRITICAL — read these before responding
@@ -287,19 +327,27 @@ CLIENT_ADVISOR_SYSTEM_PROMPT = """You are a senior reviewer being consulted by a
 
 2. **DO NOT respond in the worker's voice.** Never write "I will...", "My plan is...", "Let me...". You are NOT the worker. You are the reviewer talking AT the worker. Use "you" / "your" / "the plan" — second-person, never first-person.
 
-3. **Your only value is the gap.** Tell the worker what they CAN'T see — what they missed, what's risky, what better approach exists. Anything the worker already wrote in their own message is something they already know — never repeat it.
+3. **Your value is the gap OR the green light — both are real answers.** Tell the worker what they CAN'T see. Sometimes what they can't see is that their plan is already good enough. "This is sound — proceed" is a complete, valuable review, not a failure to find something. Never repeat what the worker already wrote.
+
+4. **Every suggestion you make becomes work the worker must do.** They act on what you say. An unnecessary suggestion is not free advice — it spends their remaining time, context and attention, which you cannot see. Raise something only when acting on it beats not acting on it. If they are building more than the stated goal needs, say so: "you are overbuilding X — cut it" is as useful as any gap.
+
+5. **Justify scope by the user's goal, not by best practice.** Extra interfaces, extra hardening, extra validation, extra abstraction: propose these only when the stated goal requires them. A reviewer who reflexively adds rigor makes the worker slower and no more correct.
+
+6. **If a claim of yours is checkable, hand over the check.** When you assert something about the data, the environment, or the code that the worker could verify in one command, give that command and tell them to run it before committing. You are reasoning over a flattened transcript and can be confidently wrong; a cheap check beats your confidence. Never tell the worker to reject their own primary-source evidence without a test that settles it.
 
 # Output shape
 
 Reply in this exact format. No preamble. No sign-off.
 
-**Gaps:** 1-3 short bullets on what's missing, wrong, or unclear in the plan. If nothing material → write "Nothing material missing." (one bullet, no more).
+**Verdict:** exactly one of — `proceed` (plan is sound, execute it) / `adjust` (workable, but change something specific) / `stop — rethink` (the approach is wrong). Pick `proceed` whenever the plan would reach the stated goal, even if you can imagine a more thorough version.
 
-**Risks:** 1-3 short bullets on what could break, surprise, or bite later. Concrete failure modes only — not generic disclaimers.
+**Gaps:** 0-3 short bullets on what's missing, wrong, or unclear. Write "None." when the plan is sufficient — that is the expected answer for a sound plan, not a cop-out. Do not manufacture a gap to fill the slot.
 
-**Do next:** ONE sentence. The single most-important next action.
+**Risks:** 0-3 short bullets on what could break, surprise, or bite later. Concrete failure modes only — not generic disclaimers. "None." is allowed.
 
-If the worker's whole approach is fundamentally wrong, skip the format and write a short "Stop — rethink: ..." paragraph instead, then the one-sentence next action.
+**Do next:** ONE sentence. The single most-important next action — which may be "execute the plan as written".
+
+On `stop — rethink`, skip Gaps/Risks and write a short paragraph on why the approach is wrong, then the one-sentence next action.
 
 # Style
 

--- a/tests/test_advisor_effort_wiring.py
+++ b/tests/test_advisor_effort_wiring.py
@@ -771,3 +771,84 @@ class TestAdvisorAlwaysAsksForAdvice(unittest.TestCase):
                 fwd = self._fwd(hist)
                 self.assertEqual(fwd[-1]["role"], "user")
                 self.assertIn(self._suffix(), fwd[-1]["content"])
+
+
+class TestReviewerPromptMandate(unittest.TestCase):
+    """The reviewer prompt is OURS — the TS reference has no equivalent,
+    because upstream's advisor is server-side and its behaviour lives in the
+    API. So these are design invariants, not port fidelity.
+
+    Pinned after an 89-task differential where the original "your only value
+    is the gap" framing made the advisor a scope-expansion engine: measured
+    against the same worker with no advisor, cancel-async-tasks 11 steps/0.0
+    vs 7/1.0, headless-terminal 52/0.0 vs 19/1.0, sam-cell-seg 73/0.0 vs
+    18/1.0.
+    """
+
+    def _prompt(self) -> str:
+        from src.utils.advisor import CLIENT_ADVISOR_SYSTEM_PROMPT
+
+        return CLIENT_ADVISOR_SYSTEM_PROMPT
+
+    def test_approving_a_plan_is_a_first_class_verdict(self) -> None:
+        """A reviewer that can only add is half a reviewer."""
+        p = self._prompt().lower()
+        self.assertIn("proceed", p)
+        self.assertNotIn(
+            "your only value is the gap", p,
+            msg="the gap-only mandate is what made every consultation "
+                "generate work",
+        )
+
+    def test_gaps_may_be_empty(self) -> None:
+        """'None.' must be an expected answer, not a rarely-taken footnote."""
+        p = self._prompt()
+        self.assertIn("0-3", p, msg="Gaps/Risks must permit zero bullets")
+        self.assertNotIn(
+            "**Gaps:** 1-3", p,
+            msg="a mandatory 1-3 slot forces the model to manufacture gaps",
+        )
+
+    def test_suggestions_are_framed_as_costing_the_worker_work(self) -> None:
+        p = self._prompt().lower()
+        self.assertTrue(
+            "becomes work" in p or "spends their" in p,
+            msg="the reviewer must know its suggestions are not free",
+        )
+
+    def test_scope_is_justified_by_the_goal_not_best_practice(self) -> None:
+        p = self._prompt().lower()
+        self.assertIn("best practice", p)
+        self.assertTrue("overbuild" in p or "cut it" in p)
+
+    def test_reconcile_protocol_fires_from_the_reviewer_side(self) -> None:
+        """The worker-side policy already says 'surface the conflict', but
+        that text is a byte-for-byte port we must not edit — and it was not
+        firing. The reviewer must hand over the check itself."""
+        p = self._prompt().lower()
+        self.assertIn("checkable", p)
+        self.assertTrue(
+            "command" in p and "verify" in p,
+            msg="a checkable claim must come with the command that settles it",
+        )
+        self.assertIn("confidently wrong", p)
+
+    def test_worker_side_instructions_remain_a_byte_for_byte_port(self) -> None:
+        """ADVISOR_TOOL_INSTRUCTIONS mirrors typescript/src/utils/advisor.ts
+        and must not drift — the reconcile fix deliberately went into the
+        reviewer prompt instead, precisely to keep this intact."""
+        from src.utils.advisor import ADVISOR_TOOL_INSTRUCTIONS as T
+
+        for phrase in (
+            "Give the advice serious weight.",
+            "which constraint breaks the tie?",
+            "the advisor adds most of its value on the first call",
+        ):
+            self.assertIn(phrase, T, msg=f"ported text lost: {phrase!r}")
+
+    def test_style_and_anti_echo_rules_survive(self) -> None:
+        """The rebalance must not lose what already worked."""
+        p = self._prompt()
+        self.assertIn("DO NOT restate", p)
+        self.assertIn("DO NOT respond in the worker's voice", p)
+        self.assertIn("Terse.", p)


### PR DESCRIPTION
## The problem

The reviewer prompt told the model **"your only value is the gap"** and gave it an output format demanding 1-3 Gaps and 1-3 Risks. A strong model asked to find problems always finds real ones — and every one became work the worker had to do. The `"Nothing material missing"` escape hatch fired essentially **never** across 300+ consultations.

Measured on an 89-task terminal-bench differential, same worker with and without the advisor:

| task | with advisor | without |
|---|---|---|
| `cancel-async-tasks` | 11 steps / **0.0** | 7 steps / **1.0** |
| `headless-terminal` | 52 steps / **0.0** | 19 steps / **1.0** |
| `sam-cell-seg` | 73 steps / **0.0** | 18 steps / **1.0** |

The advice was expert-grade in every case. It was also 1.6×, 2.7× and 4.1× the work, for a worse outcome. **A reviewer that can only add is half a reviewer** — its floor isn't zero, it's negative whenever the simpler path would have succeeded.

## This prompt is ours, not a port

The TypeScript reference has **no equivalent**. Upstream's advisor is server-side, so the reviewer's behaviour is defined by the API and never appears in client code — `typescript/src/utils/advisor.ts` declares the schema and the *when-to-call* policy and nothing else. Client-side mode is a Python extension that made non-Anthropic advisors possible, and it obliged us to author the reviewer's mandate ourselves. There is no fidelity argument for any line of it.

## Changes

- `proceed` is a **first-class verdict**; Gaps/Risks are `0-3` with `"None."` the expected answer for a sound plan
- suggestions are framed as spending the worker's **unseen** remaining time and attention
- scope must be justified by the user's goal, not best practice — *"you are overbuilding X — cut it"* named as equally useful

### Reconcile protocol, from the reviewer's side

`ADVISOR_TOOL_INSTRUCTIONS` already tells the worker to surface a conflict rather than silently switch — but that text is a **byte-for-byte port** that must not drift, and it wasn't firing. Requiring the **reviewer** to hand over a verifying command when its claim is checkable achieves the same protocol without touching ported text. A test pins that the ported text is unchanged.

Not hypothetical: on `raman-fitting` the reviewer asserted *"G = 3745, 2D = 6328"*, told the worker to reject the competing reading, and was **wrong** — the grader expected exactly the rejected reading.

## Verification — reported honestly

Re-ran the four tasks the advisor lost, on the same code:

| task | new | old advisor | no advisor |
|---|---|---|---|
| `headless-terminal` | 22 steps → **1.0** | 52 → 0.0 | 19 → 1.0 |
| `sam-cell-seg` | 45 steps → **1.0** | 73 → 0.0 | 18 → 1.0 |
| `raman-fitting` | 39 steps → 0.0 *(timeout)* | 32 → 0.0 | 41 → 1.0 |
| `cancel-async-tasks` | 11 steps → 0.0 | 11 → 0.0 | 7 → 1.0 |

**Both scope-expansion cases recovered**, with steps down 58% and 38%. That is the mechanism this PR targets, and it moved.

The other two did not, and I'm not claiming them:
- `raman-fitting` now **times out** rather than following wrong advice. Its advice did improve markedly — it now says *"verify in one command before anything else"*, gives three independent confirmations, and derives that column 1 is `1e7/shift` in nm. Better reasoning, still too slow.
- `cancel-async-tasks` is **unchanged** at 11 steps — a different mechanism, not diagnosed.

**n=4 against a ±20-task replicate-noise floor**, so read this as "did the mechanism change" (steps, and whether advice seeks evidence), not as a score verdict.

Full suite **9769 passed, 10 skipped, exit 0**.

## Deliberately not included

Resource-awareness plumbing, enforcing "first call carries the value", the stale model allowlist, and subagent advisor access — all identified, all separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)