### PR TITLE
fix(desktop): default UI scale 90% → 100% (fonts read too small)

### DIFF
--- a/ui-desktop/electron/zoom.test.ts
+++ b/ui-desktop/electron/zoom.test.ts
@@ -26,10 +26,10 @@ test('storage key stays stable so persisted zoom survives upgrades', () => {
   assert.equal(ZOOM_STORAGE_KEY, 'clawcodex:desktop:zoomLevel')
 })
 
-test('default zoom matches the Appearance 90% preset', () => {
+test('default zoom matches the Appearance 100% preset', () => {
   assert.equal(ZOOM_STEP, 0.1)
-  assert.equal(zoomLevelToPercent(DEFAULT_ZOOM_LEVEL), 90)
-  assert.equal(DEFAULT_ZOOM_LEVEL, percentToZoomLevel(90))
+  assert.equal(zoomLevelToPercent(DEFAULT_ZOOM_LEVEL), 100)
+  assert.equal(DEFAULT_ZOOM_LEVEL, percentToZoomLevel(100))
 })
 
 test('clampZoomLevel rejects garbage and enforces bounds', () => {

--- a/ui-desktop/electron/zoom.ts
+++ b/ui-desktop/electron/zoom.ts
@@ -5,8 +5,10 @@
  * Chromium actual-size baseline); Chromium's internal unit is the zoom level,
  * where factor = 1.2 ^ level.
  *
- * Our shipped default is the Appearance 90% preset — tight enough to feel
- * denser than Chromium 100%, and selected in the UI Scale control on first run.
+ * Our shipped default is the Appearance 100% preset — Chromium's actual-size
+ * baseline. The reference implementation shipped a denser 90%, which reads
+ * too small on typical displays; users who prefer dense can pick 90% in the
+ * UI Scale control (or Ctrl/Cmd+-), and the choice persists.
  */
 
 export const ZOOM_STORAGE_KEY = 'clawcodex:desktop:zoomLevel'
@@ -18,8 +20,8 @@ const MAX_ZOOM_LEVEL = 9
 /** Half Chromium's default step; matching the shortcuts and View menu. */
 export const ZOOM_STEP = 0.1
 
-/** Appearance 90% preset. Fresh installs + Actual Size / Ctrl+0. */
-export const DEFAULT_ZOOM_LEVEL = Math.log(0.9) / Math.log(ZOOM_FACTOR_BASE)
+/** Appearance 100% preset. Fresh installs + Actual Size / Ctrl+0. */
+export const DEFAULT_ZOOM_LEVEL = 0
 
 export function clampZoomLevel(value) {
   if (!Number.isFinite(value)) {

--- a/ui-desktop/src/app/settings/appearance-settings.tsx
+++ b/ui-desktop/src/app/settings/appearance-settings.tsx
@@ -67,7 +67,7 @@ function ThemePreview({ name, mode }: { name: string; mode: 'light' | 'dark' }) 
 }
 
 // UI scale presets, as zoom percentages. 100 is Chromium's actual-size
-// baseline; the shipped default is the 90% preset. Ids double as the percent
+// baseline and the shipped default. Ids double as the percent
 // values sent to the main process. A Cmd/Ctrl +/- step landing between
 // presets highlights nothing, and the row description keeps showing the
 // exact current percent.


### PR DESCRIPTION
The reference implementation shipped a deliberately dense **90% zoom preset** as the default; on typical displays the base typography reads too small (user report). This ships Chromium's actual-size **100%** baseline instead:

- Fresh installs and **⌘0 / Ctrl+0** land on 100%.
- The Appearance → UI Scale control highlights 100% as the default; 90% stays available for dense-preference users, and any choice persists per install (`zoom-state.json`).
- **⌘+/⌘−** and Ctrl+wheel zoom unchanged.

electron vitest: 78 files green (zoom suite updated to the new baseline); typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)