### PR TITLE
feat(web): let AskUserQuestion actually reach the user

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -448,6 +448,26 @@ class _AgentSession:
                     "goal_rev": goal_rev,
                 })
             return
+        if subtype == "set_ask_user_interactive":
+            # The capability negotiation the multi-session transport lacks (see
+            # the spawn-time wiring, which defaults to the non-interactive
+            # answer precisely BECAUSE it cannot know whether the client
+            # renders questions). A client that does render them says so here,
+            # and only then does AskUserQuestion actually reach a human.
+            #
+            # One-way on purpose: a client can enable it, and the only thing
+            # that turns it back off is the session ending. Toggling it off
+            # mid-turn would strand a question already blocking a worker
+            # thread with no one left to answer it -- that case is the ask
+            # timeout's job, not this handler's.
+            enabled = inner.get("enabled") is not False
+            if self.tool_context is None:
+                self._reply(request_id, {"ok": False, "error": "session not ready"})
+                return
+            if enabled:
+                self.tool_context.ask_user = self.ask_user
+            self._reply(request_id, {"ok": True, "interactive": bool(enabled)})
+            return
         if subtype == "set_permission_mode":
             mode = inner.get("mode")
             # Validate BEFORE setting: an unknown string would land verbatim in

--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -120,6 +120,12 @@ class DesktopSession:
         # approval per session).
         self._pending_asks: dict[str, dict[str, Any]] = {}
         self._last_ask_id: str | None = None
+        # AskUserQuestion rides its own slot rather than sharing _last_ask_id:
+        # an approval click and a question submit are different replies, and a
+        # single slot would let either resolve the other's request.
+        self._pending_question: str | None = None
+        # Set only once a client has said it renders questions (see _create).
+        self.asks_questions = False
         self.sockets: set[WebSocket] = set()
         # Scheduled session.info refreshes; held so they aren't GC'd mid-flight.
         self._background: set[asyncio.Task] = set()
@@ -265,16 +271,28 @@ class DesktopSession:
         if not rid:
             return
         self._pending_asks[rid] = request
-        self._last_ask_id = rid
 
         if subtype == "can_use_tool":
+            # Claimed by the approval lane only; a question must not land in
+            # this slot or an approval click would answer it.
+            self._last_ask_id = rid
             await self._broadcast("approval.request", approval_request_payload(request))
             return
+
+        if subtype == "ask_user_question" and self.asks_questions:
+            payload = question_request_payload(rid, request)
+            # A malformed question set has nothing to render; falling through
+            # to the decline below is better than an empty modal the user
+            # cannot dismiss.
+            if payload is not None:
+                self._pending_question = rid
+                await self._broadcast("question.request", payload)
+                return
+
         # Unknown ask: deny rather than hang the agent behind an invisible
         # prompt (the desktop has no surface for it yet).
         logger.warning("desktop session %s: unsupported ask %s — denying", self.session_id, subtype)
         self._pending_asks.pop(rid, None)
-        self._last_ask_id = None
         await self._reply_ask(rid, {"behavior": "deny", "message": f"unsupported prompt {subtype}"})
 
     async def _reply_ask(self, rid: str, response: Any) -> None:
@@ -451,6 +469,87 @@ class DesktopSession:
         await self._reply_ask(rid, reply)
         return {"resolved": True}
 
