### PR TITLE
feat(recap): end-of-turn recap + tab-acceptable suggested next prompt

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -548,3 +548,25 @@ def set_effort(value: Optional[str]) -> None:
     cfg["settings"] = section
     mgr.save_global(cfg)
     invalidate_settings_cache()
+
+
+def set_recap_enabled(enabled: bool) -> None:
+    """Persist the end-of-turn-recap toggle (``settings.recap_enabled``) and
+    invalidate the settings read-cache.
+
+    Same shape as :func:`set_effort` — a nested *settings* field
+    (``src/settings/types.py``), written to the global config's ``"settings"``
+    section and made visible to the very next ``get_settings()`` so the
+    agent-server's post-turn check flips mid-session without a restart.
+    """
+    from src.settings.settings import invalidate_settings_cache
+
+    mgr = _get_default_manager()
+    cfg = mgr.load_global()
+    section = cfg.get("settings")
+    if not isinstance(section, dict):
+        section = {}
+    section["recap_enabled"] = bool(enabled)
+    cfg["settings"] = section
+    mgr.save_global(cfg)
+    invalidate_settings_cache()

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -22,6 +22,8 @@ server → client (``messages_from_agent``)::
     {type:'control_request', request_id, request:{subtype:'can_use_tool', …}}
     {type:'control_response', response:{subtype, request_id, response}}  # to client pulls
     {type:'result', subtype:'success'|'error'|'cancelled', usage, num_turns, …}
+    {type:'system', subtype:'recap', session_id, recap, suggestion}
+                                             # post-turn recap line + tab-acceptable composer prefill
 
 client → server (``send_to_agent``)::
 
@@ -32,6 +34,8 @@ client → server (``send_to_agent``)::
     {type:'control_request', request_id, request:{subtype:'set_model', model, provider?}}
                                              # replies {ok, model, warning?} | {ok:false, error}
     {type:'control_request', request_id, request:{subtype:'get_settings'|'get_context_usage'}}
+    {type:'control_request', request_id, request:{subtype:'set_recap', value:'on'|'off'}}
+                                             # /recap toggle; replies {ok, value} | {ok:false, error}
     {type:'control_request', request_id, request:{subtype:'worktree_status'}}
                                              # {ok, active, name?, path?, branch?, git_ok?, dirty_files?, commits?}
     {type:'control_request', request_id, request:{subtype:'worktree_exit', action:'keep'|'remove'}}
@@ -235,6 +239,18 @@ class _AgentSession:
     _turns_since_memory: int = 0
     _memory_counter_hydrated: bool = False
     _memory_review_thread: threading.Thread | None = None
+    # End-of-turn recap + tab-acceptable suggestion (src/services/turn_recap):
+    # a post-turn small-model fork, one at a time, emitting one system/recap
+    # frame. Staleness is a TWO-key check at emit: ``_stats_turns`` equality
+    # AND ``_recap_serial`` equality. The odometer alone has an ABA hole —
+    # /clear zeroes it, /rewind recounts it DOWN, /resume re-seeds it, so a
+    # slow fork can watch the value leave and come back while the
+    # conversation underneath it was replaced. ``_recap_serial`` is
+    # monotonic (same idea as ``_goal_rev``): bumped on EVERY completed
+    # turn (btw/internal included) and on every conversation-identity
+    # change (/clear, /rewind, /resume), so ABA is unrepresentable.
+    _recap_thread: threading.Thread | None = None
+    _recap_serial: int = 0
     # /loop + Cron* + ScheduleWakeup engine (docs/en/scheduled-tasks port).
     # The worker's idle branch pops due tasks and runs their prompts as
     # internal turns; _build_runtime hands this to tool_context so the
@@ -668,7 +684,12 @@ class _AgentSession:
                 "available_output_styles": self._available_output_styles(),
                 # /logo — the persisted startup-logo palette (None = default).
                 "logo_color": _current_logo_color(),
+                # /recap — end-of-turn recap + composer suggestion toggle.
+                "recap": _recap_setting_enabled(),
             })
+            return
+        if subtype == "set_recap":
+            self._do_set_recap(request_id, inner.get("value"))
             return
         if subtype == "get_context_usage":
             self._reply(request_id, self._context_usage())
@@ -933,6 +954,8 @@ class _AgentSession:
                 # Fresh conversation, fresh odometer (token/cost totals are
                 # process-wide spend and deliberately survive /clear).
                 self._stats_turns = 0
+                # Conversation identity changed — kill any in-flight recap.
+                self._recap_serial += 1
                 # Fresh conversation, fresh review cadence (the donor's
                 # counters are per-agent-lifetime; a gateway reset builds a
                 # new agent). Hydration stays done — the counter simply
@@ -2661,6 +2684,45 @@ class _AgentSession:
             return
         self._reply(request_id, {"ok": True, "logo_color": name})
 
