### PR TITLE
feat(web): choose the folder a session runs in

### DIFF
--- a/src/server/desktop_fs.py
+++ b/src/server/desktop_fs.py
@@ -1,0 +1,151 @@
+"""Directory browsing for the GUI clients' workspace picker.
+
+A browser has no OS file chooser it can trust with a real path: the File System
+Access API hands back an opaque handle, not something the agent can `cd` into.
+So the picker browses the *server's* filesystem through this module, one level
+at a time.
+
+Shape mirrors the reference implementation's `DirectoryListing`
+(`packages/host/directory-picker`), because two properties in it are worth
+copying exactly:
+
+- **Every path is absolute and comes from the server.** Clients never join path
+  segments themselves, which is what keeps a Windows path from being assembled
+  with the wrong separator by a client that has never seen one.
+- **`crumbs` is the whole ancestor chain**, so the picker's breadcrumb is a row
+  of jump targets rather than a string the client has to re-split.
+
+Scope: read-only, directories only. This adds no reach the agent does not
+already have — it runs in this process, whose tools can read the filesystem —
+and the transport is the same loopback, token-gated socket. What it must not do
+is *hide* a failure: an unreadable directory raises rather than returning an
+empty listing that looks like an empty folder.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+# Entries returned for one level before the tail is cut. A home directory with
+# a few thousand children should not stall the picker, and nobody scrolls that
+# far — the client shows `truncated` and the user narrows with the filter.
+DEFAULT_LIMIT = 500
+
+
+def _is_hidden(path: Path, name: str) -> bool:
+    """Hidden by the platform's own convention.
+
+    POSIX is the dot prefix. Windows carries a real attribute, and the dot
+    convention is not used there — a `.config` directory copied onto Windows is
+    an ordinary folder, while `AppData` is genuinely hidden and has no dot.
+    """
+    if name.startswith("."):
+        return True
+    if os.name != "nt":
+        return False
+    try:
+        attributes = path.stat().st_file_attributes  # type: ignore[attr-defined]
+    except (OSError, AttributeError):
+        return False
+    return bool(attributes & stat.FILE_ATTRIBUTE_HIDDEN)
+
+
+def _entry(path: Path, name: str | None = None) -> dict[str, Any]:
+    return {
+        "name": name if name is not None else (path.name or str(path)),
+        "path": str(path),
+        "hidden": _is_hidden(path, name if name is not None else path.name),
+    }
+
+
+def _crumbs(path: Path) -> list[dict[str, Any]]:
+    """Ancestor chain from the filesystem root to ``path``, inclusive.
+
+    The root crumb carries its full path as its name (``/`` on POSIX, ``C:\\``
+    on Windows) — a base name would be empty and unclickable.
+    """
+    chain = [path, *path.parents]
+    crumbs: list[dict[str, Any]] = []
+    for ancestor in reversed(chain):
+        name = ancestor.name or str(ancestor)
+        crumbs.append({"name": name, "path": str(ancestor), "hidden": False})
+    return crumbs
+
+
+def home_directory() -> Path:
+    """The account's home directory, or the filesystem root if it has none."""
+    try:
+        return Path.home()
+    except (RuntimeError, OSError):
+        return Path(os.sep)
+
+
+def list_directory(
+    path: str | None = None,
+    *,
+    limit: int = DEFAULT_LIMIT,
+) -> dict[str, Any]:
+    """One directory level: its children, its ancestry, and the home root.
+
+    ``path`` absent (or empty) lists the home directory — the picker's opening
+    view. Children are directories only, including symlinks that resolve to
+    one; a file is not a workspace.
+
+    Raises ``ValueError`` when the target does not exist, is not a directory,
+    or cannot be read. That is deliberate: an empty ``entries`` list must mean
+    "this directory has no subdirectories", never "we could not look".
+    """
+    home = home_directory()
+    target = Path(path).expanduser() if path else home
+
+    try:
+        resolved = target.resolve()
+    except OSError as exc:  # pragma: no cover - platform-specific
+        raise ValueError(f"cannot resolve {target}: {exc}") from exc
+
+    if not resolved.exists():
+        raise ValueError(f"no such directory: {resolved}")
+    if not resolved.is_dir():
+        raise ValueError(f"not a directory: {resolved}")
+
+    entries: list[dict[str, Any]] = []
+    truncated = False
+    try:
+        with os.scandir(resolved) as scan:
+            for item in scan:
+                try:
+                    # follow_symlinks: a symlink INTO a project is a normal way
+                    # to reach one, and refusing it would be surprising.
+                    if not item.is_dir(follow_symlinks=True):
+                        continue
+                except OSError:
+                    # A broken link or a mount we cannot stat: skip the row
+                    # rather than fail the whole listing.
+                    continue
+                entries.append(_entry(Path(item.path), item.name))
+    except PermissionError as exc:
+        raise ValueError(f"permission denied: {resolved}") from exc
+    except OSError as exc:
+        raise ValueError(f"cannot read {resolved}: {exc}") from exc
+
+    # Case-insensitive so `Downloads` and `apps` interleave the way a person
+    # reading the list expects, rather than by byte value.
+    entries.sort(key=lambda entry: str(entry["name"]).lower())
+
+    if limit > 0 and len(entries) > limit:
+        entries = entries[:limit]
+        truncated = True
+
+    return {
+        "path": str(resolved),
+        "home": str(home),
+        "crumbs": _crumbs(resolved),
+        "entries": entries,
+        "truncated": truncated,
+    }
+
+
+__all__ = ["DEFAULT_LIMIT", "home_directory", "list_directory"]

