### PR TITLE
fix(tui): repoint the provider label on a model switch, and pick effort in /model

### DIFF
--- a/src/providers/effort_options.py
+++ b/src/providers/effort_options.py
@@ -1,0 +1,109 @@
+"""Which reasoning-effort levels a given (provider, model) pair actually accepts.
+
+The ``/model`` picker's third step offers these, so the list has to be the
+levels the model will really take rather than the union ladder ``/effort``
+validates against. The knowledge already exists, scattered across the two
+paths that send effort on the wire; this module is the one place that reads
+them together and answers the question the picker asks.
+
+Two directions of error, and they are not symmetric — the same asymmetry
+``_model_supports_xhigh_effort`` documents:
+
+* offering a level the model REJECTS is fatal, because a 400 on the effort
+  level is not retried or downgraded anywhere, so every subsequent request
+  fails;
+* omitting a level the model would have accepted merely hides a choice.
+
+So this errs toward the narrower list wherever the codebase actually knows,
+and falls back to the full ladder only where it does not.
+"""
+
+from __future__ import annotations
+
+from src.settings.constants import VALID_EFFORT_VALUES
+
+#: The clawcodex ladder, minus the empty "auto" sentinel. Anything offered
+#: has to survive ``_do_set_effort``'s validation, which keys off this.
+LADDER: tuple[str, ...] = tuple(v for v in VALID_EFFORT_VALUES if v)
+
+#: Offered first on every model that supports effort at all: clears the
+#: session override and lets the provider pick (``/effort auto``).
+AUTO = "auto"
+
+
+def effort_options(provider_name: str | None, model: str | None) -> dict[str, object]:
+    """The effort levels ``model`` accepts under ``provider_name``.
+
+    Returns ``{"supported": bool, "levels": [...]}``. ``supported`` False
+    means the model takes no effort parameter at all — the picker skips its
+    third step rather than offering a list that cannot be applied. ``levels``
+    never includes ``auto``; the caller prepends it, since "let the provider
+    decide" is meaningful exactly when some real level is also on offer.
+    """
+    canonical = _canonical(provider_name)
+
+    if canonical == "anthropic":
+        return _anthropic_options(model)
+
+    if canonical == "openai":
+        return _openai_options(model)
+
+    # Every other provider: the codebase carries no per-model effort table,
+    # and the OpenAI-compatible paths pass the value through as a body field
+    # that unsupported models IGNORE rather than reject (kimi-k3 was probed
+    # doing exactly that — silently dropped, not a 400). A quietly-ignored
+    # level costs nothing; withholding the whole ladder would remove a
+    # working control from every non-first-party provider.
+    return {"supported": True, "levels": list(LADDER)}
+
+
+def _canonical(provider_name: str | None) -> str:
+    if not provider_name:
+        return ""
+
+    try:
+        from src.providers import canonical_provider_name
+
+        return canonical_provider_name(provider_name)
+    except Exception:  # noqa: BLE001 — an unknown slug is not an error here
+        return provider_name.strip().lower()
+
+
+def _anthropic_options(model: str | None) -> dict[str, object]:
+    """Claude: effort is GA on a short allowlist, and ``xhigh`` is gated
+    inside it. Both predicates live in query.py because that is where the
+    request is built; importing them keeps one source of truth rather than
+    a copy that silently rots when a new model is added there."""
+    from src.query.query import _model_supports_effort, _model_supports_xhigh_effort
+
+    if not _model_supports_effort(model):
+        # Not a failure — the request still succeeds, the API just uses its
+        # own default and a requested level is dropped on the floor. That is
+        # precisely the silent no-op the picker should not offer.
+        return {"supported": False, "levels": []}
+
+    xhigh_ok = _model_supports_xhigh_effort(model)
+
+    # ``max`` is broadly accepted (the 400 that rejects xhigh on sonnet-4-6
+    # names max among the supported levels), so only xhigh needs gating.
+    return {
+        "supported": True,
+        "levels": [lvl for lvl in LADDER if lvl != "xhigh" or xhigh_ok],
+    }
+
+
+def _openai_options(model: str | None) -> dict[str, object]:
+    """OpenAI: the Responses API rejects a reasoning block outright on
+    non-reasoning models, so those get no third step at all."""
+    from src.providers.openai_responses import OPENAI_REASONING_EFFORTS, supports_reasoning
+
+    if not supports_reasoning(model or ""):
+        return {"supported": False, "levels": []}
+
+    # Intersect rather than pass through: OPENAI_REASONING_EFFORTS carries
+    # ``none``, which ``/effort`` would reject, and omits ``max``, which
+    # OpenAI 400s on for the same model OpenRouter tolerates it for.
+    return {
+        "supported": True,
+        "levels": [lvl for lvl in LADDER if lvl in OPENAI_REASONING_EFFORTS],
+    }

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -548,6 +548,9 @@ class _AgentSession:
         if subtype == "list_model_providers":
             self._do_list_model_providers(request_id)
             return
