### PR TITLE
feat(web): @ file mentions in the composer

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -504,6 +504,107 @@ class DesktopSession:
         return {"resolved": True}
 
 
+# cwd -> (expires_at, files, truncated). A mention is typed one keystroke at a
+# time and `rg --files` runs per call; the TTL is short enough that a file
+# created while typing appears in the same sitting.
+_FILE_CACHE_TTL_S = 5.0
+_file_cache: dict[str, tuple[float, list[str], bool]] = {}
+
+
+# Pruned by the fallback walker below. Not a .gitignore substitute — just the
+# directories that are noise in every repo and would otherwise dominate a
+# mention menu.
+_WALK_SKIP = {
+    ".git", ".hg", ".svn", ".venv", "venv", "node_modules", "__pycache__",
+    ".mypy_cache", ".pytest_cache", ".ruff_cache", "dist", "build", ".next",
+    ".turbo", "target", ".idea", ".tox",
+}
+_WALK_MAX_FILES = 5000
+
+
+def _walk_workspace_files(cwd: str) -> tuple[list[str], bool]:
+    """A file list without ripgrep, for machines that do not have it.
+
+    Degraded on purpose and knowingly: this does NOT read .gitignore, so it can
+    surface files ``rg --files`` would hide. That is a worse list than
+    ripgrep's — but a mention picker that works everywhere beats one that is
+    silently empty wherever ``rg`` is not installed, and the paths it offers
+    are real files either way.
+
+    BREADTH-first, which matters more than it looks. Depth-first spends the cap
+    on whichever subtree sorts first: measured on this repo it produced 5000
+    files that stopped at ``install.ps1`` and contained not one
+    ``ui-web/src/...`` path, so the obvious query returned nothing. Level order
+    gives every directory its shallow files before any subtree goes deep, so
+    truncation drops the deepest paths — the ones least likely to be typed —
+    rather than everything after the letter I.
+    """
+    import os
+    from collections import deque
+
+    found: list[str] = []
+    queue: deque[str] = deque([cwd])
+
+    while queue:
+        current = queue.popleft()
+        try:
+            entries = sorted(os.scandir(current), key=lambda e: e.name)
+        except OSError:
+            # One unreadable directory should not end the walk; the rest of
+            # the tree is still a useful list.
+            continue
+
+        for entry in entries:
+            if entry.name.startswith("."):
+                continue
+            try:
+                directory = entry.is_dir(follow_symlinks=False)
+            except OSError:
+                continue
+
+            if directory:
+                if entry.name not in _WALK_SKIP:
+                    queue.append(entry.path)
+
+                continue
+
+            rel = os.path.relpath(entry.path, cwd)
+            found.append(rel.replace(os.sep, "/") if os.sep != "/" else rel)
+
+            if len(found) >= _WALK_MAX_FILES:
+                return found, True
+
+    return found, False
+
+
+def _workspace_files_cached(cwd: str) -> tuple[list[str], bool]:
+    """``list_workspace_files`` behind a short per-directory TTL.
+
+    Falls back to a plain walk when ripgrep is missing. Any OTHER failure
+    propagates: an unreadable directory is a real answer the caller reports,
+    not something to paper over with a partial list.
+    """
+    import time
+
+    from src.services.workspace_search import list_workspace_files
+
+    now = time.monotonic()
+    hit = _file_cache.get(cwd)
+    if hit is not None and hit[0] > now:
+        return hit[1], hit[2]
+
+    try:
+        files, truncated = list_workspace_files(cwd)
+    except Exception as exc:  # noqa: BLE001 — narrowed by the message check
+        if "ripgrep" not in str(exc).lower():
+            raise
+        logger.info("fs.search_files: ripgrep unavailable, walking %s instead", cwd)
+        files, truncated = _walk_workspace_files(cwd)
+
+    _file_cache[cwd] = (now + _FILE_CACHE_TTL_S, files, truncated)
+    return files, truncated
+
+
 def _wants_questions(params: dict[str, Any]) -> bool:
     """Whether this client declared it can render AskUserQuestion."""
     capabilities = params.get("capabilities")