--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -557,6 +557,7 @@ class GatewayConnection:
             "commands.catalog": self.commands_catalog,
             "complete.slash": self.complete_slash,
             "complete.path": self.complete_empty,
+            "fs.list_directory": self.fs_list_directory,
             "slash.exec": self.slash_exec,
             "command.dispatch": self.command_dispatch,
             "setup.status": self.setup_status,
@@ -866,6 +867,21 @@ class GatewayConnection:
 
     async def complete_empty(self, _: dict[str, Any]) -> dict[str, Any]:
         return {"items": []}
+
+    async def fs_list_directory(self, params: dict[str, Any]) -> dict[str, Any]:
+        """One directory level for the workspace picker.
+
+        Runs off the event loop: ``scandir`` on a cold or network-mounted
+        directory blocks, and this socket also carries the turn's stream.
+        """
+        import asyncio as _asyncio
+
+        from src.server.desktop_fs import list_directory
+
+        path = params.get("path")
+        return await _asyncio.to_thread(
+            list_directory, str(path) if path else None
+        )
 
     async def slash_exec(self, params: dict[str, Any]) -> dict[str, Any]:
         from src.server.desktop_slash import dispatch_slash

--- a/tests/server/test_desktop_fs.py
+++ b/tests/server/test_desktop_fs.py
@@ -9,11 +9,37 @@ to read sends the user hunting for a project that is right there.
 from __future__ import annotations
 
 import os
+import tempfile
 from pathlib import Path
 
 import pytest
 
 from src.server.desktop_fs import home_directory, list_directory
+
+# Windows needs Developer Mode or elevation to create a symlink, so the two
+# symlink cases below are probed rather than assumed. Probing beats checking
+# `os.name`: an unprivileged Windows runner and a privileged one differ, and
+# only the attempt can tell them apart.
+
+
+def _symlinks_available() -> bool:
+    try:
+        with tempfile.TemporaryDirectory() as scratch:
+            root = Path(scratch)
+            (root / "target").mkdir()
+            (root / "link").symlink_to(root / "target", target_is_directory=True)
+        return True
+    except (OSError, NotImplementedError):
+        return False
+
+
+SYMLINKS = _symlinks_available()
+needs_symlinks = pytest.mark.skipif(not SYMLINKS, reason="symlink creation not permitted here")
+
+# `os.geteuid` is Unix-only, and a skipif condition is evaluated at import
+# time even when an earlier skipif on the same test already matched — reading
+# it directly takes the whole module down on Windows during collection.
+IS_ROOT = getattr(os, "geteuid", lambda: 1)() == 0
 
 
 @pytest.fixture()
@@ -76,9 +102,11 @@ def test_crumbs_run_root_to_target_inclusive(tree: Path) -> None:
     listing = list_directory(str(tree / "alpha"))
     crumbs = listing["crumbs"]
     assert crumbs[-1]["path"] == str((tree / "alpha").resolve())
-    assert crumbs[0]["path"] == os.path.abspath(os.sep) or Path(crumbs[0]["path"]).parent == Path(
-        crumbs[0]["path"]
-    )
+    # The first crumb is the filesystem root, whatever it is called on this
+    # platform (`/` on POSIX, a drive root on Windows): the one thing true of
+    # a root everywhere is that it is its own parent.
+    root = Path(crumbs[0]["path"])
+    assert root.parent == root
     # Each crumb is a jump target, so each must be a real absolute path.
     for crumb in crumbs:
         assert os.path.isabs(crumb["path"])
