### PR TITLE
feat(vision): give a text-only model eyes via a configurable vision_analyze tool

### DIFF
--- a/src/command_system/builtins.py
+++ b/src/command_system/builtins.py
@@ -31,6 +31,7 @@ from .statusline import STATUSLINE_COMMAND
 from .theme_command import THEME_COMMAND
 from .eco_command import ECO_COMMAND
 from .fusion_command import FUSION_COMMAND
+from .vision_command import VISION_COMMAND
 from .effort_command import EFFORT_COMMAND
 from .model_command import MODEL_COMMAND
 from .logo_command import LOGO_COMMAND
@@ -1499,6 +1500,7 @@ def get_builtin_commands() -> list[Command]:
         CONTEXT_COMMAND,
         COMPACT_COMMAND,
         ADVISOR_COMMAND,
+        VISION_COMMAND,
         INIT_COMMAND,
         AUTO_FIX_COMMAND,
         REVIEW_COMMAND,

--- a/src/command_system/vision_command.py
+++ b/src/command_system/vision_command.py
@@ -1,0 +1,155 @@
+"""/vision — configure the model that answers ``vision_analyze``.
+
+    /vision                        show the current pairing
+    /vision <provider>:<model>     set it (and turn the tool on)
+    /vision on                     re-enable the last pairing
+    /vision off                    disable without forgetting it
+
+Grammar matches ``/advisor``: ``<provider>:<model>``, split on the FIRST
+colon so model ids containing ``/`` or further ``:`` survive intact
+(``openrouter:z-ai/glm-4.5v``). Both halves are required — clawcodex is
+multi-provider and the same model name sits behind several of them, so the
+provider cannot be inferred from the model.
+
+Writes the GLOBAL config tier only; :mod:`src.providers.vision_config`
+explains why that is a security requirement rather than a convenience. No
+``AppState`` field and no ``settings`` key: that config module is the single
+reader, so there is nothing to keep in sync.
+
+Every path is headless-safe, so the command behaves identically in the TUI,
+``-p`` headless, and the SDK.
+"""
+
+from __future__ import annotations
+
+from .types import CommandContext, LocalCommand, LocalCommandResult
+
+_USAGE = "Usage: /vision <provider>:<model> | on | off"
+
+
+def _configured_providers() -> list[str]:
+    """Provider keys present in the global config's ``providers`` map."""
+    try:
+        from .. import config as cfg_mod
+
+        providers = cfg_mod._get_default_manager().load_global().get("providers")
+        if isinstance(providers, dict):
+            return sorted(providers.keys())
+    except Exception:  # noqa: BLE001
+        pass
+    return []
+
+
+def _text(value: str) -> LocalCommandResult:
+    return LocalCommandResult(type="text", value=value)
+
+
+def vision_command_call(args: str, context: CommandContext) -> LocalCommandResult:
+    from ..providers.vision_config import (
+        load_vision_config,
+        save_vision_config,
+        set_vision_enabled,
+    )
+
+    arg = (args or "").strip()
+    current = load_vision_config()
+
+    if not arg:
+        if current is None:
+            return _text(
+                "Vision is not configured. Set one with /vision <provider>:<model> "
+                "(e.g. /vision openai:gpt-5.6-luna) — it lets a text-only model "
+                "call vision_analyze on an image."
+            )
+        return _text(f"Vision model: {current.selector}")
+
+    lowered = arg.lower()
+
+    if lowered in ("off", "disable", "none"):
+        if current is None:
+            return _text("Vision already off.")
+        set_vision_enabled(False)
+        return _text(f"Vision disabled (was {current.selector}).")
+
+    if lowered in ("on", "enable"):
+        # Re-arm a pairing that ``off`` preserved, so the user does not have
+        # to retype it. Only meaningful when provider+model are still on disk.
+        if current is not None:
+            return _text(f"Vision already on ({current.selector}).")
+        set_vision_enabled(True)
+        restored = load_vision_config()
+        if restored is None:
+            # ``enabled`` flipped but no pairing was ever saved — say so
+            # rather than reporting success for a config that cannot work.
+            set_vision_enabled(False)
+            return _text(f"No saved vision model to enable. {_USAGE}")
+        return _text(f"Vision enabled ({restored.selector}).")
+
+    if ":" not in arg:
+        providers = _configured_providers()
+        hint = f" Configured providers: {', '.join(providers)}." if providers else ""
+        return _text(f"{_USAGE} (got {arg!r}).{hint}")
+
+    provider_part, model_part = arg.split(":", 1)
+    provider_part = provider_part.strip()
+    model_part = model_part.strip()
+    if not provider_part or not model_part:
+        return _text(f"Both halves required. {_USAGE} (got {arg!r}).")
+
+    # Validate against the real provider registry, NOT just the config's
+    # ``providers`` map. Two reasons the map alone is wrong: it is empty on a
+    # fresh install (which would let ANY string through and persist a config
+    # that can never work), and it misses aliases that
+    # ``get_provider_config`` would happily resolve.
+    try:
+        from ..config import get_provider_config
+
+        get_provider_config(provider_part)
+    except Exception:
+        providers = _configured_providers()
+        hint = f" Configured providers: {', '.join(providers)}." if providers else ""
+        return _text(f"Unknown provider {provider_part!r}.{hint}")
+
+    # Credentials: the tool would otherwise advertise itself, get called, and
+    # die on "Missing credentials" — and because Read's stub starts naming it
+    # the moment it is configured, the failure would look like a tool bug.
+    warning = ""
+    try:
+        from ..providers import provider_has_credentials, resolve_api_key
+
+        if not provider_has_credentials(provider_part, resolve_api_key(provider_part)):
+            warning = (
+                f"\nWarning: no API key found for {provider_part}. "
+                "Run /login or set its API key env var before using it."
+            )
+    except Exception:  # noqa: BLE001 — never block configuration on this check
+        pass
+
+    # Vision capability is a WARNING, not a refusal: the model table is not
+    # exhaustive and a freshly released vision model should not be blocked by
+    # our catalogue lagging. Same permissive stance ``supports_vision`` takes.
+    try:
+        from ..models.capabilities import supports_vision
+
+        if not supports_vision(model_part):
+            warning += (
+                f"\nNote: {model_part} is recorded as NOT vision-capable. "
+                "If that is wrong it will still be used."
+            )
+    except Exception:  # noqa: BLE001
+        pass
+
+    cfg = save_vision_config(provider_part, model_part)
+    return _text(
+        f"Vision model set to {cfg.selector}. vision_analyze is now available."
+        f"{warning}"
+    )
+
+
+VISION_COMMAND = LocalCommand(
+    name="vision",
+    description="Configure the vision model used by the vision_analyze tool",
+    argument_hint="[<provider>:<model> | on | off]",
+    supports_non_interactive=True,
+)
+VISION_COMMAND.set_call(vision_command_call)

--- a/src/providers/fusion_provider.py
+++ b/src/providers/fusion_provider.py
@@ -566,6 +566,64 @@ class FusionProvider:
             text = text[:_MAX_DESCRIPTION_CHARS] + "… [description truncated]"
         return text
 
+    @staticmethod
+    def _requery_handle(source: dict[str, Any]) -> str:
+        """A trailing hint telling the base model how to look again.
+
+        Ported from hermes-agent (``run_agent.py:4455-4458``), which appends
+        ``[If you need a closer look, use vision_analyze with image_url: …]``
+        to the note it substitutes for an image.
+
+        Why this matters: a description is ONE fixed pass, and this provider
+        discards ``source`` the moment it returns — nothing here can produce
+        those bytes again. Before this hint, a base model that needed the VAT
+        line off an invoice the generic pass skimmed had no recourse at all.
+        The budget-exhausted branch below has been telling the model to "ask
+        about this image on its own" since it was written; only now is that
+        instruction something it can actually act on.
+
+        Emitted on EVERY branch, not just success — hermes appends its handle
+        on failure paths too (``gateway/run.py:13421,:13428``), and a failed
+        description is precisely when a second look is worth most.
+
+        HANDLE CHOICE. hermes's handle is the image's own path/URL, and it
+        deliberately emits NO handle for ``data:`` URLs rather than a dead
+        one. This provider sits at egress and usually holds only base64, so
+        the same rule applies: a URL source gets an exact handle, and base64
+        gets a path-free pointer that leans on the model already knowing where
+        the image came from (it just called ``Read`` on it). Inventing a
+        handle for pasted bytes would need a byte registry, which hermes
+        declines to build and which would blow up this module's small
+        description cache.
+
+        Silent when no vision tool is configured — an instruction the user
+        cannot satisfy is worse than none.
+        """
+        try:
+            from src.providers.vision_config import vision_is_configured
+
+            if not vision_is_configured():
+                return ""
+        except Exception:  # noqa: BLE001 — a hint must never break substitution
+            return ""
+
+        url = source.get("url")
+        if isinstance(url, str) and url.strip():
+            # NOT "use vision_analyze with image_url: <url>" as hermes writes
+            # it: hermes's tool downloads URLs (httpx + SSRF validation +
+            # a size cap), and this port deliberately does not. Telling the
+            # model to pass a URL to a tool that refuses URLs would spend a
+            # tool call to earn a refusal, so the instruction names the step
+            # that actually works.
+            return (
+                f"\n[If you need a closer look, download {url.strip()} (e.g. "
+                "with Bash) and call vision_analyze on the saved file.]"
+            )
+        return (
+            "\n[If you need a closer look, call vision_analyze with the file "
+            "path you read this image from and a specific question.]"
+        )
+
     def _substitute(self, block: Any, budget: "_Budget") -> Any:
         """Return the replacement for one image block (or the block itself)."""
         source = _image_source(block)
@@ -575,13 +633,14 @@ class FusionProvider:
         label = _describe_size(source)
         prefix = f"[Image ({label})" if label else "[Image"
         vision = self._fusion.vision.selector
