### PR TITLE
feat(web): reasoning effort selector

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -652,6 +652,7 @@ class GatewayConnection:
             "question.respond": self.question_respond,
             "permission.cycle": self.permission_cycle,
             "model.options": self.model_options,
+            "effort.options": self.effort_options,
             "config.get": self.config_get,
             "config.set": self.config_set_rpc,
             "commands.catalog": self.commands_catalog,
@@ -913,6 +914,37 @@ class GatewayConnection:
     async def permission_cycle(self, params: dict[str, Any]) -> dict[str, Any]:
         result = await self._session(params).control_query("cycle_permission_mode", {})
         return result or {}
+
+    async def effort_options(self, params: dict[str, Any]) -> dict[str, Any]:
+        """The effort levels the given (or running) model will actually accept.
+
+        Queried per model rather than ridden along on ``model.options``: the
+        ladder is a property of the MODEL and some providers enumerate hundreds
+        of them, so answering for all of them upfront would bloat every picker
+        open to serve one row.
+
+        ``supported`` False means the model takes no effort parameter at all —
+        the client is expected to show no control rather than a list it cannot
+        apply. With no live session there is nothing to ask, and saying
+        ``supported: false`` is the honest answer: a level chosen now has
+        nowhere to go.
+        """
+        session = self._first_session(params)
+        if session is None:
+            return {"supported": False, "levels": [], "current": ""}
+        result = await session.control_query(
+            "effort_options",
+            {"provider": _clean(params.get("provider")), "model": _clean(params.get("model"))},
+        )
+        if not isinstance(result, dict) or result.get("ok") is False:
+            return {"supported": False, "levels": [], "current": ""}
+        return {
+            "current": result.get("current") or "",
+            "levels": result.get("levels") or [],
+            "model": result.get("model") or "",
+            "provider": result.get("provider") or "",
+            "supported": result.get("supported") is True,
+        }
 
     async def model_options(self, params: dict[str, Any]) -> dict[str, Any]:
         session = self._first_session(params)

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -288,3 +288,73 @@ def test_answering_with_nothing_pending_is_reported_not_replied_to() -> None:
 
     assert asyncio.run(session.respond_question("submit", {"q": "a"})) == {"resolved": False}
     assert agent.replies == []
+
+
+# ── effort options ────────────────────────────────────────────────────────────
+#
+# The ladder is a property of the MODEL: `supported: false` means the model
+# takes no effort parameter, and the client is expected to show no control
+# rather than a list it cannot apply. Every failure path therefore has to
+# report "unsupported", never an empty-but-supported ladder.
+
+
+class _Queryable:
+    """A session stub that answers one control query with a canned reply."""
+
+    def __init__(self, reply: Any) -> None:
+        self.reply = reply
+        self.asked: tuple[str, dict[str, Any]] | None = None
+
+    async def control_query(self, subtype: str, params: dict[str, Any]) -> Any:
+        self.asked = (subtype, params)
+        return self.reply
+
+
+def _effort(reply: Any, *, live: bool = True) -> dict[str, Any]:
+    from src.server.desktop_gateway_methods import GatewayConnection
+
+    connection = GatewayConnection.__new__(GatewayConnection)
+    session = _Queryable(reply) if live else None
+    connection._first_session = lambda params: session  # type: ignore[method-assign]
+    return asyncio.run(GatewayConnection.effort_options(connection, {}))
+
+
+def test_effort_reports_unsupported_with_no_live_session() -> None:
+    # Nothing to ask and nowhere to apply a level; claiming a ladder would
+    # offer a control that silently does nothing.
+    assert _effort(None, live=False) == {"supported": False, "levels": [], "current": ""}
+
+
+def test_effort_passes_through_the_model_ladder() -> None:
+    result = _effort(
+        {
+            "ok": True,
+            "supported": True,
+            "levels": ["low", "high"],
+            "current": "high",
+            "model": "m",
+            "provider": "p",
+        }
+    )
+
+    assert result == {
+        "current": "high",
+        "levels": ["low", "high"],
+        "model": "m",
+        "provider": "p",
+        "supported": True,
+    }
+
+
+def test_effort_reports_unsupported_when_the_model_takes_no_parameter() -> None:
+    assert _effort({"ok": True, "supported": False, "levels": []})["supported"] is False
+
+
+def test_effort_reports_unsupported_when_the_control_fails() -> None:
+    # A picker built on an error reply would list nothing and still render.
+    assert _effort({"ok": False, "error": "boom"})["supported"] is False
+    assert _effort(None)["supported"] is False
+
+
+def test_effort_never_claims_support_on_a_truthy_non_true_flag() -> None:
+    assert _effort({"ok": True, "supported": "yes", "levels": ["low"]})["supported"] is False

