### PR TITLE
feat(tui): CC-parity task checklist HUD, and make the checklist actually appear

### DIFF
--- a/src/agent/conversation.py
+++ b/src/agent/conversation.py
@@ -47,12 +47,20 @@ class Conversation:
         content: MessageContent,
         *,
         usage: dict[str, Any] | None = None,
+        isMeta: bool = False,
     ):
+        """``isMeta`` marks injected context (plan-mode / task-reminder
+        attachments), not a real prompt. Dropping it here was a real defect:
+        the persisted reminder came back ``isMeta=False``, so
+        ``_count_prompt_turns`` counted it as a user turn and ``/rewind``
+        treated it as a rewind boundary."""
         if len(self.messages) >= self.max_history:
             self.messages.pop(0)
 
         normalized_content = _normalize_message_content(content)
-        self.messages.append(create_message(role, normalized_content, usage=usage))
+        self.messages.append(
+            create_message(role, normalized_content, usage=usage, isMeta=isMeta)
+        )
 
     def add_user_message(self, content: MessageContent):
         # ``MessageContent = str | list[ContentBlock]``: ``add_message`` ->

--- a/src/context_system/prompt_assembly.py
+++ b/src/context_system/prompt_assembly.py
@@ -990,9 +990,74 @@ _ACTIONS_SECTION = (
     "measure twice, cut once."
 )
 
+# Module 5, the task-tool bullet — the one line in the system prompt that
+# tells the model to keep a checklist. Two variants, chosen per surface by
+# ``_task_tool_bullet``:
+#
+# INTERACTIVE (TUI / REPL): the reference's own wording
+# (getUsingYourToolsSection, typescript/src/constants/prompts.ts:264-270),
+# verbatim but for the tool name. The damped variant below was measured on
+# headless benchmark runs and its rationale — "a task list you are the only
+# reader of is overhead" — is FALSE interactively: the checklist renders as
+# the pinned HUD above the composer, and the user reads it. Damping it here
+# was the main reason interactive sessions almost never showed the panel.
+_TASK_TOOL_BULLET_INTERACTIVE = (
+    "- Break down and manage your work with the {name} tool. These tools "
+    "are helpful for planning your work and helping the user track your "
+    "progress. Mark each task as completed as soon as you are done with "
+    "the task. Do not batch up multiple tasks before marking them as "
+    "completed.\n"
+)
+
+# NON-INTERACTIVE (--print / SDK / eval harnesses): the damped wording, kept
+# exactly where it was measured. The port dropped the reference's skip
+# conditions, leaving an unconditional imperative; measured over 14 clawcodex
+# and 21 Claude Code trials on seven shared terminal-bench 2.1 tasks
+# (2026-07-26), steps per trial spent on task-tool bookkeeping: clawcodex
+# 0.21, Claude Code 0.00 — the reference never reaches for it on work this
+# size. Together with memory writes (0.43 vs 0.00) that is 27% of the
+# remaining step gap, spent on bookkeeping rather than the task.
+_TASK_TOOL_BULLET_NON_INTERACTIVE = (
+    "- Break down and manage multi-step work with the {name} tool. Skip "
+    "it when the work is a single straightforward task, or is trivial enough "
+    "that tracking it adds nothing — a task list you are the only reader of "
+    "is overhead, not progress.\n"
+)
+
+
+def _task_tool_bullet() -> str:
+    """The task-tool bullet for the current surface.
+
+    Two independent axes, resolved from the same process-global flags that
+    gate tool exposure so the prompt can never name a tool the session does
+    not have (previously headless sessions were told about ``TaskCreate``
+    while their toolkit only carried ``TodoWrite``):
+
+    * name — ``TaskCreate`` when TaskV2 is the active surface
+      (``is_todo_v2_enabled``: interactive, or ``CLAUDE_CODE_ENABLE_TASKS``),
+      else ``TodoWrite``. Mirrors the reference's pick-from-enabled-tools
+      (prompts.ts:264: ``[TASK_CREATE, TODO_WRITE].find(enabled)``).
+    * wording — imperative interactively, damped headless (see the two
+      constants above).
+    """
+    from src.bootstrap.state import get_is_non_interactive_session
+    from src.utils.task_flags import is_todo_v2_enabled
+
+    name = "TaskCreate" if is_todo_v2_enabled() else "TodoWrite"
+    template = (
+        _TASK_TOOL_BULLET_NON_INTERACTIVE
+        if get_is_non_interactive_session()
+        else _TASK_TOOL_BULLET_INTERACTIVE
+    )
+    # ``.replace`` like the section template below, and for the same reason:
+    # prose constants must not turn a future literal brace into a KeyError.
+    return template.replace("{name}", name)
+
+
 # Module 5: Tool usage guidelines