@@ -124,7 +152,7 @@ def test_a_file_target_raises(tree: Path) -> None:
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
-@pytest.mark.skipif(os.geteuid() == 0, reason="root reads regardless of mode")
+@pytest.mark.skipif(IS_ROOT, reason="root reads regardless of mode")
 def test_unreadable_directory_raises_rather_than_looking_empty(tmp_path: Path) -> None:
     """The failure this module exists to avoid: a permission error rendered as
     an empty folder, sending the user hunting for a project that is right
@@ -140,6 +168,7 @@ def test_unreadable_directory_raises_rather_than_looking_empty(tmp_path: Path) -
         locked.chmod(0o755)
 
 
+@needs_symlinks
 def test_an_unstattable_child_is_skipped_not_fatal(tmp_path: Path) -> None:
     """A broken symlink costs its own row, not the whole listing."""
     (tmp_path / "real").mkdir()
@@ -147,6 +176,7 @@ def test_an_unstattable_child_is_skipped_not_fatal(tmp_path: Path) -> None:
     assert _names(list_directory(str(tmp_path))) == ["real"]
 
 
+@needs_symlinks
 def test_symlink_to_a_directory_is_listed(tmp_path: Path) -> None:
     """Reaching a project through a symlink is normal; refusing it is not."""
     (tmp_path / "real").mkdir()

--- a/tests/server/test_desktop_fs.py
+++ b/tests/server/test_desktop_fs.py
@@ -1,0 +1,172 @@
+"""Directory browsing for the workspace picker (``src/server/desktop_fs.py``).
+
+The property that matters most here is the one about failure: an empty
+``entries`` list must mean "no subdirectories", never "we could not look". A
+picker that silently shows an empty folder for a directory it lacks permission
+to read sends the user hunting for a project that is right there.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from src.server.desktop_fs import home_directory, list_directory
+
+
+@pytest.fixture()
+def tree(tmp_path: Path) -> Path:
+    """A directory with children of every kind the picker must handle."""
+    (tmp_path / "alpha").mkdir()
+    (tmp_path / "Beta").mkdir()
+    (tmp_path / ".hidden").mkdir()
+    (tmp_path / "zeta").mkdir()
+    (tmp_path / "a-file.txt").write_text("not a workspace", encoding="utf-8")
+    return tmp_path
+
+
+def _names(listing: dict) -> list[str]:
+    return [entry["name"] for entry in listing["entries"]]
+
+
+# ── listing ──────────────────────────────────────────────────────────────────
+
+
+def test_lists_only_directories(tree: Path) -> None:
+    """A file is never a workspace, so it is never a row."""
+    assert "a-file.txt" not in _names(list_directory(str(tree)))
+
+
+def test_sorts_case_insensitively(tree: Path) -> None:
+    """`Beta` belongs between `alpha` and `zeta` where a reader expects it —
+    byte order would file every capitalized name first."""
+    assert _names(list_directory(str(tree))) == [".hidden", "alpha", "Beta", "zeta"]
+
+
+def test_flags_hidden_without_removing_it(tree: Path) -> None:
+    """The backend reports the platform's convention; the client decides
+    whether to show it."""
+    entries = {entry["name"]: entry for entry in list_directory(str(tree))["entries"]}
+    assert entries[".hidden"]["hidden"] is True
+    assert entries["alpha"]["hidden"] is False
+
+
+def test_every_entry_carries_an_absolute_path(tree: Path) -> None:
+    """Clients never join path segments themselves — that is how a Windows
+    path ends up assembled with the wrong separator."""
+    for entry in list_directory(str(tree))["entries"]:
+        assert os.path.isabs(entry["path"])
+        assert Path(entry["path"]).parent == tree.resolve()
+
+
+def test_empty_directory_lists_nothing_and_does_not_fail(tmp_path: Path) -> None:
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    listing = list_directory(str(empty))
+    assert listing["entries"] == []
+    assert listing["truncated"] is False
+
+
+# ── ancestry ─────────────────────────────────────────────────────────────────
+
+
+def test_crumbs_run_root_to_target_inclusive(tree: Path) -> None:
+    listing = list_directory(str(tree / "alpha"))
+    crumbs = listing["crumbs"]
+    assert crumbs[-1]["path"] == str((tree / "alpha").resolve())
+    assert crumbs[0]["path"] == os.path.abspath(os.sep) or Path(crumbs[0]["path"]).parent == Path(
+        crumbs[0]["path"]
+    )
+    # Each crumb is a jump target, so each must be a real absolute path.
+    for crumb in crumbs:
+        assert os.path.isabs(crumb["path"])
+
+
+def test_root_crumb_is_named_not_blank(tree: Path) -> None:
+    """`Path('/').name` is empty; a nameless crumb is an unclickable gap."""
+    assert list_directory(str(tree))["crumbs"][0]["name"] != ""
+
+
+def test_reports_the_home_root(tree: Path) -> None:
+    assert list_directory(str(tree))["home"] == str(home_directory())
+
+
+# ── defaults and normalisation ───────────────────────────────────────────────
+
+
+def test_no_path_opens_home() -> None:
+    assert list_directory()["path"] == str(home_directory().resolve())
+    assert list_directory("")["path"] == str(home_directory().resolve())
+
+
+def test_expands_a_user_relative_path() -> None:
+    assert list_directory("~")["path"] == str(home_directory().resolve())
+
+
+def test_resolves_traversal_to_a_real_path(tree: Path) -> None:
+    listing = list_directory(str(tree / "alpha" / ".." / "zeta"))
+    assert listing["path"] == str((tree / "zeta").resolve())
+
+
+# ── failure is never silent ──────────────────────────────────────────────────
+
+
+def test_missing_directory_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="no such directory"):
+        list_directory(str(tmp_path / "nope"))
+
+
+def test_a_file_target_raises(tree: Path) -> None:
+    with pytest.raises(ValueError, match="not a directory"):
+        list_directory(str(tree / "a-file.txt"))
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+@pytest.mark.skipif(os.geteuid() == 0, reason="root reads regardless of mode")
+def test_unreadable_directory_raises_rather_than_looking_empty(tmp_path: Path) -> None:
+    """The failure this module exists to avoid: a permission error rendered as
+    an empty folder, sending the user hunting for a project that is right
+    there."""
+    locked = tmp_path / "locked"
+    locked.mkdir()
+    (locked / "child").mkdir()
+    locked.chmod(0o000)
+    try:
+        with pytest.raises(ValueError, match="permission denied"):
+            list_directory(str(locked))
+    finally:
+        locked.chmod(0o755)
+
+
+def test_an_unstattable_child_is_skipped_not_fatal(tmp_path: Path) -> None:
+    """A broken symlink costs its own row, not the whole listing."""
+    (tmp_path / "real").mkdir()
+    (tmp_path / "broken").symlink_to(tmp_path / "does-not-exist")
+    assert _names(list_directory(str(tmp_path))) == ["real"]
+
+
+def test_symlink_to_a_directory_is_listed(tmp_path: Path) -> None:
+    """Reaching a project through a symlink is normal; refusing it is not."""
+    (tmp_path / "real").mkdir()
+    (tmp_path / "link").symlink_to(tmp_path / "real", target_is_directory=True)
+    assert _names(list_directory(str(tmp_path))) == ["link", "real"]
+
+
+# ── bounds ───────────────────────────────────────────────────────────────────
+
+
+def test_caps_a_large_listing_and_says_so(tmp_path: Path) -> None:
+    for index in range(12):
+        (tmp_path / f"d{index:02d}").mkdir()
+
+    listing = list_directory(str(tmp_path), limit=5)
+    assert len(listing["entries"]) == 5
+    assert listing["truncated"] is True
+    # The cut is off the name-sorted tail, so the visible head is stable.
+    assert _names(listing) == ["d00", "d01", "d02", "d03", "d04"]
+
+
+def test_a_listing_under_the_cap_is_not_marked_truncated(tree: Path) -> None:
+    assert list_directory(str(tree), limit=100)["truncated"] is False