+        handle = self._requery_handle(source)
 
         key = _image_key(self._scope(), source)
         if key is None:
             logger.warning("[fusion] image block has no data or url; substituting note")
             return {
                 "type": "text",
-                "text": f"{prefix}: not described — the image block carried no data.]",
+                "text": f"{prefix}: not described — the image block carried no data.]{handle}",
             }
 
         cached = _cache_get(key)
@@ -591,9 +650,12 @@ class FusionProvider:
             if isinstance(cached, _Failure):
                 return {
                     "type": "text",
-                    "text": f"{prefix}: could not be described ({vision}): {cached.reason}]",
+                    "text": f"{prefix}: could not be described ({vision}): {cached.reason}]{handle}",
                 }
-            return {"type": "text", "text": f"{prefix}, described by {vision}]\n{cached}"}
+            return {
+                "type": "text",
+                "text": f"{prefix}, described by {vision}]\n{cached}{handle}",
+            }
 
         exhausted = budget.exhausted()
         if exhausted:
@@ -602,7 +664,7 @@ class FusionProvider:
                 "type": "text",
                 "text": (
                     f"{prefix}: not described — {exhausted}. Ask about this image "
-                    "on its own to have it described.]"
+                    f"on its own to have it described.]{handle}"
                 ),
             }
 
@@ -626,11 +688,14 @@ class FusionProvider:
                 "type": "text",
                 "text": (
                     f"{prefix}: could not be described — the vision model "
-                    f"({vision}) failed: {exc}]"
+                    f"({vision}) failed: {exc}]{handle}"
                 ),
             }
         _cache_put(key, description)
-        return {"type": "text", "text": f"{prefix}, described by {vision}]\n{description}"}
+        return {
+            "type": "text",
+            "text": f"{prefix}, described by {vision}]\n{description}{handle}",
+        }
 
     def _fuse_content(self, content: Any, budget: "_Budget") -> tuple[Any, bool]:
         """Rewrite a content list. Returns ``(content, changed)``.

--- a/src/providers/vision_config.py
+++ b/src/providers/vision_config.py
@@ -1,0 +1,192 @@
+"""Configuration for the ``vision_analyze`` tool — a borrowed pair of eyes.
+
+A text-only main model (DeepSeek V4, gpt-oss-120b, …) cannot take an image
+block at all: the request 400s with ``unknown variant `image_url`, expected
+`text``` before the model gets a turn. A **fusion model**
+(``src/providers/fusion_models.py``) fixes that by substituting every image
+with a description at the provider layer.
+
+This module configures the other half of the answer: a TOOL the model calls
+on demand, with its own question. The two are complementary, not rival —
+fusion covers images that are already in flight (a paste, a ``Read`` result)
+and cannot be declined; the tool covers "look again, and this time tell me
+the VAT line", which fusion's single fixed-prompt pass cannot express.
+``fusion_models.py``'s own note says as much: *"there is no per-call tool
+invocation"*. Now there is.
+
+Storage
+-------
+The **global** config tier only (``~/.clawcodex/config.json`` -> ``"vision"``),
+read with ``load_global`` / written with ``set_global`` — never the merged
+tier.
+
+That is a security decision, and a stronger case than the identical one made
+for ``fusionModels``. This key names the provider that RECEIVES IMAGE BYTES.
+Settings-block keys merge ``global < project < local``, and a ``vision``
+entry there would not be covered by ``_UNTRUSTED_TIER_BLOCKED_KEYS``
+(``src/config.py``, which withholds only ``env`` / ``providers`` /
+``default_provider`` from committable tiers) — so a checked-out repo could
+silently redirect the user's screenshots to a provider of its choosing while
+riding the user's stored credentials. A terminal screenshot routinely
+contains keys. Keeping the key global-only means a project tier can never
+contribute one, so no strip rule is needed.
+
+Deliberately NOT a ``SettingsSchema`` field: ``SettingsSchema.from_dict``
+files unknown keys into ``settings.extra`` with no error and no warning, so a
+``vision_provider`` key there would read as configured while being inert.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+#: Config key holding the vision-tool configuration (global tier only).
+VISION_KEY = "vision"
+
+#: Default per-call ceiling for one vision request. Matches the fusion
+#: default (``fusion_models.DEFAULT_VISION_TIMEOUT_MS``) so the two paths
+#: behave the same against a slow provider.
+DEFAULT_VISION_TIMEOUT_MS = 60_000
+
+
+@dataclass(frozen=True)
+class VisionConfig:
+    """A resolved, usable vision configuration.
+
+    Only ever constructed when both halves are present — see
+    :func:`load_vision_config`.
+    """
+
+    provider: str
+    model: str
+    #: Extra instruction appended to the per-call prompt. The model's own
+    #: ``question`` is the primary steer; this is for standing preferences
+    #: ("always transcribe numbers digit by digit").
+    prompt: str = ""
+    timeout_ms: int = DEFAULT_VISION_TIMEOUT_MS
+
+    @property
+    def selector(self) -> str:
+        """``provider:model``, the spelling used in user-facing messages."""
+        return f"{self.provider}:{self.model}"
+
+
+def _manager():
+    """The shared :class:`~src.config.ConfigManager`.
+
+    Resolved through the module attribute at call time (not imported at
+    module scope) so test isolation that re-points the config dir is
+    honoured — the ``config.py`` ``_global_config_file`` discipline. Same
+    reasoning as ``fusion_models._manager``.
+    """
+    from src import config as cfg_mod
+
+    return cfg_mod._get_default_manager()
+
+
+def _coerce_int(value: object, default: int) -> int:
+    try:
+        out = int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    return out if out > 0 else default
+
+
+def load_vision_config() -> VisionConfig | None:
+    """The configured vision model, or ``None`` when unusable.
+
+    ``None`` — meaning "the tool stays hidden" — unless ALL of:
+
+    * ``enabled`` is true. Default OFF, mirroring ``advisor_enabled``: this
+      spends money at a second vendor, so it is opt-in.
+    * ``provider`` AND ``model`` are both non-empty. Half a config is a
+      misconfiguration, not a partial feature — clawcodex is multi-provider
+      and the same model name lives behind several of them, so the provider
+      cannot be inferred from the model. Same both-halves rule the advisor
+      enforces for ``advisor_provider`` / ``advisor_model``.
+
+    Never raises: a broken config yields ``None``, because vision is an
+    enhancement and a config problem must not brick startup or the tool list.
+
+    Note ``strict`` boolean coercion — ``bool("false")`` is ``True`` in
+    Python, so a quoted ``"enabled": "false"`` would otherwise silently turn
+    the tool on. hermes hit exactly this (``agent/image_routing.py``) and
+    guards it the same way.
+    """
+    try:
+        raw = _manager().load_global().get(VISION_KEY)
+    except Exception:  # noqa: BLE001 — an enhancement must not brick startup
+        return None
+    if not isinstance(raw, dict):
+        return None
+
+    enabled = raw.get("enabled")
+    if enabled is not True:  # strict: only a real JSON true enables it
+        return None
+
+    provider = raw.get("provider")
+    model = raw.get("model")
+    if not isinstance(provider, str) or not provider.strip():
+        return None
+    if not isinstance(model, str) or not model.strip():
+        return None
+
+    prompt = raw.get("prompt")
+    return VisionConfig(
+        provider=provider.strip(),
+        model=model.strip(),
+        prompt=prompt.strip() if isinstance(prompt, str) else "",
+        timeout_ms=_coerce_int(raw.get("timeout_ms"), DEFAULT_VISION_TIMEOUT_MS),
+    )
+
+
+def save_vision_config(
+    provider: str, model: str, *, prompt: str = "", timeout_ms: int | None = None
+) -> VisionConfig:
+    """Write the vision block (global tier) and return the resolved config."""
+    # Read-modify-write. A fresh block would silently discard ``prompt`` and
+    # ``timeout_ms``, which are hand-edited (no command sets them) — so
+    # re-pointing the model with /vision would wipe a standing instruction
+    # the user had configured, without saying so.
+    try:
+        existing = _manager().load_global().get(VISION_KEY)
+    except Exception:  # noqa: BLE001
+        existing = None
+    block: dict[str, Any] = dict(existing) if isinstance(existing, dict) else {}
+    block.update(
+        {"enabled": True, "provider": provider.strip(), "model": model.strip()}
+    )
+    if prompt.strip():
+        block["prompt"] = prompt.strip()
+    if timeout_ms is not None:
+        block["timeout_ms"] = int(timeout_ms)
+    _manager().set_global(VISION_KEY, block)
+    return VisionConfig(
+        provider=block["provider"],
+        model=block["model"],
+        prompt=block.get("prompt", ""),
+        timeout_ms=_coerce_int(block.get("timeout_ms"), DEFAULT_VISION_TIMEOUT_MS),
+    )
+
+
+def set_vision_enabled(enabled: bool) -> None:
+    """Flip the master switch, preserving provider/model so ``/vision on``
+    can restore a previous pairing without retyping it."""
+    try:
+        raw = _manager().load_global().get(VISION_KEY)
+    except Exception:  # noqa: BLE001
+        raw = None
+    block = dict(raw) if isinstance(raw, dict) else {}
+    block["enabled"] = bool(enabled)
+    _manager().set_global(VISION_KEY, block)
+
+
+def vision_is_configured() -> bool:
+    """Whether ``vision_analyze`` should be offered to the model.
+
+    The tool's ``is_enabled`` gate. Kept separate from
+    :func:`load_vision_config` so callers that only need the boolean read as
+    such at the call site.
+    """
+    return load_vision_config() is not None

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -857,6 +857,9 @@ class _AgentSession:
         if subtype == "fusion":
             self._do_fusion_command(request_id, inner.get("arg"))
             return