-# Mirrors TS getUsingYourToolsSection()
-_USING_TOOLS_SECTION = (
+# Mirrors TS getUsingYourToolsSection(). Holds a ``{task_tool_bullet}``
+# placeholder — ``_using_tools_section_text`` fills it per surface.
+_USING_TOOLS_SECTION_TEMPLATE = (
     "# Using your tools\n"
     "- Do NOT use the Bash to run commands when a relevant dedicated tool "
     "is provided. Using dedicated tools allows the user to better "
@@ -1037,17 +1102,7 @@ _USING_TOOLS_SECTION = (
     "  - Reserve Bash for system commands and terminal operations that "
     "require shell execution. If you are unsure and there is a relevant "
     "dedicated tool, default to using the dedicated tool.\n"
-    # The port dropped the reference's skip conditions, leaving an
-    # unconditional imperative. Measured over 14 clawcodex and 21 Claude Code
-    # trials on seven shared terminal-bench 2.1 tasks (2026-07-26), steps per
-    # trial spent on task-tool bookkeeping: clawcodex 0.21, Claude Code 0.00 —
-    # the reference never reaches for it on work this size. Together with
-    # memory writes (0.43 vs 0.00) that is 27% of the remaining step gap,
-    # spent on bookkeeping rather than the task.
-    "- Break down and manage multi-step work with the TaskCreate tool. Skip "
-    "it when the work is a single straightforward task, or is trivial enough "
-    "that tracking it adds nothing — a task list you are the only reader of "
-    "is overhead, not progress.\n"
+    "{task_tool_bullet}"
     # Two clauses were dropped in the port, and together they are what turns
     # a permission into a practice: the imperative to maximize, and the
     # dependency carve-out that tells the model when NOT to — without which
@@ -1167,8 +1222,16 @@ def _build_actions_section(use_cache: bool) -> SystemPromptSection | None:
 
 
 def _build_using_tools_section(use_cache: bool) -> SystemPromptSection | None:
-    """Module 5: Tool usage guidelines. Mirrors TS getUsingYourToolsSection()."""
-    return SystemPromptSection(id="using_tools", content=_USING_TOOLS_SECTION, cache_scope=CacheScope.GLOBAL, order=4)
+    """Module 5: Tool usage guidelines. Mirrors TS getUsingYourToolsSection().
+
+    Content varies only on process-lifetime flags (interactivity, the
+    TaskV2 env opt-in), so the GLOBAL cache scope stays coherent — the text
+    cannot change within a process.
+    """
+    # ``.replace`` not ``.format``: the section text is prose and a future
+    # edit adding a literal brace must not turn into a KeyError.
+    content = _USING_TOOLS_SECTION_TEMPLATE.replace("{task_tool_bullet}", _task_tool_bullet())
+    return SystemPromptSection(id="using_tools", content=content, cache_scope=CacheScope.GLOBAL, order=4)
 
 
 def _build_tone_style_section(use_cache: bool) -> SystemPromptSection | None:

--- a/src/context_system/task_reminder.py
+++ b/src/context_system/task_reminder.py
@@ -1,0 +1,228 @@
+"""Periodic task-tool reminder — port of ``getTaskReminderAttachments``.
+
+Reference: ``typescript/src/utils/attachments.ts:3714-3771`` (gates + turn
+counting via ``getTaskReminderTurnCounts`` at :3658, thresholds at :269) and
+the ``task_reminder`` renderer in ``typescript/src/utils/messages.ts:2606``
+(the reminder text itself).
+
+Every ``TURNS_SINCE_WRITE`` assistant turns without a TaskCreate/TaskUpdate
+call — throttled to at most one nudge per ``TURNS_BETWEEN_REMINDERS`` turns —
+the model gets a ``<system-reminder>`` suggesting the task tools, with the
+current task list attached. This was never ported, and its absence was one of
+the reasons the interactive checklist HUD rarely appeared: once a session
+started without todos, nothing ever steered the model back.
+
+One DELIBERATE delta from the reference: non-interactive sessions get no
+reminder at all. The TB2.1 harness measurements that damped the system-prompt
+bullet (see ``prompt_assembly._TASK_TOOL_BULLET_NON_INTERACTIVE``) apply with
+the same force here — headless bookkeeping is overhead nobody reads. The
+reference nudges both surfaces.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from .plan_mode import _is_human_turn  # noqa: F401  (re-exported for tests)
+from .plan_mode import _message_text, _role
+
+# Mirrors TODO_REMINDER_CONFIG (attachments.ts:269-272).
+TURNS_SINCE_WRITE = 10
+TURNS_BETWEEN_REMINDERS = 10
+
+# The reminder's opening phrase doubles as the scan marker for the throttle
+# (the reference matches ``attachment.type === 'task_reminder'``; here the
+# persisted meta message's text is what survives into later turns). Known
+# benign false positive: a UserPromptSubmit hook whose additionalContext
+# echoes this phrase is also ``<system-reminder>``-wrapped and would read as
+# a recent reminder — suppressing at most one nudge for ten turns. Role
+# filtering already excludes the model quoting it.
+_REMINDER_MARKER = "The task tools haven't been used recently"
+
+_SYSTEM_REMINDER_PREFIX = "<system-reminder>"
+
+# Verbatim from messages.ts:2617.
+_REMINDER_TEXT = (
+    "The task tools haven't been used recently. If you're working on tasks "
+    "that would benefit from tracking progress, consider using TaskCreate "
+    "to add new tasks and TaskUpdate to update task status (set to "
+    "in_progress when starting, completed when done). Also consider "
+    "cleaning up the task list if it has become stale. Only use these if "
+    "relevant to the current work. This is just a gentle reminder - ignore "
+    "if not applicable. Make sure that you NEVER mention this reminder to "
+    "the user\n"
+)
+
+
+def _is_thinking_only(message: Any) -> bool:
+    """Assistant message whose content is all thinking blocks.
+
+    Mirrors the reference's ``isThinkingMessage`` skip in the turn counter —
+    a thinking-only commit is not an assistant *turn*. Empty block content is
+    skipped too: the reference's ``[].every(...)`` is vacuously true
+    (messages.ts:3315), so an empty-content assistant commit does not count
+    as a turn there either.
+    """
+    content = getattr(message, "content", None)
+    if content is None and isinstance(message, dict):
+        content = message.get("content")
+    if not isinstance(content, list):
+        return False
+    return all(
+        (block.get("type") if isinstance(block, dict) else getattr(block, "type", None))
+        in ("thinking", "redacted_thinking")
+        for block in content
+    )
+
+
+def _uses_task_tools(message: Any) -> bool:
+    """Assistant message carrying a TaskCreate/TaskUpdate tool_use block."""
+    content = getattr(message, "content", None)
+    if content is None and isinstance(message, dict):
+        content = message.get("content")
+    if not isinstance(content, list):
+        return False
+    for block in content:
+        if isinstance(block, dict):
+            block_type = block.get("type")
+            name = block.get("name")
+        else:
+            block_type = getattr(block, "type", None)
+            name = getattr(block, "name", None)
+        if block_type == "tool_use" and name in ("TaskCreate", "TaskUpdate"):
+            return True
+    return False
+
+
+def _is_task_reminder_attachment(message: Any) -> bool:
+    if _role(message) != "user":
+        return False
+    text = _message_text(message)
+    return text.lstrip().startswith(_SYSTEM_REMINDER_PREFIX) and _REMINDER_MARKER in text
+
+
+def get_task_reminder_turn_counts(messages: list[Any]) -> tuple[int, int]:
+    """(assistant turns since last TaskCreate/TaskUpdate, since last reminder).
+
+    Exact port of ``getTaskReminderTurnCounts`` (attachments.ts:3658-3711):
+    walk backwards; thinking-only assistant messages don't count as turns;
+    the turn that itself carries the task tool_use is checked BEFORE the
+    counter increments, so it contributes zero; each counter freezes once its
+    event is found; stop early when both are.
+    """
+    mgmt_found = False
+    reminder_found = False
+    turns_since_mgmt = 0
+    turns_since_reminder = 0
+
+    for message in reversed(messages):
+        if _role(message) == "assistant":
+            if _is_thinking_only(message):
+                continue
+            if not mgmt_found and _uses_task_tools(message):
+                mgmt_found = True
+            if not mgmt_found:
+                turns_since_mgmt += 1
+            if not reminder_found:
+                turns_since_reminder += 1
+        elif not reminder_found and _is_task_reminder_attachment(message):
+            reminder_found = True
+
+        if mgmt_found and reminder_found:
+            break
+
+    return turns_since_mgmt, turns_since_reminder
+
+
+def _format_task_list(tasks: dict[str, Any] | None) -> str:
+    """``#id. [status] subject`` per task — messages.ts:2613-2615.
+
+    Skips ``metadata._internal`` entries, the same defense-in-depth filter
+    TaskList applies (tasks_v2.py) — the reminder must not list a task the
+    listing tool itself would hide.
+    """
+    if not tasks:
+        return ""
+    lines: list[str] = []
+    for task in tasks.values():
+        if not isinstance(task, dict):
+            continue
+        if (task.get("metadata") or {}).get("_internal"):
+            continue
+        lines.append(
+            f"#{task.get('id', '?')}. [{task.get('status', 'pending')}] {task.get('subject', '')}"
+        )
+    return "\n".join(lines)
+
+
+def build_task_reminder_attachment(
+    messages: list[Any],
+    *,
+    tools: list[Any] | None = None,
+    tasks: dict[str, Any] | None = None,
+) -> list[str]:
+    """The reminder text due this turn, or ``[]``.
+
+    ``tools`` is the live tool list (registry contents) — the reference skips
+    when TaskUpdate is not in the toolkit (:3739). Its OTHER toolkit gate —
+    skip when Brief is present (:3731, the coworker surface where
+    SendUserMessage owns communication) — is deliberately NOT ported:
+    clawcodex registers Brief unconditionally in the default registry, so
+    membership carries no surface information and the transplanted gate
+    would simply disable the reminder everywhere (measured: it did, caught
+    by the wiring test). If a coworker-style surface ever lands, gate on
+    whatever marks that surface, not on Brief's presence.
+
+    ``tasks`` is ``tool_context.tasks``, the TaskCreate store, listed in the
+    reminder body exactly as the reference lists ``listTasks()``.
+    """
+    from src.bootstrap.state import get_is_non_interactive_session
+    from src.utils.task_flags import is_todo_v2_enabled
+
+    # Parity gate (:3718) — the reminder names TaskCreate/TaskUpdate, which
+    # only the TaskV2 surface has.
+    if not is_todo_v2_enabled():
+        return []
+
+    # DELIBERATE delta — headless stays nudge-free (module docstring).
+    if get_is_non_interactive_session():
+        return []
+
+    # Parity gates: ant users (:3722), reminder kill-switch (messages.ts:2610).
+    if os.environ.get("USER_TYPE") == "ant":
+        return []
+    if os.environ.get("OPENCLAUDE_DISABLE_TOOL_REMINDERS", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    ):
+        return []
+
+    if not messages:
+        return []
+
+    tool_names = set()
+    for tool in tools or []:
+        name = getattr(tool, "name", None) or (tool.get("name") if isinstance(tool, dict) else None)
+        if name:
+            tool_names.add(str(name))
+
+    if "TaskUpdate" not in tool_names:
+        return []
+
+    turns_since_mgmt, turns_since_reminder = get_task_reminder_turn_counts(messages)
+    if turns_since_mgmt < TURNS_SINCE_WRITE or turns_since_reminder < TURNS_BETWEEN_REMINDERS:
+        return []
+
+    text = _REMINDER_TEXT
+    task_items = _format_task_list(tasks)
+    if task_items:
+        text += f"\n\nHere are the existing tasks:\n\n{task_items}"
+
+    return [text]
+
+
+__all__ = [
+    "TURNS_BETWEEN_REMINDERS",
+    "TURNS_SINCE_WRITE",
+    "build_task_reminder_attachment",
+    "get_task_reminder_turn_counts",
+]

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -828,7 +828,7 @@ def run_headless(options: HeadlessOptions) -> int:
                             # on_message there is no SDK envelope to emit
                             # here, but keep the paths distinct anyway.
                             on_attachment=lambda m: session.conversation.add_message(
-                                m.role, m.content
+                                m.role, m.content, isMeta=getattr(m, "isMeta", False)
                             ),
                             # Critic C2: pass the OWNING controller so
                             # the provider's chat_stream_response listens

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -653,6 +653,35 @@ async def run_query_as_agent_loop(
             logging.getLogger(__name__).debug("plan-mode attachment wiring failed",
                                               exc_info=True)
 
+    # Task-tool reminder (port of getTaskReminderAttachments,
+    # typescript/src/utils/attachments.ts:3714). Same real-user-turn gate and
+    # the same PERSISTED delivery as the plan block above — the throttle scans
+    # the transcript for the previous reminder, so it must survive into later
+    # turns' initial_messages.
+    if memory_recall_enabled:
+        try:
+            from src.context_system.plan_mode import wrap_in_system_reminder
+            from src.context_system.task_reminder import (
+                build_task_reminder_attachment,
+            )
+            from src.types.messages import create_user_message
+
+            reminder_texts = build_task_reminder_attachment(
+                messages_for_query,
+                tools=tool_registry.list_tools(),
+                tasks=getattr(tool_context, "tasks", None),
+            )
+            for text in reminder_texts:
+                reminder_msg = create_user_message(
+                    content=wrap_in_system_reminder(text), isMeta=True,
+                )
+                messages_for_query.append(reminder_msg)
+                if on_attachment is not None:
+                    on_attachment(reminder_msg)
+        except Exception:  # noqa: BLE001 — must never block a turn
+            logging.getLogger(__name__).debug("task-reminder wiring failed",
+                                              exc_info=True)
+
     params = QueryParams(
         messages=messages_for_query,
         system_prompt=system_prompt,

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -3001,6 +3001,11 @@ class _AgentSession:
             def is_prompt(m: Any) -> bool:
                 if getattr(m, "role", None) != "user":
                     return False
+                # Injected context (plan-mode / task-reminder attachments) is
+                # not a rewind boundary — without this, /rewind 1 lands on the
+                # most recent reminder instead of the user's actual message.
+                if getattr(m, "isMeta", False):
+                    return False
                 c = getattr(m, "content", None)
                 if isinstance(c, str):
                     return True
@@ -3019,10 +3024,8 @@ class _AgentSession:
             removed = len(msgs) - target
             del msgs[target:]
             # Rewound turns leave the odometer — recount from what's left.
-            # NOTE: `is_prompt` above counts isMeta text messages (rewind
-            # boundaries pre-date the odometer); _count_prompt_turns excludes
-            # them, so the recount can sit below the number of boundaries
-            # rewind saw. Fine for an odometer; don't reuse is_prompt here.
+            # `is_prompt` and `_count_prompt_turns` now apply the same isMeta
+            # exclusion, so the recount matches the boundaries rewind saw.
             self._stats_turns = _count_prompt_turns(msgs)
             self._reply(request_id, {"ok": True, "removed": removed, "count": len(msgs)})
         except Exception as exc:  # noqa: BLE001
@@ -4871,7 +4874,7 @@ class _AgentSession:
                 # keeps the instructions in later turns' context and lets the
                 # cadence scan find prior attachments.
                 on_attachment=lambda m: self.session.conversation.add_message(
-                    m.role, m.content
+                    m.role, m.content, isMeta=getattr(m, "isMeta", False)
                 ),
             ))
         except AbortError:

--- a/tests/test_system_prompt_full.py
+++ b/tests/test_system_prompt_full.py
@@ -13,7 +13,7 @@ from src.context_system.prompt_assembly import (
     _SYSTEM_SECTION,
     _DOING_TASKS_SECTION,
     _ACTIONS_SECTION,
-    _USING_TOOLS_SECTION,
+    _USING_TOOLS_SECTION_TEMPLATE,
     _TONE_STYLE_SECTION,
     _OUTPUT_EFFICIENCY_SECTION,
     _NON_INTERACTIVE_PROMPT,
@@ -353,24 +353,56 @@ class TestBuildFullSystemPrompt:
 
 
 class TestTaskToolGating:
+    """The task-tool bullet is per-surface (``_task_tool_bullet``).
+
+    Headless keeps the damped TB2.1-tuned wording — measured over 14
+    clawcodex and 21 Claude Code trials on seven shared terminal-bench 2.1
+    tasks (2026-07-26): task-tool steps per trial were 0.21 vs 0.00, 27% of
+    the remaining step gap spent on bookkeeping. Interactive restores the
+    reference's imperative (prompts.ts getUsingYourToolsSection): the damped
+    rationale — "a task list you are the only reader of" — is false there,
+    because the checklist renders as the pinned HUD the user watches.
+    """
+
     def setup_method(self):
         get_system_prompt_cache().invalidate_all()
 
-    def test_task_tool_carries_the_reference_skip_conditions(self):
-        """The port dropped them, leaving an unconditional imperative.
+    def teardown_method(self):
+        from src.bootstrap.state import set_is_interactive
 
-        Reference: "Skip using this tool when: There is only a single,
-        straightforward task; the task is trivial and tracking it provides no
-        organizational benefit."  clawcodex kept only "Break down and manage
-        your work with the TaskCreate tool."
+        set_is_interactive(False)
+        get_system_prompt_cache().invalidate_all()
 
-        Measured over 14 clawcodex and 21 Claude Code trials on seven shared
-        terminal-bench 2.1 tasks (2026-07-26): task-tool steps per trial were
-        0.21 for clawcodex and 0.00 for Claude Code — it never reaches for it
-        on work this size. With memory writes (0.43 vs 0.00) that is 27% of
-        the remaining step gap spent on bookkeeping.
-        """
+    def test_headless_keeps_the_damped_wording_and_its_own_tool_name(self):
         prompt = build_full_system_prompt(use_cache=False)
         assert "Break down and manage multi-step work" in prompt
-        assert "Skip it when" in prompt, "the skip condition is the whole fix"
+        assert "Skip it when" in prompt, "the skip condition is the measured fix"
         assert "trivial enough" in prompt
+        # Headless sessions expose TodoWrite, not TaskV2 — the bullet used to
+        # name TaskCreate, a tool those sessions do not have.
+        assert "TodoWrite tool" in prompt
+        assert "TaskCreate" not in prompt
+
+    def test_interactive_restores_the_reference_imperative(self):
+        from src.bootstrap.state import set_is_interactive
+
+        set_is_interactive(True)
+        prompt = build_full_system_prompt(use_cache=False)
+        assert "Break down and manage your work with the TaskCreate tool" in prompt
+        assert "helping the user track your progress" in prompt
+        assert "Mark each task as completed as soon as you are done" in prompt
+        assert "Skip it when" not in prompt
+
+    def test_env_opt_in_names_task_create_even_headless(self):
+        import os
+        from unittest import mock
+
+        # CLAUDE_CODE_ENABLE_TASKS flips the exposed toolset to TaskV2
+        # (task_flags.is_todo_v2_enabled) without making the session
+        # interactive — wording stays damped, the name follows the tool.
+        with mock.patch.dict(os.environ, {"CLAUDE_CODE_ENABLE_TASKS": "1"}):
+            prompt = build_full_system_prompt(use_cache=False)
+
+        assert "Break down and manage multi-step work" in prompt
+        assert "TaskCreate tool" in prompt
+        assert "TodoWrite" not in prompt

--- a/tests/test_task_reminder.py
+++ b/tests/test_task_reminder.py
@@ -1,0 +1,175 @@
+"""Task-tool reminder — port of ``getTaskReminderAttachments``.
+
+Reference: typescript/src/utils/attachments.ts:3658-3771 (turn counting +
+gates) and typescript/src/utils/messages.ts:2606-2628 (reminder text).
+"""
+from __future__ import annotations
+
+import os
+from unittest import mock
+
+import pytest
+
+from src.bootstrap.state import set_is_interactive
+from src.context_system.plan_mode import wrap_in_system_reminder
+from src.context_system.task_reminder import (
+    TURNS_BETWEEN_REMINDERS,
+    TURNS_SINCE_WRITE,
+    build_task_reminder_attachment,
+    get_task_reminder_turn_counts,
+)
+
+
+class _Tool:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+TASK_TOOLS = [_Tool("TaskCreate"), _Tool("TaskUpdate"), _Tool("Bash")]
+
+
+def assistant(*blocks: dict) -> dict:
+    return {"role": "assistant", "content": list(blocks) or [{"type": "text", "text": "ok"}]}
+
+
+def user(text: str = "hi") -> dict:
+    return {"role": "user", "content": text}
+
+
+def tool_use(name: str) -> dict:
+    return {"type": "tool_use", "id": "t1", "name": name, "input": {}}
+
+
+def reminder_msg() -> dict:
+    """A previously-persisted reminder, exactly as the wiring stores it."""
+    return {
+        "role": "user",
+        "content": wrap_in_system_reminder(
+            "The task tools haven't been used recently. …"
+        ),
+    }
+
+
+def turns(n: int) -> list[dict]:
+    out: list[dict] = []
+    for _ in range(n):
+        out.append(user())
+        out.append(assistant())
+    return out
+
+
+@pytest.fixture()
+def interactive():
+    set_is_interactive(True)
+    yield
+    set_is_interactive(False)
+
+
+# ---------------------------------------------------------------------------
+# Turn counting (getTaskReminderTurnCounts)
+# ---------------------------------------------------------------------------
+
+
+def test_counts_assistant_turns() -> None:
+    assert get_task_reminder_turn_counts(turns(4)) == (4, 4)
+
+
+def test_task_tool_turn_resets_and_does_not_count_itself() -> None:
+    # The reference checks the tool_use BEFORE incrementing, so the turn that
+    # itself manages tasks contributes zero to the management counter.
+    messages = [*turns(5), assistant(tool_use("TaskCreate")), *turns(3)]
+    assert get_task_reminder_turn_counts(messages) == (3, 9)
+
+
+def test_task_update_counts_as_management_too() -> None:
+    messages = [*turns(2), assistant(tool_use("TaskUpdate")), *turns(1)]
+    assert get_task_reminder_turn_counts(messages)[0] == 1
+
+
+def test_thinking_only_messages_are_not_turns() -> None:
+    thinking = assistant({"type": "thinking", "thinking": "hmm", "signature": ""})
+    messages = [*turns(2), thinking, thinking]
+    assert get_task_reminder_turn_counts(messages) == (2, 2)
+
+
+def test_prior_reminder_freezes_the_reminder_counter() -> None:
+    messages = [*turns(20), reminder_msg(), *turns(3)]
+    since_mgmt, since_reminder = get_task_reminder_turn_counts(messages)
+    assert since_reminder == 3
+    assert since_mgmt == 23
+
+
+# ---------------------------------------------------------------------------
+# Builder gates (getTaskReminderAttachments)
+# ---------------------------------------------------------------------------
+
+
+def _due() -> list[dict]:
+    return turns(TURNS_SINCE_WRITE)
+
+
+def test_fires_with_the_reference_text(interactive) -> None:
+    texts = build_task_reminder_attachment(_due(), tools=TASK_TOOLS)
+
+    assert len(texts) == 1
+    assert texts[0].startswith("The task tools haven't been used recently")
+    assert "consider using TaskCreate" in texts[0]
+    assert "TaskUpdate to update task status" in texts[0]
+    assert "NEVER mention this reminder to the user" in texts[0]
+    assert "Here are the existing tasks" not in texts[0]
+
+
+def test_lists_existing_tasks(interactive) -> None:
+    tasks = {"a1": {"id": "a1", "subject": "Ship it", "status": "pending"}}
+    texts = build_task_reminder_attachment(_due(), tools=TASK_TOOLS, tasks=tasks)
+
+    assert "Here are the existing tasks:" in texts[0]
+    assert "#a1. [pending] Ship it" in texts[0]
+
+
+def test_headless_gets_no_reminder() -> None:
+    # The deliberate delta from the reference: the TB2.1 measurements that
+    # damped the prompt bullet apply here with the same force.
+    assert build_task_reminder_attachment(_due(), tools=TASK_TOOLS) == []
+
+
+def test_throttled_until_enough_turns_since_write(interactive) -> None:
+    assert build_task_reminder_attachment(turns(TURNS_SINCE_WRITE - 1), tools=TASK_TOOLS) == []
+
+
+def test_throttled_after_a_recent_reminder(interactive) -> None:
+    messages = [*turns(20), reminder_msg(), *turns(TURNS_BETWEEN_REMINDERS - 1)]
+    assert build_task_reminder_attachment(messages, tools=TASK_TOOLS) == []
+
+    messages = [*turns(20), reminder_msg(), *turns(TURNS_BETWEEN_REMINDERS)]
+    assert build_task_reminder_attachment(messages, tools=TASK_TOOLS) != []
+
+
+def test_recent_task_management_resets_the_clock(interactive) -> None:
+    messages = [*turns(20), assistant(tool_use("TaskUpdate")), *turns(2)]
+    assert build_task_reminder_attachment(messages, tools=TASK_TOOLS) == []
+
+
+def test_requires_task_update_in_the_toolkit(interactive) -> None:
+    assert build_task_reminder_attachment(_due(), tools=[_Tool("Bash")]) == []
+
+
+def test_brief_presence_does_not_disable_the_reminder(interactive) -> None:
+    # The reference's Brief gate (attachments.ts:3731) is deliberately not
+    # ported: clawcodex registers Brief unconditionally, so the transplanted
+    # gate disabled the reminder on every surface (caught by the wiring test).
+    assert build_task_reminder_attachment(_due(), tools=[*TASK_TOOLS, _Tool("Brief")]) != []
+
+
+def test_empty_conversation_gets_no_reminder(interactive) -> None:
+    assert build_task_reminder_attachment([], tools=TASK_TOOLS) == []
+
+
+def test_kill_switch_env(interactive) -> None:
+    with mock.patch.dict(os.environ, {"OPENCLAUDE_DISABLE_TOOL_REMINDERS": "1"}):
+        assert build_task_reminder_attachment(_due(), tools=TASK_TOOLS) == []
+
+
+def test_ant_users_are_skipped(interactive) -> None:
+    with mock.patch.dict(os.environ, {"USER_TYPE": "ant"}):
+        assert build_task_reminder_attachment(_due(), tools=TASK_TOOLS) == []

--- a/tests/test_task_reminder_wiring.py
+++ b/tests/test_task_reminder_wiring.py
@@ -1,0 +1,143 @@
+"""The task reminder actually reaches the conversation.
+
+Unit coverage lives in test_task_reminder.py; this drives the real
+``run_query_as_agent_loop`` and asserts the reminder is appended to the
+outgoing messages and persisted via ``on_attachment`` — the wiring in
+agent_loop_compat, which no unit test touches.
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.bootstrap.state import set_is_interactive
+from src.providers.base import ChatResponse
+from src.query.agent_loop_compat import run_query_as_agent_loop
+from src.tool_system.context import ToolContext
+from src.tool_system.defaults import build_default_registry
+from src.types.messages import AssistantMessage, UserMessage
+
+MARKER = "The task tools haven't been used recently"
+
+
+class _Provider:
+    """Non-streaming fake that records what the model was sent."""
+
+    def __init__(self) -> None:
+        self.base_url = None
+        self.model = "claude-test"
+        self.seen_messages: list[Any] = []
+
+    def chat_stream_response(self, *_args: Any, **_kwargs: Any) -> ChatResponse:
+        raise NotImplementedError  # force the non-stream path
+
+    def chat(self, messages: Any = None, *args: Any, **kwargs: Any) -> ChatResponse:
+        self.seen_messages = list(messages or kwargs.get("messages") or [])
+
+        return ChatResponse(
+            content="done",
+            model="test",
+            usage={"input_tokens": 0, "output_tokens": 0},
+            finish_reason="end_turn",
+            tool_uses=None,
+        )
+
+
+def _text(message: Any) -> str:
+    content = getattr(message, "content", None)
+    if content is None and isinstance(message, dict):
+        content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(
+            str(b.get("text", "")) if isinstance(b, dict) else str(getattr(b, "text", ""))
+            for b in content
+        )
+    return ""
+
+
+@pytest.fixture()
+def interactive():
+    set_is_interactive(True)
+    yield
+    set_is_interactive(False)
+
+
+def test_reminder_lands_in_the_conversation_and_persists(interactive) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        context = ToolContext(workspace_root=Path(tmp))
+        provider = _Provider()
+        persisted: list[Any] = []
+
+        # 11 turn pairs with no task-tool usage → both counters past 10.
+        history: list[Any] = []
+        for i in range(11):
+            history.append(UserMessage(content=f"step {i}"))
+            history.append(AssistantMessage(content=[{"type": "text", "text": "ok"}]))
+        history.append(UserMessage(content="continue"))
+
+        asyncio.run(
+            run_query_as_agent_loop(
+                initial_messages=history,
+                provider=provider,  # type: ignore[arg-type]
+                tool_registry=build_default_registry(),
+                tool_context=context,
+                system_prompt="",
+                max_turns=2,
+                on_attachment=persisted.append,
+            )
+        )
+
+        sent = [m for m in provider.seen_messages if MARKER in _text(m)]
+        assert sent, "reminder never reached the model"
+        assert "<system-reminder>" in _text(sent[0])
+
+        kept = [m for m in persisted if MARKER in _text(m)]
+        assert kept, "reminder was not persisted via on_attachment"
+
+
+def test_persisted_reminder_is_meta_not_a_prompt(interactive) -> None:
+    """The attachment must persist as ``isMeta`` — dropping the flag made the
+    reminder count as a real user turn (stats odometer) and a /rewind
+    boundary. Drives the same ``Conversation.add_message`` seam the two
+    ``on_attachment`` lambdas use."""
+    from src.agent.conversation import Conversation
+    from src.server.agent_server import _count_prompt_turns
+    from src.types.messages import create_user_message
+
+    conv = Conversation()
+    conv.add_message("user", "a real prompt")
+    reminder = create_user_message(content=f"<system-reminder>\n{MARKER} …\n</system-reminder>", isMeta=True)
+    conv.add_message(reminder.role, reminder.content, isMeta=getattr(reminder, "isMeta", False))
+
+    assert getattr(conv.messages[-1], "isMeta", False) is True
+    assert _count_prompt_turns(conv.messages) == 1
+
+    # And it survives the save/load round-trip the throttle scan depends on.
+    restored = Conversation.from_dict(conv.to_dict())
+    assert getattr(restored.messages[-1], "isMeta", False) is True
+    assert _count_prompt_turns(restored.messages) == 1
+
+
+def test_no_reminder_on_a_short_conversation(interactive) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        context = ToolContext(workspace_root=Path(tmp))
+        provider = _Provider()
+
+        asyncio.run(
+            run_query_as_agent_loop(
+                initial_messages=[UserMessage(content="hi")],
+                provider=provider,  # type: ignore[arg-type]
+                tool_registry=build_default_registry(),
+                tool_context=context,
+                system_prompt="",
+                max_turns=2,
+            )
+        )
+
+        assert not any(MARKER in _text(m) for m in provider.seen_messages)

--- a/ui-tui/src/__tests__/busyLine.test.ts
+++ b/ui-tui/src/__tests__/busyLine.test.ts
@@ -58,7 +58,7 @@ describe('BusyLine', () => {
     expect(plain.trim()).toBe('')
   })
 
-  it('shows the in-progress todo activeForm as the verb and the pending todo as Next', () => {
+  it('shows the in-progress todo activeForm as the verb', () => {
     resetTurnState()
     patchTurnState({
       lastDeltaAt: Date.now(),
@@ -71,9 +71,27 @@ describe('BusyLine', () => {
     const plain = stripAnsi(busyRender(Date.now()))
 
     expect(plain).toContain('Extracting the loader…')
-    expect(plain).toContain('Next: Add unit tests')
+    // The full checklist hangs right below (LiveTodoPanel attached variant),
+    // so the one-line Next: hint would duplicate its first pending row.
+    expect(plain).not.toContain('Next:')
     // under 30s: no elapsed/token suffix
     expect(plain).not.toContain('tokens')
+  })
+
+  it('shows Next: only when the checklist is hidden (ctrl+t)', () => {
+    resetTurnState()
+    patchTurnState({
+      lastDeltaAt: Date.now(),
+      todoCollapsed: true,
+      todos: [
+        { activeForm: 'Extracting the loader', content: 'Extract loader', id: '1', status: 'in_progress' },
+        { content: 'Add unit tests', id: '2', status: 'pending' }
+      ]
+    })
+
+    const plain = stripAnsi(busyRender(Date.now()))
+
+    expect(plain).toContain('Next: Add unit tests')
   })
 
   it('adds the dim elapsed + ~token suffix only after 30s', () => {

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -67,7 +67,10 @@ describe('createGatewayEventHandler', () => {
     patchUiState({ showReasoning: true })
   })
 
-  it('archives incomplete todos into transcript flow at end of turn so they scroll up', () => {
+  it('keeps an incomplete list pinned in the HUD across the turn boundary', () => {
+    // CC parity: the checklist persists until the work is done (REPL.tsx:4934
+    // renders TaskListV2 while idle). Archiving it at every turn end was why
+    // the pinned panel vanished the moment a turn completed.
     const appended: Msg[] = []
 
     const todos = [
@@ -84,15 +87,12 @@ describe('createGatewayEventHandler', () => {
 
     onEvent({ payload: { text: 'Started a todo list.' }, type: 'message.complete' } as any)
 
-    const trail = appended.find(msg => msg.kind === 'trail' && msg.todos?.length)
     const finalText = appended.find(msg => msg.role === 'assistant' && msg.text === 'Started a todo list.')
 
     expect(finalText).toBeDefined()
-    expect(trail).toMatchObject({ kind: 'trail', role: 'system', todos, todoIncomplete: true })
-    // Todo archive must sit ABOVE the final assistant text so the panel
-    // doesn't visibly jump across the final answer at end-of-turn.
-    expect(appended.indexOf(trail!)).toBeLessThan(appended.indexOf(finalText!))
-    expect(getTurnState().todos).toEqual([])
+    // No transcript archive for an unfinished list — it stays live.
+    expect(appended.find(msg => msg.kind === 'trail' && msg.todos?.length)).toBeUndefined()
+    expect(getTurnState().todos).toEqual(todos)
   })
 
   it('archives completed todos into transcript flow at end of turn', () => {

--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -36,6 +36,12 @@ describe('shouldPassThroughToGlobalHandler', () => {
     expect(shouldPassThroughToGlobalHandler('b', key({ ctrl: true }))).toBe(true)
   })
 
+  it('passes ctrl+t through so the task-checklist toggle reaches the global handler', () => {
+    expect(shouldPassThroughToGlobalHandler('t', key({ ctrl: true }))).toBe(true)
+    // Plain "t" is typing, not the toggle.
+    expect(shouldPassThroughToGlobalHandler('t', key())).toBe(false)
+  })
+
   it('does not swallow ordinary typing keys', () => {
     expect(shouldPassThroughToGlobalHandler('h', key(), parseVoiceRecordKey('ctrl+o'))).toBe(false)
     expect(shouldPassThroughToGlobalHandler('o', key(), parseVoiceRecordKey('ctrl+o'))).toBe(false)

--- a/ui-tui/src/__tests__/todoHud.test.tsx
+++ b/ui-tui/src/__tests__/todoHud.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * The pinned task checklist (CC's TaskListV2), in its three live shapes:
+ *
+ *  busy, expanded — rows hang off the busy line through the `  └  ` connector
+ *    (the original's Spinner.tsx:275 mount inside MessageResponse):
+ *
+ *      ✳ Building the parser… (…)
+ *        └  ✔ Map call sites
+ *           ◼ Extract loader
+ *           ◻ Add tests
+ *
+ *  busy, hidden (ctrl+t) — the panel yields to the busy line's `Next:` row
+ *    (the original's expandedView='none').
+ *
+ *  idle — the standalone header render, which persists between turns while
+ *    the list is incomplete (REPL.tsx:4934).
+ */
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@clawcodex/ink'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.hoisted(() => {
+  process.env.FORCE_COLOR = '0'
+  process.env.NO_COLOR = '1'
+})
+
+import { patchTurnState, resetTurnState } from '../app/turnStore.js'
+import { patchUiState } from '../app/uiStore.js'
+import { BusyLine } from '../components/busyLine.js'
+import { ComposerFooter } from '../components/composerFooter.js'
+import { LiveTodoPanel } from '../components/streamingAssistant.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+import type { TodoItem } from '../types.js'
+
+const renderToString = (element: React.ReactElement): string => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 100, isTTY: false, rows: 44 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(element, {
+    patchConsole: false,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin: stdin as unknown as NodeJS.ReadStream,
+    stdout: stdout as unknown as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return stripAnsi(output)
+}
+
+const TODOS: TodoItem[] = [
+  { activeForm: 'Mapping call sites', content: 'Map call sites', id: '1', status: 'completed' },
+  { activeForm: 'Extracting the loader', content: 'Extract loader', id: '2', status: 'in_progress' },
+  { content: 'Add tests', id: '3', status: 'pending' }
+]
+
+beforeEach(() => {
+  resetTurnState()
+  patchTurnState({ todos: TODOS })
+  patchUiState({ busy: true, statusBar: 'off', theme: DEFAULT_THEME })
+})
+
+describe('busy: list attached under the busy line', () => {
+  it('hangs the rows off the └ connector, later rows aligned under the first', () => {
+    // Non-TTY renders append one block per frame, so match anchored rows
+    // rather than counting lines. The connector lead is 5 columns
+    // ("  └  ") and every later row indents exactly those 5 — the
+    // alignment from the reference's MessageResponse flex-row split.
+    const out = renderToString(<LiveTodoPanel />)
+
+    expect(out).toMatch(/^ {2}└ {2}✔ Map call sites$/m)
+    expect(out).toMatch(/^ {5}◼ Extract loader$/m)
+    expect(out).toMatch(/^ {5}◻ Add tests$/m)
+    // No row renders unindented — everything hangs under the connector.
+    expect(out).not.toMatch(/^[✔◼◻]/m)
+  })
+
+  it('renders no count header while attached', () => {
+    expect(renderToString(<LiveTodoPanel />)).not.toContain('tasks (')
+  })
+
+  it('suppresses the busy line\'s Next: row — the list itself is right below', () => {
+    const out = renderToString(<BusyLine t={DEFAULT_THEME} turnStartedAt={Date.now()} />)
+
+    expect(out).not.toContain('Next:')
+  })
+
+  it('ctrl+t hidden: panel yields and the busy line\'s Next: row takes over', () => {
+    patchTurnState({ todoCollapsed: true })
+
+    expect(renderToString(<LiveTodoPanel />).trim()).toBe('')
+
+    const busy = renderToString(<BusyLine t={DEFAULT_THEME} turnStartedAt={Date.now()} />)
+
+    expect(busy).toContain('Next: Add tests')
+  })
+
+  it('busy-line verb is the in-progress todo\'s activeForm', () => {
+    const busy = renderToString(<BusyLine t={DEFAULT_THEME} turnStartedAt={Date.now()} />)
+
+    expect(busy).toContain('Extracting the loader…')
+  })
+})
+
+describe('idle: standalone header render persists between turns', () => {
+  beforeEach(() => patchUiState({ busy: false }))
+
+  it('renders the count header plus rows', () => {
+    const out = renderToString(<LiveTodoPanel />)
+
+    expect(out).toContain('3 tasks (1 done, 1 in progress, 1 open)')
+    expect(out).toContain('✔ Map call sites')
+    expect(out).toContain('◼ Extract loader')
+    expect(out).not.toContain('└')
+  })
+})
+
+describe('composer footer hint', () => {
+  const footer = () =>
+    renderToString(
+      <ComposerFooter busy inputEmpty mode="bypassPermissions" sh={false} t={DEFAULT_THEME} />
+    )
+
+  it('offers ctrl+t while busy with tasks', () => {
+    expect(footer()).toContain('esc to interrupt · ctrl+t to hide tasks')
+  })
+
+  it('flips the wording when the panel is hidden', () => {
+    patchTurnState({ todoCollapsed: true })
+    expect(footer()).toContain('ctrl+t to show tasks')
+  })
+
+  it('drops the segment with no tasks', () => {
+    patchTurnState({ todos: [] })
+
+    const out = footer()
+
+    expect(out).toContain('esc to interrupt')
+    expect(out).not.toContain('ctrl+t')
+  })
+
+  it('keeps offering the toggle while idle — the pinned panel is most visible then', () => {
+    // The reference gates the toggle segment on tasks EXISTING, not on busy
+    // (getSpinnerHintParts:521); only the esc segment is loading-gated. An
+    // incomplete list stays pinned while idle, so idle is exactly when the
+    // user wants to know how to hide it.
+    const out = renderToString(
+      <ComposerFooter busy={false} inputEmpty mode="bypassPermissions" sh={false} t={DEFAULT_THEME} />
+    )
+
+    expect(out).toContain('? for shortcuts · ctrl+t to hide tasks')
+  })
+
+  it('stays quiet while idle with no tasks', () => {
+    patchTurnState({ todos: [] })
+
+    const out = renderToString(
+      <ComposerFooter busy={false} inputEmpty mode="bypassPermissions" sh={false} t={DEFAULT_THEME} />
+    )
+
+    expect(out).toContain('? for shortcuts')
+    expect(out).not.toContain('ctrl+t')
+  })
+})

--- a/ui-tui/src/__tests__/turnStore.test.ts
+++ b/ui-tui/src/__tests__/turnStore.test.ts
@@ -35,20 +35,21 @@ describe('turnStore live progress helpers', () => {
     expect(getTurnState().todos).toEqual([])
   })
 
-  it('archives incomplete todos with an incomplete flag so the hint renders', () => {
-    patchTurnState({
-      todos: [
-        { content: 'cook', id: 'cook', status: 'completed' },
-        { content: 'serve', id: 'serve', status: 'in_progress' },
-        { content: 'eat', id: 'eat', status: 'pending' }
-      ]
-    })
+  it('keeps an incomplete list live in the HUD instead of archiving it', () => {
+    // CC parity: the checklist persists across turns until the work is done
+    // (REPL.tsx:4934 renders TaskListV2 from AppState while idle). Archiving
+    // at every turn end was why the pinned panel vanished the moment a turn
+    // completed.
+    const todos = [
+      { content: 'cook', id: 'cook', status: 'completed' as const },
+      { content: 'serve', id: 'serve', status: 'in_progress' as const },
+      { content: 'eat', id: 'eat', status: 'pending' as const }
+    ]
 
-    const archived = archiveTodosAtTurnEnd()
-    expect(archived).toHaveLength(1)
-    expect(archived[0]!.todoIncomplete).toBe(true)
-    expect(archived[0]!.todos?.map(t => t.id)).toEqual(['cook', 'serve', 'eat'])
-    expect(getTurnState().todos).toEqual([])
+    patchTurnState({ todos })
+
+    expect(archiveTodosAtTurnEnd()).toEqual([])
+    expect(getTurnState().todos).toEqual(todos)
   })
 
   it('returns nothing when there are no todos at turn end', () => {

--- a/ui-tui/src/app/turnStore.ts
+++ b/ui-tui/src/app/turnStore.ts
@@ -51,14 +51,23 @@ export const archiveTodosAtTurnEnd = () => {
     return []
   }
 
-  const done = isTodoDone(state.todos)
+  // CC parity: an INCOMPLETE list is not archived — it stays live in the HUD
+  // across turns (the original's TaskListV2 renders from AppState.tasks in
+  // the idle REPL too, REPL.tsx:4934, until the work is finished). Archiving
+  // it here was the third reason the checklist "never seemed to be there":
+  // the moment a turn ended, the list left the pinned panel for a transcript
+  // block that scrolls away. startMessage()/reset() leave todos untouched,
+  // so the surviving list keeps updating on the next turn.
+  if (!isTodoDone(state.todos)) {
+    return []
+  }
 
   const msg: Msg = {
     kind: 'trail',
     role: 'system',
     text: '',
     todos: state.todos,
-    ...(done ? { todoCollapsedByDefault: true } : { todoIncomplete: true })
+    todoCollapsedByDefault: true
   }
 
   patchTurnState({ todoCollapsed: false, todos: [] })

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -21,7 +21,7 @@ import { getInputSelection } from './inputSelectionStore.js'
 import type { InputHandlerActions, InputHandlerContext, InputHandlerResult } from './interfaces.js'
 import { $isBlocked, $overlayState, patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
-import { patchTurnState } from './turnStore.js'
+import { getTurnState, patchTurnState, toggleTodoCollapsed } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
 const isCtrl = (key: { ctrl: boolean }, ch: string, target: string) => key.ctrl && ch.toLowerCase() === target
@@ -354,6 +354,7 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       // through to the wheel / PageUp / Shift+arrow handlers below.
       const promptOverlay =
         overlay.approval || overlay.billing || overlay.clarify || overlay.confirm || overlay.questions
+
       const fallThroughForScroll = promptOverlay && shouldFallThroughForScroll(key)
 
       if (promptOverlay && !fallThroughForScroll) {
@@ -664,6 +665,20 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
       patchUiState({ detailsMode: next, detailsModeCommandOverride: false })
       actions.sys(`details: ${next}`)
+
+      return
+    }
+
+    // ctrl+t — the original's app:toggleTodos (defaultBindings.ts:43): show or
+    // hide the pinned task checklist.
+    if (key.ctrl && ch === 't') {
+      // Say something even with no list — a silent no-op reads as a dead key.
+      if (!getTurnState().todos.length) {
+        return actions.sys('tasks: none yet')
+      }
+
+      toggleTodoCollapsed()
+      actions.sys(`tasks: ${getTurnState().todoCollapsed ? 'hidden' : 'shown'}`)
 
       return
     }

--- a/ui-tui/src/components/busyLine.tsx
+++ b/ui-tui/src/components/busyLine.tsx
@@ -64,6 +64,7 @@ function ShimmerVerb({ stalled, t, tick, verb }: { stalled: boolean; t: Theme; t
 export const BusyLine = memo(function BusyLine({ t, turnStartedAt }: BusyLineProps) {
   const ui = useStore($uiState)
   const todos = useTurnSelector(state => state.todos)
+  const todoCollapsed = useTurnSelector(state => state.todoCollapsed)
   const tools = useTurnSelector(state => state.tools)
   const streamedChars = useTurnSelector(state => state.streamedChars)
   const lastDeltaAt = useTurnSelector(state => state.lastDeltaAt)
@@ -136,7 +137,11 @@ export const BusyLine = memo(function BusyLine({ t, turnStartedAt }: BusyLinePro
       ? '⏸ paused'
       : `${delegation.paused ? '⏸ ' : ''}⛓ ${totals.activeCount > 0 ? `${totals.activeCount} running` : `${totals.descendantCount} spawned`}`
 
-  const nextTodo = todos.find(todo => todo.status === 'pending')
+  // The one-line "Next:" hint is the original's expandedView='none' render —
+  // it only shows while the full checklist is toggled OFF (ctrl+t). With the
+  // list attached right below through the └ connector, it would duplicate
+  // the first pending row.
+  const nextTodo = todoCollapsed ? todos.find(todo => todo.status === 'pending') : undefined
 
   return (
     <Box flexDirection="column" marginTop={1}>

--- a/ui-tui/src/components/composerFooter.tsx
+++ b/ui-tui/src/components/composerFooter.tsx
@@ -12,6 +12,7 @@
 import { Box, Text } from '@clawcodex/ink'
 import { memo } from 'react'
 
+import { useTurnSelector } from '../app/turnStore.js'
 import type { Theme } from '../theme.js'
 
 interface ModeBadge {
@@ -41,6 +42,11 @@ export const ComposerFooter = memo(function ComposerFooter({
   t,
   voiceLabel = ''
 }: ComposerFooterProps) {
+  // Reads the store directly like BusyLine/LiveTodoPanel — the hint must
+  // track live todo state, and hooks must run before any early return.
+  const todoCount = useTurnSelector(state => state.todos.length)
+  const todoCollapsed = useTurnSelector(state => state.todoCollapsed)
+
   // CC suppressHint: nothing while the user is typing.
   if (!inputEmpty) {
     return null
@@ -51,17 +57,24 @@ export const ComposerFooter = memo(function ComposerFooter({
   // with ●/◉ while recording/transcribing and reads "voice off" otherwise.
   const voiceActive = /^[●◉]/.test(voiceLabel)
 
+  // The original's toggle segment (PromptInputFooterLeftSide
+  // getSpinnerHintParts): gated on tasks EXISTING, not on busy — only the
+  // esc segment is loading-gated (:522). That matters here because an
+  // incomplete list now stays pinned while idle, and idle is exactly when a
+  // user stares at the panel wanting to know how to hide it.
+  const todoHint = todoCount > 0 ? ` · ctrl+t to ${todoCollapsed ? 'show' : 'hide'} tasks` : ''
+
   // Left hint is independent of the badge (both render, like the original's
   // byline; the badge just lives on the right here).
   const left = sh ? (
     <Text color={t.color.bashBorder}>! for bash mode</Text>
   ) : busy ? (
     <Text color={t.color.muted} dim>
-      esc to interrupt
+      esc to interrupt{todoHint}
     </Text>
   ) : (
     <Text color={t.color.muted} dim>
-      ? for shortcuts
+      ? for shortcuts{todoHint}
     </Text>
   )
 

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -65,14 +65,7 @@ export const MessageLine = memo(function MessageLine({
   const [systemOpen, setSystemOpen] = useState(false)
 
   if (msg.kind === 'trail' && msg.todos?.length) {
-    return (
-      <TodoPanel
-        defaultCollapsed={msg.todoCollapsedByDefault}
-        incomplete={msg.todoIncomplete}
-        t={t}
-        todos={msg.todos}
-      />
-    )
+    return <TodoPanel defaultCollapsed={msg.todoCollapsedByDefault} marginBottom={1} t={t} todos={msg.todos} />
   }
 
   if (msg.kind === 'trail' && (msg.tools?.length || tools.length || thinking)) {

--- a/ui-tui/src/components/streamingAssistant.tsx
+++ b/ui-tui/src/components/streamingAssistant.tsx
@@ -104,7 +104,27 @@ export const LiveTodoPanel = memo(function LiveTodoPanel() {
   const todos = useTurnSelector(state => state.todos)
   const collapsed = useTurnSelector(state => state.todoCollapsed)
 
-  return <TodoPanel collapsed={collapsed} onToggle={toggleTodoCollapsed} t={ui.theme} todos={todos} />
+  // Busy with the busy line right above (statusBar off is the only layout
+  // where it renders): hang the rows off it through the └ connector, the
+  // original's Spinner.tsx:275 mount. Hidden entirely when toggled off —
+  // the busy line's own "Next: …" row takes over, the original's
+  // expandedView='none' behavior.
+  if (ui.busy && ui.statusBar === 'off') {
+    if (collapsed) {
+      return null
+    }
+
+    return <TodoPanel t={ui.theme} todos={todos} variant="attached" />
+  }
+
+  // Idle (or busy under an opt-in status bar, which hides the busy line):
+  // the original's standalone render — count header + rows, collapsible.
+  // marginBottom keeps the last row off the composer border when the
+  // composer's own marginTop is 0 (statusBar='top'); the reference
+  // standalone carries its own margin too (TaskListV2.tsx:193).
+  return (
+    <TodoPanel collapsed={collapsed} marginBottom={1} onToggle={toggleTodoCollapsed} t={ui.theme} todos={todos} />
+  )
 })
 
 interface StreamingAssistantProps {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -1396,6 +1396,7 @@ export const shouldPassThroughToGlobalHandler = (
   (key.ctrl && input === 'c') ||
   (key.ctrl && input === 'x') ||
   (key.ctrl && input === 'o') || // ctrl+o toggles expanded tool details
+  (key.ctrl && input === 't') || // ctrl+t toggles the task checklist
   key.tab ||
   (key.shift && key.tab) ||
   key.pageUp ||

--- a/ui-tui/src/components/todoPanel.tsx
+++ b/ui-tui/src/components/todoPanel.tsx
@@ -1,7 +1,6 @@
 import { Box, Text } from '@clawcodex/ink'
 import { memo, useState } from 'react'
 
-import { countPendingTodos } from '../lib/liveProgress.js'
 import { todoGlyph } from '../lib/todo.js'
 import type { Theme } from '../theme.js'
 import type { TodoItem } from '../types.js'
@@ -14,20 +13,32 @@ const iconColor = (t: Theme, status: TodoItem['status']) =>
 // Cap the visible list like the original HUD; the summary row carries the rest.
 const MAX_VISIBLE_TODOS = 10
 
+// The original's MessageResponse lead — two spaces, └, two spaces
+// (MessageResponse.tsx:22). While busy, the whole list hangs off the busy
+// line through this connector: └ beside the first row, every later row
+// aligned under it by the flex-row split.
+const ATTACHED_LEAD = '  └  '
+
 export const TodoPanel = memo(function TodoPanel({
   collapsed,
   defaultCollapsed = false,
-  incomplete = false,
+  marginBottom = 0,
   onToggle,
   t,
-  todos
+  todos,
+  variant = 'standalone'
 }: {
   collapsed?: boolean
   defaultCollapsed?: boolean
-  incomplete?: boolean
+  marginBottom?: number
   onToggle?: () => void
   t: Theme
   todos: TodoItem[]
+  /** `standalone` (default): the original's isStandalone render — count
+   *  header + rows. Used idle and in the transcript archive. `attached`:
+   *  the busy-turn render (Spinner.tsx:275) — no header, rows hanging off
+   *  the busy line via the `  └  ` connector. */
+  variant?: 'attached' | 'standalone'
 }) {
   // Fallback local state for archived todos in transcript where there's no
   // external controller. Live TodoPanel passes collapsed+onToggle from the
@@ -55,7 +66,6 @@ export const TodoPanel = memo(function TodoPanel({
   const done = todos.filter(todo => todo.status === 'completed').length
   const inProgress = todos.filter(todo => todo.status === 'in_progress').length
   const open = todos.length - done - inProgress
-  const pending = countPendingTodos(todos)
 
   // Original standalone header: "N tasks (X done, Y in progress, Z open)".
   const headerCounts = [
@@ -72,8 +82,47 @@ export const TodoPanel = memo(function TodoPanel({
       ? ` … +${hidden.filter(todo => todo.status === 'in_progress').length} in progress, ${hidden.filter(todo => todo.status === 'pending').length} pending, ${hidden.filter(todo => todo.status === 'completed').length} completed`
       : ''
 
+  const rows = (
+    <>
+      {visible.map(todo => {
+        const isDone = todo.status === 'completed'
+        const isActive = todo.status === 'in_progress'
+        const isCancelled = todo.status === 'cancelled'
+
+        return (
+          <Text color={t.color.text} key={todo.id}>
+            <Text color={iconColor(t, todo.status)}>{todoGlyph(todo.status)} </Text>
+            <Text bold={isActive} dimColor={isDone || isCancelled} strikethrough={isDone || isCancelled}>
+              {todo.content}
+            </Text>
+          </Text>
+        )
+      })}
+      {hiddenSummary ? (
+        <Text color={t.color.muted} dim>
+          {hiddenSummary}
+        </Text>
+      ) : null}
+    </>
+  )
+
+  if (variant === 'attached') {
+    return (
+      <Box flexDirection="row" marginBottom={marginBottom}>
+        <Box flexShrink={0} width={ATTACHED_LEAD.length}>
+          <Text color={t.color.muted} dim>
+            {ATTACHED_LEAD}
+          </Text>
+        </Box>
+        <Box flexDirection="column" flexGrow={1}>
+          {rows}
+        </Box>
+      </Box>
+    )
+  }
+
   return (
-    <Box flexDirection="column" marginBottom={1}>
+    <Box flexDirection="column" marginBottom={marginBottom}>
       <Box onClick={handleToggle}>
         <Text color={t.color.muted}>
           <Text color={t.color.accent}>{effectiveCollapsed ? '▸ ' : '▾ '}</Text>
@@ -81,36 +130,12 @@ export const TodoPanel = memo(function TodoPanel({
           <Text color={t.color.statusFg} dim>
             ({headerCounts})
           </Text>
-          {incomplete && pending > 0 && (
-            <Text color={t.color.muted} dim>
-              {' '}
-              · incomplete · {pending} still {pending === 1 ? 'pending' : 'pending/in_progress'}
-            </Text>
-          )}
         </Text>
       </Box>
 
       {!effectiveCollapsed && (
         <Box flexDirection="column" marginLeft={2}>
-          {visible.map(todo => {
-            const isDone = todo.status === 'completed'
-            const isActive = todo.status === 'in_progress'
-            const isCancelled = todo.status === 'cancelled'
-
-            return (
-              <Text color={t.color.text} key={todo.id}>
-                <Text color={iconColor(t, todo.status)}>{todoGlyph(todo.status)} </Text>
-                <Text bold={isActive} dimColor={isDone || isCancelled} strikethrough={isDone || isCancelled}>
-                  {todo.content}
-                </Text>
-              </Text>
-            )
-          })}
-          {hiddenSummary ? (
-            <Text color={t.color.muted} dim>
-              {hiddenSummary}
-            </Text>
-          ) : null}
+          {rows}
         </Box>
       )}
     </Box>

--- a/ui-tui/src/lib/liveProgress.ts
+++ b/ui-tui/src/lib/liveProgress.ts
@@ -1,8 +1,5 @@
 import type { Msg, TodoItem } from '../types.js'
 
-export const countPendingTodos = (todos: readonly TodoItem[]) =>
-  todos.filter(todo => todo.status === 'in_progress' || todo.status === 'pending').length
-
 export const isTodoDone = (todos: readonly TodoItem[]) =>
   todos.length > 0 && todos.every(todo => todo.status === 'completed' || todo.status === 'cancelled')
 

--- a/ui-tui/src/lib/virtualHeights.ts
+++ b/ui-tui/src/lib/virtualHeights.ts
@@ -108,11 +108,10 @@ export const estimatedMsgHeight = (
   }
 
   if (msg.kind === 'trail' && msg.todos?.length) {
-    if (msg.todoCollapsedByDefault) {
-      return 2
-    }
-
-    return Math.max(2, msg.todos.length + 2)
+    // Only DONE lists reach the transcript now (incomplete ones stay live in
+    // the HUD), and the archive always sets todoCollapsedByDefault — so an
+    // archived checklist estimates as its collapsed header row.
+    return 2
   }
 
   const bodyWidth = transcriptBodyWidth(cols, msg.role, userPrompt, TERMUX_TUI_MODE)

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -185,7 +185,6 @@ export interface Msg {
   // (ctrl+o / /details expanded). Absent on resumed/legacy messages.
   toolsVerbose?: string[]
   todos?: TodoItem[]
-  todoIncomplete?: boolean
   todoCollapsedByDefault?: boolean
 }
 


### PR DESCRIPTION
## What

The task checklist now renders and behaves like real Claude Code's — and, more
importantly, actually shows up. Two user reports drove this: the HUD didn't
match CC's layout, and "I don't see the todo checklist often" (with a guess at
auto-planning as the cause — it isn't; plan mode is at parity on both sides).

### The HUD (ui-tui)

While busy, the list hangs off the busy line through the `  └  ` connector,
exactly the original's Spinner→MessageResponse→TaskListV2 mount:

```
✳ Mapping harbor adapter pattern + pi APIs… (3m 12s · ↓ 11.3k tokens)
  └  ◼ Map harbor adapter pattern + pi headless/extension APIs
     ◻ Write pi harbor agent adapter
     ◻ Build pi vision + Tavily websearch extension
     ◻ Validate on sample TB2.1 tasks
     ◻ Document the full-run command
```

- Busy verb = the in-progress todo's `activeForm` (already true; now the list
  below matches). ✔ green strikethrough-dim / ◼ orange bold / ◻ plain —
  `figures.tick` / `squareSmallFilled` / `squareSmall`, already exact.
- `ctrl+t` toggles the checklist (`app:toggleTodos`, defaultBindings.ts:43).
  The composer's key allowlist had to learn it — `shouldPassThroughToGlobalHandler`
  swallowed it otherwise. Hidden, the busy line falls back to CC's one-line
  `Next: …` (the original's `expandedView='none'` render); the two never
  show together.
- Footer gains `esc to interrupt · ctrl+t to hide tasks` (wording flips to
  `show` when hidden), only while busy with tasks — the original's
  `getSpinnerHintParts`.
- Idle keeps the standalone header render (`N tasks (X done, …)`), still
  click-collapsible.

### Why the checklist rarely appeared (three causes, all fixed)

1. **The system-prompt bullet was damped** — a deliberate TB2.1 harness-tuning
   change (measured 0.21 vs 0.00 steps/trial of task-tool bookkeeping) whose
   rationale, "a task list you are the only reader of is overhead," is false
   interactively: the checklist is the pinned HUD the user watches. The bullet
   is now per-surface: interactive gets the reference's imperative wording
   verbatim (`getUsingYourToolsSection`); non-interactive keeps the damped
   wording byte-for-byte. The tool NAME now follows `is_todo_v2_enabled` too —
   headless sessions were being told about `TaskCreate`, a tool their toolkit
   doesn't carry (they expose `TodoWrite`).
2. **CC's periodic reminder was never ported.** `getTaskReminderAttachments` —
   the "task tools haven't been used recently" `<system-reminder>` injected
   every 10 assistant turns, throttled to one per 10 — now exists as
   `src/context_system/task_reminder.py`: exact turn-counting port
   (before-increment ordering, thinking-only messages skipped, independent
   counters), CC's reminder text verbatim, current task list attached.
   Injected beside the plan-mode attachments in `agent_loop_compat`, persisted
   via `on_attachment` so the throttle can find the previous reminder across
   turns.
3. **The HUD archived at every turn end** (`archiveTodosAtTurnEnd`), so the
   pinned panel vanished the moment a turn completed and the checklist
   survived only as a transcript block that scrolls away. CC keeps the list
   until it's done (REPL.tsx:4934 renders `TaskListV2` idle). Incomplete
   lists now stay live across turns — `startMessage`/`reset` already left
   todos alone, so no other lifecycle change was needed. Finished lists
   archive exactly as before.

## Deliberate deltas from the reference

- **Headless gets no reminder and keeps the damped prompt bullet** (the
  reference nudges both surfaces; headless had no reminder before either, so
  this preserves the status quo there rather than inventing an asymmetry).
  One headless byte DID change: the damped bullet now names `TodoWrite`
  instead of `TaskCreate` — fixing a prompt that named a tool headless
  sessions don't carry. This invalidates headless prompt prefix caches once;
  the TB2.1 step-efficiency measurement was taken with the old (wrong) name,
  and naming a nonexistent tool could only have hurt.
- **The checklist defaults to visible, and ctrl+t is session-scoped.** The
  reference ships collapsed (`showExpandedTodos` defaults false) and
  persists the toggle to global config. Hiding by default would recreate the
  exact complaint this change fixes. Persisting the toggle is deferred: the
  TUI has no settings channel for display prefs in either direction — review
  traced `config.get {key:'full'}` → `get_settings`, whose reply is a flat
  dict with no `display` block, meaning `applyDisplay`'s entire
  `config.display` surface (`bell_on_complete`, `tui_statusbar`,
  `tui_compact`, …) is a pre-existing dead read that no backend populates.
  Reviving that surface is its own change (see follow-ups).
- **The reference's Brief-tool gate on the reminder is not ported.** In CC,
  Brief-in-toolkit marks the coworker surface where SendUserMessage owns
  communication. clawcodex registers Brief unconditionally, so the
  transplanted gate simply disabled the reminder everywhere — caught by the
  wiring test, which drives the real `run_query_as_agent_loop` and asserts
  the reminder reaches the provider.
- **Idle render keeps the collapsible chevron header** rather than CC's
  bare-nothing when toggled off — the click affordance to reopen is worth the
  delta.

## Also fixed along the way

- **Persisted attachments lost `isMeta`** — `Conversation.add_message`
  dropped the flag, so a persisted reminder (or plan-mode attachment)
  counted as a real user turn in the stats odometer and became a `/rewind`
  boundary (`/rewind 1` landed on the reminder, not the user's message).
  Pre-existing for plan mode; the reminder made it common. `add_message` now
  threads `isMeta`, both `on_attachment` call sites pass it, and rewind's
  `is_prompt` skips meta messages.
- Removed the now-producerless `todoIncomplete` transcript path (types, the
  `TodoPanel.incomplete` prop, the unreachable virtualHeights arm).

## Follow-up (out of scope)

- **Resume doesn't rehydrate the checklist HUD.** The reminder re-lists tasks
  to the model, but the user sees nothing until the next TaskCreate/TaskUpdate.
  Restoring it needs the backend task store persisted across resume plus a
  control verb to fetch it — its own change.
- **`applyDisplay`'s `config.display` surface is dead end-to-end** (found in
  review): `get_settings` returns a flat dict, `src/config.py` has no
  `display` section, so every `display.*` key the TUI reads
  (`bell_on_complete`, `tui_statusbar`, `tui_compact`, `details_mode`, …) is
  currently unreachable by users. Wiring a real settings channel would also
  unlock persisting the ctrl+t toggle.

## Testing

- `tests/test_task_reminder.py` (16) — turn-counting port fidelity (including
  the before-increment ordering and thinking-skip), every gate, throttling
  both ways, the kill-switch envs.
- `tests/test_task_reminder_wiring.py` (2) — end-to-end through the real
  agent loop with a recording provider: the reminder reaches the model wrapped
  in `<system-reminder>` and persists via `on_attachment`; short conversations
  get nothing. This test caught the Brief-gate transplant bug.
- `tests/test_system_prompt_full.py` — per-surface bullet: damped+TodoWrite
  headless, imperative+TaskCreate interactive, damped+TaskCreate under
  `CLAUDE_CODE_ENABLE_TASKS`.
- `ui-tui/src/__tests__/todoHud.test.tsx` (10) — rendered-output assertions:
  connector + 5-column alignment, no header while attached, Next:-suppression,
  ctrl+t fallback, footer hint wording in all states.
- Two tests updated that pinned the replaced behavior (busyLine Next:-always,
  turnStore archive-incomplete); passthrough allowlist test extended.

Full suites: Python 9991 passed / 1 failed — `test_sigint_during_prefetch_clean_exit`,
a SIGINT-timing subprocess race that passes on retry, references nothing in
this diff, and predates it. ui-tui 1725 passed / 8 failed = the pre-existing
baseline (same 5 files, verified against a stashed clean tree), plus one
parallel-run flake (`execFileNoThrow`) that passes in isolation. Changed files
lint clean; the tree-wide 46 pre-existing lint errors are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
