### PR TITLE
fix(web): session ages never rendered, and add a session filter

### DIFF
--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -219,12 +219,18 @@ export interface SessionRow {
   cwd?: string | null
   id: string
   is_active?: boolean
-  last_active?: string | null
+  /**
+   * Epoch seconds OR an ISO string, depending on where the row came from —
+   * `desktop_projects.py` says so outright ("Both may be epoch floats or ISO
+   * strings (saved rows)") and coerces both. Typing this `string` is what made
+   * `Date.parse` return NaN for every live row.
+   */
+  last_active?: number | string | null
   message_count?: number
   model?: string | null
   preview?: string
   source?: string
-  started_at?: string | null
+  started_at?: number | string | null
   title?: string
 }
 

--- a/ui-web/src/sidebar/Sidebar.module.css
+++ b/ui-web/src/sidebar/Sidebar.module.css
@@ -310,3 +310,59 @@
 .connectionError .connectionDot {
   background: var(--cc-alias-state-error-primary);
 }
+
+/* Session filter. Sits under New session, above the tree, so it reads as a
+   control over the list rather than a global search of the app. */
+.search {
+  flex: none;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 30px;
+  margin: 0 2px 8px;
+  padding: 0 8px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-caption);
+}
+
+.search:focus-within {
+  border-color: var(--cc-alias-border-l2);
+}
+
+.searchInput {
+  width: 100%;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  color: var(--cc-alias-label-primary);
+  font: inherit;
+  font-size: 12px;
+  outline: none;
+}
+
+.searchInput::placeholder {
+  color: var(--cc-alias-label-caption);
+}
+
+.searchClear {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--cc-alias-label-caption);
+  cursor: pointer;
+}
+
+.searchClear:hover {
+  background: var(--cc-alias-interactive-bg-active);
+  color: var(--cc-alias-label-primary);
+}

--- a/ui-web/src/sidebar/Sidebar.tsx
+++ b/ui-web/src/sidebar/Sidebar.tsx
@@ -15,28 +15,16 @@ import {
   MoonIcon,
   PanelLeftIcon,
   PlusIcon,
+  SearchIcon,
   SunIcon,
+  XIcon,
 } from '../ui/icons.tsx'