--- a/ui-web/README.md
+++ b/ui-web/README.md
@@ -42,6 +42,7 @@ src/
   sidebar/       project/worktree/session tree
   conversation/  chat flow, message + tool + reasoning rows, composer, approvals
   trajectory/    the run as a metered ledger: timeline, rows, inspector, totals
+  workspace/     directory picker: which folder a session runs in
   details/       right-hand column: session facts, files touched, tool runs
   ui/            primitives (buttons, cards, code/diff/terminal blocks) + markdown
   styles/        design tokens, typography, scrollbars, shiki wiring

--- a/ui-web/src/conversation/ConversationRoot.tsx
+++ b/ui-web/src/conversation/ConversationRoot.tsx
@@ -28,6 +28,7 @@ import {
 } from '../state/store.ts'
 import { trajectoryStats } from '../state/trajectory.ts'
 import { TrajectoryStatsBar } from '../trajectory/TrajectoryStatsBar.tsx'
+import { WorkspaceChip } from '../workspace/WorkspaceChip.tsx'
 import { TrajectoryView } from '../trajectory/TrajectoryView.tsx'
 import { $detailsWidth, closeDetails, openDetails } from '../state/layout.ts'
 import { ArrowDownIcon, LayersIcon, MessageIcon, PlusIcon } from '../ui/icons.tsx'