+        if subtype == "effort_options":
+            self._do_effort_options(request_id, inner.get("provider"), inner.get("model"))
+            return
         if subtype == "save_provider_key":
             self._do_save_provider_key(
                 request_id, inner.get("slug"), inner.get("api_key")
@@ -1553,7 +1556,18 @@ class _AgentSession:
         # persists (model, model_provider) to user settings — /model survives
         # restarts.
         _dispatch_app_state(self, main_loop_model=model)
-        response: dict = {"ok": True, "model": getattr(self.provider, "model", model)}
+        # Echo the provider alongside the model. This path cannot CHANGE the
+        # provider (a cross-provider id is refused above), but the client
+        # displays provider and model as one line and only ever learns the
+        # provider from a reply — so a reply that omits it leaves the label
+        # stuck on whatever ``init`` said, which is wrong the moment a
+        # cross-provider switch lands via set_provider + a retry through here.
+        # The fusion and set_provider paths already echo it; this was the gap.
+        response: dict = {
+            "ok": True,
+            "model": getattr(self.provider, "model", model),
+            "provider": self.provider_name,
+        }
         known = self._available_models()
         if known and model not in known:
             response["warning"] = (
@@ -1677,6 +1691,39 @@ class _AgentSession:
         except Exception as exc:  # noqa: BLE001
             logger.exception("[agent-server] set_provider failed")
             self._reply(request_id, {"ok": False, "error": str(exc)})
+
+    def _do_effort_options(
+        self, request_id: object, provider: object, model: object
+    ) -> None:
+        """The /model picker's step 3: the effort levels the model just picked
+        in step 2 will actually accept.
+
+        Queried per selection rather than ridden along on
+        ``list_model_providers`` — the ladder is a property of the MODEL, and
+        some providers enumerate hundreds of them, so answering for all of
+        them upfront would bloat every picker open to serve one row.
+
+        ``current`` lets the picker preselect the session's live level.
+        Defaults fall back to the session's own provider so a caller that
+        omits ``provider`` still gets a sensible answer.
+        """
+        try:
+            from src.providers.effort_options import effort_options
+
+            slug = provider if isinstance(provider, str) and provider else self.provider_name
+            name = model if isinstance(model, str) and model else getattr(self.provider, "model", "")
+            options = effort_options(slug, name)
+        except Exception as exc:  # noqa: BLE001 — never break the control channel
+            logger.exception("[agent-server] effort_options failed")
+            self._reply(request_id, {"ok": False, "error": str(exc)})
+            return
+        self._reply(request_id, {
+            "ok": True,
+            "current": self._effort or "",
+            "model": name,
+            "provider": slug,
+            **options,
+        })
 
     def _do_list_model_providers(self, request_id: object) -> None:
         """Every provider ClawCodex knows about — the /model picker's step 1.

--- a/tests/providers/test_effort_options.py
+++ b/tests/providers/test_effort_options.py
@@ -1,0 +1,119 @@
+"""The /model picker's step 3: which effort levels a model actually accepts.
+
+The list has to be the levels the model will really take, not the union
+ladder ``/effort`` validates against — offering a level the model rejects is
+fatal (a 400 on the effort level is retried nowhere), while omitting one
+merely hides a choice.
+"""
+
+import pytest
+
+from src.providers.effort_options import LADDER, effort_options
+from src.settings.constants import VALID_EFFORT_VALUES
+
+
+class TestAnthropic:
+    def test_opus_5_carries_the_full_ladder(self):
+        """Wire-probed 2026-07-25: opus-5 accepts xhigh and max."""
+        assert effort_options("anthropic", "claude-opus-5") == {
+            "supported": True,
+            "levels": ["low", "medium", "high", "xhigh", "max"],
+        }
+
+    def test_sonnet_4_6_drops_xhigh_but_keeps_max(self):
+        """sonnet-4-6 rejects xhigh with a 400 whose message names the levels
+        it does take — "high, low, max, medium" — so max stays and only xhigh
+        is gated. Offering xhigh here would 400 every subsequent request."""
+        r = effort_options("anthropic", "claude-sonnet-4-6")
+
+        assert r["supported"] is True
+        assert "xhigh" not in r["levels"]
+        assert "max" in r["levels"]
+
+    def test_a_model_outside_the_effort_allowlist_gets_no_step(self):
+        """Effort on a non-effort Claude model is a silent no-op: the request
+        succeeds and the level is dropped on the floor. That is exactly the
+        dead choice step 3 must not offer."""
+        assert effort_options("anthropic", "claude-haiku-4-5-20251001") == {
+            "supported": False,
+            "levels": [],
+        }
+
+
+class TestOpenAI:
+    def test_a_reasoning_model_drops_max(self):
+        """OPENAI_REASONING_EFFORTS omits max — OpenAI 400s on it for the same
+        model OpenRouter tolerates it for, so the clamp is provider-scoped."""
+        r = effort_options("openai", "gpt-5.6-luna")
+
+        assert r["supported"] is True
+        assert "max" not in r["levels"]
+        assert r["levels"] == ["low", "medium", "high", "xhigh"]
+
+    def test_none_never_leaks_into_the_ladder(self):
+        """``none`` is an OpenAI level but not a clawcodex one — _do_set_effort
+        would reject it, so an offered row would be unapplicable."""
+        assert "none" not in effort_options("openai", "gpt-5.6-luna")["levels"]
+
+    def test_a_non_reasoning_model_gets_no_step(self):
+        """A reasoning block on gpt-4o is a hard 400, verified live."""
+        assert effort_options("openai", "gpt-4o")["supported"] is False
+
+    def test_chat_variants_are_not_reasoning_models(self):
+        assert effort_options("openai", "gpt-5-chat-latest")["supported"] is False
+
+
+class TestOtherProviders:
+    @pytest.mark.parametrize(
+        ("provider", "model"),
+        [("deepseek", "deepseek-v4-flash"), ("moonshot", "kimi-k3"), ("zai", "glm-5.2")],
+    )
+    def test_providers_without_a_table_get_the_full_ladder(self, provider, model):
+        """No per-model effort table exists for these, and the compat paths
+        pass the value through as a body field unsupported models IGNORE
+        (kimi-k3 was probed doing exactly that). Withholding the ladder would
+        remove a working control from every non-first-party provider."""
+        assert effort_options(provider, model) == {"supported": True, "levels": list(LADDER)}
+
+    def test_an_alias_resolves_to_its_canonical_provider(self):
+        """``glm`` is an alias of ``zai``; a raw compare would misroute it."""
+        assert effort_options("glm", "glm-5.2") == effort_options("zai", "glm-5.2")
+
+    def test_an_unknown_provider_still_answers(self):
+        assert effort_options("not-a-real-provider", "some-model")["supported"] is True
+
+
+class TestLadderContract:
+    def test_the_ladder_matches_the_settings_source_of_truth(self):
+        """Every offered level has to survive _do_set_effort, which validates
+        against VALID_EFFORT_VALUES. A drift here means a row the picker shows
+        and the backend refuses."""
+        assert LADDER == tuple(v for v in VALID_EFFORT_VALUES if v)
+
+    @pytest.mark.parametrize(
+        ("provider", "model"),
+        [
+            ("anthropic", "claude-opus-5"),
+            ("anthropic", "claude-sonnet-4-6"),
+            ("openai", "gpt-5.6-luna"),
+            ("deepseek", "deepseek-v4-flash"),
+        ],
+    )
+    def test_no_offered_level_is_unapplicable(self, provider, model):
+        for level in effort_options(provider, model)["levels"]:
+            assert level in VALID_EFFORT_VALUES
+
+    def test_auto_is_never_a_backend_level(self):
+        """The picker prepends `auto` itself — it means "clear the override",
+        not a value to send."""
+        assert "auto" not in effort_options("anthropic", "claude-opus-5")["levels"]
+
+    def test_an_unsupported_model_reports_an_empty_ladder(self):
+        """`supported: False` and a non-empty `levels` would let a caller that
+        checks only one of the two offer dead rows."""
+        r = effort_options("anthropic", "claude-haiku-4-5-20251001")
+
+        assert r["supported"] is False and r["levels"] == []
+
+    def test_a_missing_model_is_not_an_error(self):
+        assert effort_options("anthropic", None)["supported"] is False

--- a/tests/server/test_model_provider_picker.py
+++ b/tests/server/test_model_provider_picker.py
@@ -33,9 +33,11 @@ class _StubSession:
     picker contract instead of the WebSocket harness.
     """
 
-    def __init__(self, provider_name: str = "anthropic", models=None, fusion=None):
+    def __init__(self, provider_name: str = "anthropic", models=None, fusion=None, effort=None):
         self.provider_name = provider_name
         self.provider = SimpleNamespace(model="claude-opus-5")
+        # The session's live /effort level; step 3 preselects it.
+        self._effort = effort
         self._models = list(models or [])
         self._fusion = fusion
         self.replies: list[tuple[object, dict]] = []
@@ -565,6 +567,52 @@ class TestDisconnectProviderControl:
         assert "project config" in sess.last["error"]
 
 
+# ── step 3: effort options ───────────────────────────────────────────────────
+
+
+class TestEffortOptions:
+    """The ``effort_options`` control behind the picker's third step."""
+
+    def test_reports_the_levels_for_the_model_being_selected(self):
+        """Keyed off the ARGUMENTS, not the session — step 3 runs before the
+        switch is applied, so answering for the live model would describe the
+        model the user is leaving."""
+        sess = _StubSession("anthropic")
+        _AgentSession._do_effort_options(sess, "r1", "anthropic", "claude-sonnet-4-6")
+
+        assert sess.last["ok"] is True
+        assert sess.last["supported"] is True
+        # sonnet-4-6 400s on xhigh; opus-5 (the session's live model) does not.
+        assert "xhigh" not in sess.last["levels"]
+
+    def test_reports_an_unsupported_model_as_such(self):
+        sess = _StubSession("anthropic")
+        _AgentSession._do_effort_options(sess, "r1", "anthropic", "claude-haiku-4-5-20251001")
+
+        assert sess.last["supported"] is False
+        assert sess.last["levels"] == []
+
+    def test_echoes_the_live_effort_so_the_picker_can_preselect(self):
+        sess = _StubSession("anthropic", effort="xhigh")
+        _AgentSession._do_effort_options(sess, "r1", "anthropic", "claude-opus-5")
+
+        assert sess.last["current"] == "xhigh"
+
+    def test_an_unset_effort_is_reported_as_empty_not_null(self):
+        sess = _StubSession("anthropic")
+        _AgentSession._do_effort_options(sess, "r1", "anthropic", "claude-opus-5")
+
+        assert sess.last["current"] == ""
+
+    def test_falls_back_to_the_session_when_arguments_are_missing(self):
+        sess = _StubSession("anthropic")
+        _AgentSession._do_effort_options(sess, "r1", None, None)
+
+        assert sess.last["provider"] == "anthropic"
+        assert sess.last["model"] == "claude-opus-5"
+        assert sess.last["supported"] is True
+
+
 # ── the cross-provider signal ────────────────────────────────────────────────
 
 
@@ -581,6 +629,18 @@ class TestCrossProviderSignal:
         assert reply["provider"] == "anthropic"
         # The human-readable half stays intact.
         assert "openai" in reply["error"]
+
+    def test_a_successful_switch_echoes_the_provider(self):
+        """The client renders provider and model as one phrase and only ever
+        learns the provider from a reply. Omitting it here left the label stuck
+        on whatever ``init`` said, so a cross-provider selection displayed the
+        new model beside the old provider (``anthropic · gpt-5.6-luna``). The
+        fusion and set_provider paths already echoed it; this one did not."""
+        sess = _StubSession("anthropic")
+        _AgentSession._do_set_model(sess, "r1", "claude-sonnet-5", "anthropic")
+
+        assert sess.last["ok"] is True
+        assert sess.last["provider"] == "anthropic"
 
     def test_an_alias_spelling_is_not_a_cross_provider_switch(self):
         """A session launched as ``--provider glm`` keeps that spelling while

--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -186,6 +186,47 @@ describe('createSlashHandler', () => {
     })
   })
 
+  it('repoints the provider label when /model crosses providers', async () => {
+    patchUiState({
+      info: { cwd: '/w/app', model: 'claude-opus-5', profile_name: 'anthropic', skills: {}, tools: {} } as never,
+      sid: 'sid-abc'
+    })
+
+    const ctx = buildCtx({
+      gateway: {
+        ...buildGateway(),
+        rpc: vi.fn(() => Promise.resolve({ provider: 'openai', value: 'gpt-5.6-luna' }))
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/model gpt-5.6-luna --provider openai')).toBe(true)
+    await vi.waitFor(() => {
+      // Both halves move, or the line reads `anthropic · gpt-5.6-luna`.
+      expect(getUiState().info?.model).toBe('gpt-5.6-luna')
+      expect(getUiState().info?.profile_name).toBe('openai')
+    })
+  })
+
+  it('leaves the provider label alone for a same-provider /model switch', async () => {
+    patchUiState({
+      info: { cwd: '/w/app', model: 'claude-opus-5', profile_name: 'anthropic', skills: {}, tools: {} } as never,
+      sid: 'sid-abc'
+    })
+
+    const ctx = buildCtx({
+      gateway: {
+        ...buildGateway(),
+        rpc: vi.fn(() => Promise.resolve({ value: 'claude-sonnet-5' }))
+      }
+    })
+
+    expect(createSlashHandler(ctx)('/model claude-sonnet-5')).toBe(true)
+    await vi.waitFor(() => {
+      expect(getUiState().info?.model).toBe('claude-sonnet-5')
+    })
+    expect(getUiState().info?.profile_name).toBe('anthropic')
+  })
+
   it('honors TUI picker session scope without adding --global', async () => {
     patchUiState({ sid: 'sid-abc' })
 

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -383,7 +383,53 @@ describe('GatewayClient NDJSON adapter', () => {
   it('falls back to the requested model when an older backend acks without echoing it', async () => {
     const p = gw.request('config.set', { key: 'model', value: 'x-model' })
     await replyToControl('set_model', { ok: true })
+    // No `provider` key at all: an absent provider means "unchanged", and
+    // synthesizing one here would let a caller overwrite a correct label.
     await expect(p).resolves.toEqual({ value: 'x-model' })
+  })
+
+  it('passes the provider the backend echoes through to the caller', async () => {
+    const p = gw.request('config.set', { key: 'model', value: 'deepseek-v4-pro' })
+    await replyToControl('set_model', { model: 'deepseek-v4-pro', ok: true, provider: 'deepseek' })
+    await expect(p).resolves.toEqual({ provider: 'deepseek', value: 'deepseek-v4-pro' })
+  })
+
+  // ── step 3: the effort ladder for the model being selected ───────────────
+
+  it('reports the effort ladder for the model the picker asks about', async () => {
+    const p = gw.request('model.effort_options', { model: 'claude-opus-5', provider: 'anthropic' })
+    await replyToControl('effort_options', {
+      current: 'xhigh',
+      levels: ['low', 'medium', 'high', 'xhigh', 'max'],
+      ok: true,
+      supported: true
+    })
+
+    await expect(p).resolves.toEqual({
+      current: 'xhigh',
+      levels: ['low', 'medium', 'high', 'xhigh', 'max'],
+      supported: true
+    })
+
+    const req = seen.find(f => f.request?.subtype === 'effort_options')!.request
+    expect(req.model).toBe('claude-opus-5')
+    expect(req.provider).toBe('anthropic')
+  })
+
+  it('treats an errored effort lookup as "no ladder" rather than failing the switch', async () => {
+    // The model is already chosen by the time this runs, so a refusal must
+    // degrade to the two-step flow, not reject and strand the picker.
+    const p = gw.request('model.effort_options', { model: 'm', provider: 'p' })
+    await replyToControl('effort_options', { error: 'boom', ok: false })
+
+    await expect(p).resolves.toEqual({ levels: [], supported: false })
+  })
+
+  it('drops non-string levels from a malformed reply', async () => {
+    const p = gw.request('model.effort_options', { model: 'm', provider: 'p' })
+    await replyToControl('effort_options', { levels: ['low', 3, null, 'max'], ok: true, supported: true })
+
+    await expect(p).resolves.toMatchObject({ levels: ['low', 'max'] })
   })
 
   it('rejects with the backend error when the model switch is refused', async () => {
@@ -429,14 +475,30 @@ describe('GatewayClient NDJSON adapter', () => {
       provider_mismatch: true
     })
     await reply('set_provider', { model: 'gpt-5.4', ok: true, provider: 'openai' })
+    // No `provider` in the retry's reply — an older backend. The switch still
+    // has to report where the session landed, or the caller leaves the stats
+    // line reading `anthropic · gpt-5.4`.
     await reply('set_model', { model: 'gpt-5.4', ok: true })
 
-    await expect(p).resolves.toEqual({ value: 'gpt-5.4' })
+    await expect(p).resolves.toEqual({ provider: 'openai', value: 'gpt-5.4' })
 
     const switched = seen.find(f => f.request?.subtype === 'set_provider')!.request
     expect(switched.provider).toBe('openai')
     // Two set_model frames: the probe that got refused, then the retry.
     expect(seen.filter(f => f.request?.subtype === 'set_model')).toHaveLength(2)
+  })
+
+  it('prefers the provider the retry itself reports over the requested one', async () => {
+    const reply = makeReplier()
+    const p = gw.request('config.set', { key: 'model', value: 'gpt-5.4 --provider openai' })
+
+    await reply('set_model', { ok: false, provider: 'anthropic', provider_mismatch: true })
+    await reply('set_provider', { model: 'gpt-5.4', ok: true, provider: 'openai' })
+    // The backend canonicalizes the slug it was sent; its answer wins so the
+    // label matches what the session is actually on.
+    await reply('set_model', { model: 'gpt-5.4', ok: true, provider: 'openai-compat' })
+
+    await expect(p).resolves.toEqual({ provider: 'openai-compat', value: 'gpt-5.4' })
   })
 
   it('surfaces a failed provider switch instead of the model error', async () => {

--- a/ui-tui/src/__tests__/modelPicker.test.tsx
+++ b/ui-tui/src/__tests__/modelPicker.test.tsx
@@ -1,0 +1,331 @@
+/**
+ * The /model picker's three steps: provider → model → effort.
+ *
+ * Step 3 is conditional by design — a model that accepts no effort parameter
+ * gets the two-step flow it always had, because a list whose every row is a
+ * silent no-op is worse than no list. These drive real keys through a mounted
+ * component, since the stage transitions ARE the behavior.
+ */
+import { PassThrough } from 'node:stream'
+
+import { renderSync } from '@clawcodex/ink'
+import React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ModelPicker } from '../components/modelPicker.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
+
+const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+const ARROW_DOWN = '[B'
+const ENTER = '\r'
+const ESC = ''
+
+// Ink brackets every frame in a synchronized-update pair (BSU … ESU) and, into
+// a PassThrough, flushes each one more than once — so the accumulated output
+// contains EVERY stage this picker has ever painted. Asserting a stage against
+// it would pass for any stage already visited, which is exactly the mistake
+// that let a broken Esc target go unnoticed. Assert against the last frame.
+const BSU = '[?2026h'
+const ESU = '[?2026l'
+
+const lastFrame = (output: string): string => {
+  const frames = output
+    .split(BSU)
+    .map(chunk => chunk.split(ESU)[0] ?? '')
+    .filter(frame => stripAnsi(frame).trim() !== '')
+
+  return stripAnsi(frames.at(-1) ?? '')
+}
+
+const PROVIDERS = [
+  {
+    authenticated: true,
+    is_current: true,
+    models: ['claude-opus-5', 'claude-haiku-4-5'],
+    name: 'anthropic',
+    slug: 'anthropic',
+    total_models: 2
+  }
+]
+
+interface FakeReplies {
+  effort?: { current?: string; levels?: string[]; supported?: boolean }
+  /** Hold the effort reply open so the loading state can be driven. */
+  effortDeferred?: boolean
+  effortRejects?: boolean
+}
+
+function mount(replies: FakeReplies = {}) {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let out = ''
+
+  stdout.on('data', (c: Buffer) => {
+    out += c.toString()
+  })
+  Object.assign(stdout, { columns: 100, rows: 40 })
+  Object.assign(stdin, { isTTY: true, ref: () => {}, setRawMode: () => {}, unref: () => {} })
+
+  const onCancel = vi.fn()
+  const onSelect = vi.fn()
+  const requests: Array<{ method: string; params: unknown }> = []
+  let releaseEffort = () => {}
+
+  const gw = {
+    request: (method: string, params: unknown) => {
+      requests.push({ method, params })
+
+      if (method === 'model.options') {
+        return Promise.resolve({ model: 'claude-opus-5', provider: 'anthropic', providers: PROVIDERS })
+      }
+
+      if (method === 'model.effort_options') {
+        if (replies.effortRejects) {
+          return Promise.reject(new Error('backend said no'))
+        }
+
+        const answer = replies.effort ?? { current: '', levels: [], supported: false }
+
+        if (replies.effortDeferred) {
+          return new Promise(resolve => {
+            releaseEffort = () => resolve(answer)
+          })
+        }
+
+        return Promise.resolve(answer)
+      }
+
+      return Promise.resolve({})
+    }
+  }
+
+  const app = renderSync(
+    React.createElement(ModelPicker, {
+      gw: gw as never,
+      onCancel,
+      onSelect,
+      sessionId: 'sid-1',
+      t: DEFAULT_THEME
+    }),
+    {
+      exitOnCtrlC: false,
+      patchConsole: false,
+      stderr: stderr as NodeJS.WriteStream,
+      stdin: stdin as NodeJS.ReadStream,
+      stdout: stdout as NodeJS.WriteStream
+    }
+  )
+
+  return {
+    /** The stage currently on screen — see lastFrame. */
+    frame: () => lastFrame(out),
+    onCancel,
+    onSelect,
+    output: () => stripAnsi(out),
+    async press(seq: string, settle = 30) {
+      stdin.write(seq)
+      await delay(settle)
+    },
+    async releaseEffort(settle = 30) {
+      releaseEffort()
+      await delay(settle)
+    },
+    requests,
+    unmount: () => app.unmount()
+  }
+}
+
+const FULL_LADDER = { current: '', levels: ['low', 'medium', 'high', 'xhigh', 'max'], supported: true }
+
+/** Walk to the model list, then select the first model. */
+async function toEffortStage(p: ReturnType<typeof mount>) {
+  await delay(30)
+  await p.press(ENTER) // provider → model
+  await p.press(ENTER) // model → effort (or apply, when unsupported)
+}
+
+describe('ModelPicker step 3 — effort', () => {
+  it('labels the flow as three steps', async () => {
+    const p = mount()
+    await delay(30)
+
+    expect(p.frame()).toContain('step 1/3')
+    p.unmount()
+  })
+
+  it('offers auto plus the levels the model accepts', async () => {
+    const p = mount({ effort: FULL_LADDER })
+    await toEffortStage(p)
+
+    const frame = p.frame()
+
+    expect(frame).toContain('step 3/3')
+    expect(frame).toContain('1. auto')
+    expect(frame).toContain('2. low')
+    expect(frame).toContain('6. max')
+    p.unmount()
+  })
+
+  it('asks the backend about the model just chosen, not the live one', async () => {
+    const p = mount({ effort: FULL_LADDER })
+    await delay(30)
+    await p.press(ENTER)
+    await p.press(ARROW_DOWN) // second model
+    await p.press(ENTER)
+
+    const ask = p.requests.find(r => r.method === 'model.effort_options')
+
+    expect(ask?.params).toEqual({ model: 'claude-haiku-4-5', provider: 'anthropic' })
+    p.unmount()
+  })
+
+  it('applies the model with the chosen level', async () => {
+    const p = mount({ effort: FULL_LADDER })
+    await toEffortStage(p)
+    await p.press(ARROW_DOWN) // auto → low
+    await p.press(ENTER)
+
+    expect(p.onSelect).toHaveBeenCalledWith(expect.stringContaining('claude-opus-5 --provider anthropic'), 'low')
+    p.unmount()
+  })
+
+  it('sends no effort when auto is chosen', async () => {
+    // `auto` means "clear the override", which is the picker's own row — not
+    // a level to hand to /effort.
+    const p = mount({ effort: FULL_LADDER })
+    await toEffortStage(p)
+    await p.press(ENTER)
+
+    expect(p.onSelect).toHaveBeenCalledWith(expect.any(String), undefined)
+    p.unmount()
+  })
+
+  it('preselects the session’s live level so Enter-through changes nothing', async () => {
+    const p = mount({ effort: { ...FULL_LADDER, current: 'xhigh' } })
+    await toEffortStage(p)
+    await p.press(ENTER)
+
+    expect(p.onSelect).toHaveBeenCalledWith(expect.any(String), 'xhigh')
+    p.unmount()
+  })
+
+  it('skips the step entirely for a model with no effort ladder', async () => {
+    const p = mount({ effort: { levels: [], supported: false } })
+    await toEffortStage(p)
+
+    expect(p.onSelect).toHaveBeenCalledWith(expect.stringContaining('claude-opus-5'), undefined)
+    expect(p.output()).not.toContain('step 3/3')
+    p.unmount()
+  })
+
+  it('applies the model anyway when the capability lookup fails', async () => {
+    // The model is already chosen by this point; a failed lookup must not
+    // strand the user on a blank step.
+    const p = mount({ effortRejects: true })
+    await toEffortStage(p)
+
+    expect(p.onSelect).toHaveBeenCalledWith(expect.stringContaining('claude-opus-5'), undefined)
+    p.unmount()
+  })
+
+  it('goes back to the model list, not out to the providers', async () => {
+    const p = mount({ effort: FULL_LADDER })
+    await toEffortStage(p)
+
+    expect(p.frame()).toContain('step 3/3')
+
+    // A lone ESC is the prefix of every escape SEQUENCE, so the input parser
+    // holds it until it can rule one out — give it longer than a plain key.
+    await p.press(ESC, 200)
+
+    const frame = p.frame()
+
+    expect(frame).toContain('step 2/3')
+    expect(frame).not.toContain('step 1/3')
+    expect(p.onCancel).not.toHaveBeenCalled()
+    p.unmount()
+  })
+
+  it('does not dispatch a switch when backing out of step 3', async () => {
+    const p = mount({ effort: FULL_LADDER })
+    await toEffortStage(p)
+    // A lone ESC is the prefix of every escape SEQUENCE, so the input parser
+    // holds it until it can rule one out — give it longer than a plain key.
+    await p.press(ESC, 200)
+
+    expect(p.onSelect).not.toHaveBeenCalled()
+    p.unmount()
+  })
+
+  it('ignores Enter while the ladder is still loading', async () => {
+    // Without the loading guard this applies with no effort AND the reply
+    // then lands on a stage the user has already left — one keystroke, two
+    // switches.
+    const p = mount({ effort: FULL_LADDER, effortDeferred: true })
+    await toEffortStage(p)
+
+    expect(p.frame()).toContain('loading effort levels…')
+
+    await p.press(ENTER)
+
+    expect(p.onSelect).not.toHaveBeenCalled()
+
+    await p.releaseEffort()
+    await p.press(ENTER)
+
+    expect(p.onSelect).toHaveBeenCalledTimes(1)
+    p.unmount()
+  })
+
+  it('honors allowEffortStep=false for draft-only callers', async () => {
+    // The new-prompt-session picker captures a draft and has no session to
+    // set an effort on, so it must keep the two-step flow.
+    const stdout = new PassThrough()
+    const stdin = new PassThrough()
+    Object.assign(stdout, { columns: 100, rows: 40 })
+    Object.assign(stdin, { isTTY: true, ref: () => {}, setRawMode: () => {}, unref: () => {} })
+    const onSelect = vi.fn()
+    const requests: string[] = []
+
+    const app = renderSync(
+      React.createElement(ModelPicker, {
+        allowEffortStep: false,
+        gw: {
+          request: (method: string) => {
+            requests.push(method)
+
+            return Promise.resolve(
+              method === 'model.options'
+                ? { model: 'claude-opus-5', provider: 'anthropic', providers: PROVIDERS }
+                : {}
+            )
+          }
+        } as never,
+        onCancel: vi.fn(),
+        onSelect,
+        sessionId: 'sid-1',
+        t: DEFAULT_THEME
+      }),
+      {
+        exitOnCtrlC: false,
+        patchConsole: false,
+        stderr: new PassThrough() as NodeJS.WriteStream,
+        stdin: stdin as NodeJS.ReadStream,
+        stdout: stdout as NodeJS.WriteStream
+      }
+    )
+
+    await delay(30)
+    stdin.write(ENTER)
+    await delay(30)
+    stdin.write(ENTER)
+    await delay(30)
+
+    expect(onSelect).toHaveBeenCalledWith(expect.stringContaining('claude-opus-5'), undefined)
+    expect(requests).not.toContain('model.effort_options')
+    app.unmount()
+  })
+})

--- a/ui-tui/src/__tests__/modelSwitch.test.ts
+++ b/ui-tui/src/__tests__/modelSwitch.test.ts
@@ -1,0 +1,80 @@
+/**
+ * `infoAfterModelSwitch` — the single place a completed model switch is folded
+ * back into `ui.info`.
+ *
+ * The regression it exists to prevent: the stats line renders
+ * `profile_name · model` as one phrase, and switching a model used to patch
+ * `model` alone, so a cross-provider selection displayed the NEW model beside
+ * the OLD provider (`anthropic · gpt-5.6-luna`).
+ */
+import { describe, expect, it } from 'vitest'
+
+import { infoAfterModelSwitch, modelPickerCommands } from '../domain/modelSwitch.js'
+import type { SessionInfo } from '../types.js'
+
+const base = (): SessionInfo => ({
+  cwd: '/w/app',
+  model: 'claude-opus-5',
+  profile_name: 'anthropic',
+  skills: {},
+  tools: {}
+})
+
+describe('infoAfterModelSwitch', () => {
+  it('moves the provider label along with the model', () => {
+    const next = infoAfterModelSwitch(base(), 'gpt-5.6-luna', 'openai')
+
+    expect(next.model).toBe('gpt-5.6-luna')
+    expect(next.profile_name).toBe('openai')
+  })
+
+  it('keeps the current provider when the switch reports none', () => {
+    // An absent provider means "unchanged", not "unknown" — a same-provider
+    // switch and an older backend both look like this, and blanking a correct
+    // label would be a worse bug than the stale one.
+    const next = infoAfterModelSwitch(base(), 'claude-sonnet-5')
+
+    expect(next.model).toBe('claude-sonnet-5')
+    expect(next.profile_name).toBe('anthropic')
+  })
+
+  it('preserves the rest of the session info', () => {
+    const next = infoAfterModelSwitch({ ...base(), reasoning_effort: 'high' }, 'gpt-5.6-luna', 'openai')
+
+    expect(next.cwd).toBe('/w/app')
+    expect(next.reasoning_effort).toBe('high')
+  })
+
+  it('does not mutate the info it was given', () => {
+    const info = base()
+    infoAfterModelSwitch(info, 'gpt-5.6-luna', 'openai')
+
+    expect(info.model).toBe('claude-opus-5')
+    expect(info.profile_name).toBe('anthropic')
+  })
+
+  it('seeds a minimal info when the switch beats the backend init', () => {
+    const next = infoAfterModelSwitch(null, 'gpt-5.6-luna', 'openai')
+
+    expect(next).toEqual({ model: 'gpt-5.6-luna', profile_name: 'openai', skills: {}, tools: {} })
+  })
+
+  it('leaves profile_name unset when there is neither prior info nor a provider', () => {
+    expect(infoAfterModelSwitch(null, 'gpt-5.6-luna')).toEqual({ model: 'gpt-5.6-luna', skills: {}, tools: {} })
+  })
+})
+
+describe('modelPickerCommands', () => {
+  const value = 'claude-opus-5 --provider anthropic --tui-session'
+
+  it('dispatches the model switch, then the effort', () => {
+    expect(modelPickerCommands(value, 'xhigh')).toEqual([`/model ${value}`, '/effort xhigh'])
+  })
+
+  it('emits no /effort when step 3 was skipped or answered auto', () => {
+    // Leaving the session's level untouched is the point: `auto` and "this
+    // model has no ladder" both mean "don't set one", not "reset to default".
+    expect(modelPickerCommands(value)).toEqual([`/model ${value}`])
+    expect(modelPickerCommands(value, '')).toEqual([`/model ${value}`])
+  })
+})

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -1,4 +1,5 @@
 import { attachedImageNotice, introMsg, toTranscriptMessages } from '../../../domain/messages.js'
+import { infoAfterModelSwitch } from '../../../domain/modelSwitch.js'
 import { TUI_SESSION_MODEL_FLAG } from '../../../domain/slash.js'
 import type {
   BackgroundStartResponse,
@@ -111,7 +112,7 @@ export const sessionCommands: SlashCommand[] = [
 
               patchUiState(state => ({
                 ...state,
-                info: state.info ? { ...state.info, model: r.value! } : { model: r.value!, skills: {}, tools: {} }
+                info: infoAfterModelSwitch(state.info, r.value!, r.provider)
               }))
             })
           )

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -16,6 +16,7 @@ import { MAX_HISTORY, WHEEL_SCROLL_STEP } from '../config/limits.js'
 import { hasLeadGap, prevRenderedMsg, showsInterTurnSeparator } from '../domain/blockLayout.js'
 import { SECTION_NAMES, sectionMode } from '../domain/details.js'
 import { attachedImageNotice } from '../domain/messages.js'
+import { infoAfterModelSwitch, modelPickerCommands } from '../domain/modelSwitch.js'
 import { composeTabTitle, fmtCwdBranch, shortCwd } from '../domain/paths.js'
 import { type GatewayClient } from '../gatewayClient.js'
 import type {
@@ -1143,9 +1144,12 @@ export function useMainApp(gw: GatewayClient) {
     [overlay.secret, respondWith]
   )
 
-  const onModelSelect = useCallback((value: string) => {
+  const onModelSelect = useCallback((value: string, effort?: string) => {
     patchOverlayState({ modelPicker: false })
-    slashRef.current(`/model ${value}`)
+
+    for (const command of modelPickerCommands(value, effort)) {
+      slashRef.current(command)
+    }
   }, [])
 
   const onLogoSelect = useCallback((value: string) => {
@@ -1204,10 +1208,10 @@ export function useMainApp(gw: GatewayClient) {
         maybeWarn,
         modelArg,
         newLiveSession: session.newLiveSession,
-        onModelSwitched: value =>
+        onModelSwitched: (value, result) =>
           patchUiState(state => ({
             ...state,
-            info: state.info ? { ...state.info, model: value } : { model: value, skills: {}, tools: {} }
+            info: infoAfterModelSwitch(state.info, value, result.provider)
           })),
         prompt,
         rpc,

--- a/ui-tui/src/components/activeSessionSwitcher.tsx
+++ b/ui-tui/src/components/activeSessionSwitcher.tsx
@@ -661,6 +661,9 @@ export function ActiveSessionSwitcher({
   if (pickingModel) {
     return (
       <ModelPicker
+        // A draft for a not-yet-started session: the model is carried in the
+        // prompt's --model arg, and there is no session to set an effort on.
+        allowEffortStep={false}
         allowPersistGlobal={false}
         gw={gw}
         onCancel={() => setPickingModel(false)}

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { providerDisplayNames } from '../domain/providers.js'
 import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
-import type { ModelOptionProvider, ModelOptionsResponse } from '../gatewayTypes.js'
+import type { EffortOptionsResponse, ModelOptionProvider, ModelOptionsResponse } from '../gatewayTypes.js'
 import { fuzzyRank } from '../lib/fuzzy.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
@@ -15,9 +15,24 @@ const VISIBLE = 12
 const MIN_WIDTH = 40
 const MAX_WIDTH = 90
 
-type Stage = 'provider' | 'key' | 'model' | 'disconnect'
+type Stage = 'provider' | 'key' | 'model' | 'effort' | 'disconnect'
 
-export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect, sessionId, t }: ModelPickerProps) {
+/**
+ * Offered above the model's real levels on step 3: clears the session
+ * override so the provider picks. Kept out of the backend's `levels` because
+ * "let the provider decide" is only meaningful alongside a real level.
+ */
+const AUTO_EFFORT = 'auto'
+
+export function ModelPicker({
+  allowEffortStep = true,
+  allowPersistGlobal = true,
+  gw,
+  onCancel,
+  onSelect,
+  sessionId,
+  t
+}: ModelPickerProps) {
   const [providers, setProviders] = useState<ModelOptionProvider[]>([])
   const [currentModel, setCurrentModel] = useState('')
   const [err, setErr] = useState('')
@@ -29,6 +44,13 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
   const [keyInput, setKeyInput] = useState('')
   const [keySaving, setKeySaving] = useState(false)
   const [keyError, setKeyError] = useState('')
+  // Step 3. `effortLevels` is auto + whatever the chosen model accepts;
+  // `pendingModel` is the step-2 choice held while step 3 runs, so the
+  // switch is applied once, with both halves, rather than twice.
+  const [effortLevels, setEffortLevels] = useState<string[]>([])
+  const [effortIdx, setEffortIdx] = useState(0)
+  const [effortLoading, setEffortLoading] = useState(false)
+  const [pendingModel, setPendingModel] = useState('')
   // Type-to-filter query, scoped per stage (cleared on stage change).
   const [filter, setFilter] = useState('')
 
@@ -121,12 +143,34 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
     }
   }, [models.length, modelIdx])
 
+  const buildModelValue = (slug: string, model: string) =>
+    `${model} --provider ${slug}${allowPersistGlobal && persistGlobal ? ' --global' : ` ${TUI_SESSION_MODEL_FLAG}`}`
+
+  // One exit point for the whole flow, so the switch is dispatched exactly
+  // once whether step 3 ran, was skipped, or failed to load.
+  const apply = (value: string, effort?: string) => {
+    onSelect(value, effort && effort !== AUTO_EFFORT ? effort : undefined)
+  }
+
   const back = () => {
     // Esc first clears an active filter on the list stages, before navigating.
     if ((stage === 'provider' || stage === 'model') && filter.trim()) {
       setFilter('')
       setProviderIdx(stage === 'provider' ? 0 : providerIdx)
       setModelIdx(0)
+
+      return
+    }
+
+    // Step 3 goes back one step, to the model list it came from — not all
+    // the way out to the providers.
+    if (stage === 'effort') {
+      setStage('model')
+      setEffortLevels([])
+      setEffortIdx(0)
+      setEffortLoading(false)
+      setPendingModel('')
+      setFilter('')
 
       return
     }
@@ -147,7 +191,9 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
 
   // On the list stages we capture printable keys (including 'q') into the
   // filter, so the shared overlay q/Esc handler must yield to our own handler.
-  const listStage = stage === 'provider' || stage === 'model'
+  // Step 3 joins the list stages so the shared q/Esc handler yields to ours
+  // (it has no filter of its own, but it does own Enter/Esc/arrows).
+  const listStage = stage === 'provider' || stage === 'model' || stage === 'effort'
   useOverlayKeys({ disabled: listStage, onBack: back, onClose: onCancel })
 
   useInput((ch, key) => {
@@ -286,9 +332,13 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
       return
     }
 
-    const count = stage === 'provider' ? filteredProviderRows.length : models.length
-    const sel = stage === 'provider' ? providerIdx : modelIdx
-    const setSel = stage === 'provider' ? setProviderIdx : setModelIdx
+    if (stage === 'effort' && effortLoading) {
+      return
+    }
+
+    const count = stage === 'provider' ? filteredProviderRows.length : stage === 'effort' ? effortLevels.length : models.length
+    const sel = stage === 'provider' ? providerIdx : stage === 'effort' ? effortIdx : modelIdx
+    const setSel = stage === 'provider' ? setProviderIdx : stage === 'effort' ? setEffortIdx : setModelIdx
 
     if (key.upArrow && sel > 0) {
       setSel(v => v - 1)
@@ -328,16 +378,70 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
         return
       }
 
-      const model = models[modelIdx]
+      if (stage === 'effort') {
+        const level = effortLevels[effortIdx]
 
-      if (provider && model) {
-        onSelect(
-          `${model} --provider ${provider.slug}${allowPersistGlobal && persistGlobal ? ' --global' : ` ${TUI_SESSION_MODEL_FLAG}`}`
-        )
-      } else {
-        setStage('provider')
+        // `auto` is the picker's own row, not a level to send — it means
+        // "clear the override", which is exactly what /effort auto does.
+        apply(pendingModel, level)
+
+        return
       }
 
+      const model = models[modelIdx]
+
+      if (!provider || !model) {
+        setStage('provider')
+
+        return
+      }
+
+      const value = buildModelValue(provider.slug, model)
+
+      if (!allowEffortStep) {
+        apply(value)
+
+        return
+      }
+
+      // Step 3 is offered only where it can be applied: a model that takes no
+      // effort parameter gets the two-step flow it had before, rather than a
+      // list whose every row is a no-op.
+      setPendingModel(value)
+      setEffortLoading(true)
+      setFilter('')
+      setStage('effort')
+      gw.request<EffortOptionsResponse>('model.effort_options', { model, provider: provider.slug })
+        .then(raw => {
+          const r = asRpcResult<EffortOptionsResponse>(raw)
+          const levels = r?.supported ? (r.levels ?? []) : []
+
+          if (!levels.length) {
+            apply(value)
+
+            return
+          }
+
+          const rows = [AUTO_EFFORT, ...levels]
+          setEffortLevels(rows)
+          // Land on the session's live level so Enter-through is a no-op
+          // rather than a silent reset to auto.
+          setEffortIdx(Math.max(0, rows.indexOf(r?.current || AUTO_EFFORT)))
+          setEffortLoading(false)
+        })
+        .catch(() => {
+          // The model is already chosen; a failed capability lookup must not
+          // strand the user on a blank step. Apply what we have.
+          apply(value)
+        })
+
+      return
+    }
+
+    // Step 3 has no filter, and its model value (with the persist flag baked
+    // in) was built on the way in — so a ^g toggle here would silently do
+    // nothing. Everything below this line belongs to the two list stages.
+    if (stage === 'effort') {
       return
     }
 
@@ -509,6 +613,68 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
     )
   }
 
+  // ── Effort selection stage (step 3) ──────────────────────────────────
+  if (stage === 'effort') {
+    if (effortLoading) {
+      return <Text color={t.color.muted}>loading effort levels…</Text>
+    }
+
+    const { items, offset } = windowItems(effortLevels, effortIdx, VISIBLE)
+
+    return (
+      <Box flexDirection="column" width={width}>
+        <Text bold color={t.color.accent} wrap="truncate-end">
+          Select effort (step 3/3)
+        </Text>
+
+        <Text color={t.color.muted} wrap="truncate-end">
+          {pendingModel.split(' ')[0] || '(model)'} · Esc back
+        </Text>
+
+        <Text color={t.color.muted} wrap="truncate-end">
+          Levels this model accepts · Enter to switch
+        </Text>
+
+        <Text color={t.color.muted} wrap="truncate-end">
+          {offset > 0 ? ` ↑ ${offset} more` : ' '}
+        </Text>
+
+        {Array.from({ length: Math.min(VISIBLE, Math.max(effortLevels.length, 1)) }, (_, i) => {
+          const row = items[i]
+          const idx = offset + i
+
+          if (!row) {
+            return (
+              <Text color={t.color.muted} key={`pad-${i}`} wrap="truncate-end">
+                {' '}
+              </Text>
+            )
+          }
+
+          return (
+            <Text
+              bold={effortIdx === idx}
+              color={effortIdx === idx ? t.color.accent : t.color.muted}
+              inverse={effortIdx === idx}
+              key={`effort-${row}`}
+              wrap="truncate-end"
+            >
+              {effortIdx === idx ? '▸ ' : '  '}
+              {idx + 1}. {row}
+              {row === AUTO_EFFORT ? ' · provider default' : ''}
+            </Text>
+          )
+        })}
+
+        <Text color={t.color.muted} wrap="truncate-end">
+          {offset + VISIBLE < effortLevels.length ? ` ↓ ${effortLevels.length - offset - VISIBLE} more` : ' '}
+        </Text>
+
+        <OverlayHint t={t}>↑/↓ select · Enter switch · Esc back · q close</OverlayHint>
+      </Box>
+    )
+  }
+
   // ── Provider selection stage ─────────────────────────────────────────
   if (stage === 'provider') {
     const rows = filteredProviderRows.map(({ provider: p, name }) => {
@@ -527,11 +693,11 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
     return (
       <Box flexDirection="column" width={width}>
         <Text bold color={t.color.accent} wrap="truncate-end">
-          Select provider (step 1/2)
+          Select provider (step 1/3)
         </Text>
 
         <Text color={t.color.muted} wrap="truncate-end">
-          Full model IDs on the next step · Enter to continue
+          Then a model, then its effort level · Enter to continue
         </Text>
 
         <Text color={t.color.muted} wrap="truncate-end">
@@ -597,7 +763,7 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
   return (
     <Box flexDirection="column" width={width}>
       <Text bold color={t.color.accent} wrap="truncate-end">
-        Select model (step 2/2)
+        Select model (step 2/3)
       </Text>
 
       <Text color={t.color.muted} wrap="truncate-end">
@@ -661,10 +827,18 @@ export function ModelPicker({ allowPersistGlobal = true, gw, onCancel, onSelect,
 }
 
 interface ModelPickerProps {
+  /**
+   * Whether to offer step 3. False for callers that capture the selection as
+   * a draft instead of switching the live session — they have nowhere to put
+   * an effort level, and offering a choice they would discard is worse than
+   * not offering it.
+   */
+  allowEffortStep?: boolean
   allowPersistGlobal?: boolean
   gw: GatewayClient
   onCancel: () => void
-  onSelect: (value: string) => void
+  /** `effort` is the step-3 choice, omitted for `auto` and for models with no ladder. */
+  onSelect: (value: string, effort?: string) => void
   sessionId: string | null
   t: Theme
 }

--- a/ui-tui/src/domain/modelSwitch.ts
+++ b/ui-tui/src/domain/modelSwitch.ts
@@ -1,0 +1,60 @@
+/**
+ * Folding a completed model switch back into `ui.info`.
+ *
+ * The stats line under the composer and the banner's model line both read
+ * provider and model out of the same `SessionInfo`:
+ *
+ *   anthropic · gpt-5.6-luna · ~/work/app · turns: 4 · …
+ *              ^^^^^^^^^^^^^ moved      ^^ did not
+ *
+ * `profile_name` used to be written exactly once, from the backend's `init`,
+ * while every switch patched `model` alone — so selecting a model from another
+ * provider left the two halves describing different sessions. Both apply sites
+ * (the `/model` command and the prompt-session model arg) go through here so
+ * they cannot drift apart again.
+ */
+import type { SessionInfo } from '../types.js'
+
+/**
+ * `info` with the switch applied. `provider` is optional on purpose: the
+ * backend omits it when it has nothing to say (and older backends never send
+ * it), and an absent provider means "unchanged", not "unknown" — blanking a
+ * still-correct label would be a worse bug than the stale one. A null `info`
+ * means the switch beat the backend's init; seed the minimum the type needs.
+ */
+export function infoAfterModelSwitch(
+  info: null | SessionInfo | undefined,
+  model: string,
+  provider?: string
+): SessionInfo {
+  const next: SessionInfo = info
+    ? { ...info, model }
+    : { model, skills: {}, tools: {} }
+
+  if (provider) {
+    next.profile_name = provider
+  }
+
+  return next
+}
+
+/**
+ * The slash commands a /model picker selection expands to, in dispatch order.
+ *
+ * The picker's three steps land on two independent settings, so each half
+ * re-enters its own command (the /model + /logo picker pattern) and keeps
+ * owning its RPC, persistence and transcript line — rather than teaching the
+ * /model grammar a second dimension. Effort goes second so the transcript
+ * reads model-then-effort; it is model-independent, so the order is
+ * cosmetic. An absent effort — `auto`, or a model with no ladder — emits no
+ * `/effort` at all, leaving the session's level untouched.
+ */
+export function modelPickerCommands(value: string, effort?: string): string[] {
+  const commands = [`/model ${value}`]
+
+  if (effort) {
+    commands.push(`/effort ${effort}`)
+  }
+
+  return commands
+}

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -1215,6 +1215,26 @@ export class GatewayClient extends EventEmitter {
           })
         })
 
+      case 'model.effort_options':
+        return this.controlQuery('effort_options', {
+          model: String(p.model ?? ''),
+          provider: String(p.provider ?? '')
+        }).then((r: any) => {
+          // A backend too old to know the control answers null, and an
+          // errored one answers {ok:false}. Neither is worth failing the
+          // switch over — the model is already chosen by this point, so fall
+          // back to "no ladder" and let the picker apply what it has.
+          if (r == null || r.ok === false) {
+            return { levels: [], supported: false } as T
+          }
+
+          return {
+            current: typeof r.current === 'string' ? r.current : '',
+            levels: Array.isArray(r.levels) ? r.levels.filter((l: unknown) => typeof l === 'string') : [],
+            supported: r.supported === true
+          } as T
+        })
+
       case 'model.save_key':
         return this.controlQuery('save_provider_key', {
           api_key: String(p.api_key ?? ''),
@@ -1591,7 +1611,7 @@ export class GatewayClient extends EventEmitter {
   // response: model switch" reports), so this must round-trip the control
   // rather than fire-and-forget. Scope flags are dropped: the backend persists
   // every switch (agent_server set_model → app-state on_change).
-  private setModel(raw: string): Promise<{ value: string; warning?: string }> {
+  private setModel(raw: string): Promise<{ provider?: string; value: string; warning?: string }> {
     const tokens = raw.trim().split(/\s+/).filter(Boolean)
     const modelParts: string[] = []
     let provider: string | undefined
@@ -1627,7 +1647,7 @@ export class GatewayClient extends EventEmitter {
     model: string,
     provider: string | undefined,
     allowSwitch = true
-  ): Promise<{ value: string; warning?: string }> {
+  ): Promise<{ provider?: string; value: string; warning?: string }> {
     return this.controlQuery('set_model', { model, ...(provider ? { provider } : {}) }).then((r: any) => {
       if (r == null) {
         // Tagged: a silent backend may still have APPLIED the model, so the
@@ -1657,45 +1677,55 @@ export class GatewayClient extends EventEmitter {
             // happened" while the session quietly sits on a different
             // provider AND a different model. Roll back to where we came
             // from (the mismatch reply names it) and say what actually stuck.
-            return this.applyModel(model, provider, false).catch((e: unknown) => {
-              const why = e instanceof Error ? e.message : String(e)
-              const previous = typeof r.provider === 'string' ? r.provider : ''
+            return this.applyModel(model, provider, false)
+              // The retry lands on the NEW provider, so its reply names it.
+              // Fall back to the one we just switched to for older backends
+              // that echo no provider: set_provider returning ok is proof of
+              // where the session now is, and this is the path that MOVES it.
+              .then(res => ({ ...res, provider: res.provider ?? provider }))
+              .catch((e: unknown) => {
+                const why = e instanceof Error ? e.message : String(e)
+                const previous = typeof r.provider === 'string' ? r.provider : ''
 
-              // A silent backend is NOT a known failure — it may have applied
-              // the model. Rolling back would then throw away a switch that
-              // worked, so report the uncertainty instead of acting on it.
-              if ((e as { indeterminate?: boolean })?.indeterminate) {
-                throw new Error(
-                  `switched to '${provider}' but the model selection got no response — ` +
-                    `the session may be on '${provider}'`
-                )
-              }
+                // A silent backend is NOT a known failure — it may have applied
+                // the model. Rolling back would then throw away a switch that
+                // worked, so report the uncertainty instead of acting on it.
+                if ((e as { indeterminate?: boolean })?.indeterminate) {
+                  throw new Error(
+                    `switched to '${provider}' but the model selection got no response — ` +
+                      `the session may be on '${provider}'`
+                  )
+                }
 
-              if (!previous) {
-                throw new Error(`switched to '${provider}' but could not select '${model}': ${why}`)
-              }
+                if (!previous) {
+                  throw new Error(`switched to '${provider}' but could not select '${model}': ${why}`)
+                }
 
-              return this.controlQuery('set_provider', { provider: previous }).then((back: any) => {
-                throw new Error(
-                  back != null && back.ok !== false
-                    ? // set_provider resets the model to that provider's
-                      // configured default and persists it, so the provider is
-                      // restored but the previously-selected model is not.
-                      `could not select '${model}' on '${provider}': ${why} — rolled back to ` +
-                        `'${previous}' (its default model)`
-                    : `could not select '${model}': ${why} — session is now on '${provider}'`
-                )
+                return this.controlQuery('set_provider', { provider: previous }).then((back: any) => {
+                  throw new Error(
+                    back != null && back.ok !== false
+                      ? // set_provider resets the model to that provider's
+                        // configured default and persists it, so the provider is
+                        // restored but the previously-selected model is not.
+                        `could not select '${model}' on '${provider}': ${why} — rolled back to ` +
+                          `'${previous}' (its default model)`
+                      : `could not select '${model}': ${why} — session is now on '${provider}'`
+                  )
+                })
               })
-            })
           })
         }
 
         throw new Error(typeof r.error === 'string' && r.error ? r.error : 'model switch failed')
       }
 
-      // Older backends ack {ok:true} without echoing the model.
+      // Older backends ack {ok:true} without echoing the model — or, for
+      // `provider`, without echoing it at all. Omit the key in that case so
+      // callers can tell "unchanged/unknown" (keep the current label) from a
+      // real move, rather than blanking a provider that is still correct.
       return {
         value: typeof r.model === 'string' && r.model ? r.model : model,
+        ...(typeof r.provider === 'string' && r.provider ? { provider: r.provider } : {}),
         ...(typeof r.warning === 'string' && r.warning ? { warning: r.warning } : {})
       }
     })

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -263,6 +263,13 @@ export interface ConfigSetResponse {
   ok?: boolean
   /** permission_mode only: whether the choice was written to settings.json. */
   persisted?: boolean
+  /**
+   * model only: the provider the session ended up on. A cross-provider
+   * selection moves it, so the stats line's provider half has to follow the
+   * model's — absent from older backends, which is why callers keep the
+   * previous label rather than blanking it.
+   */
+  provider?: string
   value?: string
   warning?: string
 }
@@ -576,6 +583,19 @@ export interface ModelOptionsResponse {
   model?: string
   provider?: string
   providers?: ModelOptionProvider[]
+}
+
+/**
+ * The effort ladder one model actually accepts — the picker's step 3.
+ * `supported: false` means the model takes no effort parameter at all, and
+ * the picker skips the step rather than offering a list that cannot apply.
+ * `levels` excludes `auto`; the picker prepends it.
+ */
+export interface EffortOptionsResponse {
+  /** The session's live level, '' when unset (i.e. auto). */
+  current?: string
+  levels?: string[]
+  supported?: boolean
 }
 
 // ── MCP ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## The bug

The session-stats line renders `provider · model` as one phrase, but the provider half was written **exactly once** — from the backend's `init` frame — while every model switch patched `model` alone. A cross-provider selection showed the new model beside the old provider:

```
anthropic · gpt-5.6-luna · ~/work/elon-blog · turns: 4 · …
^^^^^^^^^ stale           ^^^^^^^^^^^^^^^^ moved
```

Three layers each dropped the provider, and the reported case hit all three:

1. `_do_set_model` replied `{ok, model}` with no `provider` — while both sibling paths, `_do_set_fusion_model` and `_do_set_provider`, already echoed it.
2. `applyModel` returned only `{value, warning}`, discarding it even when sent.
3. `session.ts` and `useMainApp.ts` both did `{ ...state.info, model }`, never touching `profile_name`.

On the cross-provider path the backend had *already* answered `set_provider` with `{ok: true, provider: "openai"}` — it said where the session moved, and the client threw the answer away.

**Fix:** threaded end to end, with one shared helper (`domain/modelSwitch.ts`) so the two apply sites cannot drift again. An absent provider means "unchanged", not "unknown", so a same-provider switch never blanks a still-correct label. The `/model` picker re-enters `/model <value>`, so it rides the same path.

## `/model` gains a third step

Provider → model → **effort**, offering the levels that model actually accepts. The ladder is resolved from the same predicates that gate the wire, so the list is what the model will really take rather than the union ladder `/effort` validates against:

| provider / model | offered |
|---|---|
| `claude-opus-5`, `claude-opus-4-8` | low, medium, high, xhigh, max |
| `claude-sonnet-4-6` | low, medium, high, max — **no xhigh** (400s on it) |
| `claude-haiku-4-5`, `gpt-4o`, `gpt-5-chat-latest` | *step skipped* |
| `gpt-5.6-luna` (OpenAI reasoning) | low, medium, high, xhigh — **no max** |
| deepseek / moonshot / zai … | full ladder |

The asymmetry drives the design: offering a level the model **rejects** is fatal (a 400 on the effort level is retried or downgraded nowhere, so every subsequent request fails), while omitting one merely hides a choice. So it errs narrow wherever the codebase actually knows, and falls back to the full ladder only where it does not.

Design decisions worth flagging for review:

- **A model with no ladder keeps the two-step flow** rather than being shown a list whose every row is a silent no-op. Same for the new-prompt-session picker (`allowEffortStep={false}`), which captures a draft and has no session to set an effort on.
- **`auto` is the picker's own row**, not a backend level — it means "clear the override", and emits no `/effort` at all.
- **The step preselects the session's live level**, so Enter-through changes nothing.
- **Effort is session-scoped**, exactly as `/effort` already is; the `^g` global toggle stays model-only.
- Queried per selection rather than ridden along on `list_model_providers` — the ladder is a property of the *model*, and some providers enumerate hundreds.

## Verification

- **+38 tests.** Backend resolver across 10 provider/model pairs, the `effort_options` control, the RPC mapping, the picker's stage transitions (real keys through a mounted component), and the command expansion.
- **14/14 mutants killed** — each behavior reverted individually, confirming a test fails. Two findings from this: the backend mutation initially hit the wrong one of six identical lines, and the back-navigation test was asserting against *cumulative* Ink output, so `step 2/3` was already in the buffer from the earlier visit and the assertion proved nothing. Now asserts the last painted frame.
- **Python: 10079 passed, 12 skipped, 0 failures** (the full suite CI runs).
- **ui-tui: 1850 passed**, with the same 8 failures that pre-exist on `origin/main` — baseline captured and compared, zero new. Note ui-tui has no CI gate; that suite was run locally.
- Typecheck clean; 0 lint errors in changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)