+        if subtype == "vision":
+            self._do_vision_command(request_id, inner.get("arg"))
+            return
         if subtype == "worktree_status":
             await self._do_worktree_status(request_id)
             return
@@ -3867,6 +3870,51 @@ class _AgentSession:
             })
         except Exception as exc:  # noqa: BLE001 — must not kill the control channel
             logger.exception("[agent-server] advisor command failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _do_vision_command(self, request_id: object, arg: object) -> None:
+        """Control handler for /vision — set the vision_analyze model.
+
+        Bridges to ``vision_command.vision_command_call``, which owns the
+        grammar (``<provider>:<model>`` | on | off).
+
+        ``single_session``-gated for the same reason as /fusion and /advisor:
+        this persists USER-level config (``~/.clawcodex/config.json`` ->
+        ``vision``), so on the multi-session WS transport one client's
+        ``/vision off`` would disable the tool for every other session on the
+        host.
+
+        Reply shape mirrors /fusion: transport-level ``ok`` is True whenever
+        the command ran; command-level rejections ride ``text``.
+        """
+        if not self.config.single_session:
+            self._reply(request_id, {
+                "ok": False,
+                "error": "/vision is only available on single-session "
+                         "(stdio) transports — it persists user-level "
+                         "settings.",
+            })
+            return
+        try:
+            from src.command_system.types import CommandContext
+            from src.command_system.vision_command import vision_command_call
+
+            ctx = CommandContext(
+                workspace_root=Path(self.cwd),
+                cwd=Path(self.cwd),
+                conversation=getattr(self.session, "conversation", None),
+                cost_tracker=None,
+                history=None,
+                app_state_store=None,
+                provider=self.provider,
+            )
+            result = vision_command_call(str(arg or ""), ctx)
+            self._reply(request_id, {
+                "ok": True,
+                "text": str(getattr(result, "value", "") or ""),
+            })
+        except Exception as exc:  # noqa: BLE001 — must not kill the control channel
+            logger.exception("[agent-server] /vision command failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
 
     def _do_fusion_command(self, request_id: object, arg: object) -> None:

--- a/src/tool_system/tools/__init__.py
+++ b/src/tool_system/tools/__init__.py
@@ -38,6 +38,7 @@ from .tasks_v2 import (
 from .team import TeamCreateTool, TeamDeleteTool
 from .todo_write import TodoWriteTool
 from .tool_search import make_tool_search_tool
+from .vision_analyze import VisionAnalyzeTool
 from .web_fetch import WebFetchTool
 from .web_search import WebSearchTool
 from .worktree import EnterWorktreeTool, ExitWorktreeTool
@@ -91,6 +92,7 @@ ALL_STATIC_TOOLS: list[Tool] = [
     TeamCreateTool,
     TeamDeleteTool,
     TodoWriteTool,
+    VisionAnalyzeTool,
     WebFetchTool,
     WebSearchTool,
     WriteTool,
@@ -139,6 +141,7 @@ __all__ = [
     "TeamCreateTool",
     "TeamDeleteTool",
     "TodoWriteTool",
+    "VisionAnalyzeTool",
     "WebFetchTool",
     "WebSearchTool",
     "WriteTool",

--- a/src/tool_system/tools/read.py
+++ b/src/tool_system/tools/read.py
@@ -284,6 +284,90 @@ def _is_partial_read(fp_entry: tuple[int, ...] | tuple[int, int, bool]) -> bool:
 # Core call implementation
 # ---------------------------------------------------------------------------
 
+def _text_only_vision_stub(
+    path: Path, context: ToolContext, kind: str = "image"
+) -> ToolResult | None:
+    """A text stub instead of an image block, when the model cannot see.
+
+    Returns ``None`` — meaning "proceed with the normal image pipeline" — in
+    every case except a model KNOWN to be text-only running WITHOUT a fusion
+    wrapper.
+
+    Why this exists: this tool decides on file extension alone, so ``Read
+    foo.png`` emits an image block for any model. A text-only provider
+    (DeepSeek V4, gpt-oss-120b) answers that with ``400 unknown variant
+    `image_url`, expected `text``` and the turn is spent before the model can
+    do anything about it — including calling ``vision_analyze``. Handing back
+    a path-bearing note instead keeps the turn alive AND tells the model
+    exactly how to see the image.
+
+    THE FUSION TRAP, and why the ``unwrap_provider`` check is load-bearing:
+    when a fusion model is active the provider on the context is a
+    ``FusionProvider`` whose ``.model`` reports the BASE model — text-only by
+    definition, since that is the entire reason someone configures fusion. A
+    naive capability check therefore fires on exactly the configuration that
+    already works, and would replace the image block that ``FusionProvider``
+    needs to substitute. ``unwrap_provider`` follows ``.inner``, so a wrapper
+    is detectable; anything wrapped is left alone.
+
+    Unknown models are left alone too: ``supports_vision`` only returns False
+    on an exact ``MODEL_CONFIGS`` hit, so an uncatalogued model keeps today's
+    behaviour rather than silently losing image support.
+    """
+    provider = getattr(context, "_active_provider", None)
+    if provider is None:
+        # No provider on the context (unit tests, pre-startup): unchanged.
+        return None
+
+    from src.providers import unwrap_provider
+
+    if unwrap_provider(provider) is not provider:
+        return None  # wrapped (fusion) — it will substitute; do not interfere
+
+    model = getattr(provider, "model", "") or ""
+    if not model:
+        return None
+
+    from src.models.capabilities import supports_vision
+
+    if supports_vision(model):
+        return None
+
+    from src.providers.vision_config import vision_is_configured
+
+    if kind == "pdf":
+        # A PDF must NOT be sent to vision_analyze: that tool accepts only
+        # the image extensions above, so naming it here would cost the model
+        # a second tool call and a hard refusal. Rendered pages are images,
+        # so the capability problem is the same, but the remedy is not.
+        return ToolResult(
+            name="Read",
+            output=(
+                f"[PDF pages not rendered: the active model ({model}) cannot "
+                "see images, and page rendering produces images. Extract the "
+                "text instead — e.g. `pdftotext` via Bash — or read the file "
+                "without the 'pages' argument.]"
+            ),
+            content_type="text",
+        )
+
+    if vision_is_configured():
+        hint = (
+            f' Call vision_analyze with image_url="{path}" and a specific '
+            "question to have it described."
+        )
+    else:
+        hint = (
+            " No vision model is configured — run /vision <provider>:<model> "
+            "to enable image support for this model."
+        )
+    return ToolResult(
+        name="Read",
+        output=f"[Image not loaded: the active model ({model}) cannot see images.{hint}]",
+        content_type="text",
+    )
+
+
 def _read_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
     file_path = tool_input["file_path"]
     if not isinstance(file_path, str) or not file_path:
@@ -393,6 +477,12 @@ def _read_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
             # User asked for specific pages -> extract them via poppler and
             # return as image blocks. Mirrors TS FileReadTool.ts:898-948 PDF
             # page-extraction flow.
+            #
+            # Same capability gate as the image branch: rendered pages ARE
+            # image blocks, so a text-only model 400s on them identically.
+            _stub = _text_only_vision_stub(path, context, kind="pdf")
+            if _stub is not None:
+                return _stub
             first_page, last_page = _parse_pdf_pages(pages_param)
             from src.utils.pdf_extraction import (
                 PdfExtractionFailed as _PdfErr,
@@ -490,6 +580,11 @@ def _read_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
     # the same reason -- see FileReadTool.ts:528-529.
     ext_no_dot = suffix.lstrip(".")
     if ext_no_dot in IMAGE_EXTENSIONS:
+        # Before building an image block, check the model can actually
+        # receive one. See _text_only_vision_stub for the fusion carve-out.
+        _stub = _text_only_vision_stub(path, context)
+        if _stub is not None:
+            return _stub
         if stat.st_size == 0:
             raise ToolInputError(f"Image file is empty: {path}")
         # Lazy import keeps the read.py import cheap for non-image paths.

--- a/src/tool_system/tools/vision_analyze.py
+++ b/src/tool_system/tools/vision_analyze.py
@@ -1,0 +1,388 @@
+"""``vision_analyze`` — borrow a vision model's eyes, on demand, with a question.
+
+Ported from hermes-agent (``tools/vision_tools.py``), whose two-parameter
+``(image_url, question)`` schema this keeps so the two stay recognisable.
+
+Why this exists alongside fusion
+--------------------------------
+A fusion model (``src/providers/fusion_models.py``) substitutes every image
+with a description at the provider layer. That is the only thing that can
+rescue an image which is ALREADY in flight — a pasted screenshot, a ``Read``
+result — because the request 400s before the model gets a turn. But it runs
+ONE fixed "describe everything" pass and then discards the bytes, so a base
+model that needs the VAT line off an invoice the generic pass skimmed has no
+recourse. ``fusion_models.py`` states the gap itself: *"there is no per-call
+tool invocation."*
+
+This tool is that invocation. The model supplies its own ``question``, which
+is concatenated into the vision prompt, so the second look is targeted rather
+than generic. It is also what makes vision reachable with NO fusion model
+configured at all.
+
+Local paths only, deliberately
+------------------------------
+``image_url`` accepts a filesystem path. Remote ``http(s)`` is refused with a
+clear message rather than fetched: doing it safely needs URL validation, a
+redirect guard and a size cap (hermes carries all three), and that is its own
+change. Paths run through ``ToolContext.ensure_readable_path``, so the
+existing workspace containment rules apply for free — this tool cannot be
+used to read an image outside the allowed roots.
+
+Cost
+----
+Unlike the fusion vision leg — whose tokens are logged but, by that module's
+own admission, "appear in no clawcodex total" — this call self-records via
+``record_api_usage``, the same way the client-side advisor does.
+"""
+
+from __future__ import annotations
+
+import base64
+import threading
+from pathlib import Path
+from typing import Any
+
+from ..build_tool import Tool, build_tool
+from ..context import ToolContext
+from ..protocol import ToolResult
+
+#: Cap on the returned description, mirroring the fusion path's
+#: ``_MAX_DESCRIPTION_CHARS`` so neither route can blow up a turn. Kept
+#: below ``max_result_size_chars`` deliberately: this bound is about what a
+#: model should have to read, the tool-result bound is a transport backstop.
+_MAX_ANSWER_CHARS = 8_000
+
+_BASE_PROMPT = (
+    "You are describing an image for a software engineer who cannot see it. "
+    "Transcribe every piece of visible text verbatim — code, terminal output, "
+    "error messages, labels and numbers — and describe layout and any UI "
+    "elements. Do not speculate about intent."
+)
+
+
+def _err(message: str) -> ToolResult:
+    return ToolResult(name="vision_analyze", output=message, is_error=True)
+
+
+def _load_image(raw_path: str, context: ToolContext) -> tuple[dict[str, Any], str] | ToolResult:
+    """Resolve+read the image, returning an Anthropic ``source`` dict.
+
+    Returns a ``ToolResult`` instead when the input is unusable — the caller
+    surfaces it as a tool error rather than raising, so a bad path costs the
+    model one tool call rather than the whole turn.
+    """
+    candidate = raw_path.strip()
+    if candidate.lower().startswith(("http://", "https://")):
+        return _err(
+            "vision_analyze takes a local file path, not a URL. Download the "
+            "image first (e.g. with Bash) and pass the resulting path."
+        )
+    if candidate.startswith("data:"):
+        return _err(
+            "vision_analyze takes a local file path, not a data: URL. Write "
+            "the bytes to a file first and pass that path."
+        )
+
+    try:
+        # Containment: the same guard every other file-reading tool uses.
+        path = Path(context.ensure_readable_path(candidate))
+    except Exception as exc:  # noqa: BLE001 — surface as a tool error
+        return _err(f"Cannot read {candidate!r}: {exc}")
+
+    # Existence before extension: a typo'd path should say "no such file",
+    # not "not a supported image", which sends the model looking for a
+    # converter it does not need.
+    if not path.is_file():
+        return _err(f"No such image file: {path}")
+
+    from .read import IMAGE_EXTENSIONS
+
+    ext = path.suffix.lstrip(".").lower()
+    if ext not in IMAGE_EXTENSIONS:
+        return _err(
+            f"Not a supported image: {path} (expected one of "
+            f"{', '.join(sorted(IMAGE_EXTENSIONS))})."
+        )
+
+    # Reuse Read's pipeline wholesale rather than reimplementing it. Two
+    # things it gets right that a naive read_bytes()+extension does not:
+    #
+    #  * MAGIC BYTES decide media_type, not the filename. A JPEG saved as
+    #    .png would otherwise ship a mismatched media_type and come back as
+    #    a confusing provider 400 that reads like an outage.
+    #  * DOWNSCALING. The API ceiling is API_IMAGE_MAX_BASE64_SIZE (5 MB),
+    #    and a retina screenshot — the common case here — routinely exceeds
+    #    the 3.75 MB raw budget. Without this, exactly the images this
+    #    feature exists for would be rejected by the vendor.
+    from src.utils.image_processor import (
+        IMAGE_READ_SAFETY_CAP,
+        ImageProcessingError,
+        detect_image_format_from_buffer,
+        maybe_resize_image,
+        read_file_bytes,
+    )
+
+    try:
+        # Bounded: guards against a symlinked /dev/zero or a TOCTOU-grown
+        # file, same reasoning as read.py's bounded read.
+        raw = read_file_bytes(path, IMAGE_READ_SAFETY_CAP)
+    except OSError as exc:
+        return _err(f"Cannot read {path}: {exc}")
+    if not raw:
+        return _err(f"Image file is empty: {path}")
+
+    try:
+        sniffed = detect_image_format_from_buffer(raw)
+        result = maybe_resize_image(raw, len(raw), format_hint=sniffed)
+        data, media_type = result.data, result.media_type
+    except ImageProcessingError as exc:
+        # DIVERGENCE from read.py, which falls back to raw bytes here "so the
+        # model at least sees something". That is right for Read, whose
+        # consumer may still be a vision model; it is wrong here, where the
+        # bytes go straight to a vendor that would answer with an opaque 400.
+        # A clear tool error is the better failure.
+        return _err(f"Cannot process image {path}: {exc}")
+
+    # No token-budget compression step (read.py's compress_image_to_token_budget):
+    # that bounds what an image costs in the MAIN model's context, and this
+    # image never enters it — only the vision model's reply does, itself
+    # capped by _MAX_ANSWER_CHARS. The size ceiling above is the one that
+    # matters here.
+
+    source = {
+        "type": "base64",
+        "media_type": media_type,
+        "data": base64.b64encode(data).decode("ascii"),
+    }
+    return source, str(path)
+
+
+def _vision_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+    # Local imports: this tool sits in the static registry and we don't want
+    # every boot path to wake providers/config. Same reasoning as advisor.py.
+    from src.providers.vision_config import load_vision_config
+
+    cfg = load_vision_config()
+    if cfg is None:
+        # Defence in depth: ``is_enabled`` should have kept this tool out of
+        # the schema, but registry dispatch looks tools up by NAME and
+        # bypasses that gate entirely (see AdvisorTool's note).
+        return _err(
+            "Vision unavailable: no vision model configured. Run "
+            "/vision <provider>:<model> to set one."
+        )
+
+    raw_path = tool_input.get("image_url") or tool_input.get("image_path") or ""
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return _err("vision_analyze requires 'image_url' (a local file path).")
+    question = tool_input.get("question")
+    question = question.strip() if isinstance(question, str) else ""
+
+    loaded = _load_image(raw_path, context)
+    if isinstance(loaded, ToolResult):
+        return loaded
+    source, resolved_path = loaded
+
+    prompt = _BASE_PROMPT
+    if cfg.prompt:
+        prompt = f"{prompt}\n\nAdditional instructions: {cfg.prompt}"
+    if question:
+        # The whole point of the tool: a targeted question rather than
+        # fusion's fixed pass. Mirrors hermes's prompt composition.
+        prompt = f"{prompt}\n\nThen answer this specific question:\n{question}"
+
+    try:
+        text, usage = _ask_vision_model(cfg, source, prompt)
+    except Exception as exc:  # noqa: BLE001 — a failed look must not kill the turn
+        return _err(f"Vision call to {cfg.selector} failed: {exc}")
+
+    if not text:
+        return _err(f"Vision model {cfg.selector} returned no text.")
+    if len(text) > _MAX_ANSWER_CHARS:
+        text = text[:_MAX_ANSWER_CHARS] + "… [truncated]"
+
+    _record_usage(cfg, usage)
+    return ToolResult(
+        name="vision_analyze",
+        output=f"[{resolved_path} — described by {cfg.selector}]\n{text}",
+        content_type="text",
+    )
+
+
+def _ask_vision_model(cfg: Any, source: dict[str, Any], prompt: str) -> tuple[str, dict]:
+    """One vision call. Raises on transport failure; caller degrades."""
+    from src.config import get_provider_config
+    from src.providers import get_provider_class, resolve_api_key
+
+    provider_cls = get_provider_class(cfg.provider)
+    raw_cfg = dict(get_provider_config(cfg.provider) or {})
+    # Translate config keys to constructor kwargs EXPLICITLY. Never
+    # ``**raw_cfg`` — ``default_model`` and any future config field would be
+    # forwarded as kwargs and crash the constructor. And ``resolve_api_key``
+    # rather than ``raw_cfg["api_key"]``, so a provider whose key lives in an
+    # env var works instead of dying on "Missing credentials".
+    provider = _cached_provider(cfg, provider_cls, raw_cfg)
+
+    # The image is handed over in ANTHROPIC block shape and the target
+    # provider translates it: OpenAI-compatible providers turn it into an
+    # ``image_url`` data URI in ``_prepare_messages``, Anthropic-wire
+    # providers take it as-is. One call shape covers every vision provider —
+    # the same trick FusionProvider._describe_once relies on.
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": prompt},
+                {"type": "image", "source": dict(source)},
+            ],
+        }
+    ]
+    response = provider.chat(
+        messages,
+        model=cfg.model,
+        max_tokens=2_000,
+        timeout=_timeout_for(provider, cfg),
+    )
+    text = (getattr(response, "content", "") or "").strip()
+    usage = getattr(response, "usage", None)
+    return text, usage if isinstance(usage, dict) else _usage_to_dict(usage)
+
+
+#: One provider instance per (provider, model, base_url), built lazily.
+#: A fresh SDK client per call leaks connection pools; FusionProvider caches
+#: its vision provider under a lock for the same reason.
+_provider_cache: dict[tuple, Any] = {}
+_provider_lock = threading.Lock()
+
+
+def _cached_provider(cfg: Any, provider_cls: Any, raw_cfg: dict) -> Any:
+    from src.providers import resolve_api_key
+
+    # The resolved KEY is part of the cache key, not just provider/model/url.
+    # Without it a rotated credential or a fresh ``/login`` would keep reusing
+    # a client built with the dead one for the life of the process — this
+    # cache is module-global, unlike FusionProvider's per-instance one, so
+    # nothing rebuilds it on a provider switch either.
+    api_key = resolve_api_key(cfg.provider, raw_cfg)
+    key = (cfg.provider, cfg.model, raw_cfg.get("base_url"), api_key)
+    cached = _provider_cache.get(key)
+    if cached is not None:
+        return cached
+    with _provider_lock:
+        cached = _provider_cache.get(key)
+        if cached is not None:
+            return cached
+        cached = provider_cls(
+            api_key=api_key,
+            base_url=raw_cfg.get("base_url"),
+            model=cfg.model,
+        )
+        _provider_cache[key] = cached
+        return cached
+
+
+def _timeout_for(provider: Any, cfg: Any) -> Any:
+    """A phase-split timeout, never a bare float.
+
+    ``httpx`` expands a bare float across ALL FOUR phases, so a 60s budget
+    becomes a 60s CONNECT timeout — a dead host hangs the turn for a minute
+    instead of failing fast. FusionProvider documents this same hazard.
+    """
+    seconds = max(1.0, cfg.timeout_ms / 1000.0)
+    try:
+        import httpx
+
+        return httpx.Timeout(seconds, connect=min(15.0, seconds))
+    except Exception:  # noqa: BLE001 — fall back rather than fail the call
+        return seconds
+
+
+def _usage_to_dict(usage: Any) -> dict:
+    if usage is None:
+        return {}
+    out = {}
+    for key in ("input_tokens", "output_tokens"):
+        value = getattr(usage, key, None)
+        if isinstance(value, int):
+            out[key] = value
+    return out
+
+
+def _record_usage(cfg: Any, usage: dict) -> None:
+    """Fold the vision call into the session cost totals.
+
+    This is the deliberate difference from the fusion vision leg, which only
+    logs its usage and therefore bills real money that shows up in no
+    clawcodex total. A tool call has no excuse not to be accounted.
+    """
+    if not usage:
+        return
+    try:
+        from src.cost_tracker import record_api_usage
+
+        # ``record_api_usage(model, usage)`` — a usage MAPPING, not kwargs.
+        record_api_usage(cfg.model, usage)
+    except Exception:  # noqa: BLE001 — accounting must never break the result
+        pass
+
+
+def _vision_enabled() -> bool:
+    """Gate for the advertised tool schema. Defaults OFF.
+
+    Off by default because this spends money at a SECOND vendor — the same
+    reasoning that makes ``advisor_enabled`` opt-in. ``is_enabled`` takes no
+    arguments, so it cannot consult the active provider; a settings/config
+    read is the only thing available here, and it is the right gate anyway
+    (a configured vision model is useful to a vision-capable main model too).
+    """
+    try:
+        from src.providers.vision_config import vision_is_configured
+
+        return vision_is_configured()
+    except Exception:  # noqa: BLE001 — a broken config hides the tool
+        return False
+
+
+VisionAnalyzeTool: Tool = build_tool(
+    name="vision_analyze",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "image_url": {
+                "type": "string",
+                "description": "Local file path to the image (png, jpg, gif, webp).",
+            },
+            "question": {
+                "type": "string",
+                "description": (
+                    "Your specific question about the image. Be concrete — this "
+                    "is what makes the answer better than a generic description."
+                ),
+            },
+        },
+        "required": ["image_url", "question"],
+        # Tolerant on dispatch, like AdvisorTool: registry validation runs
+        # this against whatever the model actually emitted, and some workers
+        # decorate calls with extra fields. Failing a whole consultation over
+        # an ignored key trades a working tool for schema pedantry.
+        "additionalProperties": True,
+    },
+    call=_vision_call,
+    prompt=(
+        "Ask a vision-capable model about a local image and get a text answer.\n\n"
+        "Use this when you need to see an image but your own model cannot, or "
+        "when an image was described to you and you need a closer look at "
+        "something specific. Always pass a concrete question — 'what is the "
+        "total amount and VAT on this invoice?' beats 'describe this'."
+    ),
+    description=lambda _input: "Ask a vision model about an image",
+    is_enabled=_vision_enabled,
+    # NOT is_read_only, despite only reading a file locally: this tool
+    # SHIPS those bytes to a third-party vendor and spends money doing it.
+    # ``is_read_only`` is the flag auto-approval logic keys off, and a
+    # screenshot routinely contains credentials — marking this read-only
+    # would make it a no-prompt exfiltration path for anything under
+    # ``allowed_roots``. NOT concurrency-safe for the same reason plus one
+    # more: nothing here bounds fan-out, so a parallel batch is N paid calls.
+    max_result_size_chars=50_000,
+)

--- a/tests/test_vision_analyze.py
+++ b/tests/test_vision_analyze.py
@@ -1,0 +1,630 @@
+"""The ``vision_analyze`` tool, its config, and the two guards around it.
+
+Vision for a text-only model has three moving parts and each fails silently
+if it breaks, so each gets a test that can actually fail:
+
+* the global-tier config (a half-configured block must read as OFF, not as a
+  partial feature),
+* the ``Read`` gate (an image block reaching a text-only model is a 400 that
+  ends the turn), and
+* the fusion re-query handle (a description with no way back is what this
+  change exists to fix).
+
+The global config these touch is isolated per test by the autouse
+``_isolate_user_permission_settings`` fixture in ``tests/conftest.py``, which
+repoints ``config.GLOBAL_CONFIG_DIR`` / ``GLOBAL_CONFIG_FILE`` at ``tmp_path``
+— nothing here writes the developer's real ``~/.clawcodex/config.json``.
+"""
+
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.providers.vision_config import (
+    DEFAULT_VISION_TIMEOUT_MS,
+    VISION_KEY,
+    load_vision_config,
+    save_vision_config,
+    set_vision_enabled,
+    vision_is_configured,
+)
+from src.tool_system.context import ToolContext
+from src.tool_system.tools.vision_analyze import VisionAnalyzeTool
+
+# A 1x1 PNG — enough for the loader paths; no test here makes a real call.
+_PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+
+
+def _write_block(block: object) -> None:
+    """Put a raw ``vision`` block in the (isolated) global config."""
+    from src import config as cfg_mod
+
+    cfg_mod._get_default_manager().set_global(VISION_KEY, block)
+
+
+# ---------------------------------------------------------------- config
+
+
+class TestVisionConfig:
+    def test_absent_reads_as_unconfigured(self) -> None:
+        assert load_vision_config() is None
+        assert vision_is_configured() is False
+
+    def test_round_trip(self) -> None:
+        cfg = save_vision_config("openai", "gpt-5.6-luna")
+        assert cfg.selector == "openai:gpt-5.6-luna"
+        loaded = load_vision_config()
+        assert loaded is not None
+        assert (loaded.provider, loaded.model) == ("openai", "gpt-5.6-luna")
+        assert loaded.timeout_ms == DEFAULT_VISION_TIMEOUT_MS
+
+    @pytest.mark.parametrize(
+        "block",
+        [
+            {"provider": "openai", "model": "gpt-5.6-luna"},  # no enabled key
+            {"enabled": True, "provider": "openai"},  # no model
+            {"enabled": True, "model": "gpt-5.6-luna"},  # no provider
+            {"enabled": True, "provider": "  ", "model": "gpt-5.6-luna"},
+            {"enabled": False, "provider": "openai", "model": "gpt-5.6-luna"},
+            "not-a-dict",
+        ],
+    )
+    def test_half_configured_reads_as_off(self, block: object) -> None:
+        # A partial config is a misconfiguration, not a partial feature —
+        # otherwise the tool advertises itself and then fails at call time.
+        _write_block(block)
+        assert load_vision_config() is None
+
+    @pytest.mark.parametrize("truthy_looking", ["true", "1", "yes", 1])
+    def test_enabled_requires_a_real_json_true(self, truthy_looking: object) -> None:
+        # bool("false") is True in Python, so a stringly-typed flag would
+        # silently arm a paid second provider. hermes guards this the same way.
+        _write_block(
+            {"enabled": truthy_looking, "provider": "openai", "model": "gpt-5.6-luna"}
+        )
+        assert load_vision_config() is None
+
+    def test_disable_preserves_the_pairing(self) -> None:
+        save_vision_config("openai", "gpt-5.6-luna")
+        set_vision_enabled(False)
+        assert load_vision_config() is None  # off
+        set_vision_enabled(True)
+        cfg = load_vision_config()
+        assert cfg is not None and cfg.selector == "openai:gpt-5.6-luna"
+
+
+# ------------------------------------------------------------------ tool
+
+
+class TestVisionToolGate:
+    def test_hidden_until_configured(self) -> None:
+        assert VisionAnalyzeTool.is_enabled() is False
+        save_vision_config("openai", "gpt-5.6-luna")
+        assert VisionAnalyzeTool.is_enabled() is True
+
+    def test_dispatch_without_config_is_a_tool_error_not_a_crash(
+        self, tmp_path: Path
+    ) -> None:
+        # Registry dispatch looks tools up by NAME and bypasses is_enabled,
+        # so the in-body check is load-bearing, not redundant.
+        ctx = ToolContext(workspace_root=tmp_path, cwd=tmp_path)
+        result = VisionAnalyzeTool.call(
+            {"image_url": "x.png", "question": "what?"}, ctx
+        )
+        assert result.is_error
+        assert "no vision model configured" in result.output.lower()
+
+
+class TestVisionToolInput:
+    @pytest.fixture(autouse=True)
+    def _configured(self):
+        save_vision_config("openai", "gpt-5.6-luna")
+
+    def _call(self, tmp_path: Path, image: str) -> object:
+        ctx = ToolContext(workspace_root=tmp_path, cwd=tmp_path)
+        return VisionAnalyzeTool.call({"image_url": image, "question": "q"}, ctx)
+
+    @pytest.mark.parametrize(
+        "image, expected",
+        [
+            ("https://example.com/a.png", "not a url"),
+            ("http://example.com/a.png", "not a url"),
+            ("data:image/png;base64,AAAA", "not a data:"),
+        ],
+    )
+    def test_remote_and_data_urls_are_refused_clearly(
+        self, tmp_path: Path, image: str, expected: str
+    ) -> None:
+        # v1 is local-paths-only; fetching remotely needs SSRF defences that
+        # are their own change. The refusal must say what to do instead.
+        result = self._call(tmp_path, image)
+        assert result.is_error
+        assert expected in result.output.lower()
+
+    def test_non_image_extension_refused(self, tmp_path: Path) -> None:
+        target = tmp_path / "notes.txt"
+        target.write_text("hi")
+        result = self._call(tmp_path, str(target))
+        assert result.is_error
+        assert "not a supported image" in result.output.lower()
+
+    def test_missing_file_refused(self, tmp_path: Path) -> None:
+        result = self._call(tmp_path, str(tmp_path / "nope.png"))
+        assert result.is_error
+        assert "no such image file" in result.output.lower()
+
+    def test_question_reaches_the_vision_prompt(self, tmp_path: Path) -> None:
+        # The entire reason this tool beats fusion's fixed pass.
+        target = tmp_path / "shot.png"
+        target.write_bytes(_PNG_BYTES)
+        seen: dict = {}
+
+        def _fake(cfg, source, prompt):
+            seen["prompt"] = prompt
+            seen["source"] = source
+            return "the answer", {"input_tokens": 5, "output_tokens": 7}
+
+        import src.tool_system.tools.vision_analyze as mod
+
+        original = mod._ask_vision_model
+        mod._ask_vision_model = _fake
+        try:
+            ctx = ToolContext(workspace_root=tmp_path, cwd=tmp_path)
+            result = VisionAnalyzeTool.call(
+                {"image_url": str(target), "question": "what is the VAT total?"}, ctx
+            )
+        finally:
+            mod._ask_vision_model = original
+
+        assert not result.is_error
+        assert "what is the VAT total?" in seen["prompt"]
+        assert seen["source"]["type"] == "base64"
+        assert seen["source"]["media_type"] == "image/png"
+        assert "the answer" in result.output
+
+
+# ------------------------------------------------------------- Read gate
+
+
+def _ctx_with_provider(tmp_path: Path, provider: object) -> ToolContext:
+    ctx = ToolContext(workspace_root=tmp_path, cwd=tmp_path)
+    setattr(ctx, "_active_provider", provider)
+    return ctx
+
+
+def _plain_provider(model: str) -> MagicMock:
+    p = MagicMock()
+    p.model = model
+    p.inner = None  # unwrap_provider stops here → not a wrapper
+    return p
+
+
+class TestReadImageGate:
+    """``Read`` must not hand an image block to a model that cannot take one."""
+
+    def _read(self, tmp_path: Path, provider: object):
+        from src.tool_system.tools.read import _text_only_vision_stub
+
+        return _text_only_vision_stub(tmp_path / "shot.png", _ctx_with_provider(tmp_path, provider))
+
+    def test_text_only_model_gets_a_stub(self, tmp_path: Path) -> None:
+        stub = self._read(tmp_path, _plain_provider("deepseek-v4-flash"))
+        assert stub is not None
+        assert "cannot see images" in stub.output
+
+    def test_stub_names_the_tool_when_vision_is_configured(self, tmp_path: Path) -> None:
+        save_vision_config("openai", "gpt-5.6-luna")
+        stub = self._read(tmp_path, _plain_provider("deepseek-v4-flash"))
+        assert stub is not None
+        assert "vision_analyze" in stub.output
+        assert "shot.png" in stub.output  # the handle must be actionable
+
+    def test_stub_points_at_setup_when_vision_is_not_configured(
+        self, tmp_path: Path
+    ) -> None:
+        stub = self._read(tmp_path, _plain_provider("deepseek-v4-flash"))
+        assert stub is not None
+        assert "/vision" in stub.output
+
+    def test_vision_capable_model_is_untouched(self, tmp_path: Path) -> None:
+        assert self._read(tmp_path, _plain_provider("claude-opus-5")) is None
+
+    def test_unknown_model_is_untouched(self, tmp_path: Path) -> None:
+        # supports_vision only returns False on an exact table hit, so an
+        # uncatalogued model keeps today's behaviour rather than silently
+        # losing image support.
+        assert self._read(tmp_path, _plain_provider("some-new-model-9000")) is None
+
+    def test_no_provider_on_context_is_untouched(self, tmp_path: Path) -> None:
+        from src.tool_system.tools.read import _text_only_vision_stub
+
+        ctx = ToolContext(workspace_root=tmp_path, cwd=tmp_path)
+        assert _text_only_vision_stub(tmp_path / "shot.png", ctx) is None
+
+    def test_fusion_wrapped_provider_is_NOT_gated(self, tmp_path: Path) -> None:
+        """The trap this guard exists for.
+
+        A ``FusionProvider``'s ``.model`` reports the BASE model, which is
+        text-only by definition — that is why someone configured fusion. So a
+        naive capability check fires on exactly the setup that already works,
+        and would strip the image block FusionProvider needs to substitute.
+        """
+        from src.providers.fusion_models import FusionModel, parse_selector
+        from src.providers.fusion_provider import FusionProvider
+
+        fusion = FusionProvider(
+            _plain_provider("deepseek-v4-flash"),
+            FusionModel(
+                name="dsV",
+                base=parse_selector("deepseek:deepseek-v4-flash", field="base"),
+                vision=parse_selector("openai:gpt-5.6-luna", field="vision"),
+            ),
+        )
+        assert fusion.model == "deepseek-v4-flash"  # the trap, made explicit
+        assert self._read(tmp_path, fusion) is None
+
+
+# --------------------------------------------------- fusion re-query handle
+
+
+class TestFusionRequeryHandle:
+    """Every substituted string must offer a way back to the image.
+
+    hermes appends its handle on failure branches too, and that is where it
+    matters most: a failed description is exactly when a second look is worth
+    something. The budget-exhausted branch has always told the model to "ask
+    about this image on its own" — only with a handle is that actionable.
+    """
+
+    def _handle(self, source: dict) -> str:
+        from src.providers.fusion_provider import FusionProvider
+
+        return FusionProvider._requery_handle(source)
+
+    def test_silent_when_no_vision_tool_is_configured(self) -> None:
+        # An instruction the user cannot satisfy is worse than none.
+        assert self._handle({"type": "base64", "data": "AAAA"}) == ""
+
+    def test_base64_source_gets_a_path_free_pointer(self) -> None:
+        save_vision_config("openai", "gpt-5.6-luna")
+        out = self._handle({"type": "base64", "data": "AAAA"})
+        assert "vision_analyze" in out
+        assert "file path" in out
+
+    def test_url_source_names_a_step_the_tool_can_actually_serve(self) -> None:
+        # hermes writes "use vision_analyze with image_url: <url>" because ITS
+        # tool downloads URLs. This port refuses them, so repeating hermes's
+        # wording would spend a tool call to earn a refusal.
+        save_vision_config("openai", "gpt-5.6-luna")
+        out = self._handle({"type": "url", "url": "https://x/y.png"})
+        assert "https://x/y.png" in out
+        assert "download" in out.lower()
+        assert "vision_analyze" in out
+
+    @staticmethod
+    def _fusion():
+        from src.providers.fusion_models import FusionModel, parse_selector
+        from src.providers.fusion_provider import FusionProvider
+
+        inner = MagicMock()
+        inner.inner = None
+        return FusionProvider(
+            inner,
+            FusionModel(
+                name="dsV",
+                base=parse_selector("deepseek:deepseek-v4-flash", field="base"),
+                vision=parse_selector("openai:gpt-5.6-luna", field="vision"),
+            ),
+        )
+
+    def test_every_substituted_branch_carries_the_handle(self) -> None:
+        """Drive all five branches for real, not by scraping the source.
+
+        A source-text scan is brittle (it already missed the two multi-line
+        branches). Exercising the branches is what actually proves a model
+        gets a way back from every one of them.
+        """
+        import src.providers.fusion_provider as mod
+        from src.providers.fusion_provider import _Budget, _Failure
+
+        save_vision_config("openai", "gpt-5.6-luna")
+        fusion = self._fusion()
+        block = {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "AAAA"},
+        }
+        results: dict[str, str] = {}
+
+        # (1) no payload — source carries neither data nor url
+        empty = {"type": "image", "source": {"type": "base64", "media_type": "image/png"}}
+        results["no-payload"] = fusion._substitute(empty, _Budget(4))["text"]
+
+        # (2) cached failure  and  (3) cache hit — seed the module cache
+        key = mod._image_key(fusion._scope(), block["source"])
+        mod._cache_put(key, _Failure("boom"))
+        results["cached-failure"] = fusion._substitute(block, _Budget(4))["text"]
+        mod._cache_put(key, "a description")
+        results["cache-hit"] = fusion._substitute(block, _Budget(4))["text"]
+
+        # (4) budget exhausted — a fresh key so the cache does not short-circuit
+        other = {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "BBBB"},
+        }
+        results["exhausted"] = fusion._substitute(other, _Budget(0))["text"]
+
+        # (5) live failure — a third key, with the vision call raising
+        third = {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "CCCC"},
+        }
+        original = fusion._describe
+        fusion._describe = MagicMock(side_effect=RuntimeError("provider down"))
+        try:
+            results["live-failure"] = fusion._substitute(third, _Budget(4))["text"]
+        finally:
+            fusion._describe = original
+
+        assert len(results) == 5
+        missing = [name for name, text in results.items() if "vision_analyze" not in text]
+        assert not missing, (
+            "these substituted branches offer the model no way back to the "
+            f"image: {missing}\n"
+            + "\n".join(f"  {k}: {v!r}" for k, v in results.items())
+        )
+
+    def test_branches_stay_silent_without_a_vision_tool(self) -> None:
+        # Same five paths, no vision configured: no dangling instruction.
+        from src.providers.fusion_provider import _Budget
+
+        fusion = self._fusion()
+        block = {
+            "type": "image",
+            "source": {"type": "base64", "media_type": "image/png", "data": "ZZZZ"},
+        }
+        text = fusion._substitute(block, _Budget(0))["text"]
+        assert "vision_analyze" not in text
+
+
+# ------------------------------------------------ Read gate, through the tool
+
+
+class TestReadToolCallSite:
+    """The gate must be wired into ``Read``, not merely implemented.
+
+    Testing ``_text_only_vision_stub`` alone proves nothing: deleting the
+    call site in ``_read_call`` leaves such tests green while the feature is
+    entirely dead. These drive ``ReadTool.call``.
+    """
+
+    def _png(self, tmp_path: Path) -> Path:
+        target = tmp_path / "shot.png"
+        target.write_bytes(_PNG_BYTES)
+        return target
+
+    def test_text_only_model_gets_text_not_an_image_block(self, tmp_path: Path) -> None:
+        from src.tool_system.tools.read import ReadTool
+
+        target = self._png(tmp_path)
+        ctx = _ctx_with_provider(tmp_path, _plain_provider("deepseek-v4-flash"))
+        result = ReadTool.call({"file_path": str(target)}, ctx)
+        assert isinstance(result.output, str), (
+            "a text-only model must not receive an image block — that is the "
+            "400 this gate exists to prevent"
+        )
+        assert "cannot see images" in result.output
+
+    def test_vision_capable_model_still_gets_the_image(self, tmp_path: Path) -> None:
+        from src.tool_system.tools.read import ReadTool
+
+        target = self._png(tmp_path)
+        ctx = _ctx_with_provider(tmp_path, _plain_provider("claude-opus-5"))
+        result = ReadTool.call({"file_path": str(target)}, ctx)
+        assert isinstance(result.output, dict)
+        assert result.output.get("type") == "image"
+
+    def test_fusion_still_gets_the_image_to_substitute(self, tmp_path: Path) -> None:
+        from src.providers.fusion_models import FusionModel, parse_selector
+        from src.providers.fusion_provider import FusionProvider
+        from src.tool_system.tools.read import ReadTool
+
+        fusion = FusionProvider(
+            _plain_provider("deepseek-v4-flash"),
+            FusionModel(
+                name="dsV",
+                base=parse_selector("deepseek:deepseek-v4-flash", field="base"),
+                vision=parse_selector("openai:gpt-5.6-luna", field="vision"),
+            ),
+        )
+        target = self._png(tmp_path)
+        result = ReadTool.call({"file_path": str(target)}, _ctx_with_provider(tmp_path, fusion))
+        assert isinstance(result.output, dict) and result.output.get("type") == "image"
+
+    def test_pdf_pages_stub_does_not_name_a_tool_that_refuses_pdfs(
+        self, tmp_path: Path
+    ) -> None:
+        # Through ReadTool.call, like its siblings: the PDF branch is a
+        # SECOND call site, and testing the helper alone would leave it as
+        # dead as the image branch was.
+        #
+        # vision_analyze accepts only image extensions, so naming it for a
+        # .pdf would cost a tool call and return a hard refusal.
+        from src.tool_system.tools.read import ReadTool
+
+        target = tmp_path / "doc.pdf"
+        # Minimal and never parsed: the gate returns before extraction.
+        target.write_bytes(b"%PDF-1.4\n%stub\n")
+        ctx = _ctx_with_provider(tmp_path, _plain_provider("deepseek-v4-flash"))
+        result = ReadTool.call({"file_path": str(target), "pages": "1-2"}, ctx)
+        assert isinstance(result.output, str), result.output
+        assert "vision_analyze" not in result.output
+        assert "pdftotext" in result.output
+
+
+# ------------------------------------------------------------ /vision command
+
+
+class TestVisionCommand:
+    def _run(self, arg: str):
+        from src.command_system.types import CommandContext
+        from src.command_system.vision_command import vision_command_call
+
+        ctx = CommandContext(
+            workspace_root=Path("."), cwd=Path("."), conversation=None,
+            cost_tracker=None, history=None,
+        )
+        return vision_command_call(arg, ctx).value
+
+    def test_bare_reports_unconfigured_then_configured(self) -> None:
+        assert "not configured" in self._run("")
+        save_vision_config("openai", "gpt-5.6-luna")
+        assert "openai:gpt-5.6-luna" in self._run("")
+
+    def test_off_then_on_round_trips_without_retyping(self) -> None:
+        save_vision_config("openai", "gpt-5.6-luna")
+        assert "disabled" in self._run("off")
+        assert load_vision_config() is None
+        assert "enabled" in self._run("on").lower()
+        cfg = load_vision_config()
+        assert cfg is not None and cfg.selector == "openai:gpt-5.6-luna"
+
+    def test_on_without_a_saved_pairing_does_not_claim_success(self) -> None:
+        out = self._run("on")
+        assert "no saved vision model" in out.lower()
+        # Assert the RAW block, not load_vision_config(): the both-halves
+        # rule rejects {"enabled": true} on its own, so a load-based
+        # assertion returns None whether or not the un-flip happened and
+        # cannot distinguish fixed from broken.
+        from src import config as cfg_mod
+
+        raw = cfg_mod._get_default_manager().load_global().get(VISION_KEY)
+        assert not (isinstance(raw, dict) and raw.get("enabled")), (
+            f"left a half-armed config behind: {raw!r}"
+        )
+
+    def test_missing_colon_is_rejected(self) -> None:
+        assert "Usage" in self._run("openai")
+        assert load_vision_config() is None
+
+    def test_empty_half_is_rejected(self) -> None:
+        assert "Both halves" in self._run("openai:")
+        assert load_vision_config() is None
+
+    def test_unknown_provider_is_rejected_even_with_no_providers_configured(
+        self,
+    ) -> None:
+        # The isolated config has no providers map. Validating against it
+        # alone would let ANY string through and persist a config that can
+        # never work, while advertising the tool as available.
+        out = self._run("definitely-not-a-provider:some-model")
+        assert "Unknown provider" in out
+        assert load_vision_config() is None
+
+    def test_known_provider_is_accepted(self) -> None:
+        out = self._run("openai:gpt-5.6-luna")
+        assert "set to openai:gpt-5.6-luna" in out
+        cfg = load_vision_config()
+        assert cfg is not None and cfg.selector == "openai:gpt-5.6-luna"
+
+    def test_non_vision_model_warns_but_still_saves(self) -> None:
+        out = self._run("deepseek:deepseek-v4-flash")
+        assert "NOT vision-capable" in out
+        assert load_vision_config() is not None
+
+
+class TestSaveDoesNotClobberHandEditedFields:
+    def test_prompt_and_timeout_survive_a_repoint(self) -> None:
+        # No command sets these, so they are hand-edited — silently wiping
+        # them on the next /vision would destroy user config without a word.
+        _write_block(
+            {
+                "enabled": True,
+                "provider": "openai",
+                "model": "gpt-5.6-luna",
+                "prompt": "always transcribe numbers digit by digit",
+                "timeout_ms": 12_345,
+            }
+        )
+        save_vision_config("zai", "glm-5v-turbo")
+        cfg = load_vision_config()
+        assert cfg is not None
+        assert cfg.selector == "zai:glm-5v-turbo"
+        assert cfg.prompt == "always transcribe numbers digit by digit"
+        assert cfg.timeout_ms == 12_345
+
+
+class TestImagePipelineReuse:
+    """Magic bytes and downscaling — the two halves of the media/size fix.
+
+    Both were correct but unpinned: reverting either left the whole file
+    green, so the next refactor of ``_load_image`` would silently
+    reintroduce a confusing provider 400.
+    """
+
+    @staticmethod
+    def _source(tmp_path: Path, name: str, raw: bytes) -> dict:
+        target = tmp_path / name
+        target.write_bytes(raw)
+        save_vision_config("openai", "gpt-5.6-luna")
+        seen: dict = {}
+
+        def _fake(cfg, source, prompt):
+            seen["source"] = source
+            return "ok", {}
+
+        import src.tool_system.tools.vision_analyze as mod
+
+        original = mod._ask_vision_model
+        mod._ask_vision_model = _fake
+        try:
+            ctx = ToolContext(workspace_root=tmp_path, cwd=tmp_path)
+            result = VisionAnalyzeTool.call(
+                {"image_url": str(target), "question": "q"}, ctx
+            )
+        finally:
+            mod._ask_vision_model = original
+        assert not result.is_error, result.output
+        return seen["source"]
+
+    def test_media_type_comes_from_magic_bytes_not_the_extension(
+        self, tmp_path: Path
+    ) -> None:
+        # A JPEG saved as .png must ship image/jpeg. Trusting the filename
+        # sends a mismatched media_type and the provider 400s with an error
+        # that reads like a vendor outage.
+        from io import BytesIO
+
+        from PIL import Image
+
+        buf = BytesIO()
+        Image.new("RGB", (8, 8), (10, 20, 30)).save(buf, format="JPEG")
+        source = self._source(tmp_path, "shot.png", buf.getvalue())
+        assert source["media_type"] == "image/jpeg"
+
+    def test_oversized_images_are_downscaled_before_shipping(
+        self, tmp_path: Path
+    ) -> None:
+        # The API ceiling is 5 MB base64 / 3.75 MB raw, and a retina
+        # screenshot — the case this feature exists for — exceeds it.
+        from io import BytesIO
+
+        from PIL import Image
+        from src.utils.image_processor import IMAGE_MAX_WIDTH
+
+        buf = BytesIO()
+        Image.new("RGB", (IMAGE_MAX_WIDTH * 3, 400), (200, 40, 40)).save(
+            buf, format="PNG"
+        )
+        raw = buf.getvalue()
+        source = self._source(tmp_path, "big.png", raw)
+        shipped = base64.b64decode(source["data"])
+        assert len(shipped) < len(raw), (
+            f"image was shipped at full size ({len(raw)} bytes) — "
+            "maybe_resize_image is not being applied"
+        )

