### PR TITLE
feat(eval): harbor adapter for pi, the harness DeepSeek documents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,7 @@ jobs:
               tests/test_harbor_adapter_fusion.py \
               tests/test_harbor_adapter_advisor.py \
               tests/test_harbor_adapter_vision.py \
+              tests/test_harbor_adapter_pi.py \
               -v
 
   event_file:

--- a/eval/harbor/README.md
+++ b/eval/harbor/README.md
@@ -192,6 +192,35 @@ Notes:
   snapshot carrying opus-5.
 - Its effort ladder is low|medium|high|xhigh|max as of 0.24.0.
 
+## Compare against pi (the harness DeepSeek documents)
+
+`pi_agent.py` runs [pi](https://pi.dev) — the harness DeepSeek points at for
+its V4 models — through this same harness. pi is installed from npm inside
+each container; the adapter also uploads `pi_assets/tb-tools.ts`, which adds
+`vision_analyze` and `websearch` to pi's four built-in tools (read, bash,
+edit, write). That closes the two capability gaps that would otherwise make
+some tasks impossible — it does **not** equalise the surfaces, since pi runs
+6 tools against clawcodex's much larger registry.
+
+```bash
+PYTHONPATH=$PWD/eval/harbor harbor run \
+  --dataset terminal-bench/terminal-bench-2-1 \
+  --agent pi_agent:Pi \
+  --model deepseek/deepseek-v4-flash \
+  --jobs-dir eval/harbor/jobs \
+  --job-name pi-tb21-full \
+  --ak thinking=max \
+  -n 4
+```
+
+`--ak thinking=max` lines pi up with a clawcodex run at `--ak effort=max`:
+both land on DeepSeek `reasoning_effort: "max"`. Needs `DEEPSEEK_API_KEY`
+plus `OPENAI_API_KEY` (vision) and `TAVILY_API_KEY` (search).
+
+See `RUN_PI_TB21.md` for the probed wire facts — in particular that published
+pi 0.84.1 sends `max_completion_tokens`, which DeepSeek silently ignores, so
+stock pi runs with no output cap.
+
 ## Evaluate ALL terminal-bench 2.0 tasks
 
 ```bash

--- a/eval/harbor/RUN_PI_TB21.md
+++ b/eval/harbor/RUN_PI_TB21.md
@@ -42,9 +42,8 @@ pi runs 6 tools against clawcodex's much larger registry, and that difference
 is part of what the benchmark measures — don't describe the run as
 "same tools".
 
-`vision_analyze` has been exercised on the host but **not yet in a container**
-(the smoke tasks only reached `websearch`). Run one vision task before
-committing to a full sweep.
+Both tools have been exercised in a container: `websearch` on the first smoke
+run, `vision_analyze` on `code-from-image` (one call, task scored 1.0).
 
 ## Comparability caveats
 
@@ -156,6 +155,15 @@ thinking), **2/2 reward 1.0, 0 exceptions, 6m57s**:
 Tools exercised across the two trials: `bash` x14, `write` x3, `read` x1,
 `websearch` x1 — the extension loads and executes inside the container, not
 just on the host.
+
+A second run after the failure-detection changes (`set -eu`, `--no-approve`,
+post-run `stopReason` check) confirmed no regression and exercised the vision
+path — **2/2 reward 1.0, 0 exceptions, 4m48s**:
+
+| task | reward | input | cached | output | cost | tools |
+|---|---|---|---|---|---|---|
+| code-from-image | 1.0 | 12,164 | 11,648 (95.8%) | 785 | $0.00032 | `read`, **`vision_analyze`**, `bash`, `write` |
+| prove-plus-comm | 1.0 | 57,688 | 56,320 (97.6%) | 6,993 | $0.00231 | `read` x3, `bash` x5, `edit` x2 |
 
 ## Full run
 

--- a/eval/harbor/RUN_PI_TB21.md
+++ b/eval/harbor/RUN_PI_TB21.md
@@ -1,0 +1,211 @@
+# Running pi on terminal-bench 2.1 with DeepSeek
+
+[pi](https://pi.dev) (`@earendil-works/pi-coding-agent`) is the harness
+DeepSeek documents for its V4 models
+([api-docs.deepseek.com](https://api-docs.deepseek.com/quick_start/agent_integrations/pi_mono/)).
+`pi_agent.py` runs it through the same Harbor harness as `clawcodex_agent.py`
+and `openclaude_agent.py`, so all three are directly comparable.
+
+## One-time setup
+
+```bash
+uv tool install harbor            # host CLI, needs a running Docker daemon
+
+export DEEPSEEK_API_KEY=sk-...    # the model under test
+export OPENAI_API_KEY=sk-...      # vision_analyze (gpt-5.6-luna)
+export TAVILY_API_KEY=tvly-...    # websearch
+```
+
+If `docker pull` hangs, see the credential-helper note in `README.md`.
+
+Nothing needs to be installed for pi itself: the adapter bootstraps Node >= 22
+and `npm install -g @earendil-works/pi-coding-agent@0.84.1` inside each task
+container.
+
+## Tools
+
+pi ships **four** built-in tools: `read`, `bash`, `edit`, `write`. Terminal-bench
+2.1 has tasks that need to look at an image and tasks that need the live web,
+and DeepSeek V4 is text-only, so `pi_assets/tb-tools.ts` is uploaded and loaded
+with `-e`. It registers two more, with the same argument shapes as clawcodex's
+equivalents so trajectories stay comparable:
+
+| Tool | Arguments | Backend |
+|------|-----------|---------|
+| `vision_analyze` | `image_url` (local path), `question` | OpenAI chat/completions, `PI_VISION_MODEL` (default `gpt-5.6-luna`) |
+| `websearch` | `query`, `allowed_domains?`, `blocked_domains?` | Tavily `/search` |
+
+`--ak tools=off` runs stock pi with its four built-ins only.
+
+This closes the two capability gaps; it does **not** equalise the harnesses.
+pi runs 6 tools against clawcodex's much larger registry, and that difference
+is part of what the benchmark measures — don't describe the run as
+"same tools".
+
+`vision_analyze` has been exercised on the host but **not yet in a container**
+(the smoke tasks only reached `websearch`). Run one vision task before
+committing to a full sweep.
+
+## Comparability caveats
+
+* **Project trust is off by default** (`--no-approve`). AGENTS.md / CLAUDE.md
+  load either way; trust additionally enables `.pi/settings.json`,
+  `.pi/extensions`, `.pi/skills` and `.pi/SYSTEM.md`, which would let task
+  content replace the system prompt or run its own extension code and
+  silently change what is being measured. `--ak trust_project=true` opts in.
+* **`PI_OFFLINE=1` is set**, which also pins pi to the model catalogue bundled
+  with 0.84.1 (no catalogue refresh). That is deliberate: it keeps runs
+  reproducible and keeps the exact-model-id `modelOverrides` assumption valid.
+* **The npm pin is real**: the published package ships `npm-shrinkwrap.json`,
+  so `@0.84.1` pins the whole transitive tree. Node is only pinned on the
+  tarball fallback — images shipping their own Node >= 22 use theirs, so the
+  JS runtime is not identical across all 74 tasks (same caveat as
+  `openclaude_agent.py`).
+* **Credentials are readable by the agent.** pi's bash tool inherits the
+  process environment, and tool results are serialized into `pi.jsonl` and the
+  session JSONL under the host-synced trial directory. pi has no equivalent of
+  Claude Code's `CLAUDE_CODE_SUBPROCESS_ENV_SCRUB`, so use benchmark-scoped
+  keys.
+
+## Wire facts (probed against pi 0.84.1, 2026-08-11)
+
+Captured by pointing pi's `deepseek` provider at a local recording endpoint
+(`provider === "deepseek"` is enough to trigger pi's DeepSeek auto-detection,
+so the real code path runs even against localhost).
+
+**Thinking.** `--thinking` maps through pi's catalogue entry:
+
+| `--thinking` | wire |
+|---|---|
+| `off` | `thinking: {"type":"disabled"}`, no `reasoning_effort` |
+| `minimal` / `low` / `medium` / `high` | `thinking: {"type":"enabled"}` + `reasoning_effort: "high"` |
+| `xhigh` / `max` | `thinking: {"type":"enabled"}` + `reasoning_effort: "max"` |
+
+pi's default is `medium`, i.e. `reasoning_effort: "high"`. DeepSeek's `low`
+level is not reachable through pi.
+
+**Output cap — the important one.** Published pi 0.84.1 sends
+`max_completion_tokens`, not `max_tokens`, because `isDeepSeek` is missing from
+the `useMaxTokens` chain in that build (the git tree has since fixed it).
+Verified directly against the DeepSeek API:
+
+```
+max_tokens: 16            -> completion_tokens=16   finish_reason=length
+max_completion_tokens: 16 -> completion_tokens=456  finish_reason=stop
+```
+
+DeepSeek honours `max_tokens` and **silently ignores `max_completion_tokens`**.
+So stock pi runs with **no effective output cap** and inherits the server
+default (131,072). That is the reasoning-runaway condition measured on this
+benchmark with `deepseek-v4-flash`: single requests that stream 100%
+`reasoning_content`, emit no content and no tool call, and burn a whole task
+budget at the observed 90-145 tok/s. Expect runaway timeouts in a stock run;
+that is a real property of the released harness, not an adapter bug.
+
+`--ak output_cap=40960` writes a `models.json` `modelOverrides` entry pinning
+`compat.maxTokensField: "max_tokens"` plus `maxTokens`, giving pi a cap DeepSeek
+actually honours. **Off by default** — the headline run should measure pi as a
+user following DeepSeek's own docs would get it.
+
+**Note on DeepSeek's documented config.** The `models.json` on DeepSeek's page
+puts `reasoningEffortMap` inside `compat`. pi's schema has no such key: the
+effort map is `thinkingLevelMap` and it lives at the *model* level, not inside
+`compat`. The documented key is therefore inert. It happens not to matter,
+because pi's built-in catalogue already carries the correct
+`thinkingLevelMap` and auto-detects `thinkingFormat: "deepseek"` and
+`requiresReasoningContentOnAssistantMessages` from the provider id — so you can
+skip the docs' `models.json` entirely.
+
+**Request shape.** A trivial first request is ~6.0 KB total: 2,685-char system
+prompt, 3,023 bytes of tool JSON for the four built-ins.
+
+**`--mode json` always exits 0.** `runPrintMode` only sets `exitCode = 1`
+inside its `mode === "text"` branch, and pi's `StreamFn` contract forbids
+throwing on request failures — they arrive as an assistant message with
+`stopReason: "error"`. Left alone, an expired key or a 429 storm at task 40 of
+74 would look exactly like 34 legitimately failed tasks: reward 0.0, **zero
+exceptions**, plausible token counts, and harbor's `--retry-include
+ApiRateLimitError` never firing. The adapter therefore inspects the event
+stream after the run and raises a classified `ApiError` on a terminal
+`stopReason` of `error`/`aborted`. If you fork this adapter, keep that check.
+
+## Smoke test
+
+```bash
+cd /path/to/worktree
+PYTHONPATH=$PWD/eval/harbor harbor run \
+  --dataset terminal-bench/terminal-bench-2-1 \
+  --agent pi_agent:Pi \
+  --model deepseek/deepseek-v4-flash \
+  --jobs-dir eval/harbor/jobs \
+  --job-name pi-smoke-1 \
+  -i '*prove-plus-comm*' -i '*sqlite-db-truncate*' \
+  -n 2
+```
+
+Add `--install-only` to validate the container bootstrap alone (~3 min).
+
+Validated 2026-08-11 (pi 0.84.1, `deepseek/deepseek-v4-flash`, default
+thinking), **2/2 reward 1.0, 0 exceptions, 6m57s**:
+
+| task | reward | input | cached | output | cost |
+|---|---|---|---|---|---|
+| prove-plus-comm | 1.0 | 15,476 | 12,928 (83.5%) | 1,715 | $0.00087 |
+| sqlite-db-truncate | 1.0 | 309,939 | 288,768 (93.2%) | 31,934 | $0.01271 |
+
+Tools exercised across the two trials: `bash` x14, `write` x3, `read` x1,
+`websearch` x1 — the extension loads and executes inside the container, not
+just on the host.
+
+## Full run
+
+Matched to the clawcodex baseline (`--ak effort=max`,
+`vision=openai:gpt-5.6-luna`) so the harness comparison is apples-to-apples —
+both sides sit at DeepSeek `reasoning_effort: "max"` with the same vision model:
+
+```bash
+cd /path/to/worktree
+export DEEPSEEK_API_KEY=sk-... OPENAI_API_KEY=sk-... TAVILY_API_KEY=tvly-...
+
+PYTHONPATH=$PWD/eval/harbor harbor run \
+  --dataset terminal-bench/terminal-bench-2-1 \
+  --agent pi_agent:Pi \
+  --model deepseek/deepseek-v4-flash \
+  --jobs-dir eval/harbor/jobs \
+  --job-name pi-tb21-full \
+  --ak thinking=max \
+  --ak vision_model=gpt-5.6-luna \
+  -n 4
+```
+
+For pi at its own default effort (`reasoning_effort: "high"`), drop
+`--ak thinking=max`. For a capped variant that removes the runaway failure mode,
+add `--ak output_cap=40960` and use a distinct `--job-name`.
+
+Hub datasets namespace task names, so filters must match the full name:
+`-i 'terminal-bench/fix-git'` or a glob `-i '*fix-git*'`.
+
+## Batching on this Mac
+
+A `harbor run` launched as a background task here is killed after an erratic,
+shrinking window (~110 min on the first run, then 25 → 22 → 9 min), orphaning
+in-flight containers. Practical recipe, unchanged from the flash runs:
+
+* Small batches (<= 4 tasks) of sub-~16-minute tasks, each with a **fresh**
+  `--job-name` — Harbor refuses to resume a job whose task set differs.
+* Killed batches still bank their fast finishers; re-run to recover stragglers.
+* Aggregate across job dirs afterwards rather than expecting one complete job.
+* Tasks whose single-task runtime exceeds the window (caffe ~58 m, regex-chess
+  ~52 m) are simply unmeasurable here and need a host without the cap.
+
+## Reading results
+
+```bash
+harbor view eval/harbor/jobs
+```
+
+Per-trial pi output is `agent/pi.jsonl` (pi's `--mode json` event stream) and
+session JSONL under `agent/pi-sessions/`. The adapter backfills
+`n_input_tokens` / `n_cache_tokens` / `n_output_tokens` / `cost_usd` from the
+`message_end` events, matching clawcodex's convention that `n_input_tokens` is
+the full prompt side and the cached part is also reported separately.

--- a/eval/harbor/pi_agent.py
+++ b/eval/harbor/pi_agent.py
@@ -1,0 +1,530 @@
+"""Harbor installed-agent adapter for pi (``@earendil-works/pi-coding-agent``).
+
+pi is the harness DeepSeek documents for its V4 models
+(api-docs.deepseek.com/quick_start/agent_integrations/pi_mono). This adapter
+runs it through the SAME terminal-bench harness as ``clawcodex_agent.py`` and
+``openclaude_agent.py`` so the three are directly comparable::
+
+    PYTHONPATH=eval/harbor harbor run \\
+        --dataset terminal-bench/terminal-bench-2-1 \\
+        --agent pi_agent:Pi \\
+        --model deepseek/deepseek-v4-flash \\
+        --jobs-dir eval/harbor/jobs
+
+pi is installed from npm inside each container (Node >= 22, bootstrapped from
+the official tarball when the image's node is missing or too old).
+
+Tools
+-----
+pi ships exactly four built-in tools (read, bash, edit, write). Terminal-bench
+2.1 needs two capabilities beyond those, and DeepSeek V4 is text-only, so the
+adapter uploads ``pi_assets/tb-tools.ts`` and loads it with ``-e``. It
+registers ``vision_analyze`` and ``websearch`` with the same argument shapes as
+clawcodex's equivalents. This does NOT equalise the tool surfaces — pi runs 6
+tools against clawcodex's much larger registry — it only removes the two
+capability gaps that would make some tasks impossible rather than merely
+harder. The remaining difference is a property of the harnesses and part of
+what the benchmark measures. Pass ``--ak tools=off`` to measure stock pi with
+its four built-ins only.
+
+The prompt goes in over **stdin**, not as an argv message. pi has no ``--``
+separator, and a bare argument starting with ``@`` is read as a file
+reference (``cli/args.ts``: ``arg.startsWith("@") -> fileArgs``), so a task
+instruction beginning with ``@`` or ``-`` would be silently misparsed.
+``buildInitialMessage`` concatenates piped stdin into the first user message,
+which is hazard-free for arbitrary text.
+
+Wire facts, probed against pi 0.84.1 on 2026-08-11 (see ``RUN_PI_TB21.md``)
+------------------------------------------------------------------------
+* DeepSeek thinking is controlled by ``--thinking``. pi's catalogue maps
+  minimal/low/medium/high -> ``reasoning_effort: "high"`` and xhigh/max ->
+  ``"max"``; ``off`` sends ``thinking: {"type": "disabled"}`` and no effort.
+  There is no way to request DeepSeek's ``low`` level through pi.
+* Published pi 0.84.1 sends **``max_completion_tokens``** to DeepSeek, because
+  ``isDeepSeek`` is missing from the ``useMaxTokens`` chain in that build (the
+  git tree has since fixed it). DeepSeek **honours ``max_tokens`` and silently
+  ignores ``max_completion_tokens``** — verified directly against the API:
+  ``max_tokens: 16`` truncates at 16 tokens (``finish_reason="length"``) while
+  ``max_completion_tokens: 16`` returns 456 tokens and stops normally. So
+  stock pi runs with **no effective output cap** on DeepSeek and inherits the
+  server default (131,072). That is the reasoning-runaway condition measured
+  on this benchmark with ``deepseek-v4-flash``: single requests that stream
+  100% ``reasoning_content``, emit no content and no tool call, and burn a
+  whole task budget at the observed 90-145 tok/s.
+
+  ``--ak output_cap=N`` writes a ``models.json`` override that pins
+  ``compat.maxTokensField: "max_tokens"`` and ``maxTokens: N``, giving pi a
+  cap DeepSeek actually honours. It is **off by default**: the headline run
+  should measure pi as a user following DeepSeek's own docs would get it.
+
+Agent kwargs (``--ak key=value``)
+--------------------------------
+* ``thinking`` — pi ``--thinking`` (off|minimal|low|medium|high|xhigh|max).
+  Unset means pi's own default (medium, i.e. ``reasoning_effort: "high"``).
+* ``pi_version`` — npm version to install (default below); ``latest`` allowed.
+* ``output_cap`` — see above; ``0`` (default) leaves pi stock.
+* ``tools`` — ``on`` (default) loads the vision/websearch extension, ``off``
+  runs stock pi with its four built-ins.
+* ``vision_model`` — model for ``vision_analyze`` (default
+  ``gpt-5.6-luna``, matching the clawcodex TB2.1 baseline).
+* ``extension`` — host path to the extension (default: ``pi_assets/tb-tools.ts``
+  next to this file).
+* ``trust_project`` — pass pi ``--approve`` instead of ``--no-approve``
+  (default **false**). AGENTS.md / CLAUDE.md load either way; what trust
+  actually gates is `.pi/settings.json`, `.pi/extensions`, `.pi/skills`,
+  `.pi/SYSTEM.md`, `.pi/APPEND_SYSTEM.md` and `.agents/skills`
+  (``core/trust-manager.ts``). Trusting those lets task content replace the
+  system prompt or run its own extension code, which would silently change
+  what is being benchmarked, so it is opt-in.
+
+Credential note
+---------------
+Provider keys are injected as environment variables, and pi's bash tool
+inherits the parent environment, so a task that runs ``env`` can read them and
+the result is serialized into ``pi.jsonl`` and the session JSONL — both under
+the host-synced trial directory. pi has no equivalent of Claude Code's
+``CLAUDE_CODE_SUBPROCESS_ENV_SCRUB``, so use keys scoped to benchmarking.
+"""
+
+import json
+import shlex
+from collections.abc import Iterator
+from pathlib import Path
+from typing import override
+
+from harbor.agents.installed.base import (
+    BaseInstalledAgent,
+    CliFlag,
+    NonZeroAgentExitCodeError,
+    with_prompt_template,
+)
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+from harbor.models.trial.paths import EnvironmentPaths
+
+_CONTAINER_DIR = "/installed-agent/pi"
+_CONTAINER_EXTENSION = f"{_CONTAINER_DIR}/tb-tools.ts"
+_CONTAINER_NODE_DIR = "/installed-agent/node22"
+_NODE_VERSION = "22.20.0"
+
+#: Pinned so a mid-sweep npm publish can't split a benchmark run across two
+#: harness versions. Bump deliberately, and re-probe the wire facts above.
+_DEFAULT_PI_VERSION = "0.84.1"
+_DEFAULT_VISION_MODEL = "gpt-5.6-luna"
+
+_PATH_EXPORT = f'export PATH="{_CONTAINER_NODE_DIR}/bin:$HOME/.local/bin:$PATH"'
+
+#: Credentials forwarded per model provider, mirroring clawcodex_agent's table.
+_PROVIDER_ENV_VARS: dict[str, tuple[str, ...]] = {
+    "deepseek": ("DEEPSEEK_API_KEY",),
+    "anthropic": ("ANTHROPIC_API_KEY",),
+    "openai": ("OPENAI_API_KEY",),
+    "openrouter": ("OPENROUTER_API_KEY",),
+    "zai": ("ZAI_API_KEY", "Z_AI_API_KEY"),
+    "moonshot": ("MOONSHOT_API_KEY", "KIMI_API_KEY"),
+    "google": ("GEMINI_API_KEY", "GOOGLE_API_KEY"),
+}
+
+_VALID_THINKING = ["off", "minimal", "low", "medium", "high", "xhigh", "max"]
+
+
+def _default_extension() -> Path:
+    return Path(__file__).resolve().parent / "pi_assets" / "tb-tools.ts"
+
+
+class Pi(BaseInstalledAgent):
+    """Run pi inside a Harbor task container."""
+
+    CLI_FLAGS = [
+        CliFlag(
+            "thinking",
+            cli="--thinking",
+            type="enum",
+            choices=_VALID_THINKING,
+            env_fallback="PI_THINKING",
+        ),
+    ]
+
+    def __init__(
+        self,
+        logs_dir: Path,
+        pi_version: str = _DEFAULT_PI_VERSION,
+        output_cap: int | str = 0,
+        tools: str = "on",
+        vision_model: str = _DEFAULT_VISION_MODEL,
+        extension: str | None = None,
+        trust_project: bool | str = False,
+        *args,
+        **kwargs,
+    ):
+        from harbor.utils.env import parse_bool_env_value
+
+        self._pi_version = str(pi_version).strip() or _DEFAULT_PI_VERSION
+        try:
+            self._output_cap = int(output_cap)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"output_cap must be an integer, got {output_cap!r}") from exc
+        if self._output_cap < 0:
+            raise ValueError("output_cap must be >= 0 (0 disables the override)")
+
+        tools_value = str(tools).strip().lower()
+        if tools_value not in ("on", "off"):
+            raise ValueError(f"tools must be 'on' or 'off', got {tools!r}")
+        self._tools_enabled = tools_value == "on"
+
+        self._vision_model = str(vision_model).strip() or _DEFAULT_VISION_MODEL
+        self._extension = Path(extension) if extension else _default_extension()
+        self._trust_project = parse_bool_env_value(trust_project, name="trust_project")
+
+        super().__init__(logs_dir, *args, **kwargs)
+
+        if self._tools_enabled and not self._extension.is_file():
+            raise ValueError(
+                f"pi tool extension not found at {self._extension} — expected "
+                "eval/harbor/pi_assets/tb-tools.ts, or pass --ak extension=/path/to.ts "
+                "(or --ak tools=off to run stock pi)."
+            )
+
+    @staticmethod
+    @override
+    def name() -> str:
+        return "pi"
+
+    @override
+    def get_version_command(self) -> str | None:
+        return f"{_PATH_EXPORT}; pi --version"
+
+    @override
+    def parse_version(self, stdout: str) -> str:
+        import re
+
+        match = re.search(r"(\d+\.\d+\.\d+)", stdout.strip())
+        return match.group(1) if match else stdout.strip()
+
+    # ------------------------------------------------------------------ #
+    # Install
+    # ------------------------------------------------------------------ #
+
+    @override
+    async def install(self, environment: BaseEnvironment) -> None:
+        # curl + CA certificates for the Node tarball and the npm registry.
+        await self.exec_as_root(
+            environment,
+            command=(
+                "command -v curl >/dev/null 2>&1 && "
+                "{ [ -f /etc/ssl/certs/ca-certificates.crt ] || "
+                "[ -f /etc/pki/tls/certs/ca-bundle.crt ]; } || { "
+                "if command -v apk >/dev/null 2>&1; then"
+                "  apk add --no-cache curl ca-certificates;"
+                " elif command -v apt-get >/dev/null 2>&1; then"
+                "  apt-get update && apt-get install -y curl ca-certificates;"
+                " elif command -v yum >/dev/null 2>&1; then"
+                "  yum install -y curl ca-certificates;"
+                " else"
+                '  echo "Warning: no known package manager; assuming curl available" >&2;'
+                " fi; }"
+            ),
+            env={"DEBIAN_FRONTEND": "noninteractive"},
+        )
+
+        # Node >= 22 with npm. Keep a suitable system node; otherwise the
+        # official glibc tarball, or distro packages on musl (alpine).
+        await self.exec_as_root(
+            environment,
+            command=(
+                "set -eu; "
+                "have_node() { command -v node >/dev/null 2>&1 && "
+                "command -v npm >/dev/null 2>&1 && "
+                "[ \"$(node -p 'process.versions.node.split(\".\")[0]')\" -ge 22 ]; }; "
+                "if have_node; then echo 'system node OK'; "
+                "elif [ -f /etc/alpine-release ]; then apk add --no-cache nodejs npm; "
+                "  have_node || { echo 'alpine nodejs too old (<22)' >&2; exit 1; }; "
+                "else "
+                f"  mkdir -p {_CONTAINER_NODE_DIR}; "
+                '  arch=$(uname -m); case "$arch" in '
+                "    x86_64) narch=x64;; aarch64|arm64) narch=arm64;; "
+                '    *) echo "unsupported arch $arch" >&2; exit 1;; esac; '
+                f"  curl -fsSL https://nodejs.org/dist/v{_NODE_VERSION}/"
+                f"node-v{_NODE_VERSION}-linux-$narch.tar.gz "
+                f"  | tar -xz -C {_CONTAINER_NODE_DIR} --strip-components=1; "
+                f"  {_CONTAINER_NODE_DIR}/bin/node --version; "
+                "fi"
+            ),
+        )
+
+        spec = f"@earendil-works/pi-coding-agent@{self._pi_version}"
+        await self.exec_as_root(
+            environment,
+            command=(
+                f"set -eu; {_PATH_EXPORT}; mkdir -p {_CONTAINER_DIR}; "
+                f"npm install -g --no-audit --no-fund {shlex.quote(spec)}; "
+                "pi --version"
+            ),
+        )
+
+        if self._tools_enabled:
+            await environment.upload_file(self._extension, _CONTAINER_EXTENSION)
+            await self.exec_as_root(
+                environment, command=f"chmod 644 {_CONTAINER_EXTENSION}"
+            )
+
+    # ------------------------------------------------------------------ #
+    # Run
+    # ------------------------------------------------------------------ #
+
+    def _config_dir(self) -> str:
+        # Under the synced agent dir so models.json and session JSONL come
+        # back to the host. pi writes no auth file here (provider keys arrive
+        # as environment variables) — but see the credential note in the module
+        # docstring: the transcript itself can capture a key if a task dumps
+        # its environment, and the transcript does land on the host.
+        return (EnvironmentPaths.agent_dir / "pi-config").as_posix()
+
+    def _build_env(self) -> dict[str, str]:
+        env: dict[str, str] = {}
+
+        provider = (self._parsed_model_provider or "deepseek").lower()
+        for key in _PROVIDER_ENV_VARS.get(provider, ("DEEPSEEK_API_KEY",)):
+            value = self._get_env(key)
+            if value:
+                env[key] = value
+
+        if self._tools_enabled:
+            # vision_analyze reaches a vision-capable model; websearch reaches
+            # Tavily. Absent keys are surfaced by the tools themselves as a
+            # named error rather than a missing tool.
+            for key in ("OPENAI_API_KEY", "PI_VISION_API_KEY", "TAVILY_API_KEY"):
+                value = self._get_env(key)
+                if value:
+                    env[key] = value
+            env["PI_VISION_MODEL"] = self._vision_model
+
+        env["PI_CODING_AGENT_DIR"] = self._config_dir()
+        # No update checks, package refreshes, or version pings from inside a
+        # task container: they cost wall clock and can fail the run offline.
+        env["PI_OFFLINE"] = "1"
+        env["PI_SKIP_VERSION_CHECK"] = "1"
+        env["NO_COLOR"] = "1"
+        return env
+
+    def _models_json(self) -> str | None:
+        """A models.json that gives pi an output cap DeepSeek honours."""
+        if self._output_cap <= 0:
+            return None
+        provider = (self._parsed_model_provider or "deepseek").lower()
+        model = self._parsed_model_name or "deepseek-v4-flash"
+        # `models` is an array of FULL model definitions; partial patches go
+        # in `modelOverrides`, a record keyed by model id (model-config.ts:
+        # ProviderConfigSchema). Using `models` here would require restating
+        # the whole catalogue entry.
+        return json.dumps(
+            {
+                "providers": {
+                    provider: {
+                        "modelOverrides": {
+                            model: {
+                                "maxTokens": self._output_cap,
+                                "compat": {"maxTokensField": "max_tokens"},
+                            }
+                        }
+                    }
+                }
+            },
+            indent=2,
+        )
+
+    @with_prompt_template
+    @override
+    async def run(
+        self, instruction: str, environment: BaseEnvironment, context: AgentContext
+    ) -> None:
+        env = self._build_env()
+        config_dir = self._config_dir()
+        session_dir = (EnvironmentPaths.agent_dir / "pi-sessions").as_posix()
+        log_path = (EnvironmentPaths.agent_dir / "pi.jsonl").as_posix()
+
+        parts: list[str] = [
+            "pi",
+            "--print",
+            "--mode",
+            "json",
+            "--provider",
+            shlex.quote((self._parsed_model_provider or "deepseek").lower()),
+        ]
+        if self._parsed_model_name:
+            parts += ["--model", shlex.quote(self._parsed_model_name)]
+        if self._tools_enabled:
+            parts += ["--extension", _CONTAINER_EXTENSION]
+        # Explicit either way: omitting the flag leaves projectTrustOverride
+        # undefined, which falls through to pi's saved trust store rather than
+        # meaning "untrusted" (cli/args.ts, main.ts).
+        parts.append("--approve" if self._trust_project else "--no-approve")
+        parts += ["--session-dir", shlex.quote(session_dir)]
+
+        cli_flags = self.build_cli_flags()
+        if cli_flags:
+            parts.append(cli_flags)
+
+        setup = f"mkdir -p {shlex.quote(config_dir)} {shlex.quote(session_dir)}"
+        models_json = self._models_json()
+        if models_json:
+            setup += (
+                f"; printf '%s' {shlex.quote(models_json)} "
+                f"> {shlex.quote(config_dir + '/models.json')}"
+            )
+
+        # `set -eu` so a failed mkdir or a failed models.json write aborts
+        # instead of letting pi run UNCAPPED under a silently-missing override.
+        # Harbor's _exec only prepends `set -o pipefail`, not `set -e`.
+        #
+        # Prompt via stdin: pi has no `--` separator and reads bare `@...`
+        # arguments as file references, so argv is unsafe for arbitrary text.
+        command = (
+            f"set -eu; {_PATH_EXPORT}; {setup}; "
+            f"printf '%s' {shlex.quote(instruction)} | "
+            f"{' '.join(parts)} 2>&1 | tee {log_path}"
+        )
+
+        await self.exec_as_agent(environment, command=command, env=env)
+        self._raise_on_agent_error(command)
+
+    # ------------------------------------------------------------------ #
+    # Failure detection
+    # ------------------------------------------------------------------ #
+
+    def _iter_events(self) -> Iterator[dict]:
+        """Yield JSON events from the tee'd stream, one line at a time.
+
+        Streamed rather than slurped: the log carries every bash tool result,
+        and trials run concurrently. Non-JSON lines are pi's stderr (merged by
+        `2>&1`) and are skipped.
+        """
+        log_path = self.logs_dir / "pi.jsonl"
+        try:
+            with log_path.open(encoding="utf-8", errors="replace") as handle:
+                for line in handle:
+                    line = line.strip()
+                    if not line.startswith("{"):
+                        continue
+                    try:
+                        event = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if isinstance(event, dict):
+                        yield event
+        except OSError:
+            return
+
+    def _raise_on_agent_error(self, command: str) -> None:
+        """Fail the trial when pi ended on a model/API error.
+
+        ``--mode json`` **always exits 0**. ``runPrintMode`` only assigns
+        ``exitCode = 1`` inside its ``mode === "text"`` branch
+        (``modes/print-mode.ts``), and pi's ``StreamFn`` contract forbids
+        throwing for request failures — they arrive as an assistant message
+        with ``stopReason: "error"``. So an expired key, a 429 storm or a
+        provider 500 would otherwise look exactly like a task the agent
+        legitimately failed: reward 0.0, zero exceptions, plausible tokens.
+        That turns harbor's ERROR_PATTERNS classification and
+        ``--retry-include ApiRateLimitError`` into dead code for this agent.
+
+        Checked here rather than in ``populate_context_post_run`` because only
+        an exception raised from ``run`` fails the trial. An unreadable log is
+        deliberately NOT an error: the trial may have been killed for reasons
+        harbor already records, and inventing a failure would be worse than
+        missing one.
+        """
+        terminal: dict | None = None
+        for event in self._iter_events():
+            if event.get("type") != "message_end":
+                continue
+            message = event.get("message")
+            if isinstance(message, dict) and message.get("role") == "assistant":
+                terminal = message
+
+        if terminal is None:
+            return
+        stop_reason = terminal.get("stopReason")
+        if stop_reason not in ("error", "aborted"):
+            return
+
+        message = str(terminal.get("errorMessage") or f"Request {stop_reason}")
+        detail = (
+            f"pi ended with stopReason={stop_reason!r} (exit code 0 — "
+            f"--mode json never reports failure): {message}\n"
+            f"command: {command}"
+        )
+        for compiled, exception in self._compiled_error_patterns:
+            if compiled.search(message):
+                raise exception(detail)
+        raise NonZeroAgentExitCodeError(detail)
+
+    # ------------------------------------------------------------------ #
+    # Metrics
+    # ------------------------------------------------------------------ #
+
+    @override
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        """Sum usage across pi's JSON event stream.
+
+        pi reports per-assistant-message ``Usage`` (``input``/``output``/
+        ``cacheRead``/``cacheWrite``/``cost``); harbor wants run totals.
+
+        Two event families carry usage and BOTH are counted:
+
+        * ``message_end`` for assistant messages. Filtering on the role is
+          load-bearing — pi also emits ``message_end`` for user prompts,
+          injected steering messages and tool results. ``message_update`` is
+          deliberately excluded: it repeats the same message while it streams,
+          so summing it would multiply every turn.
+        * ``compaction_end`` (``result.usage``). Compaction and branch
+          summarization issue their own LLM calls and report usage there, never
+          as a ``message_end``. Missing them undercounts by an amount that
+          GROWS with task length — exactly the long tasks where the number
+          matters — and would flatter pi against clawcodex, whose adapter takes
+          a run-level total that already includes its compaction.
+        """
+        input_tokens = 0
+        output_tokens = 0
+        cache_read = 0
+        cache_write = 0
+        cost_usd = 0.0
+        seen_usage = False
+
+        def absorb(usage: object) -> bool:
+            nonlocal input_tokens, output_tokens, cache_read, cache_write, cost_usd
+            if not isinstance(usage, dict):
+                return False
+            input_tokens += int(usage.get("input") or 0)
+            output_tokens += int(usage.get("output") or 0)
+            cache_read += int(usage.get("cacheRead") or 0)
+            cache_write += int(usage.get("cacheWrite") or 0)
+            cost = usage.get("cost")
+            if isinstance(cost, dict):
+                total = cost.get("total")
+                if isinstance(total, (int, float)):
+                    cost_usd += float(total)
+            return True
+
+        for event in self._iter_events():
+            event_type = event.get("type")
+            if event_type == "message_end":
+                message = event.get("message")
+                if isinstance(message, dict) and message.get("role") == "assistant":
+                    seen_usage |= absorb(message.get("usage"))
+            elif event_type == "compaction_end":
+                result = event.get("result")
+                if isinstance(result, dict):
+                    seen_usage |= absorb(result.get("usage"))
+
+        if not seen_usage:
+            return
+
+        # Match clawcodex_agent / openclaude_agent: n_input_tokens is the FULL
+        # prompt side. pi's `input` already excludes both cache counters, so
+        # they are added back; the cached-read part is also reported on its own.
+        context.n_input_tokens = input_tokens + cache_read + cache_write
+        context.n_cache_tokens = cache_read
+        context.n_output_tokens = output_tokens
+        if cost_usd > 0:
+            context.cost_usd = cost_usd

--- a/eval/harbor/pi_assets/tb-tools.ts
+++ b/eval/harbor/pi_assets/tb-tools.ts
@@ -1,0 +1,254 @@
+/**
+ * terminal-bench tool pack for pi: `vision_analyze` + `websearch`.
+ *
+ * pi ships four built-in tools (read, bash, edit, write). Terminal-bench 2.1
+ * contains tasks that need to look at an image and tasks that need the live
+ * web, and DeepSeek V4 is text-only (`input: ["text"]` in pi's catalogue), so
+ * neither is reachable without help. This extension adds exactly the two
+ * capabilities clawcodex exposes for the same benchmark — its `vision_analyze`
+ * and web-search tools — with the same argument shapes, so trajectories stay
+ * comparable across harnesses.
+ *
+ * Configuration is environment-only (the harbor adapter injects it):
+ *
+ *   OPENAI_API_KEY / PI_VISION_API_KEY   vision credentials
+ *   PI_VISION_MODEL                      default "gpt-5.6-luna"
+ *   PI_VISION_BASE_URL                   default "https://api.openai.com/v1"
+ *   TAVILY_API_KEY                       web search credentials
+ *
+ * A missing key is reported as a tool error naming the variable rather than
+ * hiding the tool: a silently absent tool reads to the model as "this task is
+ * impossible", which is a far more expensive failure than one loud message.
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { readFile } from "node:fs/promises";
+import { extname, resolve } from "node:path";
+import { Type } from "typebox";
+
+/** Mirrors clawcodex's `max_result_size_chars` for both tools. */
+const MAX_RESULT_CHARS = 50_000;
+/** Guard before base64: vendors reject oversized payloads with opaque errors. */
+const MAX_IMAGE_BYTES = 16 * 1024 * 1024;
+const VISION_TIMEOUT_MS = 60_000;
+const SEARCH_TIMEOUT_MS = 20_000;
+
+const DEFAULT_VISION_MODEL = "gpt-5.6-luna";
+
+/** Single source of truth, so the reported `details.model` can't drift from the one used. */
+function visionModel(): string {
+	return (process.env.PI_VISION_MODEL || DEFAULT_VISION_MODEL).trim();
+}
+
+const IMAGE_MIME_TYPES: Record<string, string> = {
+	".png": "image/png",
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif": "image/gif",
+	".webp": "image/webp",
+	".bmp": "image/bmp",
+};
+
+function truncate(text: string): string {
+	if (text.length <= MAX_RESULT_CHARS) return text;
+	return `${text.slice(0, MAX_RESULT_CHARS)}\n\n[truncated at ${MAX_RESULT_CHARS} characters]`;
+}
+
+/** Combine the caller's abort signal with a wall-clock timeout. */
+function withTimeout(signal: AbortSignal | undefined, ms: number): { signal: AbortSignal; done: () => void } {
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(new Error(`timed out after ${ms}ms`)), ms);
+	const forward = () => controller.abort(signal?.reason);
+	if (signal) {
+		if (signal.aborted) forward();
+		else signal.addEventListener("abort", forward, { once: true });
+	}
+	return {
+		signal: controller.signal,
+		done: () => {
+			clearTimeout(timer);
+			signal?.removeEventListener("abort", forward);
+		},
+	};
+}
+
+const VISION_PARAMS = Type.Object({
+	image_url: Type.String({
+		description: "Local file path to the image (png, jpg, gif, webp).",
+	}),
+	question: Type.String({
+		description:
+			"Your specific question about the image. Be concrete — this is what makes the answer better than a generic description.",
+	}),
+});
+
+const SEARCH_PARAMS = Type.Object({
+	query: Type.String({ minLength: 2, description: "The search query to use" }),
+	allowed_domains: Type.Optional(
+		Type.Array(Type.String(), { description: "Only include search results from these domains" }),
+	),
+	blocked_domains: Type.Optional(
+		Type.Array(Type.String(), { description: "Never include search results from these domains" }),
+	),
+});
+
+async function analyzeImage(
+	imagePath: string,
+	question: string,
+	signal: AbortSignal | undefined,
+): Promise<string> {
+	const apiKey = (process.env.PI_VISION_API_KEY || process.env.OPENAI_API_KEY || "").trim();
+	if (!apiKey) {
+		throw new Error(
+			"vision_analyze is not configured: set OPENAI_API_KEY (or PI_VISION_API_KEY) to a key that can reach a vision-capable model.",
+		);
+	}
+	const model = visionModel();
+	const baseUrl = (process.env.PI_VISION_BASE_URL || "https://api.openai.com/v1").trim().replace(/\/+$/, "");
+
+	const absolute = resolve(imagePath);
+	const extension = extname(absolute).toLowerCase();
+	const mimeType = IMAGE_MIME_TYPES[extension];
+	if (!mimeType) {
+		throw new Error(
+			`Unsupported image extension ${extension || "(none)"} for ${absolute}. Supported: ${Object.keys(IMAGE_MIME_TYPES).join(", ")}.`,
+		);
+	}
+
+	let bytes: Buffer;
+	try {
+		bytes = await readFile(absolute);
+	} catch (error) {
+		throw new Error(`Could not read image ${absolute}: ${(error as Error).message}`);
+	}
+	if (bytes.byteLength > MAX_IMAGE_BYTES) {
+		throw new Error(
+			`Image ${absolute} is ${bytes.byteLength} bytes, over the ${MAX_IMAGE_BYTES}-byte limit. Downscale it first (e.g. with ImageMagick) and retry.`,
+		);
+	}
+
+	const dataUri = `data:${mimeType};base64,${bytes.toString("base64")}`;
+	const timeout = withTimeout(signal, VISION_TIMEOUT_MS);
+	try {
+		const response = await fetch(`${baseUrl}/chat/completions`, {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+			body: JSON.stringify({
+				model,
+				messages: [
+					{
+						role: "user",
+						content: [
+							{ type: "text", text: question },
+							{ type: "image_url", image_url: { url: dataUri } },
+						],
+					},
+				],
+			}),
+			signal: timeout.signal,
+		});
+		if (!response.ok) {
+			const detail = (await response.text()).slice(0, 500);
+			throw new Error(`Vision model ${model} returned HTTP ${response.status}: ${detail}`);
+		}
+		const payload = (await response.json()) as {
+			choices?: Array<{ message?: { content?: string } }>;
+		};
+		const answer = payload.choices?.[0]?.message?.content?.trim();
+		if (!answer) throw new Error(`Vision model ${model} returned an empty answer.`);
+		return answer;
+	} finally {
+		timeout.done();
+	}
+}
+
+interface SearchHit {
+	title: string;
+	url: string;
+	snippet: string;
+}
+
+async function searchWeb(
+	query: string,
+	allowedDomains: string[] | undefined,
+	blockedDomains: string[] | undefined,
+	signal: AbortSignal | undefined,
+): Promise<SearchHit[]> {
+	const apiKey = (process.env.TAVILY_API_KEY || "").trim();
+	if (!apiKey) {
+		throw new Error(
+			"websearch is not configured. Set the TAVILY_API_KEY environment variable (get a free key at https://app.tavily.com).",
+		);
+	}
+
+	const body: Record<string, unknown> = { query, max_results: 15, include_answer: false };
+	if (allowedDomains && allowedDomains.length > 0) body.include_domains = allowedDomains;
+	if (blockedDomains && blockedDomains.length > 0) body.exclude_domains = blockedDomains;
+
+	const timeout = withTimeout(signal, SEARCH_TIMEOUT_MS);
+	try {
+		const response = await fetch("https://api.tavily.com/search", {
+			method: "POST",
+			headers: { "Content-Type": "application/json", Authorization: `Bearer ${apiKey}` },
+			body: JSON.stringify(body),
+			signal: timeout.signal,
+		});
+		if (!response.ok) {
+			const detail = (await response.text()).slice(0, 300);
+			throw new Error(`Tavily search error ${response.status}: ${detail}`);
+		}
+		const payload = (await response.json()) as {
+			results?: Array<{ title?: string; url?: string; content?: string }>;
+		};
+		return (payload.results ?? []).map((hit) => ({
+			title: (hit.title ?? "").trim(),
+			url: (hit.url ?? "").trim(),
+			snippet: (hit.content ?? "").trim(),
+		}));
+	} finally {
+		timeout.done();
+	}
+}
+
+export default function terminalBenchToolsExtension(pi: ExtensionAPI) {
+	pi.registerTool({
+		name: "vision_analyze",
+		label: "Vision",
+		description:
+			"Ask a vision-capable model about a local image and get a text answer. Use this when you need to see an image but your own model cannot, or when an image was described to you and you need a closer look at something specific. Always pass a concrete question — 'what is the total amount and VAT on this invoice?' beats 'describe this'.",
+		promptSnippet: "ask a vision model a concrete question about a local image file",
+		parameters: VISION_PARAMS,
+		async execute(_toolCallId, params, signal) {
+			const answer = await analyzeImage(params.image_url, params.question, signal);
+			return {
+				content: [{ type: "text", text: truncate(answer) }],
+				details: { image: params.image_url, model: visionModel() },
+			};
+		},
+	});
+
+	pi.registerTool({
+		name: "websearch",
+		label: "Web search",
+		description:
+			"Search the web and return the top results as title/url/snippet. Use it for facts that are outside the local machine or newer than your training data. Follow up with a fetch (e.g. curl via bash) when a result needs reading in full.",
+		promptSnippet: "search the web for information not available locally",
+		parameters: SEARCH_PARAMS,
+		async execute(_toolCallId, params, signal) {
+			const hits = await searchWeb(params.query, params.allowed_domains, params.blocked_domains, signal);
+			if (hits.length === 0) {
+				return {
+					content: [{ type: "text", text: `No results for: ${params.query}` }],
+					details: { query: params.query, results: 0 },
+				};
+			}
+			const rendered = hits
+				.map((hit, index) => `${index + 1}. ${hit.title}\n   ${hit.url}\n   ${hit.snippet}`)
+				.join("\n\n");
+			return {
+				content: [{ type: "text", text: truncate(`Search results for: ${params.query}\n\n${rendered}`) }],
+				details: { query: params.query, results: hits.length },
+			};
+		},
+	});
+}

--- a/tests/test_harbor_adapter_pi.py
+++ b/tests/test_harbor_adapter_pi.py
@@ -1,0 +1,304 @@
+"""Failure-detection and accounting guards for the pi harbor eval adapter.
+
+Runs ONLY in the dedicated "Harbor adapter (3.13)" CI job, which installs
+harbor explicitly. ``eval/harbor/pi_agent.py`` imports ``harbor`` at module
+scope and uses ``typing.override`` (3.12+), so under the main ``test (3.11)``
+job the ``importorskip`` below fires and every assertion here skips silently.
+A file left out of that job's file list therefore never runs at all — add new
+``tests/test_harbor_*`` files to it.
+
+Both failure modes pinned here are SILENT ones, which is why they need tests
+rather than a careful reader:
+
+1. ``pi --mode json`` exits 0 on every model/API failure. ``runPrintMode``
+   only assigns ``exitCode = 1`` inside its ``mode === "text"`` branch, and
+   pi's ``StreamFn`` contract forbids throwing for request failures — they
+   arrive as an assistant message with ``stopReason: "error"``. Without the
+   adapter's own check, an expired key or a 429 storm midway through a 74-task
+   sweep is indistinguishable from tasks the agent legitimately failed: reward
+   0.0, zero exceptions, plausible token counts, and harbor's
+   ``--retry-include ApiRateLimitError`` never firing.
+
+2. Compaction issues its own LLM calls and reports usage on ``compaction_end``,
+   never as a ``message_end``. Counting only ``message_end`` undercounts by an
+   amount that GROWS with task length — exactly the long tasks where cost
+   matters — which would flatter pi against clawcodex, whose adapter takes a
+   run-level total that already includes its compaction.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("harbor", reason="harbor is an eval-only tool dependency")
+
+from harbor.agents.installed.base import (  # noqa: E402
+    ApiRateLimitError,
+    ApiUsageLimitError,
+    NonZeroAgentExitCodeError,
+)
+from harbor.models.agent.context import AgentContext  # noqa: E402
+
+_ADAPTER_DIR = Path(__file__).resolve().parents[1] / "eval" / "harbor"
+if str(_ADAPTER_DIR) not in sys.path:
+    sys.path.insert(0, str(_ADAPTER_DIR))
+
+from pi_agent import Pi  # noqa: E402
+
+
+def _agent(tmp_path: Path, **kwargs) -> Pi:
+    return Pi(logs_dir=tmp_path, model_name="deepseek/deepseek-v4-flash", **kwargs)
+
+
+def _write_log(tmp_path: Path, events: list) -> None:
+    """Write a pi.jsonl. Plain strings are emitted verbatim (non-JSON noise)."""
+    tmp_path.joinpath("pi.jsonl").write_text(
+        "\n".join(e if isinstance(e, str) else json.dumps(e) for e in events),
+        encoding="utf-8",
+    )
+
+
+def _usage(inp: int, out: int, cache_read: int, cache_write: int, cost: float) -> dict:
+    return {
+        "input": inp,
+        "output": out,
+        "cacheRead": cache_read,
+        "cacheWrite": cache_write,
+        "cost": {"total": cost},
+    }
+
+
+def _assistant_end(usage: dict | None = None, stop_reason: str = "stop") -> dict:
+    message: dict = {"role": "assistant", "stopReason": stop_reason}
+    if usage is not None:
+        message["usage"] = usage
+    return {"type": "message_end", "message": message}
+
+
+# --------------------------------------------------------------------------- #
+# Usage accounting
+# --------------------------------------------------------------------------- #
+
+
+def test_usage_counts_compaction_and_ignores_non_assistant_events(tmp_path):
+    """Sum assistant message_end AND compaction_end; ignore everything else."""
+    _write_log(
+        tmp_path,
+        [
+            "pi startup diagnostic on stderr, not JSON",
+            # message_update repeats the streaming message — must NOT be summed.
+            {
+                "type": "message_update",
+                "message": {"role": "assistant", "usage": _usage(999, 999, 999, 999, 9.9)},
+            },
+            # pi emits message_end for user prompts and tool results too.
+            {
+                "type": "message_end",
+                "message": {"role": "user", "usage": _usage(500, 0, 0, 0, 5.0)},
+            },
+            _assistant_end(_usage(100, 10, 20, 5, 0.001)),
+            {"type": "compaction_end", "result": {"usage": _usage(1000, 50, 0, 0, 0.01)}},
+            # An aborted compaction carries result: null.
+            {"type": "compaction_end", "result": None, "aborted": True},
+            _assistant_end(_usage(200, 20, 30, 0, 0.002)),
+            # A torn final line (concurrent trials, 2>&1 interleaving).
+            '{"type":"message_end","message":{"role":"assist',
+        ],
+    )
+
+    context = AgentContext()
+    _agent(tmp_path).populate_context_post_run(context)
+
+    # input side is uncached + cacheRead + cacheWrite; pi's `input` excludes both.
+    assert context.n_input_tokens == (100 + 200 + 1000) + (20 + 30) + 5
+    assert context.n_cache_tokens == 50
+    assert context.n_output_tokens == 80
+    assert context.cost_usd == pytest.approx(0.013)
+
+
+def test_usage_absent_leaves_context_untouched(tmp_path):
+    """No usage at all must not write zeros that read as a real measurement."""
+    _write_log(tmp_path, [{"type": "agent_start"}])
+    context = AgentContext()
+    _agent(tmp_path).populate_context_post_run(context)
+    assert context.n_input_tokens is None
+    assert context.n_output_tokens is None
+
+
+def test_missing_log_is_not_an_error(tmp_path):
+    """A trial killed before pi wrote anything must not be reported as usage."""
+    context = AgentContext()
+    _agent(tmp_path).populate_context_post_run(context)
+    assert context.n_input_tokens is None
+
+
+# --------------------------------------------------------------------------- #
+# Failure detection (pi --mode json always exits 0)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    ("error_message", "expected"),
+    [
+        ("API Error: 429 rate limit exceeded", ApiRateLimitError),
+        ("too many requests", ApiRateLimitError),
+        ("Quota exceeded.", ApiUsageLimitError),
+        ("connection reset by peer", NonZeroAgentExitCodeError),
+    ],
+)
+def test_terminal_error_raises_classified(tmp_path, error_message, expected):
+    _write_log(
+        tmp_path,
+        [
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "stopReason": "error",
+                    "errorMessage": error_message,
+                },
+            }
+        ],
+    )
+    with pytest.raises(expected):
+        _agent(tmp_path)._raise_on_agent_error("pi --print --mode json")
+
+
+def test_aborted_also_raises(tmp_path):
+    _write_log(tmp_path, [_assistant_end(stop_reason="aborted")])
+    with pytest.raises(NonZeroAgentExitCodeError):
+        _agent(tmp_path)._raise_on_agent_error("cmd")
+
+
+def test_successful_run_does_not_raise(tmp_path):
+    _write_log(tmp_path, [_assistant_end(_usage(10, 1, 0, 0, 0.0))])
+    _agent(tmp_path)._raise_on_agent_error("cmd")
+
+
+def test_recovered_error_does_not_raise(tmp_path):
+    """Only the LAST assistant message decides: pi retried and then succeeded."""
+    _write_log(
+        tmp_path,
+        [
+            {
+                "type": "message_end",
+                "message": {
+                    "role": "assistant",
+                    "stopReason": "error",
+                    "errorMessage": "API Error: transient",
+                },
+            },
+            _assistant_end(_usage(10, 1, 0, 0, 0.0)),
+        ],
+    )
+    _agent(tmp_path)._raise_on_agent_error("cmd")
+
+
+def test_missing_log_does_not_invent_a_failure(tmp_path):
+    _agent(tmp_path)._raise_on_agent_error("cmd")
+
+
+# --------------------------------------------------------------------------- #
+# Command construction
+# --------------------------------------------------------------------------- #
+
+
+def _rendered_command(tmp_path: Path, **kwargs) -> str:
+    agent = _agent(tmp_path, **kwargs)
+    captured: dict = {}
+
+    async def fake_exec(environment, command=None, env=None):
+        captured["command"] = command
+        captured["env"] = env
+
+    agent.exec_as_agent = fake_exec  # type: ignore[method-assign]
+    _write_log(tmp_path, [_assistant_end(_usage(1, 1, 0, 0, 0.0))])
+    asyncio.run(Pi.run(agent, "instruction", object(), None))
+    return captured["command"]
+
+
+def test_command_aborts_when_setup_fails(tmp_path):
+    """`set -eu` or an unwritten models.json leaves pi running UNCAPPED.
+
+    Harbor's _exec prepends only `set -o pipefail`, not `set -e`, so without
+    this the trial looks clean while measuring something else.
+    """
+    assert _rendered_command(tmp_path, output_cap=40960).startswith("set -eu;")
+
+
+def test_output_cap_pins_the_field_deepseek_actually_honours(tmp_path):
+    """DeepSeek honours max_tokens and silently ignores max_completion_tokens."""
+    command = _rendered_command(tmp_path, output_cap=40960)
+    assert '"maxTokensField": "max_tokens"' in command
+    assert '"maxTokens": 40960' in command
+    # modelOverrides, not models: `models` needs a full definition and would
+    # drop the catalogue's deepseek compat flags.
+    assert "modelOverrides" in command
+
+
+def test_stock_run_writes_no_models_json(tmp_path):
+    assert "models.json" not in _rendered_command(tmp_path)
+
+
+def test_project_trust_is_explicit_in_both_directions(tmp_path):
+    """Omitting the flag means "consult the trust store", not "untrusted"."""
+    assert "--no-approve" in _rendered_command(tmp_path)
+    assert "--approve" in _rendered_command(tmp_path, trust_project=True)
+    assert "--no-approve" not in _rendered_command(tmp_path, trust_project=True)
+
+
+def test_prompt_goes_over_stdin_not_argv(tmp_path):
+    """pi has no `--` separator and reads bare `@foo` argv as a file reference."""
+    agent = _agent(tmp_path)
+    captured: dict = {}
+
+    async def fake_exec(environment, command=None, env=None):
+        captured["command"] = command
+
+    agent.exec_as_agent = fake_exec  # type: ignore[method-assign]
+    _write_log(tmp_path, [_assistant_end(_usage(1, 1, 0, 0, 0.0))])
+    hostile = "@notafile.py --print /etc/passwd `id` $HOME"
+    asyncio.run(Pi.run(agent, hostile, object(), None))
+
+    command = captured["command"]
+    # Quoted once, piped in — never a bare argv token.
+    assert f"printf '%s' '{hostile}'" in command
+    assert command.index("printf") < command.index("| pi")
+
+
+def test_tools_off_drops_the_extension(tmp_path):
+    assert "--extension" not in _rendered_command(tmp_path, tools="off")
+    assert "--extension" in _rendered_command(tmp_path)
+
+
+def test_vision_credentials_reach_the_container(tmp_path):
+    """A vision tool advertised without its key dies mid-task, quietly."""
+    agent = _agent(tmp_path)
+    agent._get_env = lambda key: f"{key}-VALUE"  # type: ignore[method-assign]
+    env = agent._build_env()
+    assert env["OPENAI_API_KEY"] == "OPENAI_API_KEY-VALUE"
+    assert env["TAVILY_API_KEY"] == "TAVILY_API_KEY-VALUE"
+    assert env["DEEPSEEK_API_KEY"] == "DEEPSEEK_API_KEY-VALUE"
+    assert env["PI_VISION_MODEL"]
+
+
+def test_tools_off_does_not_forward_tool_credentials(tmp_path):
+    agent = _agent(tmp_path, tools="off")
+    agent._get_env = lambda key: f"{key}-VALUE"  # type: ignore[method-assign]
+    env = agent._build_env()
+    assert "TAVILY_API_KEY" not in env
+    assert "PI_VISION_MODEL" not in env
+
+
+def test_output_cap_rejects_nonsense(tmp_path):
+    with pytest.raises(ValueError):
+        _agent(tmp_path, output_cap=-1)
+    with pytest.raises(ValueError):
+        _agent(tmp_path, output_cap="banana")
+    with pytest.raises(ValueError):
+        _agent(tmp_path, tools="maybe")


### PR DESCRIPTION
Adds a harbor adapter that runs [pi](https://pi.dev) (`@earendil-works/pi-coding-agent`) — the harness DeepSeek's docs point at for its V4 models — through the same terminal-bench harness as `clawcodex_agent.py` and `openclaude_agent.py`, so the three are directly comparable.

Purpose: measure the pi harness on terminal-bench 2.1 with `deepseek-v4-flash` on a machine with more headroom than this laptop.

## What's here

| File | |
|---|---|
| `eval/harbor/pi_agent.py` | the adapter (`pi_agent:Pi`) — Node ≥22 bootstrap, pinned npm install, headless run, token/cost backfill |
| `eval/harbor/pi_assets/tb-tools.ts` | pi extension adding `vision_analyze` (OpenAI vision) + `websearch` (Tavily) |
| `eval/harbor/RUN_PI_TB21.md` | probed wire facts, run recipes, comparability caveats |
| `tests/test_harbor_adapter_pi.py` | 20 tests, registered in the Harbor adapter CI job |

## Validated

Terminal-bench 2.1, `deepseek/deepseek-v4-flash`: **2/2 reward 1.0, 0 exceptions**. Token/cost backfill confirmed against `agent_result`, and `websearch` executed inside a container, proving the extension loads there.

## Wire facts probed against pi 0.84.1

Captured by pointing pi's `deepseek` provider at a recording endpoint — `provider === "deepseek"` alone triggers pi's DeepSeek auto-detection, so the real code path runs.

- `--thinking` maps `minimal/low/medium/high` → `reasoning_effort: "high"` and `xhigh/max` → `"max"`; `off` sends `thinking: {"type":"disabled"}`. DeepSeek's `low` level is unreachable through pi.
- **Published pi 0.84.1 runs uncapped on DeepSeek.** It sends `max_completion_tokens` because `isDeepSeek` is missing from the `useMaxTokens` chain in that build. Verified against the live API:

  ```
  max_tokens: 16            -> completion_tokens=16   finish_reason=length
  max_completion_tokens: 16 -> completion_tokens=456  finish_reason=stop
  ```

  DeepSeek honours the first and silently ignores the second. Left **stock by default** — that is what DeepSeek's own docs give you — with `--ak output_cap=N` writing a `modelOverrides` entry pinning `compat.maxTokensField: "max_tokens"`.
- The `reasoningEffortMap` key in DeepSeek's documented `models.json` does not exist in pi's schema (it's `thinkingLevelMap`, at model level, not in `compat`) and is inert. Harmless — the bundled catalogue already carries the right map.

## Two silent failure modes guarded

- **`pi --mode json` always exits 0.** `runPrintMode` only sets `exitCode = 1` inside its `mode === "text"` branch, and pi's `StreamFn` contract forbids throwing on request failures. An expired key or 429 storm at task 40 of 74 would otherwise be indistinguishable from 34 legitimately failed tasks — reward 0.0, zero exceptions, and `--retry-include ApiRateLimitError` never firing. The adapter now inspects the event stream and raises a classified `ApiError`.
- **Compaction usage was invisible.** Compaction reports usage on `compaction_end`, never `message_end`, so counting only the latter undercounts by an amount that grows with task length — the long tasks where cost matters, and in pi's favour. Both are summed now.

## Notes for reviewers

- Prompt goes over **stdin**: pi has no `--` separator and reads a bare `@foo` argv token as a file reference.
- Project trust defaults **off** (`--no-approve` emitted explicitly — omitting it consults pi's trust store rather than meaning untrusted). Trust would let task content ship `.pi/extensions` or replace the system prompt.
- The added tools close two capability gaps; they do **not** equalise the surfaces (pi runs 6 tools vs clawcodex's much larger registry). The docs say so rather than claiming parity.
- `vision_analyze` is exercised on the host but not yet in a container; `RUN_PI_TB21.md` flags running one vision task before a full sweep.

## Full run

```bash
PYTHONPATH=$PWD/eval/harbor harbor run \
  --dataset terminal-bench/terminal-bench-2-1 \
  --agent pi_agent:Pi \
  --model deepseek/deepseek-v4-flash \
  --jobs-dir eval/harbor/jobs \
  --job-name pi-tb21-full \
  --ak thinking=max \
  -n 4
```

`--ak thinking=max` lines pi up with a clawcodex run at `--ak effort=max` (both land on DeepSeek `reasoning_effort: "max"`). Needs `DEEPSEEK_API_KEY`, `OPENAI_API_KEY`, `TAVILY_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)