### PR TITLE
fix(tools): TaskOutput serializes like CC instead of dumping a JSON blob

### DIFF
--- a/src/tool_system/tools/tasks_v2.py
+++ b/src/tool_system/tools/tasks_v2.py
@@ -832,6 +832,12 @@ def _runtime_task_to_output(
                 name="TaskOutput",
                 output={"retrieval_status": "success", "task": None},
             )
+        # The on-disk log path, so ``_format_task_output`` can name the file
+        # that still holds everything when it trims to the tail (TS reads the
+        # same thing from ``getTaskOutputPath``). Not part of the snapshot
+        # helper's contract, so read it off the task entry directly.
+        entry = context.background_bash_tasks.get(task_id)
+        output_path = entry.get("output_path") if isinstance(entry, dict) else None
         return ToolResult(
             name="TaskOutput",
             output={
@@ -844,6 +850,7 @@ def _runtime_task_to_output(
                     "command": snapshot["command"],
                     "description": snapshot["description"],
                     "output": snapshot["output"],
+                    "output_path": output_path,
                     "truncated": snapshot["truncated"],
                     "pid": snapshot["pid"],
                     "started_at": snapshot["started_at"],
@@ -869,6 +876,16 @@ def _runtime_task_to_output(
                     "description": runtime.description,
                     "agent_type": runtime.agent_type,
                     "output": text,
+                    # So an over-32K subagent answer gets a truncation header
+                    # that names a real file. TS passes getTaskOutputPath(id)
+                    # unconditionally; without this the header degraded to
+                    # "the task's output file", which the model cannot act on.
+                    "output_path": runtime.output_file,
+                    # TS' getTaskOutputData sets this for local_agent
+                    # (TaskOutputTool.tsx:104) and the mapper emits <error>.
+                    # Without it here that part was unreachable: a genuinely
+                    # failed subagent surfaced nothing but its status.
+                    "error": runtime.error,
                 },
             },
         )
@@ -888,6 +905,190 @@ def _runtime_task_to_output(
             },
         },
     )