--- a/ui-tui/src/__tests__/visionCommand.test.ts
+++ b/ui-tui/src/__tests__/visionCommand.test.ts
@@ -1,0 +1,119 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Same fake-child harness as fusionModel.test.ts: the adapter spawns
+// `clawcodex agent-server --stdio`, so the test feeds protocol lines on the
+// fake stdout and answers the control_requests it sees on stdin.
+const harness = vi.hoisted(() => ({ proc: null as null | EventEmitter, spawnCalls: [] as unknown[][] }))
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => {
+    harness.spawnCalls.push(args)
+
+    return harness.proc
+  }
+}))
+
+import { GatewayClient } from '../gatewayClient.js'
+
+class FakeProc extends EventEmitter {
+  kill = vi.fn()
+  stderr = new PassThrough()
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+
+  line(obj: unknown): void {
+    this.stdout.write(JSON.stringify(obj) + '\n')
+  }
+}
+
+describe('/vision', () => {
+  const prevWs = process.env.CLAWCODEX_WORKSPACE
+  let gw: GatewayClient
+  let proc: FakeProc
+  let seen: any[]
+
+  beforeEach(() => {
+    process.env.CLAWCODEX_WORKSPACE = '/ws'
+    proc = new FakeProc()
+    harness.proc = proc
+    harness.spawnCalls = []
+    seen = []
+    gw = new GatewayClient()
+    gw.start()
+    gw.drain()
+  })
+
+  afterEach(() => {
+    gw.kill()
+    if (prevWs === undefined) {delete process.env.CLAWCODEX_WORKSPACE}
+    else {process.env.CLAWCODEX_WORKSPACE = prevWs}
+  })
+
+  const stdinFrames = (): any[] => {
+    const raw = (proc.stdin as any).read()?.toString() ?? ''
+
+    return raw.split('\n').filter(Boolean).map((l: string) => JSON.parse(l))
+  }
+
+  const replyToControl = async (subtype: string, response: unknown) => {
+    let req: any
+
+    await vi.waitFor(() => {
+      seen.push(...stdinFrames())
+      req = seen.find(f => f.type === 'control_request' && f.request?.subtype === subtype)
+      expect(req).toBeTruthy()
+    })
+    proc.line({ response: { request_id: req.request_id, response }, type: 'control_response' })
+  }
+
+  it('relays /vision to the backend and prints the reply', async () => {
+    const p = gw.request('slash.exec', { command: 'vision openai:gpt-5.6-luna' })
+
+    await replyToControl('vision', { ok: true, text: 'Vision model set to openai:gpt-5.6-luna.' })
+    await expect(p).resolves.toMatchObject({
+      output: expect.stringContaining('openai:gpt-5.6-luna')
+    })
+  })
+
+  it('forwards the argument verbatim — the backend owns the grammar', async () => {
+    const p = gw.request('slash.exec', { command: 'vision off' })
+
+    await vi.waitFor(() => {
+      seen.push(...stdinFrames())
+      const req = seen.find(f => f.type === 'control_request' && f.request?.subtype === 'vision')
+
+      expect(req?.request?.arg).toBe('off')
+    })
+    const req = seen.find(f => f.type === 'control_request' && f.request?.subtype === 'vision')
+
+    proc.line({ response: { request_id: req.request_id, response: { ok: true, text: 'Vision disabled.' } }, type: 'control_response' })
+    await p
+  })
+
+  it('surfaces a /vision error when the backend refuses', async () => {
+    const p = gw.request('slash.exec', { command: 'vision on' })
+
+    await replyToControl('vision', { error: '/vision is only available on single-session transports', ok: false })
+    await expect(p).resolves.toMatchObject({
+      output: expect.stringContaining('single-session')
+    })
+  })
+
+  it('lists /vision in the slash-command menu', async () => {
+    // SLASHES drives both recognition and the menu, so an entry missing here
+    // means /vision is untypeable in the TUI — and hand-editing config.json
+    // becomes the only way to turn the feature on.
+    const p = gw.request('complete.slash', { text: '/vis' })
+
+    // The menu merges dynamic workflow commands in, so that control has to
+    // be answered or the request never settles.
+    await replyToControl('list_workflow_commands', { commands: [] })
+    const r: any = await p
+
+    expect(JSON.stringify(r)).toContain('/vision')
+    expect(JSON.stringify(r)).toContain('vision_analyze')   // the description
+  })
+})

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -548,6 +548,11 @@ const SLASHES: ReadonlyArray<{ desc: string; hint?: string; name: string }> = [
     hint: '[list | create <name> <base> <vision> | delete|enable|disable <name>]',
     name: '/fusion'
   },