+    def _do_set_recap(self, request_id: object, value: object) -> None:
+        """Flip + persist the end-of-turn recap toggle (the TUI's /recap).
+
+        Delegates to :func:`src.config.set_recap_enabled` — the
+        ``set_effort`` write pattern: ``settings.recap_enabled`` in the
+        GLOBAL config (project/local overrides still win at merge) plus a
+        settings-cache invalidation so the very next post-turn check sees
+        it — no restart, no session rebuild.
+        """
+        mode = str(value or "").strip().lower()
+        if mode not in ("on", "off"):
+            self._reply(
+                request_id,
+                {"ok": False, "error": "usage: /recap [on|off|status]"},
+            )
+            return
+        try:
+            from src.config import set_recap_enabled
+
+            set_recap_enabled(mode == "on")
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("[agent-server] set_recap failed")
+            self._reply(
+                request_id, {"ok": False, "error": f"failed to persist: {exc}"}
+            )
+            return
+        # Reply with the EFFECTIVE post-write state, not the request: the
+        # write is global, and a project/local settings override wins at
+        # merge — "/recap off" must not print "off" while the feature stays
+        # on. When they disagree, say why.
+        effective = "on" if _recap_setting_enabled() else "off"
+        payload: dict[str, Any] = {"ok": True, "value": effective}
+        if effective != mode:
+            payload["note"] = (
+                "global preference saved, but a project/local settings "
+                "override keeps it " + effective
+            )
+        self._reply(request_id, payload)
+
     def _rebuild_system_prompt(self) -> bool:
         """Rebuild the cached system prompt from the live tool context.
 
@@ -2815,6 +2877,9 @@ class _AgentSession:
                 if isinstance(saved_turns, int) and not isinstance(saved_turns, bool) and saved_turns >= 0
                 else _count_prompt_turns(conv.messages)
             )
+            # Conversation identity changed — kill any in-flight recap (the
+            # re-seeded odometer can coincide with the captured serial).
+            self._recap_serial += 1
             # ch03 round-4 GAP B — restore the accumulated cost counters
             # (guarded: the reader refuses a file whose session_id header
             # doesn't match). Gated single_session like every other
@@ -3024,6 +3089,8 @@ class _AgentSession:
             # them, so the recount can sit below the number of boundaries
             # rewind saw. Fine for an odometer; don't reuse is_prompt here.
             self._stats_turns = _count_prompt_turns(msgs)
+            # Conversation identity changed — kill any in-flight recap.
+            self._recap_serial += 1
             self._reply(request_id, {"ok": True, "removed": removed, "count": len(msgs)})
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] rewind failed")
@@ -4275,6 +4342,110 @@ class _AgentSession:
             logger.debug("[agent-server] memory review hook failed",
                          exc_info=True)
 
+    def _maybe_spawn_recap(self, outcome: dict | None) -> None:
+        """Post-turn recap hook (worker thread) — CC's end-of-turn "✻ recap:"
+        line plus the tab-acceptable composer suggestion.
+
+        Fires only when the session actually returns to idle awaiting the
+        user: a completed REAL user turn (the caller runs this for neither
+        btw nor internal turns), subtype ``success`` with a non-empty
+        response, no active /goal loop (the agent keeps working), and an
+        empty inbox (a queued prompt makes the recap stale on arrival).
+        Spawns a daemon fork that builds its OWN provider (same reasoning as
+        the memory-review fork: provider objects carry per-request mutable
+        state and the next foreground turn may run concurrently), generates
+        via the small-fast-model side query, and emits ONE ``system/recap``
+        frame — dropped if the turn odometer moved or a turn is running by
+        the time it finishes. Never raises.
+        """
+        try:
+            if not outcome or outcome.get("subtype") != "success":
+                return
+            if not str(outcome.get("response_text") or "").strip():
+                return
+
+            from src.settings.settings import get_settings
+
+            if not bool(getattr(get_settings(), "recap_enabled", True)):
+                return
+            with self._lock:
+                if self._goal_mgr is not None and self._goal_mgr.is_active():
+                    return
+            if not self._inbox.empty():
+                return
+            prev = self._recap_thread
+            if prev is not None and prev.is_alive():
+                return  # one recap fork at a time
+            if self.provider is None or self.session is None:
+                return
+
+            messages = list(self.session.conversation.messages)
+            if not messages:
+                return
+            provider_name = self.provider_name
+            model = getattr(self.provider, "model", None) or self.config.model
+            serial = self._stats_turns
+            recap_serial = self._recap_serial
+
+            def _recap_target() -> None:
+                try:
+                    from src.config import get_provider_config
+                    from src.providers import (
+                        get_provider_class,
+                        resolve_api_key,
+                    )
+
+                    provider_cfg = get_provider_config(provider_name)
+                    fork_provider = get_provider_class(provider_name)(
+                        api_key=resolve_api_key(provider_name, provider_cfg),
+                        base_url=provider_cfg.get("base_url"),
+                        model=model or provider_cfg.get("default_model"),
+                    )
+                except Exception:  # noqa: BLE001 — no fork without its own client
+                    logger.debug(
+                        "[agent-server] recap provider resolution failed",
+                        exc_info=True,
+                    )
+                    return
+
+                from src.services.turn_recap import generate_turn_recap
+
+                result = asyncio.run(
+                    generate_turn_recap(messages, fork_provider)
+                )
+                if not result or not result.get("recap"):
+                    return
+                # Staleness gate: only the turn this recap describes may
+                # surface it. Two keys must BOTH be unmoved: the user-turn
+                # odometer (fails closed on a bare /clear with no follow-up
+                # turn) and the monotonic ``_recap_serial`` (closes the
+                # odometer's ABA hole — /clear zeroes it, /rewind recounts
+                # it down, /resume re-seeds it, so a slow fork could watch
+                # the count leave and come back over a replaced
+                # conversation). Plus: no in-flight turn, no queued prompt.
+                if self._stop.is_set() or not self._inbox.empty():
+                    return
+                with self._lock:
+                    if self._current_abort is not None:
+                        return
+                if self._stats_turns != serial or self._recap_serial != recap_serial:
+                    return
+                self._emit({
+                    "type": "system",
+                    "subtype": "recap",
+                    "session_id": self.session_id,
+                    "recap": str(result.get("recap") or ""),
+                    "suggestion": str(result.get("suggestion") or ""),
+                })
+
+            thread = threading.Thread(
+                target=_recap_target, name="bg-recap", daemon=True
+            )
+            self._recap_thread = thread
+            thread.start()
+        except Exception:  # noqa: BLE001 — recaps must never kill the worker
+            logger.debug("[agent-server] recap hook failed", exc_info=True)
+
     # ─── worker thread (runs query() turns) ────────────────────────────────
 
     def start(self) -> None:
@@ -4334,6 +4505,9 @@ class _AgentSession:
             # Self-improvement review — runs AFTER the response is delivered
             # so it never competes with the user's task for model attention.
             self._maybe_spawn_memory_review(outcome, pre_turn_len)
+            # End-of-turn recap + composer suggestion — same post-delivery
+            # slot, real user turns only (never btw/internal/goal turns).
+            self._maybe_spawn_recap(outcome)
             # A task that finished while the turn ran is delivered right after.
             self._deliver_task_notifications()
             # Reflect any Cron*/ScheduleWakeup change the turn made (deduped
@@ -4919,6 +5093,10 @@ class _AgentSession:
             _cost = max(0.0, get_total_cost_usd() - _cost_before)
         except Exception:  # noqa: BLE001 — cost is best-effort, never break the turn
             _cost = 0.0
+        # EVERY completed turn (btw/internal included) invalidates any
+        # in-flight recap fork — monotonic, so the odometer's ABA hole
+        # (/clear → 0 → back up; /rewind recount) can't resurrect one.
+        self._recap_serial += 1
         # One more completed user turn. Internal (notification) and btw
         # (ephemeral, rolled-back) turns don't move the odometer — same rule
         # as the deleted REPL, which only counted real prompt→response rounds.
@@ -6315,6 +6493,18 @@ def _current_logo_color() -> str | None:
         return value if is_logo_palette_name(value) else None
     except Exception:  # noqa: BLE001
         return None
+
+
+def _recap_setting_enabled() -> bool:
+    """The live end-of-turn-recap toggle (the ``get_settings`` rider for
+    /recap status). Defaults on — matching CC, where recaps ship enabled
+    with an opt-out."""
+    try:
+        from src.settings.settings import get_settings
+
+        return bool(getattr(get_settings(), "recap_enabled", True))
+    except Exception:  # noqa: BLE001
+        return True
 
 
 def _current_mode(tool_context: Any, default: str) -> str:

--- a/src/services/turn_recap.py
+++ b/src/services/turn_recap.py
@@ -1,0 +1,249 @@
+"""End-of-turn recap + suggested-next-prompt generator (CC parity).
+
+Current Claude Code ends a completed turn with a dim ``✻ recap: …`` transcript
+line (goal → where things stand → "Next: …") and pre-fills the composer with a
+short suggested follow-up prompt the user accepts with Tab. The vendored
+``typescript/`` snapshot predates the feature (its closest relative is
+``services/awaySummary.ts`` — same small-fast-model side query over the recent
+transcript), so this module is ported from the observed behavior, reusing the
+repo's established side-query conventions:
+
+* small-fast-model pin via the memdir resolver (Anthropic sessions only,
+  ``find_relevant_memories._resolve_recall_model``) — same concern as
+  ``tool_use_summary.py``: never pay the session model's price for a side call;
+* bounded recent-transcript window, mirroring awaySummary's
+  ``RECENT_MESSAGE_WINDOW = 30``;
+* non-critical contract: every failure path returns ``None`` and never raises.
+
+The wire format is two tagged lines (``RECAP:`` / ``SUGGESTION:``) rather than
+JSON — the call is served by a small model, and line tags survive sloppy output
+(stray prose, fences) that would kill ``json.loads``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Mirrors awaySummary.ts RECENT_MESSAGE_WINDOW: recaps only need recent
+# context, and a bounded window avoids "prompt too long" on large sessions.
+RECENT_MESSAGE_WINDOW = 30
+# Per-message and total character budgets for the serialized tail. The window
+# above bounds message COUNT; these bound message SIZE (a single pasted log
+# would otherwise blow the side-query budget on its own).
+PER_MESSAGE_CHARS = 700
+TOTAL_CHARS = 8000
+# A suggestion is a one-line composer prefill, not an essay.
+MAX_SUGGESTION_CHARS = 200
+
+TURN_RECAP_SYSTEM_PROMPT = (
+    "You write the end-of-turn recap for a coding-agent CLI. The user just "
+    "finished a turn and may step away; the recap tells them where they are, "
+    "and the suggestion pre-fills their next prompt (they press Tab to "
+    "accept it).\n\n"
+    "Reply with exactly two lines and nothing else:\n"
+    "RECAP: 1-3 short sentences. Lead with the high-level goal (what the "
+    "user is building, debugging, or asking about — not implementation "
+    "minutiae), then where things stand after this turn, and end with "
+    "'Next: <the concrete next step>.' Skip pleasantries, status-report "
+    "filler, and commit recaps.\n"
+    "SUGGESTION: the follow-up prompt the user would most likely type next, "
+    "as one short imperative under 12 words (e.g. 'fix all four issues and "
+    "re-run'). It must make sense sent verbatim as the next user message. "
+    "If the work is fully complete and no follow-up makes sense, write NONE."
+)
+
+
+def _block_fragment(block: Any) -> str:
+    """One transcript fragment for a content block. Text rides verbatim;
+    tool traffic collapses to its name — the assistant's own narration is
+    what a recap needs, not tool payloads (and results can be huge)."""
+    btype = getattr(block, "type", None) or (
+        block.get("type") if isinstance(block, dict) else None
+    )
+    if btype == "text":
+        text = getattr(block, "text", None) or (
+            block.get("text") if isinstance(block, dict) else ""
+        )
+        return str(text or "")
+    if btype == "tool_use":
+        name = getattr(block, "name", None) or (
+            block.get("name") if isinstance(block, dict) else ""
+        )
+        return f"[tool: {name or 'unknown'}]"
+    if btype == "tool_result":
+        return "[tool result]"
+    if btype == "thinking":
+        return ""  # never leak thinking into a side query
+    return ""
+
+
+def serialize_transcript_tail(
+    messages: list[Any],
+    *,
+    max_messages: int = RECENT_MESSAGE_WINDOW,
+    per_message_chars: int = PER_MESSAGE_CHARS,
+    total_chars: int = TOTAL_CHARS,
+) -> str:
+    """Render the last ``max_messages`` conversation messages as a compact
+    ``User:``/``Assistant:`` transcript for the recap prompt.
+
+    Tool blocks collapse to ``[tool: Name]``/``[tool result]`` markers; a
+    message that reduces to nothing (e.g. a pure tool-result carrier whose
+    marker-only body would add noise) still keeps its marker so the model can
+    see work happened, but a fully empty message is skipped. Head-drops whole
+    messages (keeping the most recent) until the total fits ``total_chars``.
+    """
+    lines: list[str] = []
+    for msg in messages[-max_messages:]:
+        role = str(getattr(msg, "role", "") or "")
+        if role not in ("user", "assistant"):
+            continue
+        content = getattr(msg, "content", "")
+        if isinstance(content, str):
+            body = content
+        elif isinstance(content, list):
+            body = " ".join(
+                frag for frag in (_block_fragment(b) for b in content) if frag
+            )
+        else:
+            body = str(content or "")
+        body = " ".join(body.split())  # collapse whitespace/newlines
+        if not body:
+            continue
+        if len(body) > per_message_chars:
+            body = body[: per_message_chars - 1] + "…"
+        lines.append(f"{'User' if role == 'user' else 'Assistant'}: {body}")
+
+    while lines and sum(len(line) + 2 for line in lines) > total_chars:
+        lines.pop(0)
+    return "\n\n".join(lines)
+
+
+_RECAP_TAG = re.compile(r"^\s*recap\s*:\s*", re.IGNORECASE)
+_SUGGESTION_TAG = re.compile(r"^\s*suggestion\s*:\s*", re.IGNORECASE)
+_FENCE = re.compile(r"^```[a-zA-Z]*\s*$")
+
+
+def parse_recap_response(text: str | None) -> tuple[str, str] | None:
+    """Parse the two-line tagged reply into ``(recap, suggestion)``.
+
+    Lenient by design (small-model output): fences are stripped, the recap
+    may spill across lines until the SUGGESTION tag, tags are
+    case-insensitive. ``NONE`` (or a missing tag) → empty suggestion. No
+    recap → ``None`` — the whole feature is skipped for the turn.
+    """
+    if not text or not text.strip():
+        return None
+    lines = [ln for ln in text.splitlines() if not _FENCE.match(ln)]
+
+    recap_parts: list[str] = []
+    suggestion_parts: list[str] = []
+    section: str | None = None
+    for line in lines:
+        if _RECAP_TAG.match(line):
+            section = "recap"
+            recap_parts.append(_RECAP_TAG.sub("", line, count=1))
+        elif _SUGGESTION_TAG.match(line):
+            section = "suggestion"
+            suggestion_parts.append(_SUGGESTION_TAG.sub("", line, count=1))
+        elif section == "recap":
+            recap_parts.append(line)
+        elif section == "suggestion":
+            suggestion_parts.append(line)
+
+    recap = " ".join(" ".join(recap_parts).split()).strip()
+    suggestion = " ".join(" ".join(suggestion_parts).split()).strip()
+    if not recap:
+        return None
+
+    # Strip decoration a model may add around the prefill text.
+    if len(suggestion) >= 2 and suggestion[0] == suggestion[-1] and suggestion[0] in "\"'`":
+        suggestion = suggestion[1:-1].strip()
+    if suggestion.upper() in ("", "NONE", "NONE."):
+        suggestion = ""
+    if len(suggestion) > MAX_SUGGESTION_CHARS:
+        suggestion = suggestion[:MAX_SUGGESTION_CHARS].rstrip()
+    return recap, suggestion
+
+
+def _resolve_recap_model(provider: Any) -> str | None:
+    """Small-fast-model pin — same resolver (and same reasoning) as
+    ``tool_use_summary._resolve_summary_model``. None = session model."""
+    try:
+        from src.memdir.find_relevant_memories import _resolve_recall_model
+
+        return _resolve_recall_model(provider)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def generate_turn_recap(
+    messages: list[Any],
+    provider: Any,
+) -> dict[str, str] | None:
+    """Generate ``{"recap": …, "suggestion": …}`` for a completed turn.
+
+    ``messages`` — conversation snapshot (``Conversation.messages``).
+    Empty transcript, missing provider, model error, or an unparseable reply
+    all yield ``None``; recaps are non-critical and never raise.
+    """
+    if not messages:
+        return None
+    try:
+        transcript = serialize_transcript_tail(messages)
+        if not transcript:
+            return None
+        if provider is None or not hasattr(provider, "chat_async"):
+            return None
+
+        # 1200, not ~300: reasoning-default models (deepseek-v4-*, kimi-k3)
+        # spend their budget on hidden reasoning BEFORE the two visible
+        # lines — a 300 cap starved the reply to a bare "RECAP:" (observed
+        # against deepseek-v4-pro). The cap is a ceiling, not a target:
+        # non-reasoning models still emit ~50 tokens.
+        kwargs: dict[str, Any] = {
+            "system": TURN_RECAP_SYSTEM_PROMPT,
+            "max_tokens": 1200,
+        }
+        model = _resolve_recap_model(provider)
+        if model:
+            kwargs["model"] = model
+        # Keep the side query cheap on reasoning-default APIs: ask for the
+        # provider's LOWEST effort, but only where the provider itself
+        # declares "low" in its vocabulary (deepseek today) — self-describing
+        # opt-in, so providers that never saw the field (Anthropic SDK would
+        # reject the kwarg) are untouched. Anthropic's non-streaming side
+        # call already runs without extended thinking.
+        supported = getattr(provider, "supported_reasoning_efforts", None)
+        if supported and "low" in supported:
+            kwargs["reasoning_effort"] = "low"
+        user_prompt = (
+            f"Recent conversation:\n\n{transcript}\n\n"
+            "Write the RECAP and SUGGESTION lines now."
+        )
+        response = await provider.chat_async(
+            [{"role": "user", "content": user_prompt}], **kwargs
+        )
+        if response is None:
+            return None
+        content = getattr(response, "content", None)
+        if isinstance(content, list):
+            # Anthropic-shape defense (same as the memdir selector):
+            # ``ChatResponse.content`` is typed str, but guard against a
+            # provider handing back raw content blocks.
+            content = "".join(
+                block.get("text", "") if isinstance(block, dict) else str(block)
+                for block in content
+            )
+        parsed = parse_recap_response(str(content or ""))
+        if parsed is None:
+            return None
+        recap, suggestion = parsed
+        return {"recap": recap, "suggestion": suggestion}
+    except Exception:  # noqa: BLE001 — recaps are non-critical
+        logger.debug("turn recap generation failed", exc_info=True)
+        return None