+
+
+#: Port of TS ``TASK_MAX_OUTPUT_DEFAULT`` / ``TASK_MAX_OUTPUT_UPPER_LIMIT``
+#: (typescript/src/utils/task/outputFormatting.ts:4-5).
+_TASK_MAX_OUTPUT_DEFAULT = 32_000
+_TASK_MAX_OUTPUT_UPPER_LIMIT = 160_000
+
+
+def _max_task_output_length() -> int:
+    """Port of ``getMaxTaskOutputLength`` — ``TASK_MAX_OUTPUT_LENGTH``, bounded.
+
+    Mirrors ``validateBoundedIntEnvVar`` (typescript/src/utils/envValidation.ts:12):
+    unset / unparseable / non-positive falls back to the default, and anything
+    above the ceiling is clamped to it.
+    """
+    import os
+
+    raw = os.environ.get("TASK_MAX_OUTPUT_LENGTH")
+    if not raw:
+        return _TASK_MAX_OUTPUT_DEFAULT
+    try:
+        parsed = int(raw, 10)
+    except (TypeError, ValueError):
+        return _TASK_MAX_OUTPUT_DEFAULT
+    if parsed <= 0:
+        return _TASK_MAX_OUTPUT_DEFAULT
+    return min(parsed, _TASK_MAX_OUTPUT_UPPER_LIMIT)
+
+
+def _format_task_output(text: str, output_path: Any) -> str:
+    """Bound the captured output for the wire. Port of ``formatTaskOutput``
+    (typescript/src/utils/task/outputFormatting.ts:22-38).
+
+    Keeps the TAIL — for a build or a test run the failure is at the end — and
+    leads with a header naming the file that still holds everything, so the
+    model can ``Read`` the rest.
+
+    The ceiling stays TS' 160,000 rather than the 50K persistence threshold, so
+    a caller who raises ``TASK_MAX_OUTPUT_LENGTH`` past ~49.7K is back on the
+    wrapper path. That is deliberate: clamping to the persistence constant
+    would couple two unrelated modules, and the clients' defensive parse
+    (``readOutputTag``) is the right backstop for it.
+
+    This is NOT a redundant third bound on top of the ~200KB read window and
+    the 50K persistence threshold, which is how an earlier revision of this
+    change read it. It is the bound that keeps the whole tagged result *under*
+    the persistence threshold, and that is load-bearing: over that threshold
+    ``maybe_persist_large_tool_result`` replaces the entire content with a
+    ``<persisted-output>`` wrapper around a 2KB HEAD preview, which cuts the
+    part list mid-``<output>`` — no closing tag, no ``<truncated>``, no
+    ``<error>``. Both clients then fail to parse what is left. Measured before
+    this was ported: a 55KB docker-build log rendered as "(No output)".
+    """
+    limit = _max_task_output_length()
+    if len(text) <= limit:
+        return text
+    path = str(output_path) if output_path else "the task's output file"
+    header = f"[Truncated. Full output: {path}]\n\n"
+    available = limit - len(header)
+    if available <= 0:
+        # DEVIATION from TS, deliberate. The reference computes
+        # ``output.slice(-availableSpace)`` with no guard, and a non-positive
+        # ``availableSpace`` silently inverts: ``slice(-0)`` is ``slice(0)``
+        # and ``slice(59)`` counts from the FRONT, so the whole log comes back
+        # and the bound is gone. Reachable here with a small
+        # ``TASK_MAX_OUTPUT_LENGTH`` (measured: limit=1 returned 100,001
+        # chars), or a pathologically long path. Replicating that would defeat
+        # the one bound that keeps this result under the persistence threshold
+        # — the entire point of the port. When there is no room for a body,
+        # the pointer to the full file is the more useful half; keep it.
+        return header.rstrip()
+    return header + text[-available:]
+
+
+def _task_output_map_result_to_api(output: Any, tool_use_id: str) -> dict[str, Any]:
+    """Serialize a TaskOutput result the way TS ``TaskOutputTool`` does.
+
+    Port of ``mapToolResultToToolResultBlockParam``
+    (typescript/src/tools/TaskOutputTool/TaskOutputTool.tsx:283-308): a short
+    list of ``<tag>value</tag>`` parts joined by blank lines, with the task's
+    output in its own ``<output>`` block.
+
+    Without this the tool fell through to ``_default_map_result_to_api``,
+    which ``json.dumps``es the whole result dict. That put the captured
+    output on the wire as a JSON *string literal* — every newline escaped to
+    a literal ``\\n``, wrapped in one unbroken line alongside ``pid`` /
+    ``started_at`` / ``finished_at`` bookkeeping the model has no use for. A
+    build log read that way is near-unparseable for the model AND for the
+    human: the transcript renders the tool_result content, so the same blob
+    was what the TUI printed under the ``TaskOutput`` row.
+
+    Two deliberate additions over the TS part list:
+
+    * ``<stuck_task_hint>`` leads when ``_guard_repeated_polls`` set it. That
+      guard documents the top-level field as its primary channel precisely
+      because a >50KB result is persisted to disk and replaced by a 2KB HEAD
+      preview — a leading part survives that truncation, a trailing one does
+      not. Emitting it first preserves the guarantee under the new format.
+    * ``<truncated>`` when the ~200KB capture window clipped the output, so
+      "this is not the whole log" stays on the wire. TS has no analog: its only
+      truncation is ``formatTaskOutput``, which announces itself inline with a
+      ``[Truncated. Full output: …]`` header. We now emit that header too, so
+      the two signals are complementary — the header means "the wire copy is
+      the tail", the tag means "even the captured copy is short of the real
+      log".
+
+    ``<description>`` is likewise ours. TS omits it because its renderer holds
+    the live task object and reads the field straight off it; here the client
+    is a separate process whose only view of the result is this content, and
+    the ``task_list`` task type (a TaskCreate todo — TS serves those from
+    TaskGet, not TaskOutput) renders as "description [status]", which is
+    nothing at all without it.
+
+    Output truncation goes through ``_format_task_output`` — see there for why
+    porting TS' 32K cap is required rather than redundant.
+    """
+    if not isinstance(output, dict):
+        return {
+            "type": "tool_result",
+            "tool_use_id": tool_use_id,
+            "content": output if isinstance(output, str) else str(output),
+        }
+
+    def tag(name: str, value: Any) -> str:
+        return f"<{name}>{value}</{name}>"
+
+    parts: list[str] = []
+
+    def add(name: str, value: Any) -> None:
+        """Append a part, skipping None. TS is type-guaranteed on these
+        fields; a plain dict here is not, and ``<status>None</status>`` reads
+        to the model as a status literally named None."""
+        if value is not None:
+            parts.append(tag(name, value))
+
+    hint = output.get("stuck_task_hint")
+    if isinstance(hint, str) and hint.strip():
+        parts.append(tag("stuck_task_hint", hint))
+
+    add("retrieval_status", output.get("retrieval_status"))
+
+    task = output.get("task")
+    if isinstance(task, dict):
+        add("task_id", task.get("task_id"))
+        add("task_type", task.get("task_type"))
+        add("status", task.get("status"))
+
+        description = task.get("description")
+        if description:
+            add("description", description)
+
+        exit_code = task.get("exit_code")
+        if exit_code is not None:
+            add("exit_code", exit_code)
+
+        if task.get("truncated"):
+            add("truncated", "true")
+
+        error = task.get("error")
+        if error:
+            add("error", error)
+
+        # ``<output>`` LAST — deliberately after ``<error>``, where TS puts it
+        # first. It is the only unbounded part, so trailing it means a head
+        # truncation (the persistence wrapper's 2KB preview, which
+        # `_format_task_output` now makes rare but the per-message aggregate
+        # budget can still trigger) can only ever eat log lines, never the
+        # metadata that says what happened. In the previous revision
+        # ``<truncated>``/``<error>`` sat after ``<output>`` and were
+        # therefore unreachable: `truncated` is only ever set for a >200KB
+        # log, which is exactly the case that gets truncated away.
+        text = task.get("output")
+        if isinstance(text, str) and text.strip():
+            # ``rstrip`` not ``strip``, matching TS' ``trimEnd()``: leading
+            # indentation on the first output line is real content. The
+            # newlines around it are delimiters the clients strip back off.
+            body = _format_task_output(text.rstrip(), task.get("output_path"))
+            parts.append(f"<output>\n{body}\n</output>")
+
+    return {
+        "type": "tool_result",
+        "tool_use_id": tool_use_id,
+        "content": "\n\n".join(parts),
+    }
 
 
 TaskOutputTool: Tool = build_tool(
@@ -915,6 +1116,7 @@ TaskOutputTool: Tool = build_tool(
         "required": ["task_id"],
     },
     call=_task_output_call,
+    map_result_to_api=_task_output_map_result_to_api,
     prompt="""\
 Get the output of a running or completed background task.
 

--- a/tests/test_task_output_serialization.py
+++ b/tests/test_task_output_serialization.py
@@ -1,0 +1,341 @@
+"""TaskOutput wire format — port of TS ``mapToolResultToToolResultBlockParam``.
+
+The tool used to fall through to ``_default_map_result_to_api``, which
+``json.dumps``ed the whole result dict. The captured log then travelled as a
+JSON string literal — every newline escaped to a literal ``\\n``, on one
+unbroken line, next to ``pid`` / ``started_at`` / ``finished_at`` bookkeeping.
+That blob went to the model AND (the transcript renders tool_result content)
+to the user's screen.
+
+Reference: typescript/src/tools/TaskOutputTool/TaskOutputTool.tsx:283-308.
+
+The golden string in ``test_matches_the_tui_golden`` is duplicated verbatim in
+ui-tui/src/__tests__/taskOutputResult.test.ts. The two runtimes cannot import
+from each other, so pinning the same literal on both sides is what keeps the
+serializer and the renderer from drifting apart.
+"""
+from __future__ import annotations
+
+import json
+
+from src.tool_system.tools.tasks_v2 import (
+    _TASK_MAX_OUTPUT_DEFAULT,
+    _TASK_MAX_OUTPUT_UPPER_LIMIT,
+    _max_task_output_length,
+    TaskOutputTool,
+)
+
+
+BUILD_LOG = (
+    "EXIT=1\n"
+    "#7 [internal] load build context\n"
+    "#9 ERROR: process did not complete successfully: exit code: 127"
+)
+
+
+def _map(output: object) -> str:
+    block = TaskOutputTool.map_result_to_api(output, "toolu_1")
+    assert block["type"] == "tool_result"
+    assert block["tool_use_id"] == "toolu_1"
+    return block["content"]
+
+
+def _bash_result(**overrides: object) -> dict:
+    task = {
+        "task_id": "baa0sty3d",
+        "task_type": "bash_background",
+        "status": "completed",
+        "exit_code": 0,
+        "command": "npm run sandbox:local:build",
+        "description": "Build the sandbox image with CA support",
+        "output": BUILD_LOG,
+        "truncated": False,
+        "pid": 75947,
+        "started_at": 1786432698.634229,
+        "finished_at": 1786432700.10884,
+    }
+    task.update(overrides)
+    return {"retrieval_status": "success", "task": task}
+
+
+# ---------------------------------------------------------------------------
+# The reported bug
+# ---------------------------------------------------------------------------
+
+
+def test_matches_the_tui_golden() -> None:
+    """Byte-for-byte anchor, shared with the TUI renderer's test."""
+    assert _map(_bash_result()) == (
+        "<retrieval_status>success</retrieval_status>\n"
+        "\n"
+        "<task_id>baa0sty3d</task_id>\n"
+        "\n"
+        "<task_type>bash_background</task_type>\n"
+        "\n"
+        "<status>completed</status>\n"
+        "\n"
+        "<description>Build the sandbox image with CA support</description>\n"
+        "\n"
+        "<exit_code>0</exit_code>\n"
+        "\n"
+        "<output>\n"
+        "EXIT=1\n"
+        "#7 [internal] load build context\n"
+        "#9 ERROR: process did not complete successfully: exit code: 127\n"
+        "</output>"
+    )
+
+
+def test_output_keeps_real_newlines() -> None:
+    content = _map(_bash_result())
+    assert "\\n" not in content
+    assert "\n#7 [internal] load build context\n" in content
+
+
+def test_drops_wire_bookkeeping_the_model_cannot_use() -> None:
+    content = _map(_bash_result())
+    for noise in ("pid", "started_at", "finished_at", "75947"):
+        assert noise not in content
+
+
+# ---------------------------------------------------------------------------
+# Part list
+# ---------------------------------------------------------------------------
+
+
+def test_omits_exit_code_when_absent() -> None:
+    """TS emits ``<exit_code>`` only for a non-None code — a still-running
+    task has none, and ``<exit_code>None</exit_code>`` would read as a
+    failure code to the model."""
+    assert "<exit_code>" not in _map(_bash_result(exit_code=None, status="running"))
+
+
+def test_keeps_a_zero_exit_code() -> None:
+    """The guard is ``is not None``, not truthiness: 0 is the success code and
+    dropping it would make every clean run look like a still-running one."""
+    assert "<exit_code>0</exit_code>" in _map(_bash_result(exit_code=0))
+
+
+def test_omits_empty_output() -> None:
+    assert "<output>" not in _map(_bash_result(output="   \n  "))
+
+
+def test_preserves_indentation_on_the_first_output_line() -> None:
+    """``rstrip()``, never ``strip()`` — leading indentation is content, and
+    the TUI strips exactly one delimiter newline back off."""
+    assert "<output>\n    indented\n</output>" in _map(_bash_result(output="    indented\n\n"))
+
+
+def test_emits_truncated_only_when_the_capture_window_clipped() -> None:
+    assert "<truncated>true</truncated>" in _map(_bash_result(truncated=True))
+    assert "<truncated>" not in _map(_bash_result(truncated=False))
+
+
+# ---------------------------------------------------------------------------
+# Output bounding (port of TS formatTaskOutput) — see _format_task_output
+# ---------------------------------------------------------------------------
+
+
+def _big_log(lines: int = 4000) -> str:
+    return "\n".join(f"#{i} step {i} " + "x" * 40 for i in range(lines))
+
+
+def test_stays_under_the_persistence_threshold() -> None:
+    """The reason the 32K cap is required, not redundant.
+
+    Over ``get_persistence_threshold`` (50K) the whole content is replaced by a
+    ``<persisted-output>`` wrapper around a 2KB HEAD preview, which cuts the
+    part list mid-``<output>``. Both clients then fail to find the closing tag.
+    Measured before this was ported: a 55KB build log rendered "(No output)".
+    """
+    import tempfile
+    from pathlib import Path
+
+    from src.services.tool_execution.tool_result_persistence import (
+        process_tool_result_block,
+    )
+
+    result = _bash_result(output=_big_log())
+    content = process_tool_result_block(
+        TaskOutputTool, result, "toolu_1", tool_results_dir=Path(tempfile.mkdtemp())
+    )["content"]
+
+    assert "<persisted-output>" not in content
+    assert content.rstrip().endswith("</output>")
+    assert len(content) <= _TASK_MAX_OUTPUT_DEFAULT + 2_000  # cap + the part list
+
+
+def test_keeps_the_tail_not_the_head() -> None:
+    """A build or a test run puts the failure at the END."""
+    content = _map(_bash_result(output=_big_log()))
+
+    assert "#3999 step 3999" in content
+    assert "#0 step 0 " not in content
+
+
+def test_truncation_names_the_file_that_still_has_everything() -> None:
+    content = _map(_bash_result(output=_big_log(), output_path="/tmp/clawcodex-bg/x.log"))
+
+    assert "[Truncated. Full output: /tmp/clawcodex-bg/x.log]" in content
+
+
+def test_truncation_header_names_the_subagent_transcript(tmp_path) -> None:
+    """A subagent must get an actionable header too. TS passes
+    ``getTaskOutputPath(task.id)`` unconditionally; carrying only the bash
+    branch's path left subagents with a header naming no file."""
+    from src.tasks.local_agent import register_async_agent
+    from src.tasks_core import generate_task_id
+    from src.tool_system.context import ToolContext
+    from src.tool_system.tools.tasks_v2 import _runtime_task_to_output
+
+    ctx = ToolContext(workspace_root=tmp_path)
+    task_id = generate_task_id("local_agent")
+    state = register_async_agent(
+        agent_id=task_id,
+        description="Find bugs",
+        prompt="find bugs",
+        agent_type="general-purpose",
+        registry=ctx.runtime_tasks,
+    )
+    state.result_text = _big_log()
+
+    content = _map(_runtime_task_to_output(task_id, state, ctx).output)
+
+    assert f"[Truncated. Full output: {state.output_file}]" in content
+
+
+def test_truncation_header_degrades_without_a_path() -> None:
+    """Backstop for a task type carrying no path at all (``task_list``)."""
+    content = _map(_bash_result(output=_big_log(), output_path=None))
+
+    assert "[Truncated. Full output: the task's output file]" in content
+
+
+def test_short_output_is_untouched() -> None:
+    assert "[Truncated." not in _map(_bash_result())
+
+
+def test_truncated_tag_survives_because_output_is_last() -> None:
+    """``<truncated>`` was unreachable when it followed ``<output>``: it is only
+    ever set for a >200KB log, which is exactly the case that got cut away."""
+    content = _map(_bash_result(output=_big_log(), truncated=True))
+
+    assert "<truncated>true</truncated>" in content
+    assert content.index("<truncated>") < content.index("<output>")
+
+
+def test_a_tiny_limit_cannot_invert_the_bound() -> None:
+    """TS computes ``slice(-availableSpace)`` unguarded, and a non-positive
+    availableSpace counts from the FRONT instead — returning the whole log and
+    removing the bound entirely. Measured on the unguarded port: limit=1 gave
+    back 100,001 chars. That would hand the >50KB result straight back to the
+    persistence wrapper, which is the failure the cap exists to prevent."""
+    import os
+    from unittest import mock
+
+    from src.tool_system.tools.tasks_v2 import _format_task_output
+
+    with mock.patch.dict(os.environ, {"TASK_MAX_OUTPUT_LENGTH": "1"}):
+        out = _format_task_output("x" * 100_000, "/tmp/clawcodex-bg/t1.log")
+
+    assert len(out) < 500
+    assert out.startswith("[Truncated. Full output: /tmp/clawcodex-bg/t1.log]")
+    assert "xxxx" not in out
+
+
+def test_env_var_bounds() -> None:
+    import os
+    from unittest import mock
+
+    with mock.patch.dict(os.environ, {"TASK_MAX_OUTPUT_LENGTH": "5000"}):
+        assert _max_task_output_length() == 5_000
+    # Above the ceiling clamps; junk and non-positive fall back to the default.
+    with mock.patch.dict(os.environ, {"TASK_MAX_OUTPUT_LENGTH": "999999"}):
+        assert _max_task_output_length() == _TASK_MAX_OUTPUT_UPPER_LIMIT
+    for bad in ("0", "-1", "abc", ""):
+        with mock.patch.dict(os.environ, {"TASK_MAX_OUTPUT_LENGTH": bad}):
+            assert _max_task_output_length() == _TASK_MAX_OUTPUT_DEFAULT
+
+
+def test_emits_error_for_a_failed_subagent(tmp_path) -> None:
+    """Driven through the real projection, not a hand-built dict.
+
+    ``_runtime_task_to_output`` did not carry ``error`` at all, so the
+    ``<error>`` part was unreachable in production and a fixture-only test
+    passed while a genuinely failed subagent surfaced nothing.
+    """
+    from src.tasks.local_agent import (
+        LocalAgentTaskState,
+        fail_agent_task,
+        register_async_agent,
+    )
+    from src.tasks_core import generate_task_id
+    from src.tool_system.context import ToolContext
+    from src.tool_system.tools.tasks_v2 import _runtime_task_to_output
+
+    ctx = ToolContext(workspace_root=tmp_path)
+    task_id = generate_task_id("local_agent")
+    register_async_agent(
+        agent_id=task_id,
+        description="Find bugs",
+        prompt="find bugs",
+        agent_type="general-purpose",
+        registry=ctx.runtime_tasks,
+    )
+    fail_agent_task(task_id, error="subagent crashed", registry=ctx.runtime_tasks)
+
+    runtime = ctx.runtime_tasks.get(task_id)
+    assert isinstance(runtime, LocalAgentTaskState)
+
+    content = _map(_runtime_task_to_output(task_id, runtime, ctx).output)
+    assert "<error>subagent crashed</error>" in content
+
+
+def test_stuck_task_hint_leads_so_it_survives_head_truncation() -> None:
+    """``_guard_repeated_polls`` documents the top-level field as its primary
+    channel: a >50KB result is persisted to disk and replaced by a 2KB HEAD
+    preview, which keeps a leading part and drops a trailing one."""
+    result = _bash_result()
+    result = {"stuck_task_hint": "[stuck-task guard] stop polling", **result}
+    assert _map(result).startswith("<stuck_task_hint>[stuck-task guard] stop polling</stuck_task_hint>")
+
+
+def test_renders_a_missing_task() -> None:
+    assert _map({"retrieval_status": "success", "task": None}) == (
+        "<retrieval_status>success</retrieval_status>"
+    )
+
+
+def test_non_dict_output_passes_through() -> None:
+    assert _map("plain text") == "plain text"
+
+
+# ---------------------------------------------------------------------------
+# Live results
+# ---------------------------------------------------------------------------
+
+
+def test_real_todo_result_is_not_json() -> None:
+    """The `task_list` branch of ``_task_output_call`` — the shape the TUI
+    renders as "description [status]", which needs ``<description>``."""
+    result = {
+        "retrieval_status": "success",
+        "task": {
+            "task_id": "7",
+            "task_type": "task_list",
+            "status": "completed",
+            "description": "Ship it",
+            "output": "all green",
+        },
+    }
+    content = _map(result)
+
+    assert "<description>Ship it</description>" in content
+    assert "<output>\nall green\n</output>" in content
+
+    try:
+        json.loads(content)
+    except json.JSONDecodeError:
+        pass
+    else:  # pragma: no cover - only reachable on a regression
+        raise AssertionError("content regressed to a JSON blob")

--- a/ui-desktop/src/lib/tool-result-summary.test.ts
+++ b/ui-desktop/src/lib/tool-result-summary.test.ts
@@ -64,6 +64,73 @@ describe('formatToolResultSummary', () => {
     expect(summary).toContain('- Title: Build report')
     expect(summary).toContain('- Completed: true')
   })
+
+  // TaskOutput is the one tool whose result is not JSON — it serializes to the
+  // original's `<tag>value</tag>` part list. Before this was decoded, the whole
+  // tag soup (including the full captured log) landed on the card.
+  describe('TaskOutput tagged results', () => {
+    const BUILD_LOG = 'EXIT=1\n#7 [internal] load build context\n#9 ERROR: exit code: 127'
+
+    const tagged = [
+      '<retrieval_status>success</retrieval_status>',
+      '',
+      '<task_id>baa0sty3d</task_id>',
+      '',
+      '<task_type>bash_background</task_type>',
+      '',
+      '<status>completed</status>',
+      '',
+      '<description>Build the sandbox image with CA support</description>',
+      '',
+      '<exit_code>0</exit_code>',
+      '',
+      `<output>\n${BUILD_LOG}\n</output>`
+    ].join('\n')
+
+    it('renders the same key-value lines the pre-tagged JSON did', () => {
+      const summary = formatToolResultSummary(tagged)
+
+      expect(summary).toContain('- Retrieval Status: success')
+      expect(summary).toContain('Status: completed')
+      expect(summary).toContain('Description: Build the sandbox image with CA support')
+      expect(summary).not.toContain('<output>')
+      expect(summary).not.toContain('</retrieval_status>')
+    })
+
+    it('keeps the stuck-task hint on the first line', () => {
+      // The backend puts it first in both serializations for the same reason:
+      // it is the one line the poll guard exists to surface. Building the
+      // record with retrieval_status first quietly demoted it, because
+      // formatRecordSummary renders in key order.
+      const withHint = `<stuck_task_hint>[stuck-task guard] stop polling</stuck_task_hint>\n\n${tagged}`
+      const summary = formatToolResultSummary(withHint)
+
+      expect(summary.split('\n')[0]).toContain('Stuck Task Hint')
+    })
+
+    it('never renders the captured log on the card', () => {
+      const noisy = tagged.replace(BUILD_LOG, `${'a'.repeat(300)}\nSECRETLINE\n${'b'.repeat(300)}`)
+
+      expect(formatToolResultSummary(noisy)).not.toContain('SECRETLINE')
+    })
+
+    it('handles the task: null result', () => {
+      expect(formatToolResultSummary('<retrieval_status>success</retrieval_status>')).toContain(
+        '- Retrieval Status: success'
+      )
+    })
+
+    it('leaves markup that is not a TaskOutput result alone', () => {
+      // A fetched page or an XML file read must not be mistaken for tag parts.
+      const html = '<html><body><p>hello</p></body></html>'
+
+      expect(formatToolResultSummary(html)).toContain('hello')
+
+      const xml = '<retrieval_status_like>not ours</retrieval_status_like>'
+
+      expect(formatToolResultSummary(xml)).toContain('not ours')
+    })
+  })
 })
 
 describe('extractToolErrorMessage', () => {

--- a/ui-desktop/src/lib/tool-result-summary.ts
+++ b/ui-desktop/src/lib/tool-result-summary.ts
@@ -51,7 +51,63 @@ function tryJson(value: string): unknown {
   }
 }
 
-const norm = (v: unknown): unknown => (typeof v === 'string' ? tryJson(v) : v)
+// TaskOutput is the one tool whose result is not JSON: it serializes to the
+// original Claude Code's `<tag>value</tag>` part list (tasks_v2.py
+// `_task_output_map_result_to_api`, ported from
+// typescript/src/tools/TaskOutputTool/TaskOutputTool.tsx). Left alone it hits
+// the plain-string path and the whole tag soup lands on the card, so decode it
+// back into the record shape the summarizer below already knows how to render.
+//
+// Anchored at the head, and only these two tags can appear there — a tool
+// result that merely *contains* markup (a fetched HTML page, an XML file read)
+// never matches, and a non-match falls through untouched.
+const TASK_OUTPUT_LEAD_TAG = /^<(?:retrieval_status|stuck_task_hint)>/
+// `output` is deliberately absent: it is in WRAPPER_KEYS, so skipField drops it
+// before any renderer sees it. Capturing it anyway would copy and trim up to
+// 200KB of log per call, unmemoized, in a render path — for a value that is
+// never displayed.
+const TASK_FIELDS = ['task_id', 'task_type', 'status', 'description', 'exit_code', 'error'] as const
+
+function tryTaggedTaskOutput(value: string): unknown {
+  const text = value.trim()
+
+  if (!TASK_OUTPUT_LEAD_TAG.test(text)) {
+    return tryJson(value)
+  }
+
+  const read = (tag: string): string | undefined =>
+    new RegExp(`<${tag}>([\\s\\S]*?)</${tag}>`).exec(text)?.[1]
+
+  const task: Json = {}
+
+  for (const field of TASK_FIELDS) {
+    const raw = read(field)
+
+    if (raw !== undefined) {
+      task[field] = raw.trim()
+    }
+  }
+
+  // Key order is the render order (formatRecordSummary walks Object.keys), and
+  // the backend puts stuck_task_hint first for the same reason it leads the
+  // tag list — it is the one line the poll guard exists to surface. Building
+  // it after retrieval_status would quietly demote it.
+  const out: Json = {}
+  const hint = read('stuck_task_hint')
+
+  if (hint !== undefined) {
+    out.stuck_task_hint = hint.trim()
+  }
+
+  out.retrieval_status = read('retrieval_status') ?? ''
+
+  // No task fields at all is the `task: null` result (unknown / evicted id).
+  out.task = Object.keys(task).length > 0 ? task : null
+
+  return out
+}
+
+const norm = (v: unknown): unknown => (typeof v === 'string' ? tryTaggedTaskOutput(v) : v)
 
 const titleCase = (k: string) =>
   k

--- a/ui-tui/src/__tests__/taskOutputResult.test.ts
+++ b/ui-tui/src/__tests__/taskOutputResult.test.ts
@@ -1,0 +1,406 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { describe, expect, it, vi } from 'vitest'
+
+const harness = vi.hoisted(() => ({ proc: null as null | EventEmitter }))
+
+vi.mock('node:child_process', () => ({ spawn: () => harness.proc }))
+
+import { formatToolResult, GatewayClient } from '../gatewayClient.js'
+
+// ── fixtures ────────────────────────────────────────────────────────────────
+
+/** The tagged content the backend now puts on the wire (tasks_v2.py
+ *  `_task_output_map_result_to_api`). Built here rather than imported so a
+ *  silent format change on either side fails one of these tests. */
+const tagged = (parts: Record<string, string | undefined>, output?: string): string =>
+  [
+    ...Object.entries(parts)
+      .filter(([, v]) => v !== undefined)
+      .map(([k, v]) => `<${k}>${v}</${k}>`),
+    ...(output === undefined ? [] : [`<output>\n${output}\n</output>`])
+  ].join('\n\n')
+
+const bashTask = (output: string, status = 'completed') =>
+  tagged(
+    {
+      retrieval_status: 'success',
+      task_id: 'baa0sty3d',
+      task_type: 'bash_background',
+      status,
+      description: 'Build the sandbox image with CA support',
+      exit_code: '0'
+    },
+    output
+  )
+
+const BUILD_LOG = [
+  'EXIT=1',
+  '#7 [internal] load build context',
+  '#7 transferring context: 1.95kB done',
+  '#7 DONE 0.0s',
+  '#8 [node-runtime 2/4] COPY fly/certs/ /usr/local/share/ca-certificates/',
+  '#9 0.101 /bin/sh: 1: update-ca-certificates: not found',
+  '#9 ERROR: process did not complete successfully: exit code: 127'
+].join('\n')
+
+// Exactly the payload from the reported bug — the pre-fix serialization. Still
+// reachable, because the TUI and the Python backend update independently: a
+// refreshed TUI talking to an older installed `clawcodex` still gets this.
+const LEGACY_JSON = JSON.stringify({
+  retrieval_status: 'success',
+  task: {
+    command: 'npm run sandbox:local:build > /tmp/sandbox-build.log 2>&1',
+    description: 'Build the sandbox image with CA support',
+    exit_code: 0,
+    finished_at: 1786432700.10884,
+    output: BUILD_LOG,
+    pid: 75947,
+    started_at: 1786432698.634229,
+    status: 'completed',
+    task_id: 'baa0sty3d',
+    task_type: 'bash_background',
+    truncated: false
+  }
+})
+
+const fmt = (result: string, name = 'TaskOutput') => formatToolResult(name, result)
+
+/** Byte-for-byte what the backend emits, duplicated verbatim from
+ *  tests/test_task_output_serialization.py::test_matches_the_tui_golden. The
+ *  two runtimes cannot import from each other, so pinning the same literal on
+ *  both sides is what catches the serializer and this renderer drifting. */
+const BACKEND_GOLDEN = [
+  '<retrieval_status>success</retrieval_status>',
+  '',
+  '<task_id>baa0sty3d</task_id>',
+  '',
+  '<task_type>bash_background</task_type>',
+  '',
+  '<status>completed</status>',
+  '',
+  '<description>Build the sandbox image with CA support</description>',
+  '',
+  '<exit_code>0</exit_code>',
+  '',
+  '<output>',
+  'EXIT=1',
+  '#7 [internal] load build context',
+  '#9 ERROR: process did not complete successfully: exit code: 127',
+  '</output>'
+].join('\n')
+
+// ── the reported bug ────────────────────────────────────────────────────────
+
+describe('TaskOutput no longer dumps its result blob', () => {
+  const expected = [
+    'EXIT=1',
+    '#7 [internal] load build context',
+    '#7 transferring context: 1.95kB done',
+    '… +4 lines (ctrl+o to expand)'
+  ].join('\n')
+
+  it('renders a background shell task the way Bash renders', () => {
+    expect(fmt(bashTask(BUILD_LOG))).toBe(expected)
+  })
+
+  it('renders the same from an older backend still sending JSON', () => {
+    expect(fmt(LEGACY_JSON)).toBe(expected)
+  })
+
+  it('renders the exact bytes the backend emits', () => {
+    expect(fmt(BACKEND_GOLDEN)).toBe(
+      'EXIT=1\n#7 [internal] load build context\n#9 ERROR: process did not complete successfully: exit code: 127'
+    )
+  })
+
+  it.each([
+    ['tagged', bashTask(BUILD_LOG)],
+    ['legacy JSON', LEGACY_JSON]
+  ])('shows no wire bookkeeping and no escaped newlines (%s)', (_label, content) => {
+    const out = fmt(content)
+
+    // The literal two-character `\n` sequence is what made the blob
+    // unreadable; a real newline is fine and expected.
+    expect(out).not.toContain(String.raw`\n`)
+    expect(out).not.toContain('retrieval_status')
+    expect(out).not.toContain('started_at')
+    expect(out).not.toContain('pid')
+    expect(out).not.toContain('{')
+    expect(out.split('\n')).toHaveLength(4)
+  })
+})
+
+// ── per-task-type branches (TaskOutputTool.tsx renderToolResultMessage) ──────
+
+describe('background shell tasks', () => {
+  it('shows the whole output when only one line would overflow', () => {
+    expect(fmt(bashTask('a\nb\nc\nd'))).toBe('a\nb\nc\nd')
+  })
+
+  it('says so when the task produced nothing', () => {
+    expect(fmt(bashTask(''))).toBe('(No output)')
+  })
+
+  it('says so for an empty tag body rather than echoing the closing tag', () => {
+    // extractTag returns null for an empty body too, so the truncated-preview
+    // fallback must not claim this one.
+    const empty = [
+      '<retrieval_status>success</retrieval_status>',
+      '',
+      '<task_id>t1</task_id>',
+      '',
+      '<task_type>bash_background</task_type>',
+      '',
+      '<output></output>'
+    ].join('\n')
+
+    expect(fmt(empty)).toBe('(No output)')
+  })
+
+  it('says so when the task produced nothing and the tag is absent', () => {
+    // `<output>` is omitted entirely for blank output, so the "no output at
+    // all" and "output was whitespace" paths must agree.
+    expect(fmt(bashTask('   \n  '))).toBe('(No output)')
+  })
+
+  it('renders a still-running task from its partial output', () => {
+    expect(fmt(bashTask('step 1 done', 'running'))).toBe('step 1 done')
+  })
+
+  it('strips only the delimiter newlines, never the task\'s own layout', () => {
+    // The backend writes `<output>\n…\n</output>`; those two newlines are
+    // framing. A blank first line or an indented first line is content.
+    expect(fmt(bashTask('\n    indented'))).toBe('\n    indented')
+  })
+})
+
+describe('subagent tasks', () => {
+  const agent = (retrieval: string, status: string) =>
+    tagged(
+      { retrieval_status: retrieval, task_id: 'a1', task_type: 'local_agent', status, description: 'Find bugs' },
+      'a long multi-paragraph answer\nthat must not be re-printed here'
+    )
+
+  it('points at the expansion instead of re-printing the answer', () => {
+    expect(fmt(agent('success', 'completed'))).toBe('Read output (ctrl+o to expand)')
+  })
+
+  it.each(['timeout', 'not_ready'])('reports %s as still running', retrieval => {
+    expect(fmt(agent(retrieval, 'running'))).toBe('Task is still running…')
+  })
+
+  it('reports a running task as still running whatever the retrieval status', () => {
+    expect(fmt(agent('partial', 'running'))).toBe('Task is still running…')
+  })
+
+  it('falls back to "not ready" for a terminal task with no output to read', () => {
+    expect(fmt(agent('partial', 'failed'))).toBe('Task not ready')
+  })
+})
+
+describe('todo and unknown task types', () => {
+  it('renders an identity line plus a bounded peek at the output', () => {
+    const todo = tagged(
+      { retrieval_status: 'success', task_id: '7', task_type: 'task_list', status: 'completed', description: 'Ship it' },
+      'all green'
+    )
+
+    expect(fmt(todo)).toBe('Ship it [completed]\nall green')
+  })
+
+  it('caps the peek at 500 characters', () => {
+    const todo = tagged(
+      { retrieval_status: 'success', task_id: '7', task_type: 'task_list', status: 'completed', description: 'Ship it' },
+      'x'.repeat(2000)
+    )
+
+    expect(fmt(todo)).toBe(`Ship it [completed]\n${'x'.repeat(500)}`)
+  })
+
+  it('renders the identity line alone when there is no output', () => {
+    const todo = tagged({
+      retrieval_status: 'success',
+      task_id: '7',
+      task_type: 'task_list',
+      status: 'pending',
+      description: 'Ship it'
+    })
+
+    expect(fmt(todo)).toBe('Ship it [pending]')
+  })
+})
+
+describe('degenerate results', () => {
+  it('reports an unknown / evicted task id', () => {
+    expect(fmt('<retrieval_status>success</retrieval_status>')).toBe('No task output available')
+    expect(fmt(JSON.stringify({ retrieval_status: 'success', task: null }))).toBe('No task output available')
+  })
+
+  it('does not mistake an empty task id for a missing task', () => {
+    // extractTag returns null for an empty body as well as an absent tag, so
+    // keying "is there a task?" on extracted content reports a real task as
+    // missing. Reachable via the unknown-TaskStateBase branch.
+    const empty = '<retrieval_status>success</retrieval_status>\n\n<task_id></task_id>\n\n<status>running</status>'
+
+    expect(fmt(empty)).toBe('[running]')
+  })
+
+  it('passes through content it does not recognize', () => {
+    expect(fmt('not json, no tags')).toBe('not json, no tags')
+    expect(fmt('{"unrelated": true}')).toBe('{"unrelated": true}')
+    expect(fmt('<persisted-output>\nOutput too large (204.8KB). Saved to: /t/x.txt\n</persisted-output>')).toBe(
+      '<persisted-output>\nOutput too large (204.8KB). Saved to: /t/x.txt\n</persisted-output>'
+    )
+  })
+
+  // The regression that shipped in the first cut of this change. A result over
+  // the persistence threshold is replaced by a <persisted-output> wrapper
+  // around a 2KB HEAD preview, which cuts the part list mid-<output>: the head
+  // tags survive, the closing </output> does not. extractTag needs the pair,
+  // so `output` came back undefined and a 55KB build log rendered as
+  // "(No output)" — a false statement, and worse than the raw dump this whole
+  // change removes. Byte-shaped exactly like build_large_tool_result_message
+  // (tool_result_persistence.py:300-314); note the HYPHEN in the tag name,
+  // which the original version of this test got wrong.
+  it('renders the log when the persistence wrapper cut <output> open', () => {
+    const preview = [
+      '<retrieval_status>success</retrieval_status>',
+      '',
+      '<task_id>baa0sty3d</task_id>',
+      '',
+      '<task_type>bash_background</task_type>',
+      '',
+      '<status>failed</status>',
+      '',
+      '<output>',
+      'EXIT=1',
+      '#7 [internal] load build context',
+      '#8 COPY fly/certs/',
+      '#9 ERROR: update-ca-certificates: not found',
+      '#10 truncated mid-li'
+    ].join('\n')
+
+    const wrapped = [
+      '<persisted-output>',
+      'Output too large (54.7KB). Full output saved to: /t/tool-results/toolu_1.txt',
+      '',
+      'Preview (first 2.0KB):',
+      preview,
+      '...',
+      '</persisted-output>'
+    ].join('\n')
+
+    const out = fmt(wrapped)
+
+    expect(out).not.toBe('(No output)')
+    expect(out.split('\n')[0]).toBe('EXIT=1')
+    expect(out).toContain('#7 [internal] load build context')
+    // The wrapper's own trailing bytes are not log lines.
+    expect(out).not.toContain('</persisted-output>')
+  })
+
+  it('does not claim "no output" when the preview ended before <output>', () => {
+    // The other half of the same class: an oversized <description> can eat the
+    // whole 2KB window, so there is no opening tag to recover from either.
+    // Showing the wrapper is honest — it names the file holding the rest.
+    const wrapped = [
+      '<persisted-output>',
+      'Output too large (54.7KB). Full output saved to: /t/tool-results/toolu_1.txt',
+      '',
+      'Preview (first 2.0KB):',
+      '<retrieval_status>success</retrieval_status>',
+      '',
+      '<task_id>t3</task_id>',
+      '',
+      '<task_type>bash_background</task_type>',
+      '',
+      `<description>${'D'.repeat(1800)}`,
+      '...',
+      '</persisted-output>'
+    ].join('\n')
+
+    const out = fmt(wrapped)
+
+    expect(out).not.toBe('(No output)')
+    expect(out).toContain('/t/tool-results/toolu_1.txt')
+  })
+
+  it('leaves errors to the error path', () => {
+    expect(formatToolResult('TaskOutput', 'No task found with ID: nope', true)).toBe(
+      'Error: No task found with ID: nope'
+    )
+  })
+
+  it.each(['AgentOutputTool', 'BashOutputTool'])('routes the %s alias to the same renderer', alias => {
+    expect(fmt(bashTask('a\nb'), alias)).toBe('a\nb')
+  })
+
+  it('still summarizes when the tool name is unknown (mid-turn attach)', () => {
+    expect(formatToolResult(undefined, bashTask('a\nb'))).toBe('a\nb')
+    expect(
+      formatToolResult(undefined, `<stuck_task_hint>stop polling</stuck_task_hint>\n\n${bashTask('a\nb')}`)
+    ).toBe('a\nb')
+  })
+
+  it('does not claim an unnamed result that is not a TaskOutput', () => {
+    expect(formatToolResult(undefined, '<retrieval_status_other>x</retrieval_status_other>')).toBe(
+      '<retrieval_status_other>x</retrieval_status_other>'
+    )
+    expect(formatToolResult(undefined, LEGACY_JSON)).toBe(LEGACY_JSON)
+  })
+})
+
+// ── end to end through the client ───────────────────────────────────────────
+
+class FakeProc extends EventEmitter {
+  kill = vi.fn()
+  stderr = new PassThrough()
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+
+  line(obj: unknown): void {
+    this.stdout.write(JSON.stringify(obj) + '\n')
+  }
+}
+
+describe('tool.complete payload', () => {
+  it('summarizes the row and keeps the full result behind ctrl+o', async () => {
+    const proc = new FakeProc()
+
+    harness.proc = proc
+
+    const events: any[] = []
+    const gw = new GatewayClient()
+
+    gw.on('event', (e: any) => events.push(e))
+    gw.start()
+    gw.drain()
+
+    const last = (t: string) => [...events].reverse().find(e => e.type === t)
+    const content = bashTask(BUILD_LOG)
+
+    proc.line({
+      message: { content: [{ id: 't1', input: { task_id: 'baa0sty3d' }, name: 'TaskOutput', type: 'tool_use' }] },
+      type: 'assistant'
+    })
+    await vi.waitFor(() => expect(last('tool.start')).toBeTruthy())
+
+    proc.line({
+      message: { content: [{ content, tool_use_id: 't1', type: 'tool_result' }] },
+      type: 'user'
+    })
+    await vi.waitFor(() => expect(last('tool.complete')).toBeTruthy())
+    gw.kill()
+
+    const payload = last('tool.complete').payload
+
+    expect(payload.result_text).toBe(
+      'EXIT=1\n#7 [internal] load build context\n#7 transferring context: 1.95kB done\n… +4 lines (ctrl+o to expand)'
+    )
+    expect(payload.error).toBeUndefined()
+    // The compact row dropped the tail, so the expandable original is retained.
+    expect(payload.result_raw).toBe(content)
+  })
+})

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -403,6 +403,246 @@ function pendingQuestionsSummary(result: string): string {
   return result
 }
 
+/** Bash-style result preview: the first few lines, then a `+N lines` hint.
+ *  Shared by the Bash tool and by TaskOutput's background-shell branch —
+ *  the original routes the latter through the very same renderer
+ *  (TaskOutputTool.tsx:384-410 hands `task.output` to BashToolResultMessage),
+ *  so the two must not drift. */
+function bashOutputSummary(result: string): string {
+  const trimmed = result.replace(/\s+$/, '')
+
+  if (!trimmed) {
+    return '(No output)'
+  }
+
+  const lines = trimmed.split('\n')
+
+  // CC parity: when exactly one line overflows, show it instead of a hint.
+  if (lines.length <= BASH_RESULT_MAX_LINES + 1) {
+    return trimmed
+  }
+
+  return [
+    ...lines.slice(0, BASH_RESULT_MAX_LINES),
+    `… +${lines.length - BASH_RESULT_MAX_LINES} lines (ctrl+o to expand)`
+  ].join('\n')
+}
+
+/** The tool's own name plus its back-compat aliases (tasks_v2.py
+ *  `aliases=("AgentOutputTool", "BashOutputTool")`). A model that calls an
+ *  alias reaches the same backend tool, so it must reach the same renderer —
+ *  in the original that is automatic, the renderer hanging off the resolved
+ *  tool object rather than off the wire name. */
+const TASK_OUTPUT_TOOL_NAMES = new Set(['AgentOutputTool', 'BashOutputTool', 'TaskOutput'])
+
+/** The two tags a TaskOutput result can open with (`stuck_task_hint` leads
+ *  when the poll guard fired). Used only when the tool name is unknown. */
+const TASK_OUTPUT_LEAD_TAG = /^<(?:retrieval_status|stuck_task_hint)>/
+
+/** A task object was serialized at all — as opposed to the `task: null`
+ *  result, which carries `<retrieval_status>` and nothing else. */
+const TASK_PRESENT_TAG = /<task_(?:id|type)>/
+
+/** Opening tag of the wrapper a result over the persistence threshold is
+ *  replaced with (tool_result_persistence.py PERSISTED_OUTPUT_TAG). Hyphen,
+ *  not underscore. */
+const PERSISTED_OUTPUT_TAG = '<persisted-output>'
+
+/** Read the `<output>` block.
+ *
+ *  The captured log is written as `<output>\n…\n</output>` so it starts on its
+ *  own line; those two newlines are delimiters, not content. Exactly one is
+ *  stripped at each end — any further blank line or indentation is the task's
+ *  own layout and must survive.
+ *
+ *  The unterminated case is real, not defensive padding. When a result clears
+ *  the persistence threshold, `maybe_persist_large_tool_result` replaces the
+ *  whole content with a `<persisted-output>` wrapper around a 2KB HEAD
+ *  preview, which lands mid-log with no closing tag. `extractTag` requires the
+ *  pair, so it returns null and the caller used to render "(No output)" for a
+ *  result that plainly contains log text — worse than the raw dump this change
+ *  removes. `_format_task_output` now keeps results under that threshold in
+ *  the normal case; the per-message aggregate budget can still trip it, so
+ *  take whatever follows the opening tag rather than claiming there was
+ *  nothing.
+ *
+ *  That "everything after the opening tag" is only safe because the serializer
+ *  emits `<output>` LAST — no metadata part can be swallowed. The two are
+ *  load-bearing on each other: reordering the part list without revisiting
+ *  this would start folding `<truncated>` / `<error>` into the log preview. */
+function readOutputTag(result: string): string | undefined {
+  const closed = extractTag(result, 'output')
+
+  if (closed !== null) {
+    return closed.replace(/^\n/, '').replace(/\n$/, '')
+  }
+
+  const open = result.indexOf('<output>')
+
+  if (open === -1) {
+    return undefined
+  }
+
+  // extractTag returns null for an EMPTY body as well as for a missing close,
+  // and only the latter is a truncated preview. Without this, `<output></output>`
+  // would take the fallback and render the literal string "</output>".
+  // Unreachable today — the serializer gates on `text.strip()` — but the guard
+  // costs one line and the failure mode is silent.
+  if (result.indexOf('</output>', open) !== -1) {
+    return ''
+  }
+
+  return (
+    result
+      .slice(open + '<output>'.length)
+      .replace(/^\n/, '')
+      // The wrapper closes itself after the cut, so drop its own trailing
+      // bytes rather than showing them as log. Both shapes
+      // build_large_tool_result_message emits: with and without the `...`
+      // has-more marker.
+      .replace(/\n?(?:\.\.\.\n)?<\/persisted-output>\s*$/, '')
+  )
+}
+
+/** The fields TaskOutput's transcript row renders, recovered from the
+ *  tool_result content. `hasTask` is false for the `task: null` result
+ *  (unknown/evicted id) — distinct from a task whose fields are simply
+ *  empty. */
+type TaskOutputView = {
+  description?: string
+  hasTask: boolean
+  output?: string
+  retrievalStatus?: string
+  status?: string
+  taskType?: string
+}
+
+/** Read a TaskOutput result out of the two serializations it can arrive in.
+ *
+ *  The tagged form is what the current backend sends (tasks_v2.py
+ *  `_task_output_map_result_to_api`). The `json.dumps` blob is what a backend
+ *  older than that fix sends, and the two ship separately — `resolveAgentCmd`
+ *  picks up whatever `clawcodex` is installed, which a TUI update does not
+ *  move. Parsing both means a skewed pair still renders instead of falling
+ *  back to the raw dump this change exists to remove. (It is NOT about
+ *  transcripts: `/resume` restores the conversation backend-side and replies
+ *  with counters only — it never replays tool results to the client, so no
+ *  stored result ever reaches this function.)
+ *
+ *  Anything else declines, and the caller shows the content as-is. Note that
+ *  the `<persisted-output>` wrapper is NOT such a case: its 2KB preview keeps
+ *  the head of the part list intact, so `<retrieval_status>` still matches and
+ *  this parses it — see `readOutputTag` for the half-cut `<output>` that
+ *  leaves behind.
+ *
+ *  Captured output that itself contains a literal `</output>` ends the tag
+ *  early and shortens the preview by that much. Same ambiguity the original's
+ *  own wire format carries; it costs a few preview lines, never correctness —
+ *  the untouched result still rides `result_raw` for ctrl+o. */
+function parseTaskOutput(result: string): TaskOutputView | undefined {
+  const retrievalStatus = extractTag(result, 'retrieval_status')
+
+  if (retrievalStatus !== null) {
+    const taskType = extractTag(result, 'task_type')
+
+    return {
+      description: extractTag(result, 'description') ?? undefined,
+      // Tag PRESENCE, not extracted content: extractTag returns null for an
+      // empty body too (`depth === 0 && content`, and '' is falsy), so a task
+      // serialized with an empty id would otherwise read as "no task".
+      hasTask: TASK_PRESENT_TAG.test(result),
+      output: readOutputTag(result),
+      retrievalStatus,
+      status: extractTag(result, 'status') ?? undefined,
+      taskType: taskType ?? undefined
+    }
+  }
+
+  try {
+    const parsed = JSON.parse(result)
+
+    if (!parsed || typeof parsed !== 'object' || !('retrieval_status' in parsed)) {
+      return undefined
+    }
+
+    const task = parsed.task
+    const str = (v: unknown) => (typeof v === 'string' ? v : undefined)
+
+    if (!task || typeof task !== 'object') {
+      return { hasTask: false, retrievalStatus: str(parsed.retrieval_status) }
+    }
+
+    return {
+      description: str(task.description),
+      hasTask: true,
+      output: str(task.output),
+      retrievalStatus: str(parsed.retrieval_status),
+      status: str(task.status),
+      taskType: str(task.task_type)
+    }
+  } catch {
+    return undefined
+  }
+}
+
+/** Port of TaskOutputTool.tsx's renderToolResultMessage
+ *  (TaskOutputResultDisplay, lines 353-582) in its non-verbose form — the
+ *  full body stays reachable behind ctrl+o via result_raw, which is the
+ *  original's `verbose` branch.
+ *
+ *  Task-type names are the backend's (`bash_background`, `local_agent`,
+ *  `task_list`), not TS' (`local_bash`, `local_agent`, `remote_agent`); the
+ *  branches are matched by role, not by spelling. */
+function taskOutputSummary(result: string): string {
+  const view = parseTaskOutput(result)
+
+  if (!view) {
+    return result
+  }
+
+  if (!view.hasTask) {
+    return 'No task output available'
+  }
+
+  const output = view.output ?? ''
+
+  // Closes the bug class this change exists to fix, rather than one instance
+  // of it. `readOutputTag` recovers a preview cut INSIDE `<output>`; a cut
+  // BEFORE it (reachable when an oversized `<description>` eats the whole 2KB
+  // window) leaves no opening tag at all, and every branch below would then
+  // report a truncated wrapper as "the task produced nothing". Showing the
+  // wrapper is honest and actionable — it names the file holding the rest.
+  if (!output && result.includes(PERSISTED_OUTPUT_TAG)) {
+    return result
+  }
+
+  // Background shell → the Bash renderer, exactly as the original does.
+  if (view.taskType === 'bash_background') {
+    return bashOutputSummary(output)
+  }
+
+  // Subagent → never the body itself. The original prints only a pointer
+  // because the result is already in the model's context and re-printing a
+  // multi-paragraph answer under the tool row buries the transcript.
+  if (view.taskType === 'local_agent') {
+    if (view.retrievalStatus === 'success') {
+      return 'Read output (ctrl+o to expand)'
+    }
+
+    if (view.retrievalStatus === 'timeout' || view.retrievalStatus === 'not_ready' || view.status === 'running') {
+      return 'Task is still running…'
+    }
+
+    return 'Task not ready'
+  }
+
+  // Todos (`task_list`) and any future task type: identity line, then a
+  // bounded peek at whatever output it carries.
+  const head = `${view.description ?? ''} [${view.status ?? 'unknown'}]`.trim()
+
+  return output ? `${head}\n${output.slice(0, 500)}` : head
+}
+
 export function formatToolResult(
   name: string | undefined,
   result: string,
@@ -503,23 +743,21 @@ export function formatToolResult(
   }
 
   if (name === 'Bash') {
-    const trimmed = result.replace(/\s+$/, '')
+    return bashOutputSummary(result)
+  }
 
-    if (!trimmed) {
-      return '(No output)'
-    }
-
-    const lines = trimmed.split('\n')
-
-    // CC parity: when exactly one line overflows, show it instead of a hint.
-    if (lines.length <= BASH_RESULT_MAX_LINES + 1) {
-      return trimmed
-    }
-
-    return [
-      ...lines.slice(0, BASH_RESULT_MAX_LINES),
-      `… +${lines.length - BASH_RESULT_MAX_LINES} lines (ctrl+o to expand)`
-    ].join('\n')
+  // Without this the whole `{"retrieval_status":…,"task":{…}}` result was
+  // printed verbatim under the tool row — a wall of JSON with every newline
+  // of the captured log escaped to a literal `\n`, plus pid/started_at/
+  // finished_at bookkeeping. Both halves are fixed: the backend now emits the
+  // original's tagged format, and this renders it the way CC does.
+  //
+  // Shape-keyed as well as name-keyed, like the WebSearch branch above: a
+  // client that attached mid-turn never saw the tool_use block, so `name` is
+  // undefined and the name test alone would drop it straight back to a raw
+  // dump. Only TaskOutput opens with these two tags.
+  if (name ? TASK_OUTPUT_TOOL_NAMES.has(name) : TASK_OUTPUT_LEAD_TAG.test(result)) {
+    return taskOutputSummary(result)
   }
 
   return result


### PR DESCRIPTION
## The bug

`TaskOutput` printed its entire result as a raw JSON blob under the tool row:

```
● TaskOutput
  ⎿ {"retrieval_status": "success", "task": {"task_id": "baa0sty3d", "task_type":
    "bash_background", "status": "completed", "exit_code": 0, "command": "…",
    "description": "…", "output": "EXIT=1\n#7 [internal] load build context\n#7
    transferring context: 1.95kB done\n…", "truncated": false, "pid": 75947,
    "started_at": 1786432698.634229, "finished_at": 1786432700.10884}}
```

Every newline of the captured build log is an escaped literal `\n`, wrapped on one
unbroken line next to `pid` / `started_at` / `finished_at` bookkeeping.

**The model was reading the same blob.** The transcript renders the tool_result
content, so this was one defect with two halves:

1. `TaskOutputTool` never passed `map_result_to_api`, so it fell through to
   `_default_map_result_to_api`, which `json.dumps`es the result dict.
2. The TUI's `formatToolResult` had no `TaskOutput` branch, so it returned that
   content verbatim.

## The fix

Both halves, ported from the reference implementation in
`typescript/src/tools/TaskOutputTool/TaskOutputTool.tsx`.

**Backend** (`tasks_v2.py`) — `_task_output_map_result_to_api`, a port of
`mapToolResultToToolResultBlockParam` (lines 283-308): `<tag>value</tag>` parts
joined by blank lines, with the captured output in its own `<output>` block and
real newlines.

```
<retrieval_status>success</retrieval_status>

<task_id>byii8g9is</task_id>

<task_type>bash_background</task_type>

<status>failed</status>

<description>demo</description>

<exit_code>3</exit_code>

<output>
line A
line B
  indented C
line D
line E
</output>
```

**TUI** (`gatewayClient.ts`) — `taskOutputSummary`, a port of
`TaskOutputResultDisplay` (lines 353-582) in its non-verbose form. Background
shell tasks route through the same Bash preview the original uses; subagent tasks
show a pointer rather than re-printing an answer already in context; todos and
unknown types show `description [status]` plus a bounded peek.

```
● TaskOutput(baa0sty3d)
  ⎿  EXIT=1
     #7 [internal] load build context
     #7 transferring context: 1.95kB done
     … +4 lines (ctrl+o to expand)
```

**Desktop** (`tool-result-summary.ts`) — the backend change would otherwise have
regressed it. `norm()` JSON-parses string content, so the desktop *was* rendering
TaskOutput as a tidy two-line summary; switching the wire format to tags dropped
it to the plain-string path and dumped the tag soup onto the card.
`tryTaggedTaskOutput` decodes the tagged form back into the record the summarizer
already knows, so the rendered summary is byte-identical before and after.

## Output bounding — why the 32K cap had to be ported

The first cut of this change dismissed TS's `formatTaskOutput` (a 32K cap on the
captured output) as a redundant third bound, given clawcodex already has a
~200KB read window and a 50K persistence threshold. That was backwards, and it
shipped a regression worse than the original bug.

Both of those bounds sit *above* the point where the structured format is
destroyed. Over the 50K threshold, `maybe_persist_large_tool_result` replaces
the whole content with a `<persisted-output>` wrapper around a 2KB **head**
preview — which cuts the part list mid-`<output>`, leaving no closing tag.
Measured through the real `process_tool_result_block`: a 55KB docker-build log
rendered as **`(No output)`**.

So `_format_task_output` is now a real port — tail-keep (a build puts its
failure at the end), a `[Truncated. Full output: <path>]` header naming the file
that still holds everything, and `_max_task_output_length` mirroring
`validateBoundedIntEnvVar` (`TASK_MAX_OUTPUT_LENGTH`, default 32,000, ceiling
160,000). The same 55KB log now maps to 32,238 chars, no wrapper, `</output>`
intact.

Two hardening changes fall out of that:

- **`<output>` is emitted last**, after `<truncated>` and `<error>`, deviating
  from TS's order. It is the only unbounded part, so trailing it means a head
  truncation can only ever eat log lines, never the metadata that says what
  happened. In the first cut `<truncated>` sat *after* `<output>` and was
  therefore unreachable — it is only ever set for a >200KB log, which is exactly
  the case that got cut away.
- **Both clients parse defensively.** `readOutputTag` recovers a preview cut
  inside `<output>`; a cut *before* it (an oversized `<description>` eating the
  2KB window) falls back to showing the wrapper, which names the file. "The task
  produced nothing" is now unreachable from a result that contains log text.

One deliberate deviation from the reference: TS computes
`output.slice(-availableSpace)` with no guard, and a non-positive
`availableSpace` silently inverts (`slice(-0)` is `slice(0)`, `slice(59)` counts
from the front), handing back the entire log. Reachable with a small
`TASK_MAX_OUTPUT_LENGTH` — measured, `limit=1` returned 100,001 chars.
Replicating that would defeat the one bound that prevents the failure above, so
it is guarded.

## Deliberate deviations from the TS part list

- **`<description>`** — TS omits it because its renderer holds the live task
  object. Here the client is a separate process whose only view is this content,
  and the `task_list` type (a TaskCreate todo) renders as `description [status]`,
  which is nothing without it.
- **`<truncated>`** — emitted only when the ~200KB capture window clipped the
  output. Complementary to the header above rather than redundant with it: the
  header means "the wire copy is the tail", the tag means "even the captured
  copy is short of the real log".
- **`<stuck_task_hint>` leads** — `_guard_repeated_polls` documents the top-level
  field as its primary channel precisely because a >50KB result is persisted to
  disk and replaced by a 2KB HEAD preview. A leading part survives that; a
  trailing one does not.
## Also fixed along the way

- `<error>` was unreachable in production: `_runtime_task_to_output` never
  carried `runtime.error`, so a genuinely failed subagent surfaced nothing but
  its status. Its test hand-built the dict, so it passed while the system was
  broken — it now drives `register_async_agent` → `fail_agent_task` →
  `_runtime_task_to_output`.
- Subagent results over 32K got a header naming no file; now threads
  `LocalAgentTaskState.output_file`.
- `<status>None</status>` was possible for a task dict missing a field (TS is
  type-guaranteed here, a plain dict isn't).
- The TUI conflated an empty `<task_id>` with an absent one, reporting a real
  task as missing.
- ui-desktop was capturing and trimming up to 200KB of log per call, in a render
  path, for a value `skipField` drops before anything displays it.

## Notes

- The legacy `json.dumps` shape still parses in both clients. Not for transcripts
  — `/resume` replies with counters and never replays tool results — but because
  the TUI spawns whatever `clawcodex` is on `PATH`, so a refreshed TUI can talk
  to an older backend.
- The TUI branch is shape-keyed as well as name-keyed, like the WebSearch branch,
  so a client that attached mid-turn (no `tool_use` bookkeeping, `name`
  undefined) doesn't fall back to a raw dump.
- Aliases `AgentOutputTool` / `BashOutputTool` route to the same renderer; in the
  original that is automatic since the renderer hangs off the resolved tool.

## Testing

- `tests/test_task_output_serialization.py` — 13 tests. Includes a byte-for-byte
  golden duplicated verbatim in the TUI test, since the two runtimes cannot
  import from each other and that literal is what catches them drifting.
- `ui-tui/src/__tests__/taskOutputResult.test.ts` — 26 tests, both
  serializations, every task-type branch, degenerate results, and an end-to-end
  pass through `GatewayClient` asserting the compact row plus retained
  `result_raw`.
- `ui-desktop/src/lib/tool-result-summary.test.ts` — 3 added, including a guard
  that fetched HTML / XML reads are not mistaken for tag parts.

Each regression test was mutation-verified — reverted the fix and confirmed the
test fails — rather than merely observed passing. The C1/M1 cases are checked
against wrapper bytes generated by the real `process_tool_result_block`, not
hand-written fixtures; the first version of that test used
`<persisted_output>` with an underscore where the real tag is
`<persisted-output>`, and passed for the wrong reason.

Verified: Python `tests/` 9899 passed / 0 failed. ui-tui full suite at exactly
the pre-existing baseline (8 failures in 5 files, all present on a stashed clean
tree), stable across repeated runs. ui-desktop tool-card surface 100/100
including the only importer of the changed module. Typecheck and lint clean on
all three packages with no new warnings.

Reviewed by the `critic` subagent across two rounds: it caught the persistence
regression, and approved after the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