+  {
+    desc: 'Set the vision model the vision_analyze tool asks about images',
+    hint: '[<provider>:<model> | on | off]',
+    name: '/vision'
+  },
   { desc: 'List running and recent dynamic workflows', name: '/workflows' },
   { desc: 'Search / manage the knowledge base', hint: '[status|list|clear|enable|disable]', name: '/knowledge' },
   {
@@ -1491,6 +1496,16 @@ export class GatewayClient extends EventEmitter {
         if (!r || Object.keys(r).length === 0) {return out('fusion: backend not ready')}
 
         return out(String(r.text ?? r.error ?? 'fusion: no response'))
+      }
+      case 'vision': {
+        // Configure the vision model behind the vision_analyze tool. The
+        // backend owns the grammar (<provider>:<model> | on | off), so this
+        // relays the arg and prints the reply, exactly like /fusion above.
+        const r = (await this.controlQuery('vision', { arg: arg ?? '' })) as any
+
+        if (!r || Object.keys(r).length === 0) {return out('vision: backend not ready')}
+
+        return out(String(r.text ?? r.error ?? 'vision: no response'))
       }
       case 'memory': {
         // Arg-ful /memory (status | pending | approve | reject) — the


### PR DESCRIPTION
## Why

A text-only model (`deepseek-v4-flash`, `gpt-oss-120b`) cannot take an image block at all — the request 400s with `unknown variant image_url, expected text` **before the model gets a turn**. clawcodex had exactly one answer: a **fusion model**.

Fusion remains the only thing that can rescue an image already in flight. But it runs **one fixed "describe everything" pass** and then discards the bytes, so a base model that needs the VAT line off an invoice the generic pass skimmed has no recourse. `fusion_models.py` names the gap itself: *"there is no per-call tool invocation."*

This adds that invocation, ported from hermes-agent:

```
vision_analyze(image_url, question)
```

The model supplies its own **question**, so the second look is targeted rather than generic. It also makes vision reachable with **no fusion model configured at all**.

## Three parts, because a tool alone would be decorative

**1. Config — global tier, deliberately.** Not in `settings`, which merges `global < project < local` and is **not** covered by `_UNTRUSTED_TIER_BLOCKED_KEYS`. A settings key would let a checked-out repo redirect your screenshots to a provider of its choosing on your credentials — and a terminal screenshot routinely contains keys. Same tier and same reasoning as `fusionModels`.

```jsonc
// ~/.clawcodex/config.json
{ "vision": { "enabled": true, "provider": "openai", "model": "gpt-5.6-luna" } }
```

**2. `Read` gate.** `Read` decided on **file extension alone**, so `Read foo.png` emitted an image block for any model and spent the turn on a 400 — including the turn in which the model might have called this tool.

> **The trap:** a `FusionProvider`'s `.model` reports the **base** model — text-only by definition, since that's why someone configures fusion. A naive capability check fires on exactly the configuration that already works and would strip the block FusionProvider needs to substitute. `unwrap_provider` detects the wrapper. This has a dedicated test.

PDFs get their own stub pointing at `pdftotext`, since `vision_analyze` accepts only image extensions — naming it there would cost a tool call to earn a refusal.

**3. Re-query handle on fusion.** hermes appends `[If you need a closer look…]` to its substituted note. Ported onto **all five** substituted branches, including the failures — hermes does the same, and a failed description is when a second look is worth most. The budget-exhausted branch has always told the model to *"ask about this image on its own"*; only now is that actionable.

Worded as **download-then-call** for URL sources: unlike hermes's tool, this port doesn't fetch remote images, so repeating hermes's wording verbatim would point at a call this tool refuses.

## Notable details

- **Image loading reuses `Read`'s pipeline** rather than reimplementing it: magic bytes decide `media_type` (a JPEG named `.png` would otherwise 400 in a way that reads like a vendor outage), and oversized images are **downscaled** — the API ceiling is 5 MB base64 and a retina screenshot, the case this exists for, exceeds it.
- **Not `is_read_only`**, despite only reading locally: this ships those bytes to a third-party vendor and spends money. That flag is what auto-approval logic keys off, so marking it read-only would make this a no-prompt exfiltration path for anything under `allowed_roots`.
- **Cost is tracked** via `record_api_usage` — unlike the fusion vision leg, whose tokens are billed but by that module's own admission "appear in no clawcodex total."
- `/vision <provider>:<model> | on | off`, wired through all three layers (`SLASHES`, `dispatchSlash`, control channel) so it's actually usable in the TUI.

## Verification

- Full Python suite **9817 passed / 0 failed**
- ui-tui typecheck clean; **16/16** TS tests (`visionCommand` + `fusionModel`)
- **Eight guards mutation-tested** — both `Read` call sites, the fusion carve-out, the handle on every branch, magic bytes, downscaling, the `/vision on` un-flip, and the TUI `SLASHES` entry. Each fails when its fix is reverted.
- Three rounds of `critic` review to APPROVE. Round 2 earned its keep: it deleted the `Read` call site — the entire reason the feature exists — and an earlier version of these tests stayed **green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)