--- a/ui-web/src/conversation/ConversationRoot.tsx
+++ b/ui-web/src/conversation/ConversationRoot.tsx
@@ -10,6 +10,7 @@ import {
   respondApproval,
   respondQuestion,
   setApprovalMode,
+  setEffort,
   setModel,
   submitPrompt,
 } from '../state/actions.ts'
@@ -18,6 +19,7 @@ import {
   $connection,
   $contextUsage,
   $conversationTab,
+  $effort,
   $models,
   $pendingApprovalMode,
   $queue,
@@ -61,6 +63,7 @@ export function ConversationRoot() {
   const sessionTitle = useStore($sessionTitle)
   const workspace = useStore($workspace)
   const models = useStore($models)
+  const effort = useStore($effort)
   const usage = useStore($contextUsage)
   const queue = useStore($queue)
   const connection = useStore($connection)
@@ -146,12 +149,16 @@ export function ConversationRoot() {
       // for the session that does not exist yet.
       approvalMode={transcript.info.approval_mode ?? pendingApproval ?? undefined}
       draft={draft}
+      effort={effort}
       hero={hero}
       models={models}
       onApprovalModeChange={mode => {
         void setApprovalMode(mode)
       }}
       onDraftChange={setDraft}
+      onEffortChange={level => {
+        void setEffort(level)
+      }}
       onModelChange={(model, provider) => {
         void setModel(model, provider)
       }}

--- a/ui-web/src/conversation/EffortSelect.test.tsx
+++ b/ui-web/src/conversation/EffortSelect.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { EffortSelect, buildEffortMenu } from './EffortSelect.tsx'
+
+afterEach(cleanup)
+
+const LADDER = ['low', 'medium', 'high', 'xhigh', 'max']
+
+function open(): void {
+  fireEvent.click(screen.getByRole('button', { name: /Reasoning effort/ }))
+}
+
+describe('buildEffortMenu', () => {
+  it('prepends auto, which the backend never sends', () => {
+    // effort_options documents this: "levels never includes auto; the caller
+    // prepends it, since 'let the provider decide' is meaningful exactly when
+    // some real level is also on offer".
+    expect(buildEffortMenu(LADDER).map(entry => ('id' in entry ? entry.id : ''))).toEqual([
+      'auto',
+      ...LADDER,
+    ])
+  })
+
+  it('does not prepend auto twice if the backend ever starts sending it', () => {
+    const ids = buildEffortMenu(['auto', 'low']).map(entry => ('id' in entry ? entry.id : ''))
+
+    expect(ids).toEqual(['auto', 'low'])
+  })
+
+  it('offers nothing when there is no real rung', () => {
+    // "Auto" alone is not a choice — it is the absence of one.
+    expect(buildEffortMenu([])).toEqual([])
+    expect(buildEffortMenu(['auto'])).toEqual([])
+  })
+
+  it('spells the rungs for a reader, xhigh included', () => {
+    const labels = buildEffortMenu(LADDER).map(entry => ('label' in entry ? entry.label : ''))
+
+    expect(labels).toEqual(['Auto', 'Low', 'Medium', 'High', 'X-High', 'Max'])
+  })
+})
+
+describe('EffortSelect', () => {
+  it('renders nothing when the model takes no effort parameter', () => {
+    // The contract's own instruction: a picker whose every choice is silently
+    // dropped is worse than no picker.
+    const { container } = render(
+      <EffortSelect onChange={vi.fn()} options={{ levels: LADDER, supported: false }} />,
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when supported is true but the ladder is empty', () => {
+    const { container } = render(
+      <EffortSelect onChange={vi.fn()} options={{ levels: [], supported: true }} />,
+    )
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows the session’s current level on the chip', () => {
+    render(
+      <EffortSelect onChange={vi.fn()} options={{ current: 'high', levels: LADDER, supported: true }} />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Reasoning effort: High' })).toBeTruthy()
+  })
+
+  it('treats an unset level as auto rather than blank', () => {
+    // Nothing told the provider what to do, so the provider is deciding —
+    // "Auto" describes what is actually happening.
+    render(<EffortSelect onChange={vi.fn()} options={{ levels: LADDER, supported: true }} />)
+
+    expect(screen.getByRole('button', { name: 'Reasoning effort: Auto' })).toBeTruthy()
+  })
+
+  it('reports the chosen level', () => {
+    const onChange = vi.fn()
+    render(
+      <EffortSelect onChange={onChange} options={{ current: 'low', levels: LADDER, supported: true }} />,
+    )
+    open()
+    fireEvent.click(screen.getByRole('menuitem', { name: /Max/ }))
+
+    expect(onChange).toHaveBeenCalledWith('max')
+  })
+
+  it('re-selecting the current level is a no-op', () => {
+    const onChange = vi.fn()
+    render(
+      <EffortSelect onChange={onChange} options={{ current: 'high', levels: LADDER, supported: true }} />,
+    )
+    open()
+    // Anchored: an unanchored /High/ also matches the X-High rung.
+    fireEvent.click(screen.getByRole('menuitem', { name: /^High/ }))
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('explains what each rung buys', () => {
+    render(<EffortSelect onChange={vi.fn()} options={{ levels: LADDER, supported: true }} />)
+    open()
+
+    expect(screen.getByRole('menuitem', { name: /Let the provider decide/ })).toBeTruthy()
+    expect(screen.getByRole('menuitem', { name: /Fastest, least thinking/ })).toBeTruthy()
+  })
+})

--- a/ui-web/src/conversation/EffortSelect.tsx
+++ b/ui-web/src/conversation/EffortSelect.tsx
@@ -1,0 +1,106 @@
+import { useMemo, useState } from 'react'
+
+import type { EffortOptionsResult } from '../gateway/protocol.ts'
+import { Menu, type MenuEntry } from '../ui/primitives/Menu.tsx'
+import { ChevronDownIcon } from '../ui/icons.tsx'
+import css from './Pickers.module.css'
+
+/** What each rung actually buys, in the order the ladder climbs. */
+const HINTS: Record<string, string> = {
+  auto: 'Let the provider decide',
+  low: 'Fastest, least thinking',
+  medium: 'Balanced',
+  high: 'More thinking, slower',
+  xhigh: 'Much more thinking',
+  max: 'Everything the model has',
+}
+
+/** Title case for a rung the hint table has never heard of. */
+function label(level: string): string {
+  if (level === 'xhigh') return 'X-High'
+
+  return level.charAt(0).toUpperCase() + level.slice(1)
+}
+
+/**
+ * Menu rows for the ladder, with `auto` on top.
+ *
+ * `effort_options` documents that it never returns `auto` and that "the caller
+ * prepends it, since 'let the provider decide' is meaningful exactly when some
+ * real level is also on offer" — so it is added here, and only here.
+ */
+export function buildEffortMenu(levels: string[]): MenuEntry[] {
+  const rungs = levels.filter(level => level !== 'auto')
+
+  if (rungs.length === 0) return []
+
+  return ['auto', ...rungs].map(level => ({
+    hint: HINTS[level],
+    id: level,
+    label: label(level),
+  }))
+}
+
+export interface EffortSelectProps {
+  disabled?: boolean
+  onChange: (effort: string) => void
+  options: EffortOptionsResult
+}
+
+/**
+ * The reasoning-effort chip, beside the model it belongs to.
+ *
+ * Renders nothing at all when the model reports `supported: false`. That is
+ * the contract's own instruction — a model that takes no effort parameter
+ * would show a picker whose every choice is silently dropped — and it is why
+ * the chip comes and goes as the model changes.
+ */
+export function EffortSelect({ disabled = false, onChange, options }: EffortSelectProps) {
+  const [open, setOpen] = useState(false)
+
+  const items = useMemo(() => buildEffortMenu(options.levels ?? []), [options.levels])
+
+  if (options.supported !== true || items.length === 0) return null
+
+  const current = options.current ?? ''
+  // An unset level IS "auto": the provider is deciding because nothing told it
+  // otherwise, so the menu marks the row that describes what is happening.
+  const selectedId = current === '' ? 'auto' : current
+
+  return (
+    <Menu
+      align="end"
+      anchor={
+        <button
+          aria-expanded={open}
+          aria-haspopup="menu"
+          aria-label={`Reasoning effort: ${label(selectedId)}`}
+          className={css.trigger}
+          disabled={disabled}
+          onClick={() => {
+            setOpen(value => !value)
+          }}
+          title={HINTS[selectedId] ?? 'Reasoning effort'}
+          type="button"
+        >
+          <span className={css.triggerLabel}>{label(selectedId)}</span>
+          <span className={[css.chevron, open ? css.chevronOpen : ''].filter(Boolean).join(' ')}>
+            <ChevronDownIcon size={12} />
+          </span>
+        </button>
+      }
+      items={items}
+      onClose={() => {
+        setOpen(false)
+      }}
+      onSelect={id => {
+        setOpen(false)
+
+        if (id !== selectedId) onChange(id)
+      }}
+      open={open}
+      selectedId={selectedId}
+      side="top"
+    />
+  )
+}

--- a/ui-web/src/conversation/InputBar.tsx
+++ b/ui-web/src/conversation/InputBar.tsx
@@ -9,10 +9,15 @@ import {
   type KeyboardEvent,
 } from 'react'
 
-import type { ContextUsageResult, ModelOptionsResult } from '../gateway/protocol.ts'
+import type {
+  ContextUsageResult,
+  EffortOptionsResult,
+  ModelOptionsResult,
+} from '../gateway/protocol.ts'
 import { $commands, $notice } from '../state/store.ts'
 import { ArrowUpIcon, StopIcon } from '../ui/icons.tsx'
 import { ContextMeter } from './ContextMeter.tsx'
+import { EffortSelect } from './EffortSelect.tsx'
 import { ModelSelect } from './ModelSelect.tsx'
 import { PermissionSelect, type ApprovalMode } from './PermissionSelect.tsx'
 import css from './InputBar.module.css'
@@ -20,10 +25,12 @@ import css from './InputBar.module.css'
 export interface InputBarProps {
   approvalMode?: ApprovalMode
   draft: string
+  effort: EffortOptionsResult
   hero?: boolean
   models: ModelOptionsResult
   onApprovalModeChange: (mode: ApprovalMode) => void
   onDraftChange: (text: string) => void
+  onEffortChange: (effort: string) => void
   onModelChange: (model: string, provider?: string) => void
   onStop: () => void
   onSubmit: (text: string) => void
@@ -46,10 +53,12 @@ const MAX_SUGGESTIONS = 40
 export function InputBar({
   approvalMode,
   draft,
+  effort,
   hero = false,
   models,
   onApprovalModeChange,
   onDraftChange,
+  onEffortChange,
   onModelChange,
   onStop,
   onSubmit,
@@ -219,6 +228,7 @@ export function InputBar({
               sessionModel={sessionModel}
               sessionProvider={sessionProvider}
             />
+            <EffortSelect onChange={onEffortChange} options={effort} />
           </div>
           <div className={css.trailing}>
             <ContextMeter usage={usage} />

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -215,6 +215,21 @@ export interface ModelOptionsResult {
   providers?: ModelOption[]
 }
 
+/**
+ * `effort.options` — the ladder the *model* accepts, asked per model rather
+ * than carried on `model.options` (some providers list hundreds).
+ *
+ * `supported: false` means the model takes no effort parameter at all, and the
+ * client is expected to show no control rather than a list it cannot apply.
+ */
+export interface EffortOptionsResult {
+  current?: string
+  levels?: string[]
+  model?: string
+  provider?: string
+  supported?: boolean
+}
+
 export interface SessionRow {
   cwd?: string | null
   id: string

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -16,6 +16,7 @@ import type {
   ContextUsageResult,
   DirectoryListing,
   GatewayEvent,
+  EffortOptionsResult,
   ModelOptionsResult,
   ProjectsTreeResult,
   SessionResumeResult,
@@ -27,6 +28,7 @@ import {
   $commands,
   $connection,
   $contextUsage,
+  $effort,
   $detailsNodeId,
   $models,
   $notice,
@@ -258,6 +260,9 @@ function adoptSession(result: SessionResumeResult): void {
 
   void refreshProjects()
   void refreshUsage()
+  // The effort ladder is a property of the model this session ended up on,
+  // which is only known now — before a session there is nothing to ask.
+  void refreshEffort()
 }
 
 export async function interrupt(): Promise<void> {
@@ -414,6 +419,7 @@ async function runSlashCommand(input: string): Promise<boolean> {
 
     // Model / permission commands change session state the chrome reads.
     void refreshModels()
+    void refreshEffort()
 
     return true
   } catch (error) {
@@ -533,6 +539,58 @@ export async function refreshModels(): Promise<void> {
   }
 }
 
+/**
+ * Re-read the effort ladder for whatever model the session is on.
+ *
+ * Called after every model switch, not once at boot: the ladder belongs to the
+ * model, so a model with no effort parameter must take the chip away rather
+ * than leave the previous model's levels on screen.
+ */
+export async function refreshEffort(): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) {
+    // Nothing to ask and nowhere to apply a choice — say so rather than
+    // offering a control that would silently do nothing.
+    $effort.set({ supported: false })
+
+    return
+  }
+
+  try {
+    $effort.set(
+      await gateway().request<EffortOptionsResult>('effort.options', { session_id: sessionId }),
+    )
+  } catch {
+    // Losing the ladder hides the chip; it does not disturb the session.
+    $effort.set({ supported: false })
+  }
+}
+
+export async function setEffort(effort: string): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) return
+
+  // Optimistic: the menu should mark the new level immediately, and the
+  // refresh below replaces this with whatever the session really took.
+  $effort.set({ ...$effort.get(), current: effort })
+
+  try {
+    const result = await gateway().request<{ error?: string; ok?: boolean; value?: string }>(
+      'config.set',
+      { key: 'effort', session_id: sessionId, value: effort },
+    )
+
+    if (result.ok === false) notice(result.error ?? 'Could not change effort', 'error')
+    else notice(`Effort: ${result.value ?? effort}`)
+  } catch (error) {
+    notice(errorText(error), 'error')
+  }
+
+  await refreshEffort()
+}
+
 export async function setModel(model: string, provider?: string): Promise<void> {
   const sessionId = $sessionId.get()
 
@@ -558,6 +616,8 @@ export async function setModel(model: string, provider?: string): Promise<void> 
   }
 
   await refreshModels()
+  // The ladder belongs to the model, so a switch can add, change or remove it.
+  await refreshEffort()
 }
 
 export async function refreshCommands(): Promise<void> {

--- a/ui-web/src/state/store.ts
+++ b/ui-web/src/state/store.ts
@@ -12,6 +12,7 @@ import type { ConnectionState } from '../gateway/client.ts'
 import type {
   CommandEntry,
   ContextUsageResult,
+  EffortOptionsResult,
   ModelOptionsResult,
   ProjectNode,
 } from '../gateway/protocol.ts'
@@ -61,6 +62,8 @@ export const $projectsLoading = atom<boolean>(false)
 export const $workspace = atom<string>('')
 
 export const $models = atom<ModelOptionsResult>({})
+/** Effort ladder for the running model; `supported: false` hides the chip. */
+export const $effort = atom<EffortOptionsResult>({ supported: false })
 export const $commands = atom<CommandEntry[]>([])
 export const $contextUsage = atom<ContextUsageResult | null>(null)
 


### PR DESCRIPTION
The backend already had every piece:

| Piece | Where |
|---|---|
| Which levels a model accepts | `effort_options` control |
| Changing it live | `set_effort` control, reachable via `config.set {key: "effort"}` |
| The current level | `reasoning_effort` on `session.info` |

The web client had no control, so effort was fixed at whatever the session spawned with. This adds `effort.options` to the gateway (mirroring `model.options`) and a chip beside the model picker.

## The ladder is a property of the *model*

That one fact drives the whole design:

- **Asked per model**, not carried on `model.options` — some providers enumerate hundreds of models, and answering for all of them upfront would bloat every picker open to serve one row. Re-asked after each model switch, so a switch can add, change, or take away the chip.

- **`supported: false` renders nothing at all.** That's `effort_options`' own instruction:

  > *"`supported` False means the model takes no effort parameter at all — the picker skips its third step rather than offering a list that cannot be applied."*

  A chip whose every choice is silently dropped is worse than no chip. Every failure path reports unsupported rather than an empty-but-*supported* ladder — including the no-session case, where a level chosen now has nowhere to go.

- **`auto` is prepended client-side**, which is where the contract says it belongs:

  > *"`levels` never includes `auto`; the caller prepends it, since 'let the provider decide' is meaningful exactly when some real level is also on offer."*

  So a model with no real rung offers no menu, rather than a menu whose only entry is "Auto".

- **An unset level displays as "Auto", not blank.** Nothing told the provider what to do, so the provider is deciding — the chip should say what is actually happening.

## Testing

11 new web specs, 5 new backend specs. Full suites green: 646 server, 203 web. `tsc` clean, bundle builds.

Verified live against a DeepSeek session: chip reads `Auto`; the menu lists Auto / Low / Medium / High / X-High / Max with what each one buys; choosing Max leaves the chip on `Max` after re-reading the level back from the session, and the backend confirms `Effort: max`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
