### PR TITLE
fix(tui): TaskCreate/TaskUpdate render nothing inline, like TodoWrite

### DIFF
--- a/ui-tui/src/__tests__/todoSurface.test.ts
+++ b/ui-tui/src/__tests__/todoSurface.test.ts
@@ -175,6 +175,90 @@ describe('turnController TodoWrite lifecycle', () => {
   })
 })
 
+// ── turnController: TaskV2 mutations are HUD-only too ───────────────────────
+
+describe('turnController TaskV2 lifecycle', () => {
+  const TASK_TODOS = [{ activeForm: 'Fixing auth', content: 'Fix auth', id: 'abc123', status: 'in_progress' }]
+
+  it('renders no trail line for TaskCreate/TaskUpdate — the checklist HUD is the whole UI', () => {
+    turnController.recordError()
+    resetTurnState()
+    turnController.startMessage()
+
+    turnController.recordToolStart('t1', 'TaskCreate', 'Fix auth')
+    expect(getTurnState().tools).toHaveLength(1)
+
+    turnController.recordToolComplete(
+      't1',
+      'TaskCreate',
+      undefined,
+      undefined,
+      0.1,
+      [{ activeForm: 'Fixing auth', content: 'Fix auth', id: 'abc123', status: 'pending' }],
+      '{"task": {"id": "abc123", "subject": "Fix auth"}}'
+    )
+
+    turnController.recordToolStart('t2', 'TaskUpdate', '')
+    turnController.recordToolComplete(
+      't2',
+      'TaskUpdate',
+      undefined,
+      undefined,
+      0.1,
+      TASK_TODOS,
+      '{"success": true, "taskId": "abc123", "updatedFields": ["status"], "statusChange": {"from": "pending", "to": "in_progress"}}'
+    )
+
+    const state = getTurnState()
+
+    expect(state.todos).toEqual(TASK_TODOS) // HUD still fed by both calls
+    expect(state.tools).toHaveLength(0) // activeTools cleared — no stranded spinner
+    expect(state.streamPendingTools).toHaveLength(0) // no `⏺ TaskCreate ⎿ {…}` rows
+    expect(state.streamSegments).toHaveLength(0)
+
+    turnController.recordError()
+    resetTurnState()
+  })
+
+  it('keeps the trail line for a REFUSED TaskUpdate (success:false is not a tool error)', () => {
+    turnController.recordError()
+    resetTurnState()
+    turnController.startMessage()
+
+    turnController.recordToolStart('t1', 'TaskUpdate', '')
+    // tasks_v2.py returns this as a normal (non-error) result, and the HUD
+    // redraws the unchanged list — so the row is the only trace of the miss.
+    turnController.recordToolComplete(
+      't1',
+      'TaskUpdate',
+      undefined,
+      undefined,
+      0.1,
+      undefined,
+      '{"success": false, "taskId": "gone", "updatedFields": [], "error": "Task not found"}'
+    )
+
+    expect(getTurnState().streamPendingTools[0]).toContain('TaskUpdate')
+
+    turnController.recordError()
+    resetTurnState()
+  })
+
+  it('keeps the trail line for TaskList/TaskGet/TaskOutput reads', () => {
+    turnController.recordError()
+    resetTurnState()
+    turnController.startMessage()
+
+    turnController.recordToolStart('t1', 'TaskList', '')
+    turnController.recordToolComplete('t1', 'TaskList', undefined, undefined, 0.1, undefined, '{"tasks": []}')
+
+    expect(getTurnState().streamPendingTools[0]).toContain('TaskList')
+
+    turnController.recordError()
+    resetTurnState()
+  })
+})
+
 // ── TodoPanel: TaskListV2 anatomy ────────────────────────────────────────────
 
 const renderToString = (element: React.ReactElement): string => {

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -18,6 +18,7 @@ import {
   sameToolTrailGroup,
   toolTrailLabel
 } from '../lib/text.js'
+import { isChecklistHudOnly } from '../lib/todo.js'
 import type { ActiveTool, ActivityItem, Msg, MsgDiffData, SubagentProgress, TodoItem } from '../types.js'
 
 import type { Notice } from './interfaces.js'
@@ -898,9 +899,16 @@ class TurnController {
     const name = this.activeTools.find(tool => tool.id === toolId)?.name ?? fallbackName
     const line = this.completeTool(toolId, fallbackName, error, summary, duration, resultText, rawText)
 
-    // The original renders NOTHING inline for todo tools — the checklist HUD
-    // is the whole UI. completeTool still ran above (clears activeTools +
-    // bookkeeping), only the trail-line append is suppressed.
+    // The original renders NOTHING inline for the checklist tools — TodoWrite
+    // and the TaskV2 mutations (TaskCreate/TaskUpdate) — because the pinned
+    // HUD is their whole UI, and recordTodos() above has already fed it this
+    // very call. completeTool still ran too (clears activeTools + bookkeeping),
+    // only the trail-line append is suppressed. A refused mutation still
+    // renders: see isChecklistHudOnly (lib/todo.ts) for why the result text
+    // has to be consulted and not just the tool name.
+    //
+    // TaskList/TaskGet/TaskOutput deliberately keep their rows: they are reads
+    // whose output (task bodies, background-shell logs) the HUD never shows.
     //
     // AskUserQuestion deliberately does NOT get the same treatment, even though
     // upstream also hides its row (userFacingName() === '', renderToolUseMessage
@@ -912,7 +920,7 @@ class TurnController {
     // the stated goal (a readable summary, not a JSON blob) without upstream's
     // exact label. Do not "fix" this to match upstream without first giving the
     // renderer that facility.
-    if (name !== 'TodoWrite' || error) {
+    if (!isChecklistHudOnly(name, error, resultText)) {
       this.pendingSegmentTools = [...this.pendingSegmentTools, line]
       this.pendingSegmentToolsVerbose = [...this.pendingSegmentToolsVerbose, this.lastVerboseLine]
       this.flushPendingToolsIntoLastSegment()

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -26,6 +26,7 @@ import {
   thinkingPreview,
   toolTrailLabel
 } from '../lib/text.js'
+import { isChecklistHudTool } from '../lib/todo.js'
 import type { Theme } from '../theme.js'
 import type {
   ActiveTool,
@@ -860,9 +861,10 @@ export const ToolTrail = memo(function ToolTrail({
   }
 
   for (const tool of tools) {
-    // Todo tools never render inline (original CC) — the checklist HUD is
-    // their entire UI; a blinking "TodoWrite" row would just be noise.
-    if (tool.name === 'TodoWrite') {
+    // Checklist tools never render inline (original CC) — the HUD is their
+    // entire UI; a blinking "TodoWrite"/"TaskUpdate" row would just be noise,
+    // and their completion appends no trail line to replace it either.
+    if (isChecklistHudTool(tool.name)) {
       continue
     }
 

--- a/ui-tui/src/lib/todo.test.ts
+++ b/ui-tui/src/lib/todo.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { todoGlyph, todoTone } from './todo.js'
+import { isChecklistHudOnly, isChecklistHudTool, todoGlyph, todoTone } from './todo.js'
 
 describe('todoGlyph', () => {
   it('uses the original TaskListV2 icons (✔ done, ◼ in-progress, ◻ pending)', () => {
@@ -17,5 +17,43 @@ describe('todoTone', () => {
     expect(todoTone('cancelled')).toBe('dim')
     expect(todoTone('pending')).toBe('body')
     expect(todoTone('in_progress')).toBe('active')
+  })
+})
+
+describe('isChecklistHudTool', () => {
+  it('covers the checklist mutations and nothing else', () => {
+    expect(isChecklistHudTool('TodoWrite')).toBe(true)
+    expect(isChecklistHudTool('TaskCreate')).toBe(true)
+    expect(isChecklistHudTool('TaskUpdate')).toBe(true)
+    // Reads whose output the HUD never shows.
+    expect(isChecklistHudTool('TaskList')).toBe(false)
+    expect(isChecklistHudTool('TaskGet')).toBe(false)
+    expect(isChecklistHudTool('TaskOutput')).toBe(false)
+    expect(isChecklistHudTool('Bash')).toBe(false)
+    expect(isChecklistHudTool(undefined)).toBe(false)
+  })
+})
+
+describe('isChecklistHudOnly', () => {
+  const ok = '{"success": true, "taskId": "abc123", "updatedFields": ["status"]}'
+  const refused = '{"success": false, "taskId": "gone", "updatedFields": [], "error": "Task not found"}'
+
+  it('hides a mutation that landed', () => {
+    expect(isChecklistHudOnly('TaskUpdate', undefined, ok)).toBe(true)
+    expect(isChecklistHudOnly('TaskCreate', undefined, '{"task": {"id": "abc123", "subject": "Fix auth"}}')).toBe(true)
+    expect(isChecklistHudOnly('TodoWrite', undefined, 'Todos have been modified successfully.')).toBe(true)
+    expect(isChecklistHudOnly('TaskUpdate', undefined, undefined)).toBe(true)
+  })
+
+  it('shows a mutation the backend refused or errored', () => {
+    expect(isChecklistHudOnly('TaskUpdate', undefined, refused)).toBe(false)
+    expect(isChecklistHudOnly('TaskUpdate', 'Error: invalid taskId', ok)).toBe(false)
+    // Backends predating the JSON results answered in prose.
+    expect(isChecklistHudOnly('TaskUpdate', undefined, 'Task #abc123 not found')).toBe(false)
+  })
+
+  it('never hides a non-checklist tool', () => {
+    expect(isChecklistHudOnly('TaskList', undefined, '{"tasks": []}')).toBe(false)
+    expect(isChecklistHudOnly('Bash', undefined, '{"success": true}')).toBe(false)
   })
 })

--- a/ui-tui/src/lib/todo.ts
+++ b/ui-tui/src/lib/todo.ts
@@ -9,3 +9,40 @@ export const todoGlyph = (status: TodoItem['status']) =>
 
 export const todoTone = (status: TodoItem['status']): TodoTone =>
   status === 'in_progress' ? 'active' : status === 'pending' ? 'body' : 'dim'
+
+// Tools whose entire UI is the pinned checklist. TodoWrite rewrites the list
+// wholesale; TaskV2 mutates one row per call, so a plan of 7 tasks costs 7
+// `⏺ TaskCreate(…) ⎿ {"task":{"id":"1383531298b4",…}}` rows up front and
+// another `⏺ TaskUpdate ⎿ {"success":true,…,"statusChange":{…}}` row per
+// status flip — a screen of JSON restating what the HUD already draws.
+const CHECKLIST_HUD_TOOLS = new Set(['TaskCreate', 'TaskUpdate', 'TodoWrite'])
+
+export const isChecklistHudTool = (name?: string) => Boolean(name && CHECKLIST_HUD_TOOLS.has(name))
+
+/** TaskV2 reports a REFUSED mutation as a *successful* tool call carrying
+ *  `{"success": false, …, "error": "Task not found"}` (tasks_v2.py
+ *  `_task_update_call`), and the HUD then redraws the unchanged checklist —
+ *  so hiding that row would swallow the failure with nothing left to show it.
+ *  Only a mutation that actually landed is HUD-only. */
+export const checklistMutationRefused = (resultText?: string): boolean => {
+  const text = resultText?.trim()
+
+  if (!text) {
+    return false
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(text)
+
+    return Boolean(parsed && typeof parsed === 'object' && (parsed as { success?: unknown }).success === false)
+  } catch {
+    // Backends predating the JSON results answered in prose ("Task #abc123
+    // not found" — tasks_v2.py `_format_task_updated`).
+    return /\bnot found\b/i.test(text)
+  }
+}
+
+/** True when a finished tool call adds nothing the checklist HUD isn't
+ *  already showing, so the transcript renders no row for it at all. */
+export const isChecklistHudOnly = (name?: string, error?: string, resultText?: string) =>
+  isChecklistHudTool(name) && !error && !checklistMutationRefused(resultText)


### PR DESCRIPTION
## What

The task checklist HUD (#827) shipped, but the TaskV2 mutations kept printing their
raw results underneath it. Planning a turn therefore cost a screenful of JSON that
restated the checklist — one `⏺ TaskCreate(…) ⎿ {"task":{"id":…}}` row per task up
front, then one `⏺ TaskUpdate ⎿ {"success":true,…,"statusChange":{…}}` row per status
flip. `TodoWrite` was already suppressed for exactly this reason (the pinned checklist
is these tools' entire UI); TaskV2 is the same tool in a per-row shape, so it now gets
the same treatment. `recordTodos()` has already fed the HUD from the very call whose
row is dropped.

**Suppression is by outcome, not just by name.** `tasks_v2.py` answers a refused
mutation with a *successful* tool call carrying
`{"success": false, …, "error": "Task not found"}` (`_task_update_call`), and the HUD
then redraws the unchanged checklist — hiding that row would leave the miss with no
trace anywhere in the UI. So `isChecklistHudOnly()` consults the result text, and a
refused (or errored) mutation keeps its row.

`TaskList` / `TaskGet` / `TaskOutput` keep their rows unconditionally: they are reads
whose output (task bodies, background-shell logs) the HUD never shows.

The live spinner row in `ToolTrail` gets the same filter, so a mutation that will
render no completion line doesn't blink a row on the way either.

## Changes

- `ui-tui/src/lib/todo.ts` — `isChecklistHudTool()` (TodoWrite/TaskCreate/TaskUpdate),
  `checklistMutationRefused()` (JSON `success:false`, with a prose fallback for
  pre-JSON backends) and `isChecklistHudOnly()`.
- `ui-tui/src/app/turnController.ts` — `recordToolComplete` swaps the hardcoded
  `name !== 'TodoWrite'` check for `isChecklistHudOnly(name, error, resultText)`.
- `ui-tui/src/components/thinking.tsx` — `ToolTrail` filters the live rows by the
  same predicate.

## Tests

5 new vitest cases (`todoSurface.test.ts`, `lib/todo.test.ts`): suppression of
TaskCreate+TaskUpdate with the HUD still fed and no stranded spinner, a refused
TaskUpdate keeping its row, TaskList keeping its row, plus units for both predicates.
Suite: `1750 passed, 8 failed` — the 8 failures are pre-existing on `main@5441d5d`
(verified by stashing this diff and re-running them: identical failures).

## Verification — deepseek-v4-pro, tmux-driven TUI

Same prompt, same model, same workspace; only the branch differs.

**BEFORE (`main@5441d5d`)**

```
 ❯ Use only the task tools. First call TaskCreate four times to add these tasks: Map the parser, Port the lexer, Wire the CLI, Write tests. Then
   call TaskUpdate to mark the first one completed and the second one in_progress. Do not use any other tool, do not read or edit files. Reply DONE
 ⏺ TaskCreate(Map the parser)
   ⎿  {"task": {"id": "70efc8b96b67", "subject": "Map the parser"}}
 ⏺ TaskCreate(Port the lexer)
   ⎿  {"task": {"id": "c3d1abf634ca", "subject": "Port the lexer"}}
 ⏺ TaskCreate(Wire the CLI)
   ⎿  {"task": {"id": "3e90801481f7", "subject": "Wire the CLI"}}
 ⏺ TaskCreate(Write tests)
   ⎿  {"task": {"id": "8e395e86b773", "subject": "Write tests"}}
 ⏺ TaskUpdate
   ⎿  {"success": true, "taskId": "70efc8b96b67", "updatedFields": ["status"], "statusChange": {"from": "pending", "to": "completed"}}
 ⏺ TaskUpdate
   ⎿  {"success": true, "taskId": "c3d1abf634ca", "updatedFields": ["status"], "statusChange": {"from": "pending", "to": "in_progress"}}

 ⏺  DONE

 ▾ 4 tasks (1 done, 1 in progress, 2 open)
   ✔ Map the parser
   ◼ Port the lexer
   ◻ Wire the CLI
   ◻ Write tests
```

**AFTER (this branch)**

```
 ❯ Use only the task tools. First call TaskCreate four times to add these tasks: Map the parser, Port the lexer, Wire the CLI, Write tests. Then
   call TaskUpdate to mark the first one completed and the second one in_progress. Do not use any other tool, do not read or edit files. Reply DONE

 ⏺  DONE

 ▾ 4 tasks (1 done, 1 in progress, 2 open)
   ✔ Map the parser
   ◼ Port the lexer
   ◻ Wire the CLI
   ◻ Write tests
```

**AFTER — a refused mutation still renders** (`TaskCreate` landed and is HUD-only;
the bogus `TaskUpdate` keeps its row)

```
 ❯ Call TaskCreate once with subject Map the parser. Then call TaskUpdate exactly once with taskId deadbeef0000 and status completed - that id is
   deliberately wrong and I want to see what the tool returns. Do not call any other tool. Reply DONE.

 ⏺ TaskUpdate
   ⎿  {"success": false, "taskId": "deadbeef0000", "updatedFields": [], "error": "Task not found"}

 ⏺  DONE

 ▾ 1 task (0 done, 1 open)
   ◻ Map the parser
```