+import { filterProjects } from './filter.ts'
+import { absoluteTime, relativeTime } from './recency.ts'
 import css from './Sidebar.module.css'
 
 export interface SidebarProps {
   collapsed: boolean
-}
-
-function relativeTime(value: string | null | undefined): string {
-  if (value === null || value === undefined || value === '') return ''
-
-  const at = Date.parse(value)
-
-  if (Number.isNaN(at)) return ''
-
-  const seconds = Math.max(0, Math.round((Date.now() - at) / 1000))
-
-  if (seconds < 60) return 'now'
-  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`
-  if (seconds < 86_400) return `${Math.floor(seconds / 3600)}h`
-
-  return `${Math.floor(seconds / 86_400)}d`
 }
 
 function sessionLabel(row: SessionRow): string {
@@ -92,7 +80,9 @@ function SessionList({ activeId, hiddenId, liveId, project }: SessionListProps) 
               >
                 {row.id === liveId && <span className={css.liveDot} />}
                 <span className={css.sessionTitle}>{sessionLabel(row)}</span>
-                <span className={css.sessionMeta}>{relativeTime(row.last_active)}</span>
+                <span className={css.sessionMeta} title={absoluteTime(row.last_active)}>
+                  {relativeTime(row.last_active)}
+                </span>
               </button>
             ))}
           </div>
@@ -119,10 +109,14 @@ export function Sidebar({ collapsed }: SidebarProps) {
   const themePreference = useStore($themePreference)
 
   const [collapsedProjects, setCollapsedProjects] = useState<Record<string, boolean>>({})
+  const [query, setQuery] = useState('')
+
+  const searching = query.trim() !== ''
 
   const ordered = useMemo(
-    () => [...projects].sort((a, b) => (b.lastActive ?? 0) - (a.lastActive ?? 0)),
-    [projects],
+    () =>
+      filterProjects(projects, query).sort((a, b) => (b.lastActive ?? 0) - (a.lastActive ?? 0)),
+    [projects, query],
   )
 
   // Resuming spawns a FRESH runtime session that replays a stored one, so the
@@ -181,13 +175,48 @@ export function Sidebar({ collapsed }: SidebarProps) {
         <span className={css.newSessionLabel}>New session</span>
       </button>
 
+      {!collapsed && (
+        <div className={css.search}>
+          <SearchIcon size={13} />
+          <input
+            aria-label="Filter sessions"
+            className={css.searchInput}
+            onChange={event => {
+              setQuery(event.target.value)
+            }}
+            onKeyDown={event => {
+              if (event.key === 'Escape') setQuery('')
+            }}
+            placeholder="Filter sessions"
+            value={query}
+          />
+          {searching && (
+            <button
+              aria-label="Clear the filter"
+              className={css.searchClear}
+              onClick={() => {
+                setQuery('')
+              }}
+              type="button"
+            >
+              <XIcon size={12} />
+            </button>
+          )}
+        </div>
+      )}
+
       <div className={css.region}>
         {!collapsed &&
           (ordered.length === 0 ? (
-            <div className={css.empty}>No sessions yet. Start one above.</div>
+            <div className={css.empty}>
+              {searching ? `No sessions match “${query.trim()}”.` : 'No sessions yet. Start one above.'}
+            </div>
           ) : (
             ordered.map(project => {
-              const isCollapsed = collapsedProjects[project.id] === true
+              // While searching, every surviving project is open: a project
+              // that kept a match is exactly the one the user is looking in,
+              // and leaving it collapsed hides the result they searched for.
+              const isCollapsed = !searching && collapsedProjects[project.id] === true
 
               return (
                 <div className={css.project} key={project.id}>

--- a/ui-web/src/sidebar/filter.test.ts
+++ b/ui-web/src/sidebar/filter.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ProjectNode, SessionRow } from '../gateway/protocol.ts'
+import { filterProjects, matches, termsOf } from './filter.ts'
+
+function row(id: string, title: string, preview = ''): SessionRow {
+  return { id, preview, title }
+}
+
+function tree(...sessions: SessionRow[]): ProjectNode[] {
+  return [
+    {
+      id: 'p1',
+      label: 'clawcodex',
+      lastActive: 2,
+      path: '/repo',
+      repos: [
+        {
+          groups: [{ id: 'l1', label: 'main', path: '/repo', sessions }],
+          id: 'r1',
+          label: 'clawcodex',
+          path: '/repo',
+        },
+      ],
+      sessionCount: sessions.length,
+    },
+  ]
+}
+
+const SESSIONS = [
+  row('a', 'Fix the sidebar timestamps'),
+  row('b', 'Use AskUserQuestion to ask a colour'),
+  row('c', 'Untitled session', 'walk me through the gateway protocol'),
+]
+
+describe('termsOf', () => {
+  it('splits on whitespace and lowercases', () => {
+    expect(termsOf('  Fix   THE Sidebar ')).toEqual(['fix', 'the', 'sidebar'])
+  })
+
+  it('yields nothing for a blank query', () => {
+    expect(termsOf('   ')).toEqual([])
+  })
+})
+
+describe('matches', () => {
+  it('requires every term, not just one', () => {
+    // Sessions are named from a prompt's first line, so the useful query is a
+    // couple of remembered fragments narrowing each other down.
+    expect(matches(SESSIONS[0]!, ['fix', 'sidebar'])).toBe(true)
+    expect(matches(SESSIONS[0]!, ['fix', 'gateway'])).toBe(false)
+  })
+
+  it('matches inside a word, not only at its start', () => {
+    expect(matches(SESSIONS[1]!, ['userquestion'])).toBe(true)
+  })
+
+  it('searches the preview as well as the title', () => {
+    // Rows titled "Untitled session" are otherwise unfindable.
+    expect(matches(SESSIONS[2]!, ['gateway'])).toBe(true)
+  })
+
+  it('ignores case', () => {
+    expect(matches(SESSIONS[0]!, ['SIDEBAR'.toLowerCase()])).toBe(true)
+  })
+
+  it('matches everything when there are no terms', () => {
+    expect(matches(SESSIONS[0]!, [])).toBe(true)
+  })
+})
+
+describe('filterProjects', () => {
+  it('returns the input untouched for a blank query', () => {
+    const projects = tree(...SESSIONS)
+
+    expect(filterProjects(projects, '   ')).toBe(projects)
+  })
+
+  it('keeps only the matching sessions', () => {
+    const [project] = filterProjects(tree(...SESSIONS), 'colour')
+
+    expect(project?.repos[0]?.groups[0]?.sessions.map(s => s.id)).toEqual(['b'])
+  })
+
+  it('re-derives the header count from what survived', () => {
+    // Otherwise the header advertises 73 sessions above a list showing one.
+    const [project] = filterProjects(tree(...SESSIONS), 'colour')
+
+    expect(project?.sessionCount).toBe(1)
+  })
+
+  it('drops a project whose sessions all failed to match', () => {
+    // A header with nothing under it reads as a rendering failure.
+    expect(filterProjects(tree(...SESSIONS), 'nothing-matches-this')).toEqual([])
+  })
+
+  it('drops an empty lane but keeps a sibling lane that matched', () => {
+    const projects: ProjectNode[] = [
+      {
+        id: 'p1',
+        label: 'clawcodex',
+        path: '/repo',
+        repos: [
+          {
+            groups: [
+              { id: 'main', label: 'main', path: '/repo', sessions: [row('a', 'gateway work')] },
+              { id: 'wt', label: 'feature', path: '/wt', sessions: [row('b', 'unrelated')] },
+            ],
+            id: 'r1',
+            label: 'clawcodex',
+            path: '/repo',
+          },
+        ],
+      },
+    ]
+
+    const [project] = filterProjects(projects, 'gateway')
+
+    expect(project?.repos[0]?.groups.map(lane => lane.id)).toEqual(['main'])
+  })
+
+  it('does not mutate the tree it was given', () => {
+    const projects = tree(...SESSIONS)
+
+    filterProjects(projects, 'colour')
+
+    expect(projects[0]?.repos[0]?.groups[0]?.sessions).toHaveLength(3)
+    expect(projects[0]?.sessionCount).toBe(3)
+  })
+})

--- a/ui-web/src/sidebar/filter.ts
+++ b/ui-web/src/sidebar/filter.ts
@@ -1,0 +1,72 @@
+import type { ProjectNode, SessionRow } from '../gateway/protocol.ts'
+
+/** What a row is searched by: its display name, then the prompt behind it. */
+function haystack(row: SessionRow): string {
+  return `${row.title ?? ''}\n${row.preview ?? ''}`.toLowerCase()
+}
+
+/**
+ * Whether a row matches, by every whitespace-separated term.
+ *
+ * AND rather than OR, and substring rather than word-prefix: sessions are
+ * named from the first line of a prompt, so the useful query is a couple of
+ * remembered fragments ("askuser colour"), not one exact word.
+ */
+export function matches(row: SessionRow, terms: string[]): boolean {
+  if (terms.length === 0) return true
+
+  const text = haystack(row)
+
+  return terms.every(term => text.includes(term))
+}
+
+/** Split a raw query into the terms `matches` tests. */
+export function termsOf(query: string): string[] {
+  return query.toLowerCase().split(/\s+/).filter(term => term !== '')
+}
+
+/**
+ * The tree with every non-matching session removed, and every project, repo
+ * and lane that ends up empty removed with it.
+ *
+ * Pruning empties matters more than it sounds: a project header with a count
+ * and nothing under it reads as "this project has matches, they just failed to
+ * render". An empty query returns the input untouched — no copying, and no
+ * chance of the filter altering what the unfiltered tree shows.
+ */
+export function filterProjects(projects: ProjectNode[], query: string): ProjectNode[] {
+  const terms = termsOf(query)
+
+  if (terms.length === 0) return projects
+
+  const kept: ProjectNode[] = []
+
+  for (const project of projects) {
+    const repos = []
+
+    for (const repo of project.repos) {
+      const groups = []
+
+      for (const lane of repo.groups) {
+        const sessions = lane.sessions.filter(row => matches(row, terms))
+
+        if (sessions.length > 0) groups.push({ ...lane, sessions })
+      }
+
+      if (groups.length > 0) repos.push({ ...repo, groups })
+    }
+
+    if (repos.length > 0) {
+      // The count is re-derived rather than carried over: the header would
+      // otherwise advertise 73 sessions above a list showing two.
+      const sessionCount = repos.reduce(
+        (total, repo) => total + repo.groups.reduce((sum, lane) => sum + lane.sessions.length, 0),
+        0,
+      )
+
+      kept.push({ ...project, repos, sessionCount })
+    }
+  }
+
+  return kept
+}

--- a/ui-web/src/sidebar/recency.test.ts
+++ b/ui-web/src/sidebar/recency.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+
+import { absoluteTime, epochMs, relativeTime } from './recency.ts'
+
+/** The reference "now" for every relative assertion. */
+const ISO_NOW = '2026-08-14T12:00:00Z'
+const NOW = Date.parse(ISO_NOW)
+
+describe('epochMs', () => {
+  it('reads the epoch-seconds float the live rows actually carry', () => {
+    // The bug this module exists for: Date.parse(1786740090.6056044) is NaN,
+    // so every live session showed a blank where its age should be.
+    expect(epochMs(1_786_740_090.605_604_4)).toBe(1_786_740_090_605.604_4)
+  })
+
+  it('reads the ISO string the saved rows carry', () => {
+    expect(epochMs(ISO_NOW)).toBe(NOW)
+  })
+
+  it('reads epoch milliseconds without multiplying them again', () => {
+    // Guessing wrong by 1000x turns "3m ago" into "50 years ago".
+    expect(epochMs(NOW)).toBe(NOW)
+  })
+
+  it('reads an epoch that survived JSON as a string', () => {
+    expect(epochMs('1786740090.6056044')).toBe(1_786_740_090_605.604_4)
+    expect(epochMs(String(NOW))).toBe(NOW)
+  })
+
+  it.each([null, undefined, '', '   ', 'not a date', 0, -5, Number.NaN, Number.POSITIVE_INFINITY])(
+    'returns null for %p rather than a bogus instant',
+    value => {
+      expect(epochMs(value as number | string | null | undefined)).toBeNull()
+    },
+  )
+})
+
+describe('relativeTime', () => {
+  it.each([
+    [NOW, 'now'],
+    [NOW - 30_000, 'now'],
+    [NOW - 5 * 60_000, '5m'],
+    [NOW - 3 * 3_600_000, '3h'],
+    [NOW - 2 * 86_400_000, '2d'],
+    [NOW - 20 * 86_400_000, '2w'],
+  ])('renders %p as %s', (at, expected) => {
+    expect(relativeTime(at, NOW)).toBe(expected)
+  })
+
+  it('renders an epoch-seconds row, which is the whole point', () => {
+    expect(relativeTime(NOW / 1000 - 300, NOW)).toBe('5m')
+  })
+
+  it('shows a slightly-future row as "now" rather than a negative age', () => {
+    // The backend stamps these; a browser clock a few seconds behind should
+    // not produce "-1m".
+    expect(relativeTime(NOW + 5000, NOW)).toBe('now')
+  })
+
+  it('renders nothing when there is no timestamp', () => {
+    // An empty cell is honest; "unknown" repeated down the list is noise.
+    expect(relativeTime(null, NOW)).toBe('')
+    expect(relativeTime(undefined, NOW)).toBe('')
+  })
+})
+
+describe('absoluteTime', () => {
+  it('gives a full timestamp for the tooltip', () => {
+    expect(absoluteTime(NOW)).toBe(new Date(NOW).toLocaleString())
+  })
+
+  it('gives nothing when there is no timestamp', () => {
+    expect(absoluteTime(null)).toBe('')
+  })
+})

--- a/ui-web/src/sidebar/recency.ts
+++ b/ui-web/src/sidebar/recency.ts
@@ -1,0 +1,77 @@
+/**
+ * Session timestamps for the sidebar.
+ *
+ * The backend hands out two shapes for the same field. `desktop_projects.py`
+ * says so in as many words — *"Both may be epoch floats or ISO strings (saved
+ * rows)"* — and coerces both on its side. The client only ever handled the
+ * string, so `Date.parse(1786740090.6)` returned NaN and every live row showed
+ * a blank where its age should be.
+ */
+
+/** Milliseconds in the units epoch timestamps plausibly arrive in. */
+const SECONDS_CUTOFF = 1e11
+
+/**
+ * Read either shape into epoch milliseconds, or `null` when there is no
+ * usable timestamp.
+ *
+ * Numeric input is treated as seconds or milliseconds by magnitude: epoch
+ * *seconds* pass 1e11 around the year 5138, and epoch *milliseconds* passed it
+ * in 1973, so anything below the cutoff is seconds. Guessing wrong by a factor
+ * of 1000 turns "3m ago" into "50 years ago", which is worse than showing
+ * nothing — hence the explicit split rather than a bare `new Date(value)`.
+ */
+export function epochMs(value: number | string | null | undefined): number | null {
+  if (value === null || value === undefined) return null
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value) || value <= 0) return null
+
+    return value < SECONDS_CUTOFF ? value * 1000 : value
+  }
+
+  const text = value.trim()
+
+  if (text === '') return null
+
+  // A numeric string is an epoch that survived a JSON round-trip as text.
+  if (/^\d+(\.\d+)?$/.test(text)) return epochMs(Number(text))
+
+  const parsed = Date.parse(text)
+
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+/**
+ * A short age for a session row: "now", "5m", "3h", "2d", "6w".
+ *
+ * Empty string when there is no timestamp — the row simply carries no age,
+ * which is honest, rather than a placeholder like "unknown" repeated down the
+ * whole list.
+ */
+export function relativeTime(
+  value: number | string | null | undefined,
+  now: number = Date.now(),
+): string {
+  const at = epochMs(value)
+
+  if (at === null) return ''
+
+  const seconds = Math.round((now - at) / 1000)
+
+  // A clock skew between the browser and the backend can put a row a few
+  // seconds into the future; "now" is truer than a negative age.
+  if (seconds < 60) return 'now'
+  if (seconds < 3600) return `${String(Math.floor(seconds / 60))}m`
+  if (seconds < 86_400) return `${String(Math.floor(seconds / 3600))}h`
+  if (seconds < 604_800) return `${String(Math.floor(seconds / 86_400))}d`
+
+  return `${String(Math.floor(seconds / 604_800))}w`
+}
+
+/** The full timestamp, for the row's tooltip. Empty when there is none. */
+export function absoluteTime(value: number | string | null | undefined): string {
+  const at = epochMs(value)
+
+  return at === null ? '' : new Date(at).toLocaleString()
+}


### PR DESCRIPTION
Two things made a 90-session sidebar unusable.

## The ages were never there

`relativeTime` was called on every row and returned `""` for almost all of them.

`last_active` arrives as an **epoch float**, the client typed it `string`, and `Date.parse(1786740090.6056044)` is `NaN`. Measured in the live UI: **12 of 91 rows** showed an age.

The 12 that worked were *saved* rows, which carry an ISO string instead — and `desktop_projects.py` already says so outright:

> *"Both may be epoch floats or ISO strings (saved rows) — coerce to a comparable float"*

The backend handles both shapes. Only the client didn't.

`recency.ts` now reads both, plus a numeric string that survived JSON as text, and splits epoch-seconds from epoch-milliseconds by magnitude rather than guessing — being wrong by 1000× turns *"3m ago"* into *"50 years ago"*, which is worse than the blank it replaces. A row with genuinely no timestamp still renders nothing rather than an "unknown" repeated down the whole list, and the full timestamp is one hover away on the row's `title`.

**After: 90 of 91.** (The one blank is a fresh session that has no timestamp yet — correct.)

## And 90 sessions named from prompt text need a filter

`filter.ts` prunes the tree to matching rows and drops every lane, repo and project that ends up empty — a header with a count and nothing under it reads as *"this project has matches, they just failed to render"* — then re-derives each header count from what actually survived, so it can't advertise 73 above a list of two.

- Terms are **AND**-ed and match as **substrings**: sessions are named from a prompt's first line, so the real query is a couple of remembered fragments narrowing each other down, not one exact word.
- The **preview is searched too**, so rows titled "Untitled session" are findable at all.
- Searching **expands collapsed projects** — a project that kept a match is exactly the one being looked in.
- Escape and the clear button reset it.

## Testing

37 new specs across the two pure modules. Full suite green: 192 web tests, `tsc` clean, bundle builds.

Verified live in the browser:
- Timestamps: **12/91 → 90/91**, reading `10m`, `12m`, `15m`, `39m`, `1h`.
- Filter: **91 rows → 5** for `askuser colour`, with the header count following to 5.
- No-match state names the query back; clear restores all 91.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