--- a/src/settings/types.py
+++ b/src/settings/types.py
@@ -216,6 +216,22 @@ class SettingsSchema:
     # (src/memory/write_approval.py). Donor default: off.
     memory_write_approval: bool = False
 
+    # End-of-turn recap + suggested next prompt (CC parity: the "✻ recap: …"
+    # transcript line and the tab-acceptable composer ghost text). One side
+    # query per completed REAL user turn; CC ships it on by default with an
+    # opt-out, mirrored here (/recap off persists this).
+    #
+    # Cost posture (deliberate, weighed against the memdir-prefetch OFF
+    # precedent): on Anthropic sessions the query pins small_fast_model; on
+    # other providers it runs on the SESSION model (the cross-provider
+    # small-model pairing is still deferred, see find_relevant_memories),
+    # bounded by an ~8K-char transcript budget, a 1200-token cap, and a
+    # low-reasoning-effort pin where the provider declares one. Kept
+    # default-on anyway because — unlike the silent prefetch — every recap
+    # line renders "(disable recaps in /recap)", so the feature advertises
+    # its own off-switch each time it costs anything.
+    recap_enabled: bool = True
+
     # Provider
     provider: str = "anthropic"
 

--- a/tests/test_turn_recap.py
+++ b/tests/test_turn_recap.py
@@ -1,0 +1,482 @@
+"""End-of-turn recap + suggestion — service unit tests and server wiring.
+
+Covers ``src/services/turn_recap.py`` (transcript serialization, the tagged
+two-line parse, the generator's never-raise contract) and the
+``_AgentSession._maybe_spawn_recap`` post-turn hook (spawn guards, the
+staleness gate, the emitted ``system/recap`` frame).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import queue as _queue
+import threading
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from src.services.turn_recap import (
+    MAX_SUGGESTION_CHARS,
+    generate_turn_recap,
+    parse_recap_response,
+    serialize_transcript_tail,
+)
+
+
+def _msg(role: str, content):
+    return SimpleNamespace(role=role, content=content)
+
+
+def _text(text: str):
+    return SimpleNamespace(type="text", text=text)
+
+
+class TestSerializeTranscriptTail(unittest.TestCase):
+    def test_renders_roles_and_collapses_tool_blocks(self):
+        messages = [
+            _msg("user", "port the recap feature"),
+            _msg("assistant", [
+                _text("On it."),
+                SimpleNamespace(type="tool_use", name="Read", input={}),
+            ]),
+            _msg("user", [SimpleNamespace(type="tool_result", content="…")]),
+            _msg("assistant", [_text("Done. Next: tests.")]),
+        ]
+        out = serialize_transcript_tail(messages)
+        self.assertEqual(out.split("\n\n"), [
+            "User: port the recap feature",
+            "Assistant: On it. [tool: Read]",
+            "User: [tool result]",
+            "Assistant: Done. Next: tests.",
+        ])
+
+    def test_skips_non_conversation_roles_and_empty_messages(self):
+        messages = [
+            _msg("system", "system prompt"),
+            _msg("user", ""),
+            _msg("assistant", [SimpleNamespace(type="thinking", thinking="…")]),
+            _msg("user", "real prompt"),
+        ]
+        out = serialize_transcript_tail(messages)
+        self.assertEqual(out, "User: real prompt")
+
+    def test_accepts_dict_shaped_blocks(self):
+        messages = [_msg("assistant", [{"type": "text", "text": "hi"},
+                                       {"type": "tool_use", "name": "Bash"}])]
+        self.assertEqual(serialize_transcript_tail(messages),
+                         "Assistant: hi [tool: Bash]")
+
+    def test_truncates_long_messages_and_collapses_whitespace(self):
+        messages = [_msg("user", "a b\n\n  c " + "x" * 2000)]
+        out = serialize_transcript_tail(messages, per_message_chars=40)
+        self.assertTrue(out.startswith("User: a b c x"))
+        self.assertTrue(out.endswith("…"))
+        # "User: " prefix + 40-char body budget
+        self.assertEqual(len(out), len("User: ") + 40)
+
+    def test_window_and_total_budget_keep_the_most_recent(self):
+        messages = [_msg("user", f"prompt {i} " + "x" * 100) for i in range(50)]
+        out = serialize_transcript_tail(
+            messages, max_messages=30, total_chars=500
+        )
+        self.assertNotIn("prompt 19 ", out)  # outside the 30-message window
+        self.assertIn("prompt 49 ", out)     # newest always survives
+        self.assertLessEqual(len(out), 500)
+        # Head-dropped: the oldest inside the window is gone too.
+        self.assertNotIn("prompt 20 ", out)
+
+
+class TestParseRecapResponse(unittest.TestCase):
+    def test_happy_path(self):
+        parsed = parse_recap_response(
+            "RECAP: Goal was X. Done. Next: re-run.\n"
+            "SUGGESTION: fix all four issues and re-run"
+        )
+        self.assertEqual(parsed, (
+            "Goal was X. Done. Next: re-run.",
+            "fix all four issues and re-run",
+        ))
+
+    def test_lenient_tags_fences_and_multiline_recap(self):
+        parsed = parse_recap_response(
+            "```\nrecap: Goal was X.\nStill the recap line.\n"
+            "Suggestion: \"run the tests\"\n```"
+        )
+        self.assertEqual(parsed, (
+            "Goal was X. Still the recap line.",
+            "run the tests",
+        ))
+
+    def test_none_suggestion_maps_to_empty(self):
+        for token in ("NONE", "none", "None."):
+            parsed = parse_recap_response(f"RECAP: Done.\nSUGGESTION: {token}")
+            self.assertEqual(parsed, ("Done.", ""), token)
+
+    def test_missing_suggestion_tag_is_fine(self):
+        self.assertEqual(parse_recap_response("RECAP: Done."), ("Done.", ""))
+
+    def test_suggestion_capped(self):
+        parsed = parse_recap_response(
+            "RECAP: Done.\nSUGGESTION: " + "y" * 400
+        )
+        assert parsed is not None
+        self.assertEqual(len(parsed[1]), MAX_SUGGESTION_CHARS)
+
+    def test_no_recap_kills_the_feature_for_the_turn(self):
+        self.assertIsNone(parse_recap_response("SUGGESTION: do things"))
+        self.assertIsNone(parse_recap_response("free-form prose only"))
+        self.assertIsNone(parse_recap_response(""))
+        self.assertIsNone(parse_recap_response(None))
+
+
+class _FakeProvider:
+    def __init__(self, reply: str | None):
+        self.reply = reply
+        self.calls: list[dict] = []
+
+    async def chat_async(self, messages, **kwargs):
+        self.calls.append({"messages": messages, **kwargs})
+        if self.reply is None:
+            return None
+        return SimpleNamespace(content=self.reply)
+
+
+class TestGenerateTurnRecap(unittest.TestCase):
+    def _messages(self):
+        return [_msg("user", "port the recap"), _msg("assistant", "done")]
+
+    def test_generates_and_parses(self):
+        provider = _FakeProvider("RECAP: Ported. Next: tests.\nSUGGESTION: run the tests")
+        result = asyncio.run(generate_turn_recap(self._messages(), provider))
+        self.assertEqual(result, {
+            "recap": "Ported. Next: tests.",
+            "suggestion": "run the tests",
+        })
+        # One bounded small side-call: system prompt + max_tokens are pinned.
+        self.assertEqual(len(provider.calls), 1)
+        self.assertEqual(provider.calls[0]["max_tokens"], 1200)
+        self.assertIn("RECAP", provider.calls[0]["system"])
+        self.assertIn("port the recap", provider.calls[0]["messages"][0]["content"])
+
+    def test_small_model_pin_rides_when_resolved(self):
+        provider = _FakeProvider("RECAP: X.\nSUGGESTION: NONE")
+        with patch(
+            "src.services.turn_recap._resolve_recap_model",
+            return_value="small-fast",
+        ):
+            result = asyncio.run(generate_turn_recap(self._messages(), provider))
+        self.assertEqual(result, {"recap": "X.", "suggestion": ""})
+        self.assertEqual(provider.calls[0]["model"], "small-fast")
+        # No effort pin for a provider without a declared vocabulary.
+        self.assertNotIn("reasoning_effort", provider.calls[0])
+
+    def test_low_effort_pin_for_declaring_providers(self):
+        provider = _FakeProvider("RECAP: X.\nSUGGESTION: NONE")
+        provider.supported_reasoning_efforts = ("low", "high", "max")
+        asyncio.run(generate_turn_recap(self._messages(), provider))
+        self.assertEqual(provider.calls[0]["reasoning_effort"], "low")
+
+    def test_no_effort_pin_when_low_not_in_vocabulary(self):
+        provider = _FakeProvider("RECAP: X.\nSUGGESTION: NONE")
+        provider.supported_reasoning_efforts = ("medium", "high")
+        asyncio.run(generate_turn_recap(self._messages(), provider))
+        self.assertNotIn("reasoning_effort", provider.calls[0])
+
+    def test_list_shaped_content_is_flattened(self):
+        class _ListProvider(_FakeProvider):
+            async def chat_async(self, messages, **kwargs):
+                self.calls.append({"messages": messages, **kwargs})
+                return SimpleNamespace(content=[
+                    {"type": "text", "text": "RECAP: Flat.\n"},
+                    {"type": "text", "text": "SUGGESTION: NONE"},
+                ])
+
+        result = asyncio.run(
+            generate_turn_recap(self._messages(), _ListProvider(None))
+        )
+        self.assertEqual(result, {"recap": "Flat.", "suggestion": ""})
+
+    def test_never_raises(self):
+        class _Boom:
+            async def chat_async(self, *a, **k):
+                raise RuntimeError("boom")
+
+        self.assertIsNone(asyncio.run(generate_turn_recap(self._messages(), _Boom())))
+        self.assertIsNone(asyncio.run(generate_turn_recap(self._messages(), None)))
+        self.assertIsNone(asyncio.run(generate_turn_recap([], _FakeProvider("x"))))
+        self.assertIsNone(
+            asyncio.run(generate_turn_recap(self._messages(), _FakeProvider(None)))
+        )
+        self.assertIsNone(
+            asyncio.run(
+                generate_turn_recap(self._messages(), _FakeProvider("no tags here"))
+            )
+        )
+
+
+def _session(**overrides):
+    from src.server.agent_server import AgentServerConfig, _AgentSession
+
+    sess = _AgentSession(
+        session_id="s1", cwd="/tmp",
+        config=AgentServerConfig(single_session=True),
+        loop=MagicMock(), out_queue=MagicMock(),
+    )
+    sess.provider = SimpleNamespace(model="m1", chat_async=None)
+    sess.provider_name = "anthropic"
+    sess.session = SimpleNamespace(
+        conversation=SimpleNamespace(messages=[_msg("user", "hi")])
+    )
+    sess._stats_turns = 3
+    for key, value in overrides.items():
+        setattr(sess, key, value)
+    return sess
+
+
+_SETTINGS_ON = SimpleNamespace(recap_enabled=True)
+_SETTINGS_OFF = SimpleNamespace(recap_enabled=False)
+
+_OUTCOME = {"subtype": "success", "response_text": "done"}
+
+
+class TestMaybeSpawnRecap(unittest.TestCase):
+    def _spawn_and_join(self, sess, outcome=_OUTCOME):
+        sess._maybe_spawn_recap(outcome)
+        thread = sess._recap_thread
+        if thread is not None:
+            thread.join(timeout=10)
+        return thread
+
+    def _run(self, sess, *, gen_result, outcome=_OUTCOME):
+        """Spawn with the provider fork + generator patched; return emits."""
+        emitted: list[dict] = []
+        sess._emit = emitted.append
+
+        async def _fake_generate(messages, provider):
+            return gen_result
+
+        fake_cls = MagicMock(return_value=SimpleNamespace(model="m1"))
+        with patch("src.settings.settings.get_settings", return_value=_SETTINGS_ON), \
+             patch("src.config.get_provider_config", return_value={}), \
+             patch("src.providers.get_provider_class", return_value=fake_cls), \
+             patch("src.providers.resolve_api_key", return_value="k"), \
+             patch("src.services.turn_recap.generate_turn_recap", _fake_generate):
+            self._spawn_and_join(sess, outcome)
+        return emitted
+
+    def test_emits_recap_frame_for_a_completed_real_turn(self):
+        sess = _session()
+        emitted = self._run(
+            sess, gen_result={"recap": "Goal was X. Next: Y.", "suggestion": "do Y"}
+        )
+        self.assertEqual(emitted, [{
+            "type": "system",
+            "subtype": "recap",
+            "session_id": "s1",
+            "recap": "Goal was X. Next: Y.",
+            "suggestion": "do Y",
+        }])
+
+    def test_no_spawn_on_failed_or_empty_turns(self):
+        for outcome in (
+            None,
+            {"subtype": "error", "response_text": "x"},
+            {"subtype": "cancelled", "response_text": ""},
+            {"subtype": "success", "response_text": "  "},
+        ):
+            sess = _session()
+            with patch("src.settings.settings.get_settings",
+                       return_value=_SETTINGS_ON):
+                sess._maybe_spawn_recap(outcome)
+            self.assertIsNone(sess._recap_thread, outcome)
+
+    def test_no_spawn_when_disabled(self):
+        sess = _session()
+        with patch("src.settings.settings.get_settings",
+                   return_value=_SETTINGS_OFF):
+            sess._maybe_spawn_recap(_OUTCOME)
+        self.assertIsNone(sess._recap_thread)
+
+    def test_no_spawn_while_goal_loop_is_active(self):
+        sess = _session(_goal_mgr=SimpleNamespace(is_active=lambda: True))
+        with patch("src.settings.settings.get_settings",
+                   return_value=_SETTINGS_ON):
+            sess._maybe_spawn_recap(_OUTCOME)
+        self.assertIsNone(sess._recap_thread)
+
+    def test_no_spawn_with_a_queued_prompt(self):
+        sess = _session()
+        sess._inbox.put("next prompt")
+        with patch("src.settings.settings.get_settings",
+                   return_value=_SETTINGS_ON):
+            sess._maybe_spawn_recap(_OUTCOME)
+        self.assertIsNone(sess._recap_thread)
+
+    def test_no_second_fork_while_one_runs(self):
+        sess = _session()
+        gate = threading.Event()
+        holder = threading.Thread(target=gate.wait, daemon=True)
+        holder.start()
+        sess._recap_thread = holder
+        try:
+            with patch("src.settings.settings.get_settings",
+                       return_value=_SETTINGS_ON):
+                sess._maybe_spawn_recap(_OUTCOME)
+            self.assertIs(sess._recap_thread, holder)
+        finally:
+            gate.set()
+
+    def test_stale_serial_drops_the_emit(self):
+        sess = _session()
+        emitted: list[dict] = []
+        sess._emit = emitted.append
+
+        async def _fake_generate(messages, provider):
+            sess._stats_turns += 1  # a new turn completed while we generated
+            return {"recap": "stale", "suggestion": "stale"}
+
+        fake_cls = MagicMock(return_value=SimpleNamespace(model="m1"))
+        with patch("src.settings.settings.get_settings", return_value=_SETTINGS_ON), \
+             patch("src.config.get_provider_config", return_value={}), \
+             patch("src.providers.get_provider_class", return_value=fake_cls), \
+             patch("src.providers.resolve_api_key", return_value="k"), \
+             patch("src.services.turn_recap.generate_turn_recap", _fake_generate):
+            self._spawn_and_join(sess)
+        self.assertEqual(emitted, [])
+
+    def test_in_flight_turn_drops_the_emit(self):
+        sess = _session()
+        sess._current_abort = object()  # a turn is running at emit time
+        emitted = self._run(sess, gen_result={"recap": "r", "suggestion": "s"})
+        self.assertEqual(emitted, [])
+
+    def test_generator_none_emits_nothing(self):
+        sess = _session()
+        emitted = self._run(sess, gen_result=None)
+        self.assertEqual(emitted, [])
+
+    def test_recap_hook_wired_exactly_once_in_the_real_prompt_branch(self):
+        """The "real user turns only" invariant, pinned structurally: the
+        module contains exactly ONE ``_maybe_spawn_recap(`` call (so it
+        cannot ALSO be wired into the btw/internal/goal/notification
+        paths), that call lives in ``_run_worker``, and it sits after the
+        memory-review hook in the real-prompt branch."""
+        import inspect
+
+        from src.server import agent_server
+        from src.server.agent_server import _AgentSession
+
+        module_src = inspect.getsource(agent_server)
+        self.assertEqual(module_src.count("self._maybe_spawn_recap("), 1)
+
+        worker_src = inspect.getsource(_AgentSession._run_worker)
+        self.assertEqual(worker_src.count("self._maybe_spawn_recap("), 1)
+        review = worker_src.index("self._maybe_spawn_memory_review(")
+        recap = worker_src.index("self._maybe_spawn_recap(")
+        self.assertGreater(recap, review)
+
+    def test_aba_odometer_move_drops_the_emit(self):
+        """The critic-proven ABA case: /clear (or /rewind) moves the
+        odometer away and a follow-up turn moves it BACK to the captured
+        value while the fork is still generating. The monotonic
+        ``_recap_serial`` (bumped by every completed turn and every
+        conversation-identity change) must drop the emit even though
+        ``_stats_turns`` matches again."""
+        sess = _session()
+        emitted: list[dict] = []
+        sess._emit = emitted.append
+
+        async def _fake_generate(messages, provider):
+            # /clear wipes (odometer 3 → 0, serial bump), then a new turn
+            # completes (odometer back to 3, serial bump again).
+            sess._recap_serial += 2
+            return {"recap": "describes the WIPED conversation",
+                    "suggestion": "continue the deleted work"}
+
+        fake_cls = MagicMock(return_value=SimpleNamespace(model="m1"))
+        with patch("src.settings.settings.get_settings", return_value=_SETTINGS_ON), \
+             patch("src.config.get_provider_config", return_value={}), \
+             patch("src.providers.get_provider_class", return_value=fake_cls), \
+             patch("src.providers.resolve_api_key", return_value="k"), \
+             patch("src.services.turn_recap.generate_turn_recap", _fake_generate):
+            self._spawn_and_join(sess)
+        self.assertEqual(emitted, [])
+
+    def test_every_identity_change_site_bumps_the_recap_serial(self):
+        """/clear, /rewind, and /resume each bump ``_recap_serial`` (the
+        odometer they also touch is non-monotonic, which is the whole ABA
+        hole), and the turn-completion path bumps it for EVERY turn —
+        btw/internal included — so any completed turn invalidates an
+        in-flight fork. Pinned per-FUNCTION (not a module-wide count), so a
+        bump relocated to an unrelated method fails the site that lost it,
+        and a legitimate future fifth site doesn't break this test."""
+        import inspect
+
+        from src.server.agent_server import _AgentSession
+
+        for fn in (
+            _AgentSession._handle_control_request,  # session.clear
+            _AgentSession._do_resume,
+            _AgentSession._do_rewind,
+            _AgentSession._run_turn,
+        ):
+            self.assertIn(
+                "self._recap_serial += 1",
+                inspect.getsource(fn),
+                f"missing recap-serial bump in {fn.__name__}",
+            )
+
+
+class TestSetRecapControl(unittest.TestCase):
+    def test_persists_and_invalidates(self):
+        sess = _session()
+        replies: list[tuple] = []
+        sess._reply = lambda rid, payload: replies.append((rid, payload))
+
+        mgr = MagicMock()
+        mgr.load_global.return_value = {"settings": {"theme": "dark"}}
+        with patch("src.config._get_default_manager", return_value=mgr), \
+             patch("src.settings.settings.invalidate_settings_cache") as inv, \
+             patch("src.server.agent_server._recap_setting_enabled",
+                   return_value=False):
+            sess._do_set_recap("r1", "off")
+
+        saved = mgr.save_global.call_args[0][0]
+        self.assertEqual(saved["settings"]["recap_enabled"], False)
+        self.assertEqual(saved["settings"]["theme"], "dark")
+        inv.assert_called_once()
+        self.assertEqual(replies, [("r1", {"ok": True, "value": "off"})])
+
+    def test_reply_reports_effective_state_when_an_override_wins(self):
+        """The write is global; a project/local override wins at merge.
+        "/recap off" must reply with the EFFECTIVE state (on) plus a note —
+        not confidently echo the request."""
+        sess = _session()
+        replies: list[tuple] = []
+        sess._reply = lambda rid, payload: replies.append((rid, payload))
+
+        mgr = MagicMock()
+        mgr.load_global.return_value = {}
+        with patch("src.config._get_default_manager", return_value=mgr), \
+             patch("src.settings.settings.invalidate_settings_cache"), \
+             patch("src.server.agent_server._recap_setting_enabled",
+                   return_value=True):
+            sess._do_set_recap("r1", "off")
+
+        self.assertEqual(len(replies), 1)
+        payload = replies[0][1]
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["value"], "on")
+        self.assertIn("override", payload["note"])
+
+    def test_rejects_bad_values(self):
+        sess = _session()
+        replies: list[tuple] = []
+        sess._reply = lambda rid, payload: replies.append((rid, payload))
+        sess._do_set_recap("r1", "sideways")
+        self.assertEqual(len(replies), 1)
+        self.assertFalse(replies[0][1]["ok"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ui-tui/src/__tests__/turnRecap.test.ts
+++ b/ui-tui/src/__tests__/turnRecap.test.ts
@@ -1,0 +1,255 @@
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
+import { resetOverlayState } from '../app/overlayStore.js'
+import { turnController } from '../app/turnController.js'
+import { resetTurnState } from '../app/turnStore.js'
+import { getUiState, patchUiState, resetUiState } from '../app/uiStore.js'
+import { shouldAcceptPendingSuggestion } from '../app/useInputHandlers.js'
+import type { Msg } from '../types.js'
+
+// Fake child process for the GatewayClient NDJSON translation test — same
+// harness as gatewayClient.test.ts (feed protocol lines, observe events).
+const harness = vi.hoisted(() => ({ proc: null as null | EventEmitter }))
+
+vi.mock('node:child_process', () => ({
+  spawn: () => harness.proc
+}))
+
+import { GatewayClient } from '../gatewayClient.js'
+
+class FakeProc extends EventEmitter {
+  kill = vi.fn()
+  stderr = new PassThrough()
+  stdin = new PassThrough()
+  stdout = new PassThrough()
+
+  line(obj: unknown): void {
+    this.stdout.write(JSON.stringify(obj) + '\n')
+  }
+}
+
+const ref = <T>(current: T) => ({ current })
+
+const buildCtx = (appended: Msg[]) =>
+  ({
+    composer: {
+      dequeue: () => undefined,
+      queueEditRef: ref<null | number>(null),
+      sendQueued: vi.fn(),
+      setInput: vi.fn()
+    },
+    gateway: {
+      gw: { request: vi.fn() },
+      rpc: vi.fn(async () => null)
+    },
+    session: {
+      STARTUP_RESUME_ID: '',
+      colsRef: ref(80),
+      newSession: vi.fn(),
+      resetSession: vi.fn(),
+      resumeById: vi.fn(),
+      setCatalog: vi.fn()
+    },
+    submission: {
+      submitRef: { current: vi.fn() }
+    },
+    system: {
+      bellOnComplete: false,
+      sys: vi.fn()
+    },
+    transcript: {
+      appendMessage: (msg: Msg) => appended.push(msg),
+      panel: vi.fn(),
+      setHistoryItems: vi.fn()
+    },
+    voice: {
+      setProcessing: vi.fn(),
+      setRecording: vi.fn(),
+      setVoiceEnabled: vi.fn()
+    }
+  }) as any
+
+describe('turn.recap event handling', () => {
+  beforeEach(() => {
+    resetOverlayState()
+    resetUiState()
+    resetTurnState()
+    turnController.fullReset()
+  })
+
+  it('appends the recap transcript line and arms the composer suggestion when idle', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({
+      payload: { recap: 'Goal was X. Done. Next: re-run.', suggestion: 'fix all four issues and re-run' },
+      type: 'turn.recap'
+    } as any)
+
+    expect(appended).toEqual([
+      { kind: 'recap', role: 'system', text: 'Goal was X. Done. Next: re-run.' }
+    ])
+    expect(getUiState().pendingSuggestion).toBe('fix all four issues and re-run')
+  })
+
+  it('drops the whole event when a new turn is already running (stale recap)', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    patchUiState({ busy: true })
+    onEvent({
+      payload: { recap: 'Goal was X. Next: Y.', suggestion: 'do Y' },
+      type: 'turn.recap'
+    } as any)
+
+    expect(appended).toEqual([])
+    expect(getUiState().pendingSuggestion).toBeNull()
+  })
+
+  it('renders a recap without a suggestion (and vice versa) independently', () => {
+    const appended: Msg[] = []
+    const onEvent = createGatewayEventHandler(buildCtx(appended))
+
+    onEvent({ payload: { recap: 'Only a recap.', suggestion: '' }, type: 'turn.recap' } as any)
+    expect(appended).toHaveLength(1)
+    expect(getUiState().pendingSuggestion).toBeNull()
+
+    onEvent({ payload: { recap: '', suggestion: 'continue the port' }, type: 'turn.recap' } as any)
+    expect(appended).toHaveLength(1) // no second transcript line
+    expect(getUiState().pendingSuggestion).toBe('continue the port')
+  })
+
+  it('startMessage expires the pending suggestion at the next turn start', () => {
+    patchUiState({ pendingSuggestion: 'fix all four issues and re-run' })
+    turnController.startMessage()
+    expect(getUiState().pendingSuggestion).toBeNull()
+    expect(getUiState().busy).toBe(true)
+  })
+})
+
+describe('shouldAcceptPendingSuggestion — Tab accepts only what is visibly suggested', () => {
+  const visible = { busy: false, completionsLen: 0, input: '', suggestion: 'fix the tests' }
+
+  it('accepts plain Tab while the ghost suggestion is showing (mid-conversation)', () => {
+    expect(shouldAcceptPendingSuggestion({ shift: false, tab: true }, visible)).toBe(true)
+  })
+
+  it('never fires for Shift+Tab — that cycles the permission mode', () => {
+    expect(shouldAcceptPendingSuggestion({ shift: true, tab: true }, visible)).toBe(false)
+  })
+
+  it('never fires for non-Tab keys', () => {
+    expect(shouldAcceptPendingSuggestion({ shift: false, tab: false }, visible)).toBe(false)
+  })
+
+  it('defers to an open completion menu', () => {
+    expect(
+      shouldAcceptPendingSuggestion({ shift: false, tab: true }, { ...visible, completionsLen: 2 })
+    ).toBe(false)
+  })
+
+  it('stays inert once the user typed something (ghost is hidden)', () => {
+    expect(shouldAcceptPendingSuggestion({ shift: false, tab: true }, { ...visible, input: 'h' })).toBe(false)
+  })
+
+  it('stays inert while a turn is running', () => {
+    expect(shouldAcceptPendingSuggestion({ shift: false, tab: true }, { ...visible, busy: true })).toBe(false)
+  })
+
+  it('stays inert with no suggestion armed', () => {
+    expect(
+      shouldAcceptPendingSuggestion({ shift: false, tab: true }, { ...visible, suggestion: null })
+    ).toBe(false)
+  })
+})
+
+describe('GatewayClient system/recap translation', () => {
+  const prevWs = process.env.CLAWCODEX_WORKSPACE
+  let events: any[]
+  let gw: GatewayClient
+  let proc: FakeProc
+
+  beforeEach(() => {
+    process.env.CLAWCODEX_WORKSPACE = '/ws'
+    proc = new FakeProc()
+    harness.proc = proc
+    events = []
+    gw = new GatewayClient()
+    gw.on('event', (e: any) => events.push(e))
+    gw.start()
+    gw.drain()
+  })
+
+  afterEach(() => {
+    gw.kill()
+
+    if (prevWs === undefined) {delete process.env.CLAWCODEX_WORKSPACE}
+    else {process.env.CLAWCODEX_WORKSPACE = prevWs}
+  })
+
+  it('maps the NDJSON system/recap frame to a turn.recap event', async () => {
+    proc.line({
+      recap: 'Goal was porting the recap feature. Next: run the tests.',
+      session_id: 's1',
+      subtype: 'recap',
+      suggestion: 'run the tests',
+      type: 'system'
+    })
+
+    await vi.waitFor(() => expect(events.find(e => e.type === 'turn.recap')).toBeTruthy())
+    expect(events.find(e => e.type === 'turn.recap').payload).toEqual({
+      recap: 'Goal was porting the recap feature. Next: run the tests.',
+      suggestion: 'run the tests'
+    })
+  })
+
+  it('coerces missing fields to empty strings', async () => {
+    proc.line({ session_id: 's1', subtype: 'recap', type: 'system' })
+
+    await vi.waitFor(() => expect(events.find(e => e.type === 'turn.recap')).toBeTruthy())
+    expect(events.find(e => e.type === 'turn.recap').payload).toEqual({ recap: '', suggestion: '' })
+  })
+
+  it('lists /recap in the commands catalog with no hint (local argumentHint is authoritative)', async () => {
+    // The completion menu is built from the gateway catalog, NOT the local
+    // slash registry — a runnable-but-undiscoverable /recap already
+    // regressed once this cycle, so pin the catalog entry itself.
+    proc.line({ cwd: '/ws', session_id: 's1', subtype: 'init', type: 'system' })
+    const p = gw.request<{ hints: Record<string, string>; pairs: [string, string][] }>('commands.catalog', {})
+
+    // The catalog awaits the backend's workflow-command list; feed the
+    // control reply like gatewayClient.test.ts's replyToControl does.
+    let req: any
+    await vi.waitFor(() => {
+      const raw = (proc.stdin as any).read()?.toString() ?? ''
+      const frames = raw.split('\n').filter(Boolean).map((l: string) => JSON.parse(l))
+
+      req = req ?? frames.find((f: any) => f.type === 'control_request' && f.request?.subtype === 'list_workflow_commands')
+      expect(req).toBeTruthy()
+    })
+    proc.line({ response: { request_id: req.request_id, response: { commands: [] } }, type: 'control_response' })
+
+    const catalog = await p
+
+    expect(catalog.pairs.some(([name]) => name === '/recap')).toBe(true)
+    expect(catalog.hints['/recap']).toBeUndefined()
+  })
+})
+
+describe('suggestion expiry wiring (source pin)', () => {
+  // resetSession/resetVisibleHistory are closures inside useSessionLifecycle
+  // — no hook harness exists in this suite, so pin the wiring at source
+  // level: both reset paths must null pendingSuggestion (the /clear, /new,
+  // /resume, and history-reset routes). The behavioral halves are covered
+  // by the startMessage test above and the uiStore default.
+  it('both session-reset paths expire pendingSuggestion', async () => {
+    const fs = await import('node:fs')
+    const src = fs.readFileSync(new URL('../app/useSessionLifecycle.ts', import.meta.url), 'utf8')
+
+    expect(src.split('pendingSuggestion: null').length - 1).toBe(2)
+  })
+})

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -912,6 +912,30 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         return
       }
 