@@ -194,9 +195,7 @@ export function ConversationRoot() {
             {workspace !== '' && (
               <>
                 <span className={css.crumbSep}>/</span>
-                <span className={css.crumb} title={workspace}>
-                  {workspace}
-                </span>
+                <WorkspaceChip variant="crumb" />
               </>
             )}
           </div>
@@ -285,7 +284,6 @@ export function ConversationRoot() {
           <HeroShell
             composer={composer}
             onSuggestion={commands.length === 0 ? undefined : setDraft}
-            workspace={workspace}
           />
         ) : (
           <>

--- a/ui-web/src/conversation/HeroShell.module.css
+++ b/ui-web/src/conversation/HeroShell.module.css
@@ -1,6 +1,6 @@
 /* The empty-state hero: mark + headline, workspace chip, then the shared input
-   card. Only the stack geometry and the chip live here — the input itself is
-   the same InputBar the docked composer renders. */
+   card. Only the stack geometry lives here — the input is the same InputBar
+   the docked composer renders, and the chip is the workspace control. */
 
 .stack {
   position: relative;
@@ -51,33 +51,6 @@
   align-items: center;
   min-width: 0;
   padding-left: calc(var(--cc-composer-side-clearance) + 8px);
-}
-
-.workspace {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  max-width: min(100%, 420px);
-  min-height: 28px;
-  padding: 0 8px;
-  border: none;
-  border-radius: 16px;
-  background: transparent;
-  color: var(--cc-alias-label-primary);
-  font-size: 13px;
-  line-height: 20px;
-  font-weight: 500;
-}
-
-.folder {
-  flex: none;
-  color: var(--cc-alias-label-primary);
-}
-
-.workspaceLabel {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .suggestions {

--- a/ui-web/src/conversation/HeroShell.tsx
+++ b/ui-web/src/conversation/HeroShell.tsx
@@ -1,13 +1,12 @@
 import type { ReactNode } from 'react'
 
 import { BrandMark } from '../ui/BrandMark.tsx'
-import { FolderIcon } from '../ui/icons.tsx'
+import { WorkspaceChip } from '../workspace/WorkspaceChip.tsx'
 import css from './HeroShell.module.css'
 
 export interface HeroShellProps {
   composer: ReactNode
   onSuggestion?: (text: string) => void
-  workspace?: string
 }
 
 /** Openers that show what the agent is for without pretending to know the repo. */
@@ -18,15 +17,8 @@ const SUGGESTIONS = [
   'Review my uncommitted changes',
 ]
 
-/** The last two path segments — enough to identify a checkout, short enough to fit. */
-function shortWorkspace(path: string): string {
-  const segments = path.split(/[/\\]/).filter(Boolean)
-
-  return segments.length <= 2 ? path : segments.slice(-2).join('/')
-}
-
 /** The empty state: the mark, the workspace you are about to work in, the composer. */
-export function HeroShell({ composer, onSuggestion, workspace }: HeroShellProps) {
+export function HeroShell({ composer, onSuggestion }: HeroShellProps) {
   return (
     <div className={css.stack}>
       <div className={css.glow} />
@@ -34,14 +26,9 @@ export function HeroShell({ composer, onSuggestion, workspace }: HeroShellProps)
         <BrandMark size={30} />
         ClawCodex
       </div>
-      {workspace !== undefined && workspace !== '' && (
-        <div className={css.workspaceRow}>
-          <span className={css.workspace} title={workspace}>
-            <FolderIcon className={css.folder} size={14} />
-            <span className={css.workspaceLabel}>{shortWorkspace(workspace)}</span>
-          </span>
-        </div>
-      )}
+      <div className={css.workspaceRow}>
+        <WorkspaceChip variant="hero" />
+      </div>
       {composer}
       {onSuggestion !== undefined && (
         <div className={css.suggestions}>

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -286,5 +286,32 @@ export interface ContextUsageResult {
   total_tokens?: number
 }
 
+/** One row in the workspace picker: a listing child or a breadcrumb ancestor. */
+export interface DirectoryEntry {
+  /** Hidden by the server platform's convention; the client decides to show it. */
+  hidden: boolean
+  /** Base name for the row; a root crumb carries its full path. */
+  name: string
+  /**
+   * Absolute path, always from the server. Clients never join path segments
+   * themselves — that is how a Windows path ends up built with the wrong
+   * separator by a client that has never seen one.
+   */
+  path: string
+}
+
+/** `fs.list_directory` — one directory level plus its ancestry. */
+export interface DirectoryListing {
+  /** Root→target ancestor chain, inclusive; every crumb is a jump target. */
+  crumbs: DirectoryEntry[]
+  /** Direct child directories, name-sorted. */
+  entries: DirectoryEntry[]
+  /** The server account's home directory. */
+  home: string
+  path: string
+  /** True when the listing was cut at the server's bound. */
+  truncated: boolean
+}
+
 /** Approval answers the gateway understands (`approval.respond`). */
 export type ApprovalChoice = 'allow' | 'deny' | 'session' | 'always'

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -14,6 +14,7 @@ import type {
   CommandEntry,
   CommandsCatalogResult,
   ContextUsageResult,
+  DirectoryListing,
   GatewayEvent,
   ModelOptionsResult,
   ProjectsTreeResult,
@@ -423,6 +424,34 @@ export async function setApprovalMode(mode: 'manual' | 'smart' | 'off'): Promise
   } catch (error) {
     notice(errorText(error), 'error')
   }
+}
+
+/* ── workspace ───────────────────────────────────────────────────────────── */
+
+/**
+ * List one directory level for the workspace picker.
+ *
+ * Errors propagate: an unreadable directory must reach the picker as a message,
+ * not as an empty folder the user would read as "nothing here".
+ */
+export async function listDirectory(path?: string): Promise<DirectoryListing> {
+  return gateway().request<DirectoryListing>(
+    'fs.list_directory',
+    path === undefined ? {} : { path },
+  )
+}
+
+/**
+ * Point the next session at `path`.
+ *
+ * A live session's working directory is fixed at spawn, so choosing a new
+ * folder while one is running starts a new session there rather than silently
+ * leaving the choice to take effect at some unclear later point.
+ */
+export async function chooseWorkspace(path: string): Promise<void> {
+  $workspace.set(path)
+
+  if ($sessionId.get() !== null) await createSession({ cwd: path })
 }
 
 /* ── model + catalogs ────────────────────────────────────────────────────── */

--- a/ui-web/src/workspace/WorkspaceChip.module.css
+++ b/ui-web/src/workspace/WorkspaceChip.module.css
@@ -1,0 +1,77 @@
+/* Anchor for the picker popover. `position: relative` on the wrapper rather
+   than on either trigger, so both variants position the popover identically. */
+.root {
+  position: relative;
+  display: inline-flex;
+  min-width: 0;
+}
+
+/* Hero variant: the pill under the headline. */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  max-width: min(100%, 420px);
+  min-height: 28px;
+  padding: 0 8px;
+  border: none;
+  border-radius: 16px;
+  background: transparent;
+  color: var(--cc-alias-label-primary);
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.chip:hover,
+.chip[aria-expanded='true'] {
+  background: var(--cc-alias-interactive-bg-hover);
+}
+
+/* Header variant: the path crumb beside the session title. */
+.crumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  max-width: 420px;
+  padding: 2px 6px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--cc-alias-label-tertiary);
+  font-size: 13px;
+  line-height: 20px;
+  cursor: pointer;
+}
+
+.crumb:hover,
+.crumb[aria-expanded='true'] {
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-secondary);
+}
+
+.icon {
+  flex: none;
+}
+
+.label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chevron {
+  flex: none;
+  color: var(--cc-alias-label-caption);
+}
+
+/* Popover seat. Hero opens downward (it sits mid-column with room below);
+   the header crumb also opens downward, directly under the chrome. */
+.popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+}

--- a/ui-web/src/workspace/WorkspaceChip.tsx
+++ b/ui-web/src/workspace/WorkspaceChip.tsx
@@ -1,0 +1,76 @@
+import { useStore } from '@nanostores/react'
+import { useCallback, useState } from 'react'
+
+import { chooseWorkspace } from '../state/actions.ts'
+import { $sessionId, $workspace } from '../state/store.ts'
+import { ChevronDownIcon, FolderIcon } from '../ui/icons.tsx'
+import { WorkspacePicker } from './WorkspacePicker.tsx'
+import css from './WorkspaceChip.module.css'
+
+export interface WorkspaceChipProps {
+  /** `hero` is the pill under the headline; `crumb` is the header path. */
+  variant?: 'crumb' | 'hero'
+}
+
+/** Enough of a path to identify the folder: its last two segments. */
+function shortPath(path: string): string {
+  const segments = path.split(/[/\\]/).filter(Boolean)
+
+  return segments.length <= 2 ? path : segments.slice(-2).join('/')
+}
+
+/**
+ * The current workspace, and the way to change it.
+ *
+ * Both call sites open the same picker. The confirm label differs because the
+ * consequence does: with no session yet the choice simply aims the next one,
+ * while a running session's working directory is fixed at spawn, so choosing a
+ * new folder starts a session there.
+ */
+export function WorkspaceChip({ variant = 'hero' }: WorkspaceChipProps) {
+  const workspace = useStore($workspace)
+  const sessionId = useStore($sessionId)
+  const [open, setOpen] = useState(false)
+
+  const onPick = useCallback((path: string) => {
+    setOpen(false)
+    void chooseWorkspace(path)
+  }, [])
+
+  const close = useCallback(() => {
+    setOpen(false)
+  }, [])
+
+  if (workspace === '') return null
+
+  return (
+    <span className={css.root}>
+      <button
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        className={variant === 'hero' ? css.chip : css.crumb}
+        onClick={() => {
+          setOpen(value => !value)
+        }}
+        title={`${workspace} — click to change`}
+        type="button"
+      >
+        <FolderIcon className={css.icon} size={variant === 'hero' ? 14 : 13} />
+        <span className={css.label}>
+          {variant === 'hero' ? shortPath(workspace) : workspace}
+        </span>
+        <ChevronDownIcon className={css.chevron} size={11} />
+      </button>
+      {open && (
+        <span className={css.popover}>
+          <WorkspacePicker
+            confirmLabel={sessionId === null ? 'Use this folder' : 'Start a session here'}
+            onClose={close}
+            onPick={onPick}
+            startPath={workspace}
+          />
+        </span>
+      )}
+    </span>
+  )
+}

--- a/ui-web/src/workspace/WorkspacePicker.module.css
+++ b/ui-web/src/workspace/WorkspacePicker.module.css
@@ -1,0 +1,238 @@
+/* Directory browser, shown as a popover anchored to whatever opened it.
+   Sized so a typical home directory needs no scrolling to scan, and capped so
+   it never becomes the tallest thing on screen. */
+.root {
+  position: absolute;
+  z-index: 200;
+  display: flex;
+  box-sizing: border-box;
+  flex-direction: column;
+  width: min(460px, calc(100vw - 32px));
+  max-height: min(440px, 70vh);
+  overflow: hidden;
+  border: 1px solid var(--cc-alias-border-inverted);
+  border-radius: 12px;
+  background: var(--cc-specific-menu);
+  box-shadow: var(--cc-shadow-lv3);
+  --cc-scrollbar-thumb: var(--cc-alias-scrollbar-bg-l2);
+  --cc-scrollbar-thumb-hover: var(--cc-alias-scrollbar-hover-l2);
+}
+
+.header {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--cc-alias-border-l1);
+}
+
+.title {
+  flex: 1;
+  color: var(--cc-alias-label-primary);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.iconButton {
+  flex: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--cc-alias-label-secondary);
+  cursor: pointer;
+}
+
+.iconButton:hover:not(:disabled) {
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-primary);
+}
+
+.iconButton:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* Breadcrumb: every ancestor is a jump target, so it scrolls sideways rather
+   than truncating — a deep path must stay fully reachable. */
+.crumbs {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  padding: 6px 8px;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--cc-alias-border-l1);
+  white-space: nowrap;
+  scrollbar-width: none;
+}
+
+.crumbs::-webkit-scrollbar {
+  display: none;
+}
+
+.crumb {
+  flex: none;
+  padding: 2px 6px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--cc-alias-label-tertiary);
+  font-size: 12px;
+  line-height: 18px;
+  cursor: pointer;
+}
+
+.crumb:hover {
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-primary);
+}
+
+.crumbCurrent {
+  color: var(--cc-alias-label-primary);
+  font-weight: 500;
+}
+
+.crumbSep {
+  flex: none;
+  color: var(--cc-alias-label-caption);
+  font-size: 11px;
+}
+
+.filter {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--cc-alias-border-l1);
+  color: var(--cc-alias-label-caption);
+}
+
+.filterInput {
+  width: 100%;
+  min-width: 0;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--cc-alias-label-primary);
+  font-size: 13px;
+}
+
+.filterInput::placeholder {
+  color: var(--cc-alias-label-caption);
+}
+
+.list {
+  flex: 1;
+  min-height: 0;
+  padding: 4px;
+  overflow-y: auto;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 5px 8px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--cc-alias-label-primary);
+  font-size: 13px;
+  line-height: 18px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.row:hover,
+.row[data-active='true'] {
+  background: var(--cc-alias-interactive-bg-hover);
+}
+
+.rowIcon {
+  flex: none;
+  color: var(--cc-alias-label-caption);
+}
+
+.rowName {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Dimmed rather than filtered out: a dotfile directory is a real destination
+   (`~/.config`), just not one to lead with. */
+.rowHidden .rowName {
+  color: var(--cc-alias-label-tertiary);
+}
+
+.rowChevron {
+  flex: none;
+  color: var(--cc-alias-label-caption);
+}
+
+.status {
+  padding: 20px 12px;
+  color: var(--cc-alias-label-caption);
+  font-size: 12px;
+  text-align: center;
+}
+
+.error {
+  color: var(--cc-alias-state-error-primary);
+}
+
+.footer {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-top: 1px solid var(--cc-alias-border-l1);
+}
+
+.currentPath {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--cc-alias-label-tertiary);
+  font-family: var(--cc-font-family-code);
+  font-size: 11px;
+  /* Truncate from the LEFT: the tail of a path identifies the folder, the head
+     is shared boilerplate. */
+  direction: rtl;
+  text-align: left;
+  text-overflow: ellipsis;
+  unicode-bidi: plaintext;
+  white-space: nowrap;
+}
+
+.toggleHidden {
+  flex: none;
+  padding: 2px 6px;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--cc-alias-label-caption);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.toggleHidden:hover {
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-secondary);
+}
+
+.toggleHidden[aria-pressed='true'] {
+  color: var(--cc-alias-label-secondary);
+}