+    async def respond_question(
+        self, action: str, answers: dict[str, str]
+    ) -> dict[str, Any]:
+        """Answer (or decline) the parked AskUserQuestion.
+
+        The agent reads anything that is not ``action == "submit"`` as a
+        decline, and filters the answers down to the questions it actually
+        asked — so an unknown key here is dropped there, not an error.
+        """
+        rid = self._pending_question
+        self._pending_question = None
+        if not rid or self._pending_asks.pop(rid, None) is None:
+            # Already answered, timed out, or never ours. Saying so lets the
+            # client drop a composer that is addressing a question the agent
+            # has since stopped waiting on.
+            return {"resolved": False}
+
+        if action != "submit":
+            await self._reply_ask(rid, {"action": "decline"})
+            return {"resolved": True}
+
+        await self._reply_ask(
+            rid,
+            {
+                "action": "submit",
+                "answers": {
+                    str(k): str(v)
+                    for k, v in answers.items()
+                    if isinstance(k, str) and isinstance(v, str)
+                },
+            },
+        )
+        return {"resolved": True}
+
+
+def _wants_questions(params: dict[str, Any]) -> bool:
+    """Whether this client declared it can render AskUserQuestion."""
+    capabilities = params.get("capabilities")
+    if isinstance(capabilities, dict):
+        return capabilities.get("ask_user_question") is True
+    if isinstance(capabilities, list):
+        return "ask_user_question" in capabilities
+    return False
+
+
+def question_request_payload(
+    request_id: str, request: dict[str, Any]
+) -> dict[str, Any] | None:
+    """Shape one ``ask_user_question`` for the client, or None if unrenderable.
+
+    Question text is the agent's answer KEY (that is the contract the tool
+    filters on), so it is carried through verbatim and echoed back rather than
+    re-derived client-side from a label or an index.
+    """
+    questions: list[dict[str, Any]] = []
+    for item in request.get("questions") or []:
+        if not isinstance(item, dict):
+            continue
+        text = item.get("question")
+        if not isinstance(text, str) or not text.strip():
+            continue
+        options: list[dict[str, str]] = []
+        for option in item.get("options") or []:
+            if isinstance(option, dict) and isinstance(option.get("label"), str):
+                entry = {"label": option["label"]}
+                description = option.get("description")
+                if isinstance(description, str) and description:
+                    entry["description"] = description
+                options.append(entry)
+        question: dict[str, Any] = {"question": text, "options": options}
+        header = item.get("header")
+        if isinstance(header, str) and header:
+            question["header"] = header
+        if item.get("multiSelect") is True:
+            question["multi_select"] = True
+        questions.append(question)
+
+    if not questions:
+        return None
+    return {"request_id": request_id, "questions": questions}
+
 
 def configured_providers_only(providers: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Keep only providers the user has actually configured.
@@ -550,6 +649,7 @@ class GatewayConnection:
             "projects.tree": self.projects_tree,
             "prompt.submit": self.prompt_submit,
             "approval.respond": self.approval_respond,
+            "question.respond": self.question_respond,
             "permission.cycle": self.permission_cycle,
             "model.options": self.model_options,
             "config.get": self.config_get,
@@ -621,6 +721,19 @@ class GatewayConnection:
             await asyncio.wait_for(session.init_seen.wait(), CONTROL_TIMEOUT_S)
         except asyncio.TimeoutError:
             logger.warning("session %s: no system/init within %ss", session_id, CONTROL_TIMEOUT_S)
+        # Capability negotiation, opt-in per client. Without it the agent
+        # substitutes the non-interactive answer for AskUserQuestion, because
+        # a client that ignored the question would park the session's worker
+        # thread until the ask timeout. Clients that render questions ask for
+        # the real thing here; the ones that don't are left exactly as before.
+        if _wants_questions(params):
+            reply = await session.control_query("set_ask_user_interactive", {"enabled": True})
+            if isinstance(reply, dict) and reply.get("ok") is not False:
+                session.asks_questions = True
+            else:
+                logger.warning(
+                    "session %s: interactive questions refused: %r", session_id, reply
+                )
         if resume:
             reply = await session.control_query("resume", {"session_id": resume})
             if not isinstance(reply, dict) or reply.get("ok") is False:
@@ -789,6 +902,13 @@ class GatewayConnection:
 
     async def approval_respond(self, params: dict[str, Any]) -> dict[str, Any]:
         return await self._session(params).respond_approval(str(params.get("choice") or "deny"))
+
+    async def question_respond(self, params: dict[str, Any]) -> dict[str, Any]:
+        raw = params.get("answers")
+        answers = raw if isinstance(raw, dict) else {}
+        return await self._session(params).respond_question(
+            str(params.get("action") or "decline"), answers
+        )
 
     async def permission_cycle(self, params: dict[str, Any]) -> dict[str, Any]:
         result = await self._session(params).control_query("cycle_permission_mode", {})

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -1,0 +1,290 @@
+"""AskUserQuestion over the desktop/web gateway.
+
+The gateway auto-denies every ask subtype it has no surface for, and the agent
+server substitutes a non-interactive answer for AskUserQuestion on the
+multi-session transport — both deliberately, because a client that ignored a
+question would park the session's worker thread until the ask timeout. These
+cover the negotiation that lets a client which *does* render questions opt in,
+and the shape of what crosses the wire once it has.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+
+from src.server.desktop_gateway_methods import (
+    DesktopSession,
+    _wants_questions,
+    question_request_payload,
+)
+
+
+class _Agent:
+    """Records what the session sends back to the agent process."""
+
+    def __init__(self) -> None:
+        self.sent: list[dict[str, Any]] = []
+
+    async def send_to_agent(self, message: dict[str, Any]) -> None:
+        self.sent.append(message)
+
+    @property
+    def replies(self) -> list[dict[str, Any]]:
+        return [m["response"] for m in self.sent if m.get("type") == "control_response"]
+
+
+def _session() -> tuple[DesktopSession, _Agent, list[tuple[str, Any]]]:
+    session = DesktopSession.__new__(DesktopSession)
+    session.session_id = "s1"
+    session._pending_asks = {}
+    session._last_ask_id = None
+    session._pending_question = None
+    session.asks_questions = False
+    agent = _Agent()
+    session.agent = agent
+    broadcasts: list[tuple[str, Any]] = []
+
+    async def _broadcast(type_: str, payload: Any) -> None:
+        broadcasts.append((type_, payload))
+
+    session._broadcast = _broadcast  # type: ignore[method-assign]
+    return session, agent, broadcasts
+
+
+def _ask(**questions: Any) -> dict[str, Any]:
+    return {
+        "request_id": "ask-1",
+        "request": {"subtype": "ask_user_question", **questions},
+    }
+
+
+# ── capability declaration ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "params,expected",
+    [
+        ({"capabilities": {"ask_user_question": True}}, True),
+        ({"capabilities": ["ask_user_question"]}, True),
+        ({"capabilities": {"ask_user_question": False}}, False),
+        ({"capabilities": {}}, False),
+        ({"capabilities": None}, False),
+        ({}, False),
+        # A truthy non-True value is not a declaration; the check is `is True`
+        # so a stray string cannot switch the agent into blocking on a human.
+        ({"capabilities": {"ask_user_question": "yes"}}, False),
+    ],
+)
+def test_wants_questions(params: dict[str, Any], expected: bool) -> None:
+    assert _wants_questions(params) is expected
+
+
+# ── payload shaping ───────────────────────────────────────────────────────────
+
+
+def test_payload_carries_question_text_verbatim() -> None:
+    # The text is the agent's answer KEY -- the tool drops any answer whose key
+    # it did not ask about -- so it must survive the trip unchanged.
+    payload = question_request_payload(
+        "r1",
+        {"questions": [{"question": "Which colour?  ", "options": [{"label": "Red"}]}]},
+    )
+
+    assert payload is not None
+    assert payload["questions"][0]["question"] == "Which colour?  "
+    assert payload["request_id"] == "r1"
+
+
+def test_payload_keeps_header_options_and_multiselect() -> None:
+    payload = question_request_payload(
+        "r1",
+        {
+            "questions": [
+                {
+                    "question": "Which files?",
+                    "header": "Scope",
+                    "multiSelect": True,
+                    "options": [
+                        {"label": "a.py", "description": "the module"},
+                        {"label": "b.py"},
+                    ],
+                }
+            ]
+        },
+    )
+
+    assert payload is not None
+    assert payload["questions"][0] == {
+        "question": "Which files?",
+        "header": "Scope",
+        "multi_select": True,
+        "options": [{"label": "a.py", "description": "the module"}, {"label": "b.py"}],
+    }
+
+
+def test_payload_allows_a_question_with_no_options() -> None:
+    # An open question is legitimate: the composer offers a text field for it.
+    payload = question_request_payload("r1", {"questions": [{"question": "Name it?"}]})
+
+    assert payload is not None
+    assert payload["questions"][0]["options"] == []
+
+
+@pytest.mark.parametrize(
+    "request_",
+    [
+        {},
+        {"questions": []},
+        {"questions": [{"question": ""}]},
+        {"questions": [{"question": "   "}]},
+        {"questions": [{"question": 42}]},
+        {"questions": ["not a dict"]},
+    ],
+)
+def test_payload_is_none_when_there_is_nothing_to_render(request_: dict[str, Any]) -> None:
+    # Falling through to the decline is better than seating an empty takeover
+    # the user cannot answer and cannot dismiss.
+    assert question_request_payload("r1", request_) is None
+
+
+def test_payload_drops_a_malformed_option_but_keeps_the_question() -> None:
+    payload = question_request_payload(
+        "r1",
+        {"questions": [{"question": "Pick", "options": [{"label": "ok"}, {"nope": 1}, "x"]}]},
+    )
+
+    assert payload is not None
+    assert payload["questions"][0]["options"] == [{"label": "ok"}]
+
+
+# ── routing ───────────────────────────────────────────────────────────────────
+
+
+def test_route_denies_a_question_when_the_client_never_declared_support() -> None:
+    # Preserves today's behavior for a client with no question surface.
+    session, agent, broadcasts = _session()
+
+    asyncio.run(session._route_ask(_ask(questions=[{"question": "Which colour?"}])))
+
+    assert [t for t, _ in broadcasts] == []
+    assert agent.replies[0]["response"]["behavior"] == "deny"
+    assert session._pending_question is None
+
+
+def test_route_broadcasts_a_question_once_the_client_has_declared_support() -> None:
+    session, agent, broadcasts = _session()
+    session.asks_questions = True
+
+    asyncio.run(session._route_ask(_ask(questions=[{"question": "Which colour?"}])))
+
+    assert [t for t, _ in broadcasts] == ["question.request"]
+    assert broadcasts[0][1]["questions"][0]["question"] == "Which colour?"
+    assert session._pending_question == "ask-1"
+    assert agent.replies == []
+
+
+def test_route_declines_an_unrenderable_question_even_when_capable() -> None:
+    session, agent, broadcasts = _session()
+    session.asks_questions = True
+
+    asyncio.run(session._route_ask(_ask(questions=[])))
+
+    assert broadcasts == []
+    assert agent.replies[0]["response"]["behavior"] == "deny"
+
+
+def test_a_question_does_not_occupy_the_approval_slot() -> None:
+    # One slot for both would let a stray approval click answer a question --
+    # an "allow" is not a submit, so the user's question would silently come
+    # back to the agent as a decline.
+    session, agent, _broadcasts = _session()
+    session.asks_questions = True
+
+    asyncio.run(session._route_ask(_ask(questions=[{"question": "Which colour?"}])))
+
+    assert session._last_ask_id is None
+    assert session._pending_question == "ask-1"
+
+    assert asyncio.run(session.respond_approval("allow")) == {"resolved": False}
+    assert agent.replies == []
+    # …and the question is still answerable.
+    assert asyncio.run(session.respond_question("submit", {"Which colour?": "Red"})) == {
+        "resolved": True
+    }
+
+
+# ── responding ────────────────────────────────────────────────────────────────
+
+
+def _park(session: DesktopSession) -> None:
+    session.asks_questions = True
+    asyncio.run(session._route_ask(_ask(questions=[{"question": "Which colour?"}])))
+
+
+def test_submit_forwards_the_answers_under_the_submit_action() -> None:
+    session, agent, _ = _session()
+    _park(session)
+
+    result = asyncio.run(session.respond_question("submit", {"Which colour?": "Red"}))
+
+    assert result == {"resolved": True}
+    assert agent.replies[0] == {
+        "request_id": "ask-1",
+        "response": {"action": "submit", "answers": {"Which colour?": "Red"}},
+    }
+
+
+def test_submit_with_no_answers_is_still_a_submit() -> None:
+    # Skipping every question is "the user submitted nothing", which the tool
+    # reports differently from a decline.
+    session, agent, _ = _session()
+    _park(session)
+
+    asyncio.run(session.respond_question("submit", {}))
+
+    assert agent.replies[0]["response"] == {"action": "submit", "answers": {}}
+
+
+def test_decline_is_not_a_submit() -> None:
+    session, agent, _ = _session()
+    _park(session)
+
+    asyncio.run(session.respond_question("decline", {"Which colour?": "Red"}))
+
+    # Anything that is not action=="submit" reads as a decline on the far side;
+    # the answers are dropped rather than smuggled through.
+    assert agent.replies[0]["response"] == {"action": "decline"}
+
+
+def test_non_string_answers_are_dropped_not_coerced_into_prose() -> None:
+    # Answer values land in text the model reads as the user's own words, so a
+    # structure that is not a string has no business being stringified into it.
+    session, agent, _ = _session()
+    _park(session)
+
+    asyncio.run(
+        session.respond_question(
+            "submit", {"Which colour?": "Red", "other": {"nested": 1}, 7: "x"}
+        )
+    )
+
+    assert agent.replies[0]["response"]["answers"] == {"Which colour?": "Red"}
+
+
+def test_answering_twice_resolves_only_once() -> None:
+    session, agent, _ = _session()
+    _park(session)
+
+    assert asyncio.run(session.respond_question("submit", {})) == {"resolved": True}
+    assert asyncio.run(session.respond_question("submit", {})) == {"resolved": False}
+    assert len(agent.replies) == 1
+
+
+def test_answering_with_nothing_pending_is_reported_not_replied_to() -> None:
+    session, agent, _ = _session()
+
+    assert asyncio.run(session.respond_question("submit", {"q": "a"})) == {"resolved": False}
+    assert agent.replies == []

--- a/ui-web/src/conversation/ConversationRoot.tsx
+++ b/ui-web/src/conversation/ConversationRoot.tsx
@@ -8,6 +8,7 @@ import {
   interrupt,
   renameSession,
   respondApproval,
+  respondQuestion,
   setApprovalMode,
   setModel,
   submitPrompt,
@@ -37,6 +38,7 @@ import { ApprovalPanel } from './ApprovalPanel.tsx'
 import { ChatView } from './ChatView.tsx'
 import { HeroShell } from './HeroShell.tsx'
 import { InputBar } from './InputBar.tsx'
+import { QuestionComposer } from './QuestionComposer.tsx'
 import { QueueDock } from './QueueDock.tsx'
 import { StatsLine } from './StatsLine.tsx'
 import css from './ConversationRoot.module.css'
@@ -164,6 +166,32 @@ export function ConversationRoot() {
     />
   )
 
+  /**
+   * What sits in the composer seat. Both takeovers block the agent, so at most
+   * one can be pending — but the order is stated rather than assumed, and an
+   * approval wins: it can be raised by a sub-agent while the main turn is
+   * already parked on a question, and the question is still there underneath
+   * once the tool is allowed or denied.
+   */
+  const seatPanel =
+    transcript.approval !== undefined ? (
+      <ApprovalPanel
+        onRespond={choice => {
+          void respondApproval(choice)
+        }}
+        request={transcript.approval}
+      />
+    ) : transcript.question !== undefined ? (
+      <QuestionComposer
+        onRespond={(action, answers) => {
+          void respondQuestion(action, answers)
+        }}
+        request={transcript.question}
+      />
+    ) : (
+      composer
+    )
+
   const banner =
     connection === 'reconnecting' || connection === 'error' ? (
       <div className={[css.banner, connection === 'error' ? css.bannerError : ''].join(' ')}>
@@ -264,16 +292,7 @@ export function ConversationRoot() {
             <TrajectoryView trajectory={trajectory} />
           </div>
           <div className={css.footer}>
-            {transcript.approval === undefined ? (
-              composer
-            ) : (
-              <ApprovalPanel
-                onRespond={choice => {
-                  void respondApproval(choice)
-                }}
-                request={transcript.approval}
-              />
-            )}
+            {seatPanel}
             <TrajectoryStatsBar stats={trajectoryStats(trajectory)} />
           </div>
         </>
@@ -318,16 +337,7 @@ export function ConversationRoot() {
             )}
             <div className={css.composerSeat} ref={seat}>
               <QueueDock items={queue} onRemove={dequeue} />
-              {transcript.approval === undefined ? (
-                composer
-              ) : (
-                <ApprovalPanel
-                  onRespond={choice => {
-                    void respondApproval(choice)
-                  }}
-                  request={transcript.approval}
-                />
-              )}
+              {seatPanel}
               <StatsLine
                 model={transcript.info.model}
                 provider={transcript.info.provider}

--- a/ui-web/src/conversation/QuestionComposer.module.css
+++ b/ui-web/src/conversation/QuestionComposer.module.css
@@ -1,0 +1,227 @@
+/* Composer takeover for AskUserQuestion. Same footprint and structure as
+   ApprovalPanel — strip, scrolling body, action row — but in the accent
+   palette rather than warn: a question is a request for input, not a risk
+   the user has to weigh. Colors ride the alias tokens, never literals. */
+
+/* Mirrors InputBar .root so the takeover is a content swap, not a layout jump. */
+.root {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 8px calc(var(--cc-composer-side-clearance) + 16px) 12px;
+}
+
+.card {
+  width: 100%;
+  max-width: var(--cc-chat-content-width);
+  overflow: hidden;
+  border: 1px solid var(--cc-alias-border-l2);
+  border-radius: 20px;
+  background: var(--cc-specific-input-major);
+  box-shadow: var(--cc-shadow-lv2);
+  --cc-scrollbar-thumb: var(--cc-alias-scrollbar-bg-l2);
+  --cc-scrollbar-thumb-hover: var(--cc-alias-scrollbar-hover-l2);
+}
+
+.strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px 10px 16px;
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-secondary);
+  font-size: 13px;
+  line-height: 18px;
+}
+
+.stripLabel {
+  flex: 1;
+  min-width: 0;
+}
+
+.close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--cc-alias-label-tertiary);
+  cursor: pointer;
+}
+
+.close:hover {
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-primary);
+}
+
+/* Question prose, option descriptions and a four-question set are all
+   unbounded in a fixed-height column. Capped and scrolling so the action row
+   stays reachable — an unanswerable question would block the agent. */
+.body {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: var(--cc-composer-text-max-height);
+  padding: 14px 16px 4px;
+  overflow-y: auto;
+}
+
+.eyebrow {
+  color: var(--cc-alias-label-tertiary);
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  line-height: 16px;
+  text-transform: uppercase;
+}
+
+.title {
+  margin: 0;
+  color: var(--cc-alias-label-primary);
+  font-size: 15px;
+  font-weight: 500;
+  line-height: 22px;
+}
+
+.options {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.option {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 12px;
+  border: 1px solid var(--cc-alias-border-l2);
+  border-radius: 12px;
+  background: transparent;
+  color: var(--cc-alias-label-primary);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.option:hover {
+  border-color: var(--cc-alias-border-inverted);
+  background: var(--cc-alias-interactive-bg-hover);
+}
+
+.optionPicked,
+.optionPicked:hover {
+  border-color: var(--cc-alias-label-primary);
+  background: var(--cc-alias-interactive-bg-active);
+}
+
+/* The index badge doubles as the checked state, so an option reads the same
+   whether it is a radio or a checkbox. */
+.mark {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin-top: 1px;
+  border: 1px solid var(--cc-alias-border-l2);
+  border-radius: 6px;
+  color: var(--cc-alias-label-tertiary);
+  font-size: 11px;
+  line-height: 1;
+}
+
+.markOn {
+  border-color: var(--cc-alias-label-primary);
+  background: var(--cc-alias-label-primary);
+  color: var(--cc-specific-input-major);
+}
+
+.optionText {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.optionLabel {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.badge {
+  padding: 0 6px;
+  border-radius: 999px;
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-tertiary);
+  font-size: 10px;
+  letter-spacing: 0.02em;
+  line-height: 16px;
+  white-space: nowrap;
+}
+
+.optionHint {
+  color: var(--cc-alias-label-tertiary);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.custom {
+  box-sizing: border-box;
+  width: 100%;
+  margin-top: 2px;
+  padding: 8px 12px;
+  border: 1px solid var(--cc-alias-border-l2);
+  border-radius: 12px;
+  background: transparent;
+  color: var(--cc-alias-label-primary);
+  font: inherit;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.custom::placeholder {
+  color: var(--cc-alias-label-dimmed);
+}
+
+.custom:focus {
+  border-color: var(--cc-alias-label-tertiary);
+  outline: none;
+}
+
+.error {
+  color: var(--cc-alias-state-warn-primary);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 16px 12px;
+}
+
+.actionsLeft {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.nextIcon {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 4px;
+}

--- a/ui-web/src/conversation/QuestionComposer.test.tsx
+++ b/ui-web/src/conversation/QuestionComposer.test.tsx
@@ -1,0 +1,258 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { PendingQuestion, QuestionRequestPayload } from '../gateway/protocol.ts'
+import { QuestionComposer, answerOf, parseRecommended } from './QuestionComposer.tsx'
+
+afterEach(cleanup)
+
+function request(...questions: PendingQuestion[]): QuestionRequestPayload {
+  return { questions, request_id: 'req-1' }
+}
+
+const COLOUR: PendingQuestion = {
+  header: 'Palette',
+  options: [
+    { description: 'Warm', label: 'Red (Recommended)' },
+    { description: 'Cool', label: 'Blue' },
+  ],
+  question: 'Which colour?',
+}
+
+function pick(name: string): void {
+  fireEvent.click(screen.getByRole('radio', { name }))
+}
+
+function send(): void {
+  fireEvent.click(screen.getByRole('button', { name: /Send answers/ }))
+}
+
+describe('parseRecommended', () => {
+  it('splits the suffix for display', () => {
+    expect(parseRecommended('Red (Recommended)')).toEqual({ recommended: true, text: 'Red' })
+    expect(parseRecommended('red (recommended)')).toEqual({ recommended: true, text: 'red' })
+  })
+
+  it('leaves a label that merely mentions the word alone', () => {
+    expect(parseRecommended('Recommended reading')).toEqual({
+      recommended: false,
+      text: 'Recommended reading',
+    })
+  })
+})
+
+describe('answerOf', () => {
+  it('omits a skipped question rather than answering it emptily', () => {
+    // The tool renders the answer map verbatim for the model, so `""` would
+    // read as the user having said something empty rather than nothing.
+    expect(answerOf({ custom: '', selected: [], skipped: true })).toBeUndefined()
+  })
+
+  it('omits an untouched question', () => {
+    expect(answerOf({ custom: '  ', selected: [], skipped: false })).toBeUndefined()
+  })
+
+  it('joins a multi-select pick with any typed addition', () => {
+    expect(answerOf({ custom: ' teal ', selected: ['Red', 'Blue'], skipped: false })).toBe(
+      'Red, Blue, teal',
+    )
+  })
+})
+
+describe('QuestionComposer', () => {
+  it('drops a description that only repeats its own label', () => {
+    // Models routinely fill the description with the label; rendering both
+    // puts the same word on two lines.
+    render(
+      <QuestionComposer
+        onRespond={vi.fn()}
+        request={request({
+          options: [{ description: 'Red', label: 'Red' }, { description: 'Cool', label: 'Blue' }],
+          question: 'Which colour?',
+        })}
+      />,
+    )
+
+    expect(screen.queryAllByText('Red')).toHaveLength(1)
+    expect(screen.getByText('Cool')).toBeTruthy()
+  })
+
+  it('shows the question, its header, and the option descriptions', () => {
+    render(<QuestionComposer onRespond={vi.fn()} request={request(COLOUR)} />)
+
+    expect(screen.getByRole('heading', { name: 'Which colour?' })).toBeTruthy()
+    expect(screen.getByText('Palette')).toBeTruthy()
+    expect(screen.getByText('Warm')).toBeTruthy()
+  })
+
+  it('strips the recommendation suffix for display but answers with the real label', () => {
+    // The label is the value the agent gets back; only the display is trimmed.
+    const onRespond = vi.fn()
+    render(<QuestionComposer onRespond={onRespond} request={request(COLOUR)} />)
+
+    expect(screen.getByText('Recommended')).toBeTruthy()
+    pick('Red (Recommended)')
+    send()
+
+    expect(onRespond).toHaveBeenCalledWith('submit', { 'Which colour?': 'Red (Recommended)' })
+  })
+
+  it('keys the answer by the question text', () => {
+    // That string is what the tool filters answers on — an index or a header
+    // would be dropped server-side without a word.
+    const onRespond = vi.fn()
+    render(<QuestionComposer onRespond={onRespond} request={request(COLOUR)} />)
+    pick('Blue')
+    send()
+
+    expect(onRespond).toHaveBeenCalledWith('submit', { 'Which colour?': 'Blue' })
+  })
+
+  it('replaces the pick in single-select', () => {
+    const onRespond = vi.fn()
+    render(<QuestionComposer onRespond={onRespond} request={request(COLOUR)} />)
+    pick('Red (Recommended)')
+    pick('Blue')
+    send()
+
+    expect(onRespond).toHaveBeenCalledWith('submit', { 'Which colour?': 'Blue' })
+  })
+
+  it('accumulates picks in multi-select and toggles them off', () => {
+    const onRespond = vi.fn()
+    const multi: PendingQuestion = { ...COLOUR, multi_select: true }
+    render(<QuestionComposer onRespond={onRespond} request={request(multi)} />)
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Red (Recommended)' }))
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Blue' }))
+    send()
+    expect(onRespond).toHaveBeenCalledWith('submit', {
+      'Which colour?': 'Red (Recommended), Blue',
+    })
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Red (Recommended)' }))
+    send()
+    expect(onRespond).toHaveBeenLastCalledWith('submit', { 'Which colour?': 'Blue' })
+  })
+
+  it('lets a typed answer replace a single-select pick', () => {
+    const onRespond = vi.fn()
+    render(<QuestionComposer onRespond={onRespond} request={request(COLOUR)} />)
+    pick('Red (Recommended)')
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'green' } })
+    send()
+
+    expect(onRespond).toHaveBeenCalledWith('submit', { 'Which colour?': 'green' })
+  })
+
+  it('answers a question that offers no options at all', () => {
+    const onRespond = vi.fn()
+    const open: PendingQuestion = { options: [], question: 'What should I name it?' }
+    render(<QuestionComposer onRespond={onRespond} request={request(open)} />)
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'atlas' } })
+    send()
+
+    expect(onRespond).toHaveBeenCalledWith('submit', { 'What should I name it?': 'atlas' })
+  })
+
+  it('refuses to advance on an untouched question', () => {
+    const onRespond = vi.fn()
+    render(<QuestionComposer onRespond={onRespond} request={request(COLOUR)} />)
+    send()
+
+    expect(onRespond).not.toHaveBeenCalled()
+    expect(screen.getByText(/Choose an option/)).toBeTruthy()
+  })
+
+  it('walks a set one question at a time and submits every answer at the end', () => {
+    const onRespond = vi.fn()
+    const second: PendingQuestion = {
+      options: [{ label: 'Yes' }, { label: 'No' }],
+      question: 'Ship it?',
+    }
+    render(<QuestionComposer onRespond={onRespond} request={request(COLOUR, second)} />)
+
+    expect(screen.getByText('Question 1 of 2')).toBeTruthy()
+    pick('Blue')
+    fireEvent.click(screen.getByRole('button', { name: /Next/ }))
+
+    expect(screen.getByText('Question 2 of 2')).toBeTruthy()
+    pick('Yes')
+    send()
+
+    expect(onRespond).toHaveBeenCalledWith('submit', {
+      'Ship it?': 'Yes',
+      'Which colour?': 'Blue',
+    })
+  })
+
+  it('lets Back revisit an earlier answer', () => {
+    const onRespond = vi.fn()
+    const second: PendingQuestion = { options: [{ label: 'Yes' }], question: 'Ship it?' }
+    render(<QuestionComposer onRespond={onRespond} request={request(COLOUR, second)} />)
+
+    pick('Red (Recommended)')
+    fireEvent.click(screen.getByRole('button', { name: /Next/ }))
+    fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+    pick('Blue')
+    fireEvent.click(screen.getByRole('button', { name: /Next/ }))
+    pick('Yes')
+    send()
+
+    expect(onRespond).toHaveBeenCalledWith('submit', {
+      'Ship it?': 'Yes',
+      'Which colour?': 'Blue',
+    })
+  })
+
+  it('skipping drops that question from the answers and still submits the rest', () => {
+    const onRespond = vi.fn()
+    const second: PendingQuestion = { options: [{ label: 'Yes' }], question: 'Ship it?' }
+    render(<QuestionComposer onRespond={onRespond} request={request(COLOUR, second)} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }))
+    pick('Yes')
+    send()
+
+    expect(onRespond).toHaveBeenCalledWith('submit', { 'Ship it?': 'Yes' })
+  })
+
+  it('skipping the only question submits nothing, which the tool reads as "no answers"', () => {
+    const onRespond = vi.fn()
+    render(<QuestionComposer onRespond={onRespond} request={request(COLOUR)} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }))
+
+    expect(onRespond).toHaveBeenCalledWith('submit', {})
+  })
+
+  it('declines on Escape', () => {
+    // The agent's worker thread is parked on this; the dismiss gesture has to
+    // resolve it, and a decline is a real answer rather than a silent drop.
+    const onRespond = vi.fn()
+    render(<QuestionComposer onRespond={onRespond} request={request(COLOUR)} />)
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onRespond).toHaveBeenCalledWith('decline', {})
+  })
+
+  it('declines from the close button', () => {
+    const onRespond = vi.fn()
+    render(<QuestionComposer onRespond={onRespond} request={request(COLOUR)} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Decline to answer' }))
+
+    expect(onRespond).toHaveBeenCalledWith('decline', {})
+  })
+
+  it('starts clean when a new request arrives', () => {
+    const onRespond = vi.fn()
+    const view = render(<QuestionComposer onRespond={onRespond} request={request(COLOUR)} />)
+    pick('Red (Recommended)')
+
+    const next: PendingQuestion = { options: [{ label: 'Yes' }], question: 'Ship it?' }
+    view.rerender(<QuestionComposer onRespond={onRespond} request={request(next)} />)
+    send()
+
+    expect(onRespond).not.toHaveBeenCalled()
+  })
+})

--- a/ui-web/src/conversation/QuestionComposer.tsx
+++ b/ui-web/src/conversation/QuestionComposer.tsx
@@ -1,0 +1,341 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+import type { PendingQuestion, QuestionRequestPayload } from '../gateway/protocol.ts'
+import { Button } from '../ui/primitives/Button.tsx'
+import { CheckIcon, ChevronRightIcon, HelpIcon, XIcon } from '../ui/icons.tsx'
+import css from './QuestionComposer.module.css'
+
+interface Draft {
+  custom: string
+  selected: string[]
+  skipped: boolean
+}
+
+/**
+ * Split the "(Recommended)" suffix the tool asks callers to append.
+ *
+ * Display only — the returned `value` keeps the original label, because that
+ * string is what gets sent back as the user's answer.
+ */
+export function parseRecommended(label: string): { recommended: boolean; text: string } {
+  const match = /^(.*?)\s*\((?:recommended)\)\s*$/i.exec(label)
+
+  return match === null
+    ? { recommended: false, text: label }
+    : { recommended: true, text: match[1] ?? label }
+}
+
+/**
+ * Fold one question's draft into the single string the tool expects, or
+ * `undefined` when the question should carry no answer at all.
+ *
+ * A skipped question is *omitted* rather than answered with an empty string:
+ * the tool renders the answer map verbatim for the model, and `"question": ""`
+ * reads as the user having said something empty rather than nothing.
+ */
+export function answerOf(draft: Draft): string | undefined {
+  if (draft.skipped) return undefined
+
+  const parts = [...draft.selected, draft.custom.trim()].filter(part => part !== '')
+
+  return parts.length === 0 ? undefined : parts.join(', ')
+}
+
+/** Whether the draft carries enough to move on (answered, or deliberately skipped). */
+function settled(draft: Draft): boolean {
+  return draft.skipped || answerOf(draft) !== undefined
+}
+
+/** Build the answer map from every draft, keyed by question text. */
+export function answersOf(
+  questions: PendingQuestion[],
+  drafts: Draft[],
+): Record<string, string> {
+  const answers: Record<string, string> = {}
+
+  questions.forEach((question, index) => {
+    const draft = drafts[index]
+
+    if (draft === undefined) return
+
+    const answer = answerOf(draft)
+
+    if (answer !== undefined) answers[question.question] = answer
+  })
+
+  return answers
+}
+
+export interface QuestionComposerProps {
+  onRespond: (action: 'decline' | 'submit', answers: Record<string, string>) => void
+  request: QuestionRequestPayload
+}
+
+/**
+ * The agent's questions, as a composer takeover.
+ *
+ * Same seat as the permission ask, and for the same reason: the agent's worker
+ * thread is blocked on this answer, so there is nothing else to type. One
+ * question at a time rather than a stacked form — a set can run to four, each
+ * with several options and prose, which is taller than the composer seat and
+ * would push the actions out of reach.
+ */
+export function QuestionComposer({ onRespond, request }: QuestionComposerProps) {
+  const questions = request.questions
+  const [index, setIndex] = useState(0)
+  const [drafts, setDrafts] = useState<Draft[]>(() =>
+    questions.map(() => ({ custom: '', selected: [], skipped: false })),
+  )
+  const [error, setError] = useState<string | null>(null)
+
+  // A fresh request reuses this component; reset rather than carrying the
+  // previous set's answers into it.
+  useEffect(() => {
+    setIndex(0)
+    setDrafts(questions.map(() => ({ custom: '', selected: [], skipped: false })))
+    setError(null)
+  }, [questions])
+
+  const question = questions[index]
+  const draft = drafts[index] ?? { custom: '', selected: [], skipped: false }
+  const last = index === questions.length - 1
+  const multi = question?.multi_select === true
+
+  const decline = useCallback(() => {
+    onRespond('decline', {})
+  }, [onRespond])
+
+  // Escape declines. The agent is blocked until this resolves, so the panel
+  // has to answer the gesture people use to dismiss things — and declining is
+  // a real answer the tool reports as "User declined", not a silent drop.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') decline()
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [decline])
+
+  const patch = useCallback(
+    (update: (current: Draft) => Draft) => {
+      setDrafts(current => current.map((item, at) => (at === index ? update(item) : item)))
+      setError(null)
+    },
+    [index],
+  )
+
+  const submit = useCallback(
+    (values: Draft[]) => {
+      const missing = values.findIndex(item => !settled(item))
+
+      if (missing >= 0) {
+        setIndex(missing)
+        setError('Choose an option, type an answer, or skip this question.')
+
+        return
+      }
+
+      onRespond('submit', answersOf(questions, values))
+    },
+    [onRespond, questions],
+  )
+
+  const choose = (label: string) => {
+    patch(current => {
+      if (multi) {
+        return {
+          ...current,
+          selected: current.selected.includes(label)
+            ? current.selected.filter(item => item !== label)
+            : [...current.selected, label],
+          skipped: false,
+        }
+      }
+
+      // Single-select: picking an option replaces both the previous pick and
+      // any typed answer, so the two inputs cannot silently combine.
+      return { custom: '', selected: [label], skipped: false }
+    })
+  }
+
+  const advance = () => {
+    if (!settled(draft)) {
+      setError('Choose an option, type an answer, or skip this question.')
+
+      return
+    }
+
+    if (last) {
+      submit(drafts)
+
+      return
+    }
+
+    setIndex(current => current + 1)
+    setError(null)
+  }
+
+  const skip = () => {
+    const next = drafts.map((item, at) =>
+      at === index ? { custom: '', selected: [], skipped: true } : item,
+    )
+
+    setDrafts(next)
+    setError(null)
+
+    if (last) submit(next)
+    else setIndex(current => current + 1)
+  }
+
+  const options = useMemo(
+    () => (question?.options ?? []).map(option => ({ ...option, ...parseRecommended(option.label) })),
+    [question],
+  )
+
+  if (question === undefined) return null
+
+  const titleId = `question-${request.request_id}-${String(index)}`
+
+  return (
+    <div className={css.root}>
+      <section aria-labelledby={titleId} className={css.card} role="dialog">
+        <div className={css.strip}>
+          <HelpIcon size={14} />
+          <span className={css.stripLabel}>
+            {questions.length === 1
+              ? 'The agent has a question'
+              : `Question ${String(index + 1)} of ${String(questions.length)}`}
+          </span>
+          <button
+            aria-label="Decline to answer"
+            className={css.close}
+            onClick={decline}
+            title="Decline to answer (Esc)"
+            type="button"
+          >
+            <XIcon size={14} />
+          </button>
+        </div>
+
+        <div className={css.body}>
+          {question.header !== undefined && question.header !== '' && (
+            <div className={css.eyebrow}>{question.header}</div>
+          )}
+          <h2 className={css.title} id={titleId}>
+            {question.question}
+          </h2>
+
+          {options.length > 0 && (
+            <div className={css.options} role={multi ? 'group' : 'radiogroup'}>
+              {options.map((option, at) => {
+                const picked = draft.selected.includes(option.label)
+                // Models routinely echo the label as the description; a line
+                // that repeats the one above it is noise, so it is dropped
+                // rather than rendered twice.
+                const hint =
+                  option.description !== undefined &&
+                  option.description.trim() !== '' &&
+                  option.description.trim() !== option.label.trim() &&
+                  option.description.trim() !== option.text.trim()
+                const hintId = `${titleId}-hint-${String(at)}`
+
+                return (
+                  <button
+                    aria-checked={picked}
+                    // The accessible name is the label verbatim — which is also
+                    // the answer value — rather than the rendered content, so a
+                    // screen reader is not read the index badge and the whole
+                    // description as the option's identity.
+                    aria-describedby={hint ? hintId : undefined}
+                    aria-label={option.label}
+                    className={[css.option, picked ? css.optionPicked : ''].filter(Boolean).join(' ')}
+                    key={option.label}
+                    onClick={() => {
+                      choose(option.label)
+                    }}
+                    role={multi ? 'checkbox' : 'radio'}
+                    type="button"
+                  >
+                    <span className={[css.mark, picked ? css.markOn : ''].filter(Boolean).join(' ')}>
+                      {picked ? <CheckIcon size={11} /> : multi ? null : String(at + 1)}
+                    </span>
+                    <span className={css.optionText}>
+                      <span className={css.optionLabel}>
+                        {option.text}
+                        {option.recommended && <span className={css.badge}>Recommended</span>}
+                      </span>
+                      {hint && (
+                        <span className={css.optionHint} id={hintId}>
+                          {option.description}
+                        </span>
+                      )}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          )}
+
+          <input
+            aria-label={options.length === 0 ? 'Your answer' : 'A different answer'}
+            className={css.custom}
+            onChange={event => {
+              const value = event.target.value
+
+              patch(current => ({
+                ...current,
+                custom: value,
+                // Typing replaces a single-select pick for the same reason
+                // picking clears the text; a multi-select answer is additive,
+                // so its checkmarks stand.
+                selected: multi ? current.selected : [],
+                skipped: false,
+              }))
+            }}
+            onKeyDown={event => {
+              if (event.key !== 'Enter' || event.nativeEvent.isComposing) return
+              event.preventDefault()
+              advance()
+            }}
+            placeholder={options.length === 0 ? 'Type your answer…' : 'Or type something else…'}
+            value={draft.custom}
+          />
+
+          {error !== null && <div className={css.error}>{error}</div>}
+        </div>
+
+        <div className={css.actions}>
+          <div className={css.actionsLeft}>
+            {index > 0 && (
+              <Button
+                onClick={() => {
+                  setIndex(current => current - 1)
+                  setError(null)
+                }}
+                size="sm"
+                variant="ghost"
+              >
+                Back
+              </Button>
+            )}
+            <Button onClick={skip} size="sm" variant="ghost">
+              Skip
+            </Button>
+          </div>
+          <Button onClick={advance} size="sm" variant="primary">
+            {last ? 'Send answers' : 'Next'}
+            {!last && (
+              <span className={css.nextIcon}>
+                <ChevronRightIcon size={12} />
+              </span>
+            )}
+          </Button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -133,9 +133,31 @@ export interface ApprovalRequestPayload {
   warning?: string
 }
 
+export interface QuestionOption {
+  description?: string
+  label: string
+}
+
+export interface PendingQuestion {
+  header?: string
+  multi_select?: boolean
+  options: QuestionOption[]
+  /**
+   * The agent's answer KEY, not just display text — the tool drops any answer
+   * whose key it did not ask about, so this string is echoed back verbatim.
+   */
+  question: string
+}
+
+export interface QuestionRequestPayload {
+  questions: PendingQuestion[]
+  request_id: string
+}
+
 /** Every push type this client acts on; anything else is ignored by design. */
 export type GatewayEventType =
   | 'approval.request'
+  | 'question.request'
   | 'error'
   | 'gateway.ready'
   | 'message.complete'

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -51,6 +51,7 @@ import {
   appendUserMessage,
   applyEvent,
   clearApproval,
+  clearQuestion,
   emptyTranscript,
   hydrateStoredMessages,
   markTurnStarted,
@@ -179,6 +180,17 @@ export interface SessionSpawnOptions {
   provider?: string
 }
 
+/**
+ * What this client can render, declared at session start.
+ *
+ * The backend defaults AskUserQuestion to a non-interactive answer because a
+ * client that ignored the question would block the agent's worker thread until
+ * the ask timeout. Declaring the capability is what makes the agent actually
+ * ask — so it belongs to the client that ships the composer, not to the
+ * backend.
+ */
+const CAPABILITIES = { ask_user_question: true }
+
 export async function createSession(options: SessionSpawnOptions = {}): Promise<void> {
   $transcript.set(emptyTranscript())
   $trajectory.set(emptyTrajectory())
@@ -187,7 +199,7 @@ export async function createSession(options: SessionSpawnOptions = {}): Promise<
   $sessionId.set(null)
   $storedSessionId.set(null)
 
-  const params: Record<string, unknown> = {}
+  const params: Record<string, unknown> = { capabilities: CAPABILITIES }
 
   if (options.cwd !== undefined && options.cwd !== '') params.cwd = options.cwd
   if (options.provider !== undefined && options.provider !== '') params.provider = options.provider
@@ -212,7 +224,7 @@ export async function resumeSession(storedId: string, cwd?: string): Promise<voi
   $detailsNodeId.set(null)
   $sessionLoading.set(true)
 
-  const params: Record<string, unknown> = { session_id: storedId }
+  const params: Record<string, unknown> = { capabilities: CAPABILITIES, session_id: storedId }
 
   if (cwd !== undefined && cwd !== '') params.cwd = cwd
 
@@ -422,6 +434,32 @@ export async function respondApproval(choice: ApprovalChoice): Promise<void> {
 
   try {
     await gateway().request('approval.respond', { session_id: sessionId, choice })
+  } catch (error) {
+    notice(errorText(error), 'error')
+  }
+}
+
+/**
+ * Answer or decline the parked AskUserQuestion.
+ *
+ * Keys are the question texts verbatim: that is what the tool filters its
+ * answers on, so a re-derived label or an index would be silently dropped on
+ * the far side.
+ */
+export async function respondQuestion(
+  action: 'decline' | 'submit',
+  answers: Record<string, string> = {},
+): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) return
+
+  // Seat the composer back immediately. The agent is unblocked either way, and
+  // leaving the takeover up until the round-trip returns reads as a hang.
+  $transcript.set(clearQuestion($transcript.get()))
+
+  try {
+    await gateway().request('question.respond', { action, answers, session_id: sessionId })
   } catch (error) {
     notice(errorText(error), 'error')
   }

--- a/ui-web/src/state/transcript.ts
+++ b/ui-web/src/state/transcript.ts
@@ -20,6 +20,7 @@ import type {
   GatewayEvent,
   MessageCompletePayload,
   MessageDeltaPayload,
+  QuestionRequestPayload,
   SessionInfoPayload,
   ToolCompletePayload,
   ToolResult,
@@ -79,6 +80,7 @@ export interface TranscriptState {
   approval?: ApprovalRequestPayload
   info: SessionInfoPayload
   nodes: TranscriptNode[]
+  question?: QuestionRequestPayload
   running: boolean
   /** Wall-clock start of the running turn, for the elapsed clock. */
   turnStartedAt?: number
@@ -383,6 +385,17 @@ export function applyEvent(state: TranscriptState, event: GatewayEvent): Transcr
     case 'approval.request':
       return { ...state, approval: (event.payload ?? {}) as ApprovalRequestPayload }
 
+    case 'question.request': {
+      const payload = event.payload as QuestionRequestPayload | undefined
+
+      // A question set with nothing in it has no composer to show and no
+      // answer to give; ignoring it leaves the normal input in place rather
+      // than seating an empty takeover the user cannot get out of.
+      if (payload === undefined || payload.questions.length === 0) return state
+
+      return { ...state, question: payload }
+    }
+
     case 'error': {
       const payload = event.payload as { message?: string } | undefined
 
@@ -413,6 +426,16 @@ export function clearApproval(state: TranscriptState): TranscriptState {
 
   const next = { ...state }
   delete next.approval
+
+  return next
+}
+
+/** Clear the pending question after the user answered or declined it. */
+export function clearQuestion(state: TranscriptState): TranscriptState {
+  if (state.question === undefined) return state
+
+  const next = { ...state }
+  delete next.question
 
   return next
 }


### PR DESCRIPTION
## The gap

The agent's `AskUserQuestion` never reached anyone on the web. The tool came back with *"no interactive user is available (headless/non-interactive mode) — proceed autonomously with your best judgment"*, and the model guessed.

Two independent reasons, both deliberate:

1. `_route_ask` in the gateway handles `can_use_tool` and **auto-denies every other subtype** — there was no surface for a question.
2. The agent server installs `_non_interactive_ask_user` on the multi-session transport, with a comment naming exactly what's missing:

   > *"On the multi-session --http transport there is no capability negotiation, so a client that ignores the ask_user_question subtype would park that session's sole worker thread for the full ask_user_timeout_s."*

That reasoning is right, so this PR **adds the negotiation** rather than removing the guard.

## How it works

A client declares what it can render at session start:

```json
{"cwd": "…", "capabilities": {"ask_user_question": true}}
```

Only then does the session send the new `set_ask_user_interactive` control (one-way: enabling is a client's call, disabling mid-question would strand a blocked worker — that's the ask timeout's job), and only then does the gateway route `ask_user_question` to a `question.request` event. `question.respond` carries `{action, answers}` back.

**A client that says nothing gets exactly today's behavior.** Verified live: same non-interactive answer, ~8s, no hang.

## The composer

Same seat as the permission ask, for the same reason — the worker thread is blocked, so there is nothing else to type. One question at a time (a set runs to four, each with options and prose — taller than the seat), option rows that double as radio or checkbox, a free-text field for an answer that isn't on the list, Skip, and Escape to decline.

## Details that matter on the wire

- **Answers are keyed by question text verbatim** — that's what the tool filters on, so a re-derived label or an index would be dropped server-side without a word.
- **A skipped question is omitted, not answered with `""`** — the tool renders the map for the model, and an empty string reads as the user having said something empty rather than nothing. Skipping everything is a submit with no answers, which the tool reports differently from a decline.
- **`(Recommended)` is stripped for display only**; the answer keeps the full label.
- **Questions get their own pending slot** — sharing `_last_ask_id` would let an approval click resolve a question, and an `allow` is not a `submit`, so it would come back as a silent decline.
- **Non-string answer values are dropped, not stringified** — those values land in prose the model reads as the user's own words.
- A question set with nothing renderable declines rather than seating an empty takeover the user can't dismiss.
- An option description identical to its label is dropped (models routinely echo it), so options don't render the same word twice.

## Testing

- **27 new backend specs** (`tests/server/test_gateway_questions.py`), **21 new web specs**. Full suites green: 641 server, 155 web. `tsc` clean, bundle builds.
- **End-to-end against a live DeepSeek session**, twice over:
  - A scripted client answered `Chartreuse` — a word the model could not have guessed — and the reply was `MY ANSWER WAS Chartreuse`.
  - Driving the built UI in a browser, a two-question set came back `ANSWERS Blue and Pear`; Escape produced *"You declined to answer"*.
  - Negative control with no capability declared: unchanged behavior, no hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