+      case 'turn.recap': {
+        // End-of-turn recap: a persistent "✻ recap: …" transcript line plus
+        // the tab-acceptable composer ghost text. The recap describes the
+        // turn that JUST ended — if the user already launched another turn
+        // while it generated, it captions the wrong moment, so drop it
+        // whole (the server gates on its side too; this covers the race).
+        if (getUiState().busy) {
+          return
+        }
+
+        const recap = String(ev.payload?.recap ?? '').trim()
+        const suggestion = String(ev.payload?.suggestion ?? '').trim()
+
+        if (recap) {
+          appendMessage({ kind: 'recap', role: 'system', text: recap })
+        }
+
+        if (suggestion) {
+          patchUiState({ pendingSuggestion: suggestion })
+        }
+
+        return
+      }
+
       case 'subagent.spawn_requested':
         // Child built but not yet running (waiting on ThreadPoolExecutor slot).
         // Preserve completed state if a later event races in before this one.

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -190,6 +190,12 @@ export interface UiState {
   notice: Notice | null
   pasteCollapseLines: number
   pasteCollapseChars: number
+  /**
+   * Server-suggested next prompt from the end-of-turn recap. Rendered as the
+   * composer's ghost text while the input is empty and idle; plain Tab
+   * accepts it into the input. Cleared on accept and at every turn start.
+   */
+  pendingSuggestion: null | string
 
   sections: SectionVisibility
   sessionTitle: string

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -633,6 +633,48 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
+    argumentHint: '[on|off|status]',
+    help: 'end-of-turn recap + tab-acceptable suggestion [on|off|status]',
+    name: 'recap',
+    run: (arg, ctx) => {
+      const mode = arg.trim().toLowerCase()
+      const valid = new Set(['', 'status', 'on', 'off'])
+
+      if (!valid.has(mode)) {
+        return ctx.transcript.sys('usage: /recap [on|off|status]')
+      }
+
+      if (!mode || mode === 'status') {
+        return ctx.gateway
+          .rpc<ConfigGetValueResponse>('config.get', { key: 'recap' })
+          .then(
+            ctx.guarded<ConfigGetValueResponse>(r => {
+              ctx.transcript.sys(`recap: ${r.value || 'on'}`)
+            })
+          )
+          .catch(ctx.guardedErr)
+      }
+
+      ctx.gateway
+        .rpc<ConfigSetResponse & { note?: string }>('config.set', { key: 'recap', value: mode })
+        .then(
+          ctx.guarded<ConfigSetResponse & { note?: string }>(r => {
+            if (r.error) {
+              ctx.transcript.sys(`recap: ${r.error}`)
+
+              return
+            }
+
+            // `value` is the EFFECTIVE state (a project/local settings
+            // override can beat the global write); `note` says so.
+            ctx.transcript.sys(`recap: ${r.value || mode}${r.note ? ` (${r.note})` : ''}`)
+          })
+        )
+        .catch(ctx.guardedErr)
+    }
+  },
+
+  {
     argumentHint: '[queue|steer|interrupt|status]',
     help: 'control busy enter mode [queue|steer|interrupt|status]',
     name: 'busy',

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -1156,7 +1156,9 @@ class TurnController {
       this.clearNotice(yieldingNoticeKey)
     }
 
-    patchUiState({ busy: true })
+    // pendingSuggestion: a recap suggestion belongs to the moment between
+    // turns — starting any turn (accepted, edited, or unrelated) expires it.
+    patchUiState({ busy: true, pendingSuggestion: null })
     patchTurnState({
       activity: [],
       lastDeltaAt: Date.now(),

--- a/ui-tui/src/app/uiStore.ts
+++ b/ui-tui/src/app/uiStore.ts
@@ -27,6 +27,7 @@ const buildUiState = (): UiState => ({
   notice: null,
   pasteCollapseLines: 5,
   pasteCollapseChars: 2000,
+  pendingSuggestion: null,
   sections: {},
   sessionTitle: '',
   sessionStats: ZERO_SESSION_STATS,

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -97,6 +97,20 @@ export const shouldAcceptPlaceholderSuggestion = (
 ): boolean =>
   key.tab && !key.shift && !state.completionsLen && !state.input && state.conversationEmpty && !state.busy
 
+/**
+ * Plain Tab accepts the end-of-turn recap suggestion showing as the
+ * composer's ghost text. Unlike the placeholder accept above this fires
+ * MID-conversation — that is the feature: the turn just ended and the server
+ * suggested the next prompt — but under the same visibility gates (idle,
+ * empty input, no completion menu open, unmodified Tab), so it can never
+ * shadow completion-accept or the Shift+Tab permission-mode cycle.
+ */
+export const shouldAcceptPendingSuggestion = (
+  key: { shift: boolean; tab: boolean },
+  state: { busy: boolean; completionsLen: number; input: string; suggestion: null | string }
+): boolean =>
+  key.tab && !key.shift && !state.completionsLen && !state.input && !state.busy && Boolean(state.suggestion)
+
 export function applyVoiceRecordResponse(
   response: null | VoiceRecordResponse,
   starting: boolean,
@@ -694,6 +708,23 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
         cActions.setInput(cState.input.slice(0, cState.compReplace) + text)
       }
+
+      return
+    }
+
+    if (
+      shouldAcceptPendingSuggestion(key, {
+        busy: live.busy,
+        completionsLen: cState.completions.length,
+        input: cState.input,
+        suggestion: live.pendingSuggestion
+      })
+    ) {
+      // Recap ghost accept: the suggestion becomes real editable input (the
+      // external value change snaps TextInput's cursor to the end) and stops
+      // being a ghost — Enter from here submits it like any typed prompt.
+      cActions.setInput(live.pendingSuggestion ?? '')
+      patchUiState({ pendingSuggestion: null })
 
       return
     }

--- a/ui-tui/src/app/useSessionLifecycle.ts
+++ b/ui-tui/src/app/useSessionLifecycle.ts
@@ -159,8 +159,17 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
     setVoiceProcessing(false)
     // sessionStats: zeros beat another session's numbers; the server
     // re-stamps truth on the clear/resume reply (session.stats event) or at
-    // the latest on the next end-of-turn result.
-    patchUiState({ bgTasks: new Set(), info: null, sessionStats: ZERO_SESSION_STATS, sid: null, usage: ZERO })
+    // the latest on the next end-of-turn result. pendingSuggestion: a recap
+    // ghost suggests the NEXT step of the conversation it came from — it
+    // never survives into a different session.
+    patchUiState({
+      bgTasks: new Set(),
+      info: null,
+      pendingSuggestion: null,
+      sessionStats: ZERO_SESSION_STATS,
+      sid: null,
+      usage: ZERO
+    })
     setHistoryItems([])
     setLastUserMsg('')
     setStickyPrompt('')
@@ -190,7 +199,9 @@ export function useSessionLifecycle(opts: UseSessionLifecycleOptions) {
       setLastUserMsg('')
       composerActions.setPasteSnips([])
       patchTurnState({ activity: [] })
-      patchUiState({ info, usage: usageFrom(info) })
+      // /clear and resume are local slashes (no turn start), so the recap
+      // ghost must expire here — it described the wiped conversation.
+      patchUiState({ info, pendingSuggestion: null, usage: usageFrom(info) })
     },
     [composerActions, setHistoryItems, setLastUserMsg, setStickyPrompt]
   )

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -348,7 +348,7 @@ const ComposerPane = memo(function ComposerPane({
                   onChange={composer.updateInput}
                   onPaste={composer.handleTextPaste}
                   onSubmit={composer.submit}
-                  placeholder={composer.empty && !ui.busy ? PLACEHOLDER : ''}
+                  placeholder={composer.empty && !ui.busy ? (ui.pendingSuggestion ?? PLACEHOLDER) : ''}
                   value={composer.input}
                   voiceRecordKey={composer.voiceRecordKey}
                 />

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -102,6 +102,28 @@ export const MessageLine = memo(function MessageLine({
     return null
   }
 
+  // End-of-turn recap (turn.recap event): "✻ recap: <summary> (disable
+  // recaps in /recap)". The body is the model's goal→status→"Next: …" line;
+  // the composer ghost suggestion rides the same event but renders in the
+  // input, not here.
+  if (msg.kind === 'recap') {
+    return (
+      <Box marginTop={leadGap ? 1 : 0}>
+        <Text wrap="wrap">
+          <Text color={t.color.accent}>✻ </Text>
+          <Text bold>recap: </Text>
+          <Text color={t.color.muted} italic>
+            {msg.text}
+          </Text>
+          <Text color={t.color.muted} dimColor>
+            {' '}
+            (disable recaps in /recap)
+          </Text>
+        </Text>
+      </Box>
+    )
+  }
+
   if (msg.role === 'tool') {
     const maxChars = Math.max(24, cols - 14)
     const stripped = hasAnsi(msg.text) ? stripAnsi(msg.text) : msg.text

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -782,6 +782,10 @@ const SLASHES: ReadonlyArray<{ desc: string; hint?: string; name: string }> = [
   { desc: 'Show context-window usage', name: '/context' },
   { desc: 'Show the total cost and duration of the current session', name: '/cost' },
   { desc: 'Toggle Bash-output token compression (RTK-style)', hint: '[on|off|status]', name: '/eco' },
+  // Local-registry command (slash/commands/session.ts) — listed here so it
+  // reaches the completion menu; per the shadowing note above it carries no
+  // hint (the local argumentHint is authoritative).
+  { desc: 'Toggle the end-of-turn recap + suggested next prompt', name: '/recap' },
   { desc: 'Undo recent turns', hint: '[<turns>]', name: '/rewind' },
   { desc: 'Toggle extended thinking', hint: '[on|off|toggle]', name: '/thinking' },
   {
@@ -1061,6 +1065,15 @@ export class GatewayClient extends EventEmitter {
           return this.controlQuery('get_settings', {}).then(s => (s ?? {}) as T)
         }
 
+        if (String(p.key ?? '') === 'recap') {
+          // /recap status — served off the get_settings rider.
+          return this.controlQuery('get_settings', {}).then(s => {
+            const enabled = (s as { recap?: boolean } | null)?.recap !== false
+
+            return { value: enabled ? 'on' : 'off' } as T
+          })
+        }
+
         return Promise.resolve({} as T)
       }
 
@@ -1096,6 +1109,16 @@ export class GatewayClient extends EventEmitter {
             const ok = (r as any)?.ok === true
 
             return (ok ? { ok: true, value: String(value ?? '') } : { ok: false }) as T
+          })
+        }
+
+        if (key === 'recap') {
+          // Round-trip so /recap reports the EFFECTIVE post-write state (a
+          // project/local settings override can beat the global write).
+          return this.controlQuery('set_recap', { value }).then(r => {
+            const res = (r ?? {}) as { error?: string; note?: string; ok?: boolean; value?: string }
+
+            return { error: res.error, note: res.note, ok: res.ok !== false, value: res.value } as T
           })
         }
 
@@ -2363,6 +2386,15 @@ export class GatewayClient extends EventEmitter {
             payload: { text: String(msg.message ?? '') },
             session_id: this.sessionId,
             type: 'review.summary'
+          })
+        } else if (msg.subtype === 'recap') {
+          // Post-turn recap: the "✻ recap: …" transcript line plus the
+          // tab-acceptable composer suggestion (ghost text). The handler
+          // drops it when a new turn is already running.
+          this.publish({
+            payload: { recap: String(msg.recap ?? ''), suggestion: String(msg.suggestion ?? '') },
+            session_id: this.sessionId,
+            type: 'turn.recap'
           })
         } else if (msg.subtype === 'cron_status') {
           // Scheduled-task transitions (/loop wakeup fired, cron job fired,

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -864,6 +864,7 @@ export type GatewayEvent =
   | { payload: { mode: string }; session_id?: string; type: 'permission.mode' }
   | { payload: { task_id: string; text: string }; session_id?: string; type: 'background.complete' }
   | { payload?: { text?: string }; session_id?: string; type: 'review.summary' }
+  | { payload: { recap: string; suggestion: string }; session_id?: string; type: 'turn.recap' }
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.spawn_requested' }
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.start' }
   | { payload: SubagentEventPayload; session_id?: string; type: 'subagent.thinking' }

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -172,7 +172,7 @@ export interface Msg {
   // (legacy backends) fall back to the markdown ```diff path.
   diffData?: MsgDiffData
   info?: SessionInfo
-  kind?: 'diff' | 'intro' | 'panel' | 'slash' | 'trail'
+  kind?: 'diff' | 'intro' | 'panel' | 'recap' | 'slash' | 'trail'
   panelData?: PanelData
   role: Role
   text: string


### PR DESCRIPTION
## What

Claude Code parity: when a turn finishes, the agent now produces an **end-of-turn recap + suggested next prompt**. The TUI shows a dim `✻ recap: …` transcript line (goal → where things stand → `Next: …`) and pre-fills the composer with the suggestion as **ghost text that plain Tab accepts** (same visual as the fresh-session placeholder: inverted first char + dim rest, cursor at position 0; accepted text becomes normal editable input with the cursor at the end).

The vendored `typescript/` snapshot predates this CC feature (nearest relative: `services/awaySummary.ts` — same small-fast-model side query over a recent-message window), so the port is from observed CC behavior, following that module's conventions.

## How

**Backend**
- `src/services/turn_recap.py` (new): serializes the last 30 conversation messages (assistant/user text verbatim; `tool_use` → `[tool: Name]`, `tool_result` → `[tool result]`, thinking never leaks), asks for a two-tagged-line reply (`RECAP:` / `SUGGESTION:`, `NONE` → no suggestion), parses leniently (fences, case, multi-line spill), never raises. `max_tokens=1200` — reasoning-default models (deepseek-v4) starve visible output at small caps; verified live (300 → the reply was literally `"RECAP:"`).
- `agent_server.py`: `_maybe_spawn_recap` runs after **real user turns only** (never btw/internal/goal continuations), gated on: `success` subtype + non-empty response, `settings.recap_enabled` (default **on**, matching CC), no active /goal loop, empty inbox, one fork at a time. The daemon fork builds its own provider instance (same reasoning as the memory-review fork) and **staleness-gates the emit on two keys**: the user-turn odometer AND a monotonic `_recap_serial` bumped by every completed turn (btw/internal included) and every conversation-identity change (`/clear`, `/rewind`, `/resume`) — the odometer alone has an ABA hole (`/clear` zeroes it, `/rewind` recounts it down, so a slow fork can watch the count leave and come back over a replaced conversation; proven by a critic probe, closed by the second key). Also dropped if a turn is in flight or a prompt is queued. Emits `{"type":"system","subtype":"recap",recap,suggestion}` after the `result` frame.
- Control plane: `set_recap` control persists `settings.recap_enabled` to global config + invalidates the settings cache; `get_settings` reply gains a `recap` bool.

**TUI**
- `gatewayClient` maps `system/recap` → `turn.recap`; the handler drops the whole event if a new turn is already running, else appends a `kind:'recap'` transcript Msg and arms `uiState.pendingSuggestion`.
- The composer's existing placeholder channel renders the ghost (`pendingSuggestion ?? PLACEHOLDER`); `shouldAcceptPendingSuggestion` (Tab, no Shift, no completions menu, empty input, idle) inserts it — checked before the fresh-session placeholder accept, and it can never shadow completion-accept or the Shift+Tab mode cycle.
- The suggestion expires at every turn start (`startMessage`), on `/clear`/new-session (`resetSession`), and on history resets (`resetVisibleHistory`); typing hides it (placeholder semantics) and deleting back to empty restores it.
- `messageLine` renders `✻ recap: <italic muted> (disable recaps in /recap)`; new `/recap [on|off|status]` slash (clawcodex has no `/config` panel, so the hint names the real switch).

## Review

Two adversarial critic passes (opus). Round 1 surfaced: list-shaped `ChatResponse.content` handling, the `/recap` completion-catalog entry (menu ≠ local registry), stale ghost across `/clear`/resume, `set_effort`-shaped config helper reuse, and the reasoning-model cost of the side query — all addressed. Round 2 proved the odometer ABA hole by execution, and re-verified the `_recap_serial` fix drops all five stale scenarios while the quiet path still emits. Final verdict: APPROVE.

**Deliberate cost call** (recorded at the setting): off-Anthropic the query runs on the session model (the cross-provider small-model pairing remains deferred, as in the memdir selector), bounded by the 8K-char transcript budget, the 1200-token cap, and a `reasoning_effort=low` pin where the provider declares "low". Kept default-on anyway — unlike the silently-hidden memdir prefetch (defaulted off for exactly this cost concern), every recap line renders "(disable recaps in /recap)", so the feature advertises its own off-switch each time it costs anything. Side-query spend is not attributed to `/cost` — same pre-existing limitation as the memdir selector and tool-use summary (only the main query loop calls `record_api_usage`); a shared fix belongs in its own PR.

## Verification

- 32 new pytest (serializer, parser, generator contract, every spawn guard, the ABA-drop scenario, per-function serial-bump pins, `set_recap` effective-state replies) + 15 new vitest (event handling incl. busy-drop, predicate gates, expiry, NDJSON translation, the `/recap` catalog entry) — all green.
- Full pytest: 9997 passed; 1 pre-existing flake (`test_sigint_during_prefetch`, fails on pristine main too). Full vitest: 8 pre-existing failures, identical on pristine main. `tsc --noEmit` clean; eslint shows **zero new findings** vs pristine.
- **Live end-to-end** over stdio NDJSON against real DeepSeek: `init → prompt → result:success → system/recap`, correct ordering; a trivial task correctly yielded an empty suggestion (`NONE` path), a real coding transcript yielded a sensible recap + imperative suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
