### PR TITLE
feat: name a session after its first prompt

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -126,6 +126,10 @@ class DesktopSession:
         self._pending_question: str | None = None
         # Set only once a client has said it renders questions (see _create).
         self.asks_questions = False
+        # Whether this session already has a name worth keeping. True for a
+        # resumed session (it has the user's own title) and after any explicit
+        # rename, so auto-titling only ever fills in a blank.
+        self.titled = False
         self.sockets: set[WebSocket] = set()
         # Scheduled session.info refreshes; held so they aren't GC'd mid-flight.
         self._background: set[asyncio.Task] = set()
@@ -301,6 +305,55 @@ class DesktopSession:
         )
 
     # ── client-facing operations ────────────────────────────────────────────
+
+    def schedule_auto_title(self, text: str) -> None:
+        """Fire-and-forget ``auto_title``; held so it is not GC'd mid-flight."""
+        if self.titled:
+            return
+
+        task = asyncio.create_task(self._safe_auto_title(text))
+        self._background.add(task)
+        task.add_done_callback(self._background.discard)
+
+    async def _safe_auto_title(self, text: str) -> None:
+        try:
+            await self.auto_title(text)
+        except Exception:  # noqa: BLE001 — a title is never worth killing a session
+            logger.debug("desktop session %s: auto-title failed",
+                         self.session_id, exc_info=True)
+
+    async def auto_title(self, text: str) -> str | None:
+        """Name an untitled session after its first prompt.
+
+        Uses the heuristic, not ``generate_llm_title``: that one is hardcoded
+        to Anthropic and a fixed Haiku model, so on a session running any other
+        provider it would bill an account the user did not choose to use here —
+        and silently return None wherever that provider is not configured.
+        A first line with the throat-clearing stripped is a good title and
+        costs nothing.
+        """
+        if self.titled:
+            return None
+
+        from src.services.session_title import auto_title_from_message
+
+        title = auto_title_from_message(text)
+        if not title or title == "Untitled session":
+            return None
+
+        # Set before the round-trip: a second prompt arriving while this one is
+        # in flight must not start a second rename of the same session.
+        self.titled = True
+        await self.control_query("rename", {"name": title})
+        try:
+            from src.server.desktop_sessions import update_session_meta
+
+            update_session_meta(self.state.saved_sessions_dir(), self.session_id, name=title)
+        except Exception:  # noqa: BLE001 — best-effort file sync
+            logger.debug("auto_title: could not stamp the saved session", exc_info=True)
+        await self._broadcast("session.title", {"title": title})
+        await self._broadcast("sessions.changed", {})
+        return title
 
     async def submit_prompt(self, text: str) -> None:
         await self._broadcast("message.start", {})
@@ -839,6 +892,9 @@ class GatewayConnection:
                     "session %s: interactive questions refused: %r", session_id, reply
                 )
         if resume:
+            # A stored session brings its own name; auto-titling would rename
+            # someone's saved conversation after whatever they type next.
+            session.titled = True
             reply = await session.control_query("resume", {"session_id": resume})
             if not isinstance(reply, dict) or reply.get("ok") is False:
                 logger.warning("session %s: resume of %s refused: %r",
@@ -1003,7 +1059,9 @@ class GatewayConnection:
 
     async def session_title(self, params: dict[str, Any]) -> dict[str, Any]:
         title = str(params.get("title") or params.get("name") or "").strip()
-        result = await self._session(params).control_query("rename", {"name": title})
+        session = self._session(params)
+        session.titled = True
+        result = await session.control_query("rename", {"name": title})
         name = (result or {}).get("name") if isinstance(result, dict) else None
         # Also stamp the saved-session file so the sidebar row updates without a
         # live turn (rename control persists the runtime session; the sidebar
@@ -1025,6 +1083,10 @@ class GatewayConnection:
         session = self._session(params)
         text = str(params.get("text") or "")
         await session.submit_prompt(text)
+        # Scheduled, never awaited. Titling is a control round-trip, and this
+        # RPC's ack is what unlocks the composer — a session slow to answer the
+        # rename would otherwise hold the prompt ack for the control timeout.
+        session.schedule_auto_title(text)
         return {"ok": True}
 
     async def approval_respond(self, params: dict[str, Any]) -> dict[str, Any]:

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -514,3 +514,88 @@ def test_rewind_passes_the_refusal_through() -> None:
 
 def test_rewind_reports_a_session_that_did_not_answer() -> None:
     assert _rewind(None)["ok"] is False
+
+
+# ── auto session title ────────────────────────────────────────────────────────
+
+
+def _titling_session(tmp_path, titled: bool = False):
+    """A DesktopSession wired just enough to auto-title."""
+    from src.server.desktop_gateway_methods import DesktopSession
+
+    session = DesktopSession.__new__(DesktopSession)
+    session.session_id = "s1"
+    session.titled = titled
+    session._background = set()
+    renames: list[dict[str, Any]] = []
+    events: list[tuple[str, Any]] = []
+
+    async def _control_query(subtype: str, params: dict[str, Any]) -> Any:
+        renames.append({"subtype": subtype, **params})
+        return {"ok": True, "name": params.get("name")}
+
+    async def _broadcast(type_: str, payload: Any = None) -> None:
+        events.append((type_, payload))
+
+    class _State:
+        def saved_sessions_dir(self) -> str:
+            return str(tmp_path)
+
+    session.control_query = _control_query  # type: ignore[method-assign]
+    session._broadcast = _broadcast  # type: ignore[method-assign]
+    session.state = _State()  # type: ignore[assignment]
+    return session, renames, events
+
+
+def test_auto_title_names_an_untitled_session_after_its_first_prompt(tmp_path) -> None:
+    session, renames, events = _titling_session(tmp_path)
+
+    title = asyncio.run(session.auto_title("please add a retry button to the composer"))
+
+    # The heuristic strips the throat-clearing and capitalizes.
+    assert title == "Add a retry button to the composer"
+    assert renames[0]["name"] == title
+    assert ("session.title", {"title": title}) in events
+
+
+def test_auto_title_leaves_a_named_session_alone(tmp_path) -> None:
+    # A resumed session carries the user's own title, and an explicit rename
+    # is a decision auto-titling must not undo.
+    session, renames, events = _titling_session(tmp_path, titled=True)
+
+    assert asyncio.run(session.auto_title("something else entirely")) is None
+    assert renames == []
+    assert events == []
+
+
+def test_auto_title_happens_once_even_if_two_prompts_race(tmp_path) -> None:
+    # The flag is set BEFORE the rename round-trip, so a second prompt arriving
+    # while the first is in flight cannot start a second rename.
+    session, renames, _ = _titling_session(tmp_path)
+
+    asyncio.run(session.auto_title("first prompt"))
+    asyncio.run(session.auto_title("second prompt"))
+
+    assert len(renames) == 1
+
+
+def test_auto_title_skips_a_prompt_it_cannot_name(tmp_path) -> None:
+    # "Untitled session" is the heuristic's way of saying it has nothing; it
+    # would be a worse title than the blank it replaces.
+    session, renames, _ = _titling_session(tmp_path)
+
+    assert asyncio.run(session.auto_title("   ")) is None
+    assert renames == []
+    # …and the session stays open to being named by a later prompt.
+    assert session.titled is False
+
+
+def test_auto_title_survives_a_saved_file_it_cannot_stamp(tmp_path) -> None:
+    # The runtime rename is the part that matters; a file sync failure must not
+    # lose the title the client is about to be told about.
+    session, _renames, events = _titling_session(tmp_path / "does-not-exist")
+
+    title = asyncio.run(session.auto_title("run the tests"))
+
+    assert title == "Run the tests"
+    assert ("session.title", {"title": title}) in events

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -166,6 +166,7 @@ export type GatewayEventType =
   | 'message.start'
   | 'reasoning.delta'
   | 'session.info'
+  | 'session.title'
   | 'sessions.changed'
   | 'thinking.delta'
   | 'tool.complete'

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -166,6 +166,17 @@ function handleEvent(event: GatewayEvent): void {
 
   if (event.session_id !== undefined && event.session_id !== active) return
 
+  // The backend names an untitled session after its first prompt; the header
+  // reads this store, so without handling it the title would only appear on
+  // the next sidebar refresh.
+  if (event.type === 'session.title') {
+    const title = (event.payload as { title?: string } | undefined)?.title
+
+    if (title !== undefined && title !== '') $sessionTitle.set(title)
+
+    return
+  }
+
   $transcript.set(applyEvent($transcript.get(), event))
   $trajectory.set(applyTrajectoryEvent($trajectory.get(), event))
 

--- a/ui-web/src/state/transcript.test.ts
+++ b/ui-web/src/state/transcript.test.ts
@@ -330,7 +330,7 @@ describe('rehydration', () => {
 })
 
 describe('rewindLastTurn', () => {
-  const turn = (prompt: string, reply: string): GatewayEvent[] => [
+  const turn = (reply: string): GatewayEvent[] => [
     event('message.start'),
     event('message.delta', { text: reply }),
     event('message.complete'),
@@ -338,10 +338,10 @@ describe('rewindLastTurn', () => {
 
   function conversation(): TranscriptState {
     let state = appendUserMessage(emptyTranscript(), 'first question')
-    state = fold(turn('first question', 'first answer'), state)
+    state = fold(turn('first answer'), state)
     state = appendUserMessage(state, 'second question')
 
-    return fold(turn('second question', 'second answer'), state)
+    return fold(turn('second answer'), state)
   }
 
   it('cuts back to just before the last prompt and hands it back', () => {
@@ -380,9 +380,9 @@ describe('rewindLastTurn', () => {
   })
 
   it('keeps everything else on the state', () => {
-    const before = { ...conversation(), running: false, usage: { input: 5, output: 7 } }
+    const before = { ...conversation(), running: false, usage: { calls: 1, input: 5, output: 7, total: 12 } }
 
-    expect(rewindLastTurn(before)?.state.usage).toEqual({ input: 5, output: 7 })
+    expect(rewindLastTurn(before)?.state.usage).toEqual({ calls: 1, input: 5, output: 7, total: 12 })
   })
 
   it('returns null when there is no prompt to rewind to', () => {


### PR DESCRIPTION
The header read **"Untitled session"** for the life of a session, and the sidebar showed raw prompt text cut at 80 characters, mid-word.

`src/services/session_title.py::auto_title_from_message` already does this properly — strips the `please `/`can you `/`help me ` throat-clearing, capitalizes, truncates on a word — and was **wired to nothing at all**.

Titling happens in the gateway rather than the web client, so the desktop gets it too. A new `session.title` event carries it to whoever is watching, and the saved-session file is stamped for the sidebar.

## Why the heuristic and not the LLM

`session_title.py` also ships `generate_llm_title`, and it is **hardcoded to Anthropic and a fixed Haiku model**. On a session running any other provider that would bill an account the user did not choose to use here, and it silently returns `None` wherever Anthropic is not configured (which is the case on the machine I tested on). A first line with the throat-clearing stripped is a good title and costs nothing.

## Rules — all of them about not overwriting a name someone chose

- A **resumed** session is already titled; auto-titling would rename a saved conversation after whatever the user types next.
- An **explicit rename** marks the session titled, so it wins permanently.
- The flag is set **before** the rename round-trip, so two prompts racing cannot start two renames.
- A prompt the heuristic **cannot name** leaves the session open to being named by a later one.

## Scheduled, never awaited

Titling is a control round-trip, and `prompt.submit`'s ack is what unlocks the composer. Awaiting it made **the entire server test suite hang** on sessions whose stub agent never answers the rename — a good demonstration of what it would do to a real user behind a slow session.

## Testing

5 new backend specs. Full suites green: 665 server, 221 web. `tsc` clean, bundle builds.

Verified end to end for the prompt `please summarise what a quokka eats in one sentence`:

| path | value |
|---|---|
| `session.title` event | `Summarise what a quokka eats in one sentence` |
| `projects.tree` sidebar row | same |
| saved session file `name` | same |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