@@ -659,6 +760,7 @@ class GatewayConnection:
             "complete.slash": self.complete_slash,
             "complete.path": self.complete_empty,
             "fs.list_directory": self.fs_list_directory,
+            "fs.search_files": self.fs_search_files,
             "slash.exec": self.slash_exec,
             "command.dispatch": self.command_dispatch,
             "setup.status": self.setup_status,
@@ -914,6 +1016,45 @@ class GatewayConnection:
     async def permission_cycle(self, params: dict[str, Any]) -> dict[str, Any]:
         result = await self._session(params).control_query("cycle_permission_mode", {})
         return result or {}
+
+    async def fs_search_files(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Workspace files matching ``query``, for the composer's @ mentions.
+
+        Ranked server-side by ``workspace_search.filter_files`` rather than
+        shipping the list for the client to score: that is the same fuzzy
+        scorer the TUI's quick-open and the history search use, and a second
+        implementation in TypeScript would rank the same query differently on
+        two surfaces of the same app.
+
+        The file list is cached briefly per directory because ``rg --files``
+        runs per call and a mention is typed one keystroke at a time. The TTL
+        is short enough that a file created while typing shows up in the same
+        sitting.
+        """
+        import asyncio as _asyncio
+
+        from src.services.workspace_search import filter_files
+
+        cwd = _clean(params.get("cwd")) or self.state.workspace
+        query = str(params.get("query") or "")
+        try:
+            limit = max(1, min(int(params.get("limit") or 20), 100))
+        except (TypeError, ValueError):
+            limit = 20
+
+        try:
+            files, truncated = await _asyncio.to_thread(_workspace_files_cached, cwd)
+        except Exception as exc:  # noqa: BLE001 — a picker must not kill the socket
+            logger.warning("fs.search_files: listing %s failed: %s", cwd, exc)
+            # Reported rather than returned as an empty list: "no files here"
+            # and "I could not look" are different answers.
+            return {"error": str(exc), "files": [], "truncated": False}
+
+        return {
+            "files": filter_files(files, query, limit=limit),
+            "total": len(files),
+            "truncated": truncated,
+        }
 
     async def effort_options(self, params: dict[str, Any]) -> dict[str, Any]:
         """The effort levels the given (or running) model will actually accept.

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -11,9 +11,14 @@ and the shape of what crosses the wire once it has.
 from __future__ import annotations
 
 import asyncio
+import os
 from typing import Any
 
 import pytest
+
+# Evaluated at import on EVERY platform, so it must not touch a POSIX-only
+# name directly: pytest reads each skipif condition even when another matched.
+IS_ROOT = getattr(os, "geteuid", lambda: 1)() == 0
 
 from src.server.desktop_gateway_methods import (
     DesktopSession,
@@ -358,3 +363,111 @@ def test_effort_reports_unsupported_when_the_control_fails() -> None:
 
 def test_effort_never_claims_support_on_a_truthy_non_true_flag() -> None:
     assert _effort({"ok": True, "supported": "yes", "levels": ["low"]})["supported"] is False
+
+
+# ── workspace file listing (@ mentions) ───────────────────────────────────────
+
+
+def _tree(root, spec: dict) -> None:
+    """Build a directory tree from a nested dict; str values are file bodies."""
+    for name, value in spec.items():
+        path = root / name
+        if isinstance(value, dict):
+            path.mkdir(parents=True, exist_ok=True)
+            _tree(path, value)
+        else:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(value)
+
+
+def test_walk_lists_files_relative_and_posix(tmp_path) -> None:
+    from src.server.desktop_gateway_methods import _walk_workspace_files
+
+    _tree(tmp_path, {"a.py": "", "src": {"b.py": "", "deep": {"c.py": ""}}})
+
+    files, truncated = _walk_workspace_files(str(tmp_path))
+
+    assert sorted(files) == ["a.py", "src/b.py", "src/deep/c.py"]
+    assert truncated is False
+
+
+def test_walk_skips_noise_directories_and_dotfiles(tmp_path) -> None:
+    from src.server.desktop_gateway_methods import _walk_workspace_files
+
+    _tree(tmp_path, {
+        "keep.py": "",
+        ".hidden": "",
+        ".git": {"config": ""},
+        "node_modules": {"pkg": {"index.js": ""}},
+        "__pycache__": {"x.pyc": ""},
+    })
+
+    assert _walk_workspace_files(str(tmp_path))[0] == ["keep.py"]
+
+
+def test_walk_is_breadth_first_so_truncation_drops_the_deepest(tmp_path, monkeypatch) -> None:
+    # The bug this ordering exists for: depth-first spent the whole cap on
+    # whichever subtree sorted first, and the obvious query returned nothing
+    # because its directory was never reached.
+    import src.server.desktop_gateway_methods as mod
+
+    monkeypatch.setattr(mod, "_WALK_MAX_FILES", 2)
+    _tree(tmp_path, {
+        "aaa": {"deep": {"deeper": {"buried.py": ""}}, "one.py": ""},
+        "zzz": {"two.py": ""},
+    })
+
+    files, truncated = mod._walk_workspace_files(str(tmp_path))
+
+    assert truncated is True
+    # Both top-level directories are represented before anything goes deep.
+    assert "aaa/one.py" in files
+    assert "zzz/two.py" in files
+    assert "aaa/deep/deeper/buried.py" not in files
+
+
+def test_walk_survives_an_unreadable_directory(tmp_path) -> None:
+    import os
+
+    from src.server.desktop_gateway_methods import _walk_workspace_files
+
+    if IS_ROOT:
+        pytest.skip("root reads every directory regardless of mode")
+
+    _tree(tmp_path, {"readable.py": "", "locked": {"hidden.py": ""}})
+    os.chmod(tmp_path / "locked", 0o000)
+    try:
+        files, _ = _walk_workspace_files(str(tmp_path))
+    finally:
+        os.chmod(tmp_path / "locked", 0o755)
+
+    # The rest of the tree is still a useful list.
+    assert files == ["readable.py"]
+
+
+def test_cache_falls_back_to_the_walk_when_ripgrep_is_missing(tmp_path, monkeypatch) -> None:
+    import src.server.desktop_gateway_methods as mod
+
+    def _no_rg(cwd: str) -> tuple[list[str], bool]:
+        raise RuntimeError("ripgrep (rg) is required for file search but could not be found")
+
+    monkeypatch.setattr("src.services.workspace_search.list_workspace_files", _no_rg)
+    monkeypatch.setattr(mod, "_file_cache", {})
+    _tree(tmp_path, {"kept.py": ""})
+
+    assert mod._workspace_files_cached(str(tmp_path))[0] == ["kept.py"]
+
+
+def test_cache_does_not_swallow_a_real_listing_failure(tmp_path, monkeypatch) -> None:
+    # An unreadable workspace is a real answer the caller reports; papering
+    # over it with a partial list would look like an empty repository.
+    import src.server.desktop_gateway_methods as mod
+
+    def _boom(cwd: str) -> tuple[list[str], bool]:
+        raise PermissionError("nope")
+
+    monkeypatch.setattr("src.services.workspace_search.list_workspace_files", _boom)
+    monkeypatch.setattr(mod, "_file_cache", {})
+
+    with pytest.raises(PermissionError):
+        mod._workspace_files_cached(str(tmp_path))

--- a/ui-web/src/conversation/InputBar.tsx
+++ b/ui-web/src/conversation/InputBar.tsx
@@ -14,9 +14,11 @@ import type {
   EffortOptionsResult,
   ModelOptionsResult,
 } from '../gateway/protocol.ts'
+import { searchFiles } from '../state/actions.ts'
 import { $commands, $notice } from '../state/store.ts'
 import { ArrowUpIcon, StopIcon } from '../ui/icons.tsx'
 import { ContextMeter } from './ContextMeter.tsx'
+import { applyMention, mentionAt, type MentionToken } from './mentions.ts'
 import { EffortSelect } from './EffortSelect.tsx'
 import { ModelSelect } from './ModelSelect.tsx'
 import { PermissionSelect, type ApprovalMode } from './PermissionSelect.tsx'
@@ -97,9 +99,45 @@ export function InputBar({
       .slice(0, MAX_SUGGESTIONS)
   }, [commands, draft])
 
+  // The @ mention being typed, tracked from the CARET: unlike a slash command,
+  // a mention can sit anywhere in the draft and a message can hold several.
+  const [mention, setMention] = useState<MentionToken | null>(null)
+  const [files, setFiles] = useState<string[]>([])
+
+  const syncMention = useCallback((element: HTMLTextAreaElement | null) => {
+    if (element === null) return
+
+    setMention(mentionAt(element.value, element.selectionStart))
+  }, [])
+
+  // Debounced: a mention is typed one keystroke at a time, and every query
+  // costs an `rg --files` on the backend. 120ms is under the gap between
+  // keystrokes for anyone typing a path, so the menu still feels immediate.
+  useEffect(() => {
+    if (mention === null) {
+      setFiles([])
+
+      return
+    }
+
+    let live = true
+    const timer = setTimeout(() => {
+      void searchFiles(mention.query).then(result => {
+        // A reply that lands after the token moved on describes a query the
+        // user is no longer typing.
+        if (live) setFiles(result)
+      })
+    }, 120)
+
+    return () => {
+      live = false
+      clearTimeout(timer)
+    }
+  }, [mention])
+
   useEffect(() => {
     setHighlight(0)
-  }, [suggestions.length])
+  }, [suggestions.length, files.length])
 
   const accept = useCallback(
     (name: string) => {
@@ -107,6 +145,30 @@ export function InputBar({
       textarea.current?.focus()
     },
     [onDraftChange],
+  )
+
+  const acceptFile = useCallback(
+    (path: string) => {
+      if (mention === null) return
+
+      const next = applyMention(draft, mention, path)
+
+      onDraftChange(next.text)
+      setMention(null)
+      setFiles([])
+
+      // The caret has to be restored after React commits the new value, or it
+      // snaps to the end and the next mention in the sentence is unreachable.
+      requestAnimationFrame(() => {
+        const element = textarea.current
+
+        if (element === null) return
+
+        element.focus()
+        element.setSelectionRange(next.caret, next.caret)
+      })
+    },
+    [draft, mention, onDraftChange],
   )
 
   const submit = useCallback(() => {
@@ -120,6 +182,46 @@ export function InputBar({
 
   const onKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      // The file menu is checked first: it is anchored at the caret, so it is
+      // the one the user is looking at when both could be open.
+      if (files.length > 0 && mention !== null) {
+        if (event.key === 'ArrowDown') {
+          event.preventDefault()
+          setHighlight(value => (value + 1) % files.length)
+
+          return
+        }
+
+        if (event.key === 'ArrowUp') {
+          event.preventDefault()
+          setHighlight(value => (value - 1 + files.length) % files.length)
+
+          return
+        }
+
+        if (event.key === 'Tab' || (event.key === 'Enter' && !event.shiftKey)) {
+          const choice = files[highlight]
+
+          if (choice !== undefined && !event.nativeEvent.isComposing) {
+            event.preventDefault()
+            acceptFile(choice)
+
+            return
+          }
+        }
+
+        if (event.key === 'Escape') {
+          // Dismiss the menu only. Clearing the draft — what Escape does to a
+          // half-typed slash command — would throw away a sentence over a
+          // mention the user decided against.
+          event.preventDefault()
+          setMention(null)
+          setFiles([])
+
+          return
+        }
+      }
+
       if (suggestions.length > 0) {
         if (event.key === 'ArrowDown') {
           event.preventDefault()
@@ -161,7 +263,7 @@ export function InputBar({
         submit()
       }
     },
-    [accept, highlight, onDraftChange, submit, suggestions],
+    [accept, acceptFile, files, highlight, mention, onDraftChange, submit, suggestions],
   )
 
   return (
@@ -177,6 +279,27 @@ export function InputBar({
         </div>
       )}
       <div className={css.card}>
+        {mention !== null && files.length > 0 && (
+          <div className={css.popover} role="listbox">
+            {files.map((path, index) => (
+              <button
+                className={css.option}
+                data-active={index === highlight ? '' : undefined}
+                key={path}
+                onClick={() => {
+                  acceptFile(path)
+                }}
+                onPointerEnter={() => {
+                  setHighlight(index)
+                }}
+                type="button"
+              >
+                <span className={css.optionName}>{path.split('/').pop()}</span>
+                <span className={css.optionDescription}>{path}</span>
+              </button>
+            ))}
+          </div>
+        )}
         {suggestions.length > 0 && (
           <div className={css.popover} role="listbox">
             {suggestions.map((command, index) => (
@@ -207,8 +330,15 @@ export function InputBar({
             className={css.input}
             onChange={event => {
               onDraftChange(event.target.value)
+              syncMention(event.target)
             }}
+            // Clicking or arrowing through the draft moves the caret without
+            // changing the text, and a mention is defined by where the caret
+            // is — so the token has to be re-read on selection too.
             onKeyDown={onKeyDown}
+            onSelect={event => {
+              syncMention(event.currentTarget)
+            }}
             placeholder={running ? 'Queue a follow-up…' : 'Ask ClawCodex to build something…'}
             ref={textarea}
             rows={hero ? 2 : 1}

--- a/ui-web/src/conversation/mentions.test.ts
+++ b/ui-web/src/conversation/mentions.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+
+import { applyMention, mentionAt } from './mentions.ts'
+
+/** `mentionAt` with the caret marked by `|` in the fixture, for readability. */
+function at(fixture: string) {
+  const caret = fixture.indexOf('|')
+  const text = fixture.replace('|', '')
+
+  return mentionAt(text, caret)
+}
+
+describe('mentionAt', () => {
+  it('finds a mention being typed at the caret', () => {
+    expect(at('@src/cli|')).toEqual({ end: 8, query: 'src/cli', start: 0 })
+  })
+
+  it('finds one mid-sentence, which is where they usually are', () => {
+    expect(at('look at @src/cl|')).toMatchObject({ query: 'src/cl', start: 8 })
+  })
+
+  it('treats a bare @ as an open mention with an empty query', () => {
+    // Typing @ should open the menu on the whole file list, not wait for a
+    // character first.
+    expect(at('@|')).toEqual({ end: 1, query: '', start: 0 })
+  })
+
+  it('ignores an @ that does not open a word', () => {
+    // An email address and an array index are text, not triggers.
+    expect(at('me@example|')).toBeNull()
+    expect(at('arr@[0|')).toBeNull()
+  })
+
+  it('ends the mention at whitespace', () => {
+    // Once the path is settled the menu should close, not keep matching.
+    expect(at('@src/cli.py |')).toBeNull()
+    expect(at('@src/cli.py and then|')).toBeNull()
+  })
+
+  it('tracks the caret rather than the end of the draft', () => {
+    // Editing a mention earlier in a finished sentence still works: caret 8
+    // is the end of the first mention, and caret 9 is past its space, which
+    // is no longer a mention at all.
+    expect(mentionAt('@src/cli and @ui-web/src', 8)).toMatchObject({ query: 'src/cli' })
+    expect(mentionAt('@src/cli and @ui-web/src', 9)).toBeNull()
+  })
+
+  it('picks the mention the caret is in when there are several', () => {
+    const text = 'compare @a.ts with @b.ts'
+
+    expect(mentionAt(text, text.length)).toMatchObject({ query: 'b.ts', start: 19 })
+  })
+
+  it('finds nothing in a draft with no @ at all', () => {
+    expect(at('just some words|')).toBeNull()
+    expect(mentionAt('', 0)).toBeNull()
+  })
+
+  it('clamps a caret outside the text instead of throwing', () => {
+    expect(mentionAt('@src', 99)).toMatchObject({ query: 'src' })
+    expect(mentionAt('@src', -5)).toBeNull()
+  })
+})
+
+describe('applyMention', () => {
+  it('replaces the token and reports where the caret lands', () => {
+    const token = mentionAt('@src/cl', 7)!
+    const result = applyMention('@src/cl', token, 'src/cli.py')
+
+    expect(result.text).toBe('@src/cli.py ')
+    expect(result.caret).toBe(result.text.length)
+  })
+
+  it('keeps the text on both sides of the token', () => {
+    const text = 'look at @src/cl and say why'
+    const token = mentionAt(text, 15)!
+
+    expect(applyMention(text, token, 'src/cli.py').text).toBe(
+      'look at @src/cli.py  and say why',
+    )
+  })
+
+  it('leaves the caret after the trailing space, not inside the path', () => {
+    // The space closes the mention so the menu shuts and the next keystroke
+    // starts a new word.
+    const text = 'look at @src/cl and say why'
+    const token = mentionAt(text, 15)!
+    const { caret, text: next } = applyMention(text, token, 'src/cli.py')
+
+    expect(next.slice(caret - 1, caret)).toBe(' ')
+    expect(mentionAt(next, caret)).toBeNull()
+  })
+
+  it('completes a bare @ into a full mention', () => {
+    const token = mentionAt('@', 1)!
+
+    expect(applyMention('@', token, 'README.md').text).toBe('@README.md ')
+  })
+})

--- a/ui-web/src/conversation/mentions.ts
+++ b/ui-web/src/conversation/mentions.ts
@@ -1,0 +1,65 @@
+/**
+ * The `@` file-mention token in a draft.
+ *
+ * A mention is a token at the caret, not a prefix of the whole draft the way a
+ * slash command is — "look at @src/cli.py and tell me…" mentions a file in the
+ * middle of a sentence, and the same message can mention several.
+ */
+export interface MentionToken {
+  /** Index of the `@` itself. */
+  start: number
+  /** Index just past the token (the caret). */
+  end: number
+  /** Everything between the `@` and the caret. */
+  query: string
+}
+
+/**
+ * The mention being typed at `caret`, or `null` when there isn't one.
+ *
+ * The `@` has to open a word — at the start of the draft or after whitespace —
+ * so `me@example.com` and `arr@[0]` are text, not triggers. The token runs to
+ * the caret and cannot contain whitespace, which is what ends a mention: once
+ * the user types a space the path is settled and the menu should close.
+ */
+export function mentionAt(text: string, caret: number): MentionToken | null {
+  const at = Math.max(0, Math.min(caret, text.length))
+
+  for (let index = at - 1; index >= 0; index -= 1) {
+    const char = text[index] as string
+
+    if (/\s/.test(char)) return null
+
+    if (char === '@') {
+      const before = index === 0 ? '' : (text[index - 1] as string)
+
+      // Opening a word: start of draft, or preceded by whitespace. Anything
+      // else (a letter, a digit, a bracket) means this @ is part of something.
+      if (before !== '' && !/\s/.test(before)) return null
+
+      return { end: at, query: text.slice(index + 1, at), start: index }
+    }
+  }
+
+  return null
+}
+
+/**
+ * Replace the token with `@path `, and report where the caret lands.
+ *
+ * The trailing space is the reason the caret has to be reported: it closes the
+ * mention (so the menu shuts) and leaves the user typing the next word rather
+ * than back inside a path they already chose. The format matches
+ * `workspace_search.file_insertion`, which is what every other ClawCodex
+ * surface inserts.
+ */
+export function applyMention(
+  text: string,
+  token: MentionToken,
+  path: string,
+): { caret: number; text: string } {
+  const insertion = `@${path} `
+  const next = text.slice(0, token.start) + insertion + text.slice(token.end)
+
+  return { caret: token.start + insertion.length, text: next }
+}

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -230,6 +230,15 @@ export interface EffortOptionsResult {
   supported?: boolean
 }
 
+/** `fs.search_files` — workspace paths ranked by the backend's fuzzy scorer. */
+export interface FileSearchResult {
+  /** Present when the listing itself failed; "could not look" ≠ "nothing here". */
+  error?: string
+  files?: string[]
+  total?: number
+  truncated?: boolean
+}
+
 export interface SessionRow {
   cwd?: string | null
   id: string

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -17,6 +17,7 @@ import type {
   DirectoryListing,
   GatewayEvent,
   EffortOptionsResult,
+  FileSearchResult,
   ModelOptionsResult,
   ProjectsTreeResult,
   SessionResumeResult,
@@ -521,6 +522,29 @@ export async function chooseWorkspace(path: string): Promise<void> {
   $workspace.set(path)
 
   if ($sessionId.get() !== null) await createSession({ cwd: path })
+}
+
+/**
+ * Workspace paths matching `query`, for the composer's @ mentions.
+ *
+ * Ranked server-side: that is the same fuzzy scorer the TUI's quick-open uses,
+ * and a second implementation here would rank the same query differently on
+ * two surfaces of the same app.
+ */
+export async function searchFiles(query: string, limit = 12): Promise<string[]> {
+  try {
+    const result = await gateway().request<FileSearchResult>('fs.search_files', {
+      cwd: $workspace.get(),
+      limit,
+      query,
+    })
+
+    return result.files ?? []
+  } catch {
+    // The menu simply does not open; a failed lookup is not worth a banner
+    // over a draft the user is still typing.
+    return []
+  }
 }
 
 /* ── model + catalogs ────────────────────────────────────────────────────── */


### PR DESCRIPTION
Pointing at a file is the most common thing anyone does with a coding agent, and the web composer had no way to do it.

`src/services/workspace_search.py` already had every piece — the gitignore-honoring file list, the fuzzy ranker, and `file_insertion`'s `@path ` format. This exposes it as `fs.search_files` and builds the trigger on the slash palette's existing machinery.

**Ranking stays server-side.** That scorer is the one the TUI's quick-open and the history search already use; a second implementation in TypeScript would rank the same query differently on two surfaces of the same app.

## The token follows the caret

Not the draft prefix, the way a slash command does — *"look at @src/cli.py and tell me…"* mentions a file mid-sentence, and one message can mention several.

- An `@` only triggers when it **opens a word**, so `me@example.com` and `arr@[0]` stay text.
- Whitespace ends the token: once the path is settled the menu closes.
- Accepting inserts `@path ` and **restores the caret** after the trailing space — without that the caret snaps to the end and a second mention earlier in the sentence is unreachable.
- Escape dismisses the menu **without clearing the draft** (which is what it does to a half-typed slash command). A sentence shouldn't be lost over a mention the user thought better of.

## Two things found by running it

**ripgrep is not installed everywhere.** The RPC reported that honestly — *"could not look"* ≠ *"nothing here"* — which left the picker permanently empty on this machine. Added a plain-walk fallback, degraded knowingly: it does not read `.gitignore`, so it can surface files `rg` would hide. A picker that works everywhere beats one that is silently empty. A non-ripgrep failure still propagates rather than being papered over with a partial list.

**The fallback has to be breadth-first.** Depth-first spent the 5000-file cap on whichever subtree sorted first. Measured on this repo:

```
files: 5000  truncated: True
ui-web/src/conversation entries: 0
top-level dirs reached: … 'eval', 'install.ps1'
```

So the obvious query returned nothing. Level order gives every directory its shallow files before any subtree goes deep, so truncation drops the deepest paths — the ones least likely to be typed — rather than everything after the letter I. Same repo, after:

```
files: 5000  truncated: True  in 0.03s
ui-web/src/conversation entries: 36
src/server entries: 23
top-level dirs: 14
query 'ui-web/src/conv'  -> ui-web/src/conversation/ApprovalPanel.module.css, …
query 'desktop_gateway'  -> src/server/desktop_gateway.py, …_methods.py, …_translate.py
```

## Testing

13 new specs for the token logic, 6 new backend specs for the walker and the ripgrep fallback. Full suites green: 652 server, 216 web. `tsc` clean, bundle builds.

Verified live in the browser:
- `@ui-web/src/conv` lists the conversation directory.
- Clicking one yields `look at @ui-web/src/conversation/ChatView.tsx ` with the caret past the space and the menu closed.
- Sending `Read @ui-web/src/conversation/mentions.ts …` made the agent fire `Read` on exactly that path and answer from its contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
