### PR TITLE
feat(web): retry the last turn

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -744,6 +744,7 @@ class GatewayConnection:
             "session.active_list": self.session_active_list,
             "session.list": self.session_active_list,
             "session.interrupt": self.session_interrupt,
+            "session.rewind": self.session_rewind,
             "session.clear": self.session_clear,
             "session.title": self.session_title,
             "session.usage": self.session_usage,
@@ -972,6 +973,29 @@ class GatewayConnection:
     async def session_interrupt(self, params: dict[str, Any]) -> dict[str, Any]:
         await self._session(params).interrupt()
         return {"ok": True}
+
+    async def session_rewind(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Drop the last N prompt-turns from the conversation (the CLI's /rewind).
+
+        Reports ``removed`` so the client can trim its own transcript by the
+        same amount instead of guessing. The agent refuses this during an
+        active turn — it mutates the conversation the worker is reading — and
+        that refusal is passed through rather than smoothed over: a retry that
+        silently did nothing mid-turn would look like the model ignoring it.
+        """
+        try:
+            turns = max(1, int(params.get("turns") or 1))
+        except (TypeError, ValueError):
+            turns = 1
+        result = await self._session(params).control_query("rewind", {"turns": turns})
+        if not isinstance(result, dict):
+            return {"ok": False, "error": "no response from the session"}
+        return {
+            "count": result.get("count", 0),
+            "error": result.get("error", ""),
+            "ok": result.get("ok") is not False,
+            "removed": result.get("removed", 0),
+        }
 
     async def session_clear(self, params: dict[str, Any]) -> dict[str, Any]:
         result = await self._session(params).control_query("clear", {})

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -471,3 +471,46 @@ def test_cache_does_not_swallow_a_real_listing_failure(tmp_path, monkeypatch) ->
 
     with pytest.raises(PermissionError):
         mod._workspace_files_cached(str(tmp_path))
+
+
+# ── rewind (retry) ────────────────────────────────────────────────────────────
+
+
+def _rewind(reply: Any, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    from src.server.desktop_gateway_methods import GatewayConnection
+
+    connection = GatewayConnection.__new__(GatewayConnection)
+    session = _Queryable(reply)
+    connection._session = lambda p: session  # type: ignore[method-assign]
+    result = asyncio.run(GatewayConnection.session_rewind(connection, params or {}))
+    return {**result, "_asked": session.asked}
+
+
+def test_rewind_defaults_to_one_turn() -> None:
+    result = _rewind({"ok": True, "removed": 4, "count": 2})
+
+    assert result["_asked"] == ("rewind", {"turns": 1})
+    assert result["removed"] == 4
+    assert result["ok"] is True
+
+
+@pytest.mark.parametrize(
+    "given,expected",
+    [({"turns": 3}, 3), ({"turns": 0}, 1), ({"turns": -2}, 1), ({"turns": "x"}, 1), ({}, 1)],
+)
+def test_rewind_clamps_the_turn_count(given: dict[str, Any], expected: int) -> None:
+    assert _rewind({"ok": True}, given)["_asked"][1] == {"turns": expected}
+
+
+def test_rewind_passes_the_refusal_through() -> None:
+    # The agent refuses mid-turn because it mutates the conversation the worker
+    # is reading. A retry that silently did nothing would look like the model
+    # ignoring the click.
+    result = _rewind({"ok": False, "error": "cannot rewind during an active turn"})
+
+    assert result["ok"] is False
+    assert result["error"] == "cannot rewind during an active turn"
+
+
+def test_rewind_reports_a_session_that_did_not_answer() -> None:
+    assert _rewind(None)["ok"] is False

--- a/ui-web/src/conversation/ChatView.tsx
+++ b/ui-web/src/conversation/ChatView.tsx
@@ -9,6 +9,7 @@ import css from './ChatView.module.css'
 export interface ChatViewProps {
   nodes: TranscriptNode[]
   onEditPrompt?: (text: string) => void
+  onRetry?: () => void
   running: boolean
   turnStartedAt?: number
   workspace?: string
@@ -53,6 +54,7 @@ function formatClock(seconds: number): string {
 export function ChatView({
   nodes,
   onEditPrompt,
+  onRetry,
   running,
   turnStartedAt,
   workspace,
@@ -66,10 +68,18 @@ export function ChatView({
   return (
     <div className={css.root}>
       <div className={css.column}>
-        {nodes.map(node => (
+        {nodes.map((node, index) => (
           <div className={css.item} key={node.id}>
             {node.kind === 'user' && <UserMessage node={node} onEdit={onEditPrompt} />}
-            {node.kind === 'assistant' && <AssistantMessage node={node} />}
+            {node.kind === 'assistant' && (
+              <AssistantMessage
+                node={node}
+                // The newest reply only, and never mid-turn: the agent refuses
+                // to rewind while a turn is running, so offering it would be
+                // offering something that cannot happen.
+                onRetry={!running && index === nodes.length - 1 ? onRetry : undefined}
+              />
+            )}
             {node.kind === 'reasoning' && <ReasoningRow node={node} />}
             {node.kind === 'tool' && <ToolRow node={node} workspace={workspace} />}
             {node.kind === 'notice' && <NoticeMessage node={node} />}

--- a/ui-web/src/conversation/ConversationRoot.tsx
+++ b/ui-web/src/conversation/ConversationRoot.tsx
@@ -9,6 +9,7 @@ import {
   renameSession,
   respondApproval,
   respondQuestion,
+  retryLastTurn,
   setApprovalMode,
   setEffort,
   setModel,
@@ -324,6 +325,9 @@ export function ConversationRoot() {
                 <ChatView
                   nodes={transcript.nodes}
                   onEditPrompt={setDraft}
+                  onRetry={() => {
+                    void retryLastTurn()
+                  }}
                   running={transcript.running}
                   turnStartedAt={transcript.turnStartedAt}
                   workspace={workspace}

--- a/ui-web/src/conversation/MessageItem.tsx
+++ b/ui-web/src/conversation/MessageItem.tsx
@@ -39,13 +39,27 @@ function UserMessageImpl({ node, onEdit }: { node: UserNode; onEdit?: (text: str
   )
 }
 
-function AssistantMessageImpl({ node }: { node: AssistantNode }) {
+function AssistantMessageImpl({
+  node,
+  onRetry,
+}: {
+  node: AssistantNode
+  onRetry?: () => void
+}) {
   return (
     <div className={css.assistantRow}>
       <Markdown className={css.assistant} streaming={!node.sealed} text={node.text} />
       {node.sealed && (
         <div className={css.actions}>
           <CopyButton className={css.action} text={node.text} />
+          {/* Only the newest reply gets this. Re-running an earlier turn would
+              discard every turn after it, which is a different and much more
+              destructive action than "give me another answer". */}
+          {onRetry !== undefined && (
+            <button className={css.action} onClick={onRetry} title="Re-run this prompt" type="button">
+              Retry
+            </button>
+          )}
         </div>
       )}
     </div>

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -58,6 +58,7 @@ import {
   emptyTranscript,
   hydrateStoredMessages,
   markTurnStarted,
+  rewindLastTurn,
 } from './transcript.ts'
 
 let client: GatewayClient | null = null
@@ -264,6 +265,49 @@ function adoptSession(result: SessionResumeResult): void {
   // The effort ladder is a property of the model this session ended up on,
   // which is only known now — before a session there is nothing to ask.
   void refreshEffort()
+}
+
+/**
+ * Re-run the last prompt: rewind the turn on the agent, drop it here, resubmit.
+ *
+ * `Edit` puts the prompt back in the composer but leaves the old turn in the
+ * conversation, so sending it again APPENDS a second attempt the model then
+ * reads as a follow-up. Retry replaces the turn instead, which is what asking
+ * for a different answer to the same question actually means.
+ *
+ * The agent refuses to rewind during an active turn (it mutates the
+ * conversation the worker is reading), so nothing is trimmed locally until the
+ * backend confirms — otherwise a refused rewind would leave the client showing
+ * a conversation the agent still has.
+ */
+export async function retryLastTurn(): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) return
+
+  const rewound = rewindLastTurn($transcript.get())
+
+  if (rewound === null) return
+
+  try {
+    const result = await gateway().request<{ error?: string; ok?: boolean; removed?: number }>(
+      'session.rewind',
+      { session_id: sessionId, turns: 1 },
+    )
+
+    if (result.ok === false) {
+      notice(result.error === undefined || result.error === '' ? 'Could not retry' : result.error, 'error')
+
+      return
+    }
+  } catch (error) {
+    notice(errorText(error), 'error')
+
+    return
+  }
+
+  $transcript.set(rewound.state)
+  await submitPrompt(rewound.prompt)
 }
 
 export async function interrupt(): Promise<void> {

--- a/ui-web/src/state/transcript.test.ts
+++ b/ui-web/src/state/transcript.test.ts
@@ -9,6 +9,7 @@ import {
   hydrateStoredMessages,
   markTurnStarted,
   resetNodeIds,
+  rewindLastTurn,
   type AssistantNode,
   type ReasoningNode,
   type ToolNode,
@@ -325,5 +326,69 @@ describe('rehydration', () => {
     ])
 
     expect(nodes[0]).toMatchObject({ error: 'Error: denied', name: 'write_file', state: 'error' })
+  })
+})
+
+describe('rewindLastTurn', () => {
+  const turn = (prompt: string, reply: string): GatewayEvent[] => [
+    event('message.start'),
+    event('message.delta', { text: reply }),
+    event('message.complete'),
+  ]
+
+  function conversation(): TranscriptState {
+    let state = appendUserMessage(emptyTranscript(), 'first question')
+    state = fold(turn('first question', 'first answer'), state)
+    state = appendUserMessage(state, 'second question')
+
+    return fold(turn('second question', 'second answer'), state)
+  }
+
+  it('cuts back to just before the last prompt and hands it back', () => {
+    // The agent's `rewind` drops whole prompt-turns; cutting anywhere else
+    // would leave the two sides disagreeing about the conversation.
+    const result = rewindLastTurn(conversation())
+
+    expect(result?.prompt).toBe('second question')
+    expect(result?.state.nodes.map(n => n.kind)).toEqual(['user', 'assistant'])
+  })
+
+  it('takes the whole turn with it — reasoning and tool rows included', () => {
+    let state = appendUserMessage(emptyTranscript(), 'do a thing')
+    state = fold(
+      [
+        event('reasoning.delta', { text: 'thinking' }),
+        event('tool.start', { name: 'terminal', tool_id: 't1' }),
+        event('tool.complete', { tool_id: 't1' }),
+        event('message.delta', { text: 'done' }),
+        event('message.complete'),
+      ],
+      state,
+    )
+
+    expect(rewindLastTurn(state)?.state.nodes).toEqual([])
+  })
+
+  it('leaves the state it was given untouched', () => {
+    // Nothing is trimmed locally until the backend confirms the rewind.
+    const before = conversation()
+    const count = before.nodes.length
+
+    rewindLastTurn(before)
+
+    expect(before.nodes).toHaveLength(count)
+  })
+
+  it('keeps everything else on the state', () => {
+    const before = { ...conversation(), running: false, usage: { input: 5, output: 7 } }
+
+    expect(rewindLastTurn(before)?.state.usage).toEqual({ input: 5, output: 7 })
+  })
+
+  it('returns null when there is no prompt to rewind to', () => {
+    // A transcript of nothing but notices has no turn to re-run, and saying so
+    // is better than trimming something arbitrary.
+    expect(rewindLastTurn(emptyTranscript())).toBeNull()
+    expect(rewindLastTurn(fold([event('error', { message: 'boom' })]))).toBeNull()
   })
 })

--- a/ui-web/src/state/transcript.ts
+++ b/ui-web/src/state/transcript.ts
@@ -430,6 +430,36 @@ export function clearApproval(state: TranscriptState): TranscriptState {
   return next
 }
 
+/**
+ * Trim the transcript back to just before the last user prompt, and hand back
+ * the prompt that was removed.
+ *
+ * The mirror of the agent's `rewind` control, which drops whole prompt-turns:
+ * the client has to cut at the same boundary or the two disagree about what
+ * the conversation contains. A turn starts at a user message and runs to the
+ * end, so everything from that node onward goes — the assistant's reply, its
+ * reasoning, and every tool row it produced.
+ *
+ * Returns `null` when there is no prompt to rewind to, which is the honest
+ * answer for a transcript holding only a replayed session or a notice.
+ */
+export function rewindLastTurn(
+  state: TranscriptState,
+): { prompt: string; state: TranscriptState } | null {
+  for (let index = state.nodes.length - 1; index >= 0; index -= 1) {
+    const node = state.nodes[index]
+
+    if (node?.kind !== 'user') continue
+
+    return {
+      prompt: node.text,
+      state: { ...state, nodes: state.nodes.slice(0, index) },
+    }
+  }
+
+  return null
+}
+
 /** Clear the pending question after the user answered or declined it. */
 export function clearQuestion(state: TranscriptState): TranscriptState {
   if (state.question === undefined) return state


### PR DESCRIPTION
A bad answer had no recourse on the web. `Edit` puts the prompt back in the composer but leaves the old turn in the conversation, so sending it again **appends** a second attempt that the model then reads as a follow-up — which is not what *"give me another answer"* means.

This exposes the agent's existing `rewind` control as `session.rewind`, trims the client transcript to the same boundary, and resubmits the prompt.

## Details that matter

- **Nothing is trimmed locally until the backend confirms.** The agent refuses to rewind during an active turn — it mutates the conversation the worker is reading — and that refusal is passed through rather than smoothed over. A retry that silently did nothing would look like the model ignoring the click.
- **The client cuts where the agent cuts.** A prompt-turn starts at a user message and runs to the end, so the reply, its reasoning and every tool row go with it. Cutting anywhere else would leave the two sides disagreeing about what the conversation contains.
- **Newest reply only, and only when idle.** Re-running an earlier turn would discard every turn after it — a different and far more destructive action than asking for another answer.

## What's deliberately not here

The reference's action row also has 👍/👎. **The backend has no feedback sink of any kind**, so those would be buttons that do nothing. Left out until there is somewhere for the signal to go.

## Testing

5 new transcript specs, 6 new backend specs. Full suites green: 660 server, 221 web. `tsc` clean, bundle builds.

Verified live against a DeepSeek session:

| | user bubbles | answer |
|---|---|---|
| after first send | 1 | `Z` |
| after Retry | **1** | `R` |

Replaced, not appended — and then asking the model *"how many times have I asked you for a letter?"* returned **`1`**. The discarded turn is gone from its context, not just from the screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