--- a/ui-web/src/workspace/WorkspacePicker.tsx
+++ b/ui-web/src/workspace/WorkspacePicker.tsx
@@ -1,0 +1,268 @@
+import { useCallback, useEffect, useMemo, useRef, useState, type KeyboardEvent } from 'react'
+
+import type { DirectoryEntry, DirectoryListing } from '../gateway/protocol.ts'
+import { listDirectory } from '../state/actions.ts'
+import { Button } from '../ui/primitives/Button.tsx'
+import { ChevronRightIcon, FolderIcon, SearchIcon, XIcon } from '../ui/icons.tsx'
+import css from './WorkspacePicker.module.css'
+
+export interface WorkspacePickerProps {
+  /** Label for the confirm action; differs when a session is already running. */
+  confirmLabel: string
+  onClose: () => void
+  onPick: (path: string) => void
+  /** Directory to open on: the current workspace, or home when absent. */
+  startPath?: string
+}
+
+/**
+ * Browse the server's filesystem to choose where a session runs.
+ *
+ * The server's, not the browser's: a File System Access handle is opaque, and
+ * the agent needs a real path it can `cd` into. Every path in here comes from
+ * the backend for the same reason — the client never joins segments itself.
+ *
+ * Two distinct gestures on purpose: clicking a row *descends into* it, and the
+ * footer button *chooses the folder you are looking at*. Collapsing those into
+ * one makes picking a directory that has children impossible without an
+ * awkward modifier.
+ */
+export function WorkspacePicker({
+  confirmLabel,
+  onClose,
+  onPick,
+  startPath,
+}: WorkspacePickerProps) {
+  const [listing, setListing] = useState<DirectoryListing | null>(null)
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [filter, setFilter] = useState('')
+  const [showHidden, setShowHidden] = useState(false)
+  const [active, setActive] = useState(0)
+  const root = useRef<HTMLDivElement | null>(null)
+  const filterInput = useRef<HTMLInputElement | null>(null)
+  // Guards against a slow listing landing after a newer one.
+  const request = useRef(0)
+
+  const open = useCallback((path?: string) => {
+    const ticket = ++request.current
+    setLoading(true)
+    setError('')
+
+    void listDirectory(path)
+      .then(next => {
+        if (request.current !== ticket) return
+
+        setListing(next)
+        setFilter('')
+        setActive(0)
+      })
+      .catch((cause: unknown) => {
+        if (request.current !== ticket) return
+
+        // Surfaced, never swallowed: an unreadable directory rendered as an
+        // empty folder sends the user hunting for a project that is there.
+        setError(cause instanceof Error ? cause.message : String(cause))
+      })
+      .finally(() => {
+        if (request.current === ticket) setLoading(false)
+      })
+  }, [])
+
+  useEffect(() => {
+    open(startPath)
+  }, [open, startPath])
+
+  useEffect(() => {
+    filterInput.current?.focus()
+  }, [])
+
+  // Dismissal: click outside or Escape, the two gestures people already use.
+  useEffect(() => {
+    const onPointerDown = (event: PointerEvent) => {
+      if (root.current?.contains(event.target as Node) === true) return
+
+      onClose()
+    }
+
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation()
+        onClose()
+      }
+    }
+
+    document.addEventListener('pointerdown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [onClose])
+
+  const rows = useMemo(() => {
+    const needle = filter.trim().toLowerCase()
+    const entries = listing?.entries ?? []
+
+    return entries.filter(entry => {
+      if (!showHidden && entry.hidden && !needle) return false
+
+      return needle === '' || entry.name.toLowerCase().includes(needle)
+    })
+  }, [filter, listing, showHidden])
+
+  useEffect(() => {
+    setActive(0)
+  }, [rows.length])
+
+  const onFilterKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        setActive(index => Math.min(rows.length - 1, index + 1))
+
+        return
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        setActive(index => Math.max(0, index - 1))
+
+        return
+      }
+
+      if (event.key === 'Enter') {
+        event.preventDefault()
+
+        const entry = rows[active]
+
+        // Enter with no rows confirms the folder you are in — the natural
+        // outcome when the filter has narrowed everything away.
+        if (entry === undefined) {
+          if (listing !== null) onPick(listing.path)
+
+          return
+        }
+
+        open(entry.path)
+      }
+    },
+    [active, listing, onPick, open, rows],
+  )
+
+  const crumbs = listing?.crumbs ?? []
+
+  return (
+    <div className={css.root} ref={root} role="dialog">
+      <div className={css.header}>
+        <FolderIcon size={14} />
+        <span className={css.title}>Choose a folder</span>
+        <button
+          aria-label="Close"
+          className={css.iconButton}
+          onClick={onClose}
+          type="button"
+        >
+          <XIcon size={12} />
+        </button>
+      </div>
+
+      <div className={css.crumbs}>
+        {crumbs.map((crumb, index) => (
+          <span key={crumb.path}>
+            {index > 0 && <span className={css.crumbSep}>›</span>}
+            <button
+              className={[css.crumb, index === crumbs.length - 1 ? css.crumbCurrent : '']
+                .filter(Boolean)
+                .join(' ')}
+              onClick={() => {
+                open(crumb.path)
+              }}
+              type="button"
+            >
+              {crumb.name}
+            </button>
+          </span>
+        ))}
+      </div>
+
+      <div className={css.filter}>
+        <SearchIcon size={12} />
+        <input
+          aria-label="Filter folders"
+          className={css.filterInput}
+          onChange={event => {
+            setFilter(event.currentTarget.value)
+          }}
+          onKeyDown={onFilterKeyDown}
+          placeholder="Filter — ↑↓ to move, Enter to open"
+          ref={filterInput}
+          value={filter}
+        />
+      </div>
+
+      <div className={css.list}>
+        {error !== '' ? (
+          <div className={[css.status, css.error].join(' ')}>{error}</div>
+        ) : loading ? (
+          <div className={css.status}>Loading…</div>
+        ) : rows.length === 0 ? (
+          <div className={css.status}>
+            {filter === '' ? 'No subfolders here.' : 'Nothing matches that filter.'}
+          </div>
+        ) : (
+          rows.map((entry: DirectoryEntry, index) => (
+            <button
+              className={[css.row, entry.hidden ? css.rowHidden : ''].filter(Boolean).join(' ')}
+              data-active={index === active ? 'true' : undefined}
+              key={entry.path}
+              onClick={() => {
+                open(entry.path)
+              }}
+              onPointerEnter={() => {
+                setActive(index)
+              }}
+              type="button"
+            >
+              <FolderIcon className={css.rowIcon} size={13} />
+              <span className={css.rowName}>{entry.name}</span>
+              <ChevronRightIcon className={css.rowChevron} size={12} />
+            </button>
+          ))
+        )}
+        {listing?.truncated === true && (
+          <div className={css.status}>
+            Showing the first {listing.entries.length} folders — filter to narrow.
+          </div>
+        )}
+      </div>
+
+      <div className={css.footer}>
+        <button
+          aria-pressed={showHidden}
+          className={css.toggleHidden}
+          onClick={() => {
+            setShowHidden(value => !value)
+          }}
+          type="button"
+        >
+          {showHidden ? 'Hide dotfiles' : 'Show dotfiles'}
+        </button>
+        <span className={css.currentPath} title={listing?.path}>
+          {listing?.path ?? ''}
+        </span>
+        <Button
+          disabled={listing === null}
+          onClick={() => {
+            if (listing !== null) onPick(listing.path)
+          }}
+          size="sm"
+          variant="primary"
+        >
+          {confirmLabel}
+        </Button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
**Bug:** the workspace was whatever directory the server happened to start in,
and the hero chip showing it was static text — so a browser session could never
run anywhere else.

Now the chip opens a directory browser, and so does the path crumb in an active
session's header.

## Browsing the server's filesystem, not the browser's

A File System Access handle is opaque; the agent needs a real path it can `cd`
into. New `fs.list_directory` RPC returns one level plus its ancestry, shaped
after the reference implementation's `DirectoryListing` because two of its
properties are worth copying exactly:

- **Every path is absolute and comes from the server**, so a client that has
  never seen a Windows path cannot assemble one with the wrong separator.
- **`crumbs` is the whole ancestor chain**, so the breadcrumb is a row of jump
  targets rather than a string the client has to re-split.

Read-only and directories-only, which adds no reach the agent does not already
have in this same process. What it must not do is *hide* a failure: an
unreadable directory raises rather than returning an empty list, because "empty
folder" and "we could not look" are indistinguishable to a user hunting for a
project that is right there. That case has its own test.

## Two interaction decisions

- **Descend and choose are separate gestures.** Clicking a row descends into
  it; the footer button chooses the folder you are looking at. Collapsing them
  would make picking a directory that has children impossible without a
  modifier.
- **The confirm label follows the consequence.** With no session yet it reads
  "Use this folder" and aims the next one. With a session running it reads
  "Start a session here" — a session's working directory is fixed at spawn, and
  pretending otherwise would leave the choice to take effect at some unclear
  later point.

## Verified live

Picked `~/workspace/DeepSeek-Reasonix` from the hero, sent a prompt, and `pwd`
returned that path. Then switched folder mid-session from the header crumb and
got a fresh session in the new one.

18 pytest specs over the listing: sorting (case-insensitive, so `Beta` lands
between `alpha` and `zeta`), hidden flagging without removal, symlinks to
directories included, broken links skipped rather than fatal, traversal
resolved, truncation reported, and the permission case above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)