### PR TITLE
feat(web): paste, drop and pick images into the composer

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -78,6 +78,24 @@ def permission_mode_for(approval_mode: Any) -> str | None:
     return _PERMISSION_MODE_FOR.get(approval_mode.strip().lower())
 
 
+def _vision_ok(model: Any) -> bool:
+    """Whether ``model`` accepts image input, for the composer's attach path.
+
+    Unknown ids stay permissive, which is `supports_vision`'s own rule: a model
+    absent from the table is assumed capable, because a real API error beats a
+    wrong refusal. Only an exact table hit of False takes the control away.
+    """
+    if not isinstance(model, str) or not model:
+        return True
+    try:
+        from src.models.capabilities import supports_vision
+
+        return supports_vision(model)
+    except Exception:  # noqa: BLE001 — a capability lookup must not break init
+        logger.debug("vision capability lookup failed for %r", model, exc_info=True)
+        return True
+
+
 def _init_session_info(init: dict[str, Any]) -> dict[str, Any]:
     """system/init frame → the ``session.info`` payload the renderer reads."""
     payload: dict[str, Any] = {"running": False, "desktop_contract": DESKTOP_CONTRACT}
@@ -90,6 +108,9 @@ def _init_session_info(init: dict[str, Any]) -> dict[str, Any]:
     model = init.get("model")
     if model:
         payload["model"] = model
+        # The composer hides its attach control when this is False, so a
+        # screenshot is never pasted into a model that would 400 on it.
+        payload["vision"] = _vision_ok(model)
     # The renderer's picker only prefers the session's selection when BOTH
     # model and provider are set (currentPickerSelection); omitting provider
     # made the picker fall back to the catalog while the composer chip kept
@@ -186,6 +207,9 @@ class DesktopSession:
             model = settings.get("fusion") or settings.get("model")
             if model:
                 payload["model"] = str(model)
+                # Republished on every model switch, so the attach control
+                # comes and goes with the model that would have to read it.
+                payload["vision"] = _vision_ok(str(model))
             if settings.get("provider"):
                 payload["provider"] = str(settings["provider"])
             if settings.get("permission_mode"):
@@ -815,6 +839,7 @@ class GatewayConnection:
             "complete.path": self.complete_empty,
             "fs.list_directory": self.fs_list_directory,
             "fs.search_files": self.fs_search_files,
+            "image.attach": self.image_attach,
             "slash.exec": self.slash_exec,
             "command.dispatch": self.command_dispatch,
             "setup.status": self.setup_status,
@@ -1102,6 +1127,76 @@ class GatewayConnection:
     async def permission_cycle(self, params: dict[str, Any]) -> dict[str, Any]:
         result = await self._session(params).control_query("cycle_permission_mode", {})
         return result or {}
+
+    async def image_attach(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Attach a pasted or dropped image to the next prompt.
+
+        The agent's ``attach_image`` control reads a path off the machine it
+        runs on, which a browser cannot produce. So the bytes come over the
+        socket and land in a temp file the control then reads — the agent side
+        stays exactly as the TUI uses it.
+
+        ``placeholder: True`` is deliberate. It tells the agent this client
+        renders an ``[Image #N]`` chip in the prompt text, which makes the chip
+        authoritative: an image whose chip is gone at submit is dropped. That
+        is how deleting the text un-attaches the image, and it is the same
+        contract the TUI composer relies on.
+        """
+        import base64
+        import os
+        import tempfile
+
+        raw = params.get("data")
+        if not isinstance(raw, str) or not raw:
+            return {"error": "no image data"}
+
+        # Accept a data: URL as well as bare base64 — that is what a browser
+        # paste hands you, and stripping it here beats making every caller.
+        if raw.startswith("data:"):
+            _, _, raw = raw.partition(",")
+
+        try:
+            blob = base64.b64decode(raw, validate=True)
+        except Exception:  # noqa: BLE001
+            return {"error": "image data was not valid base64"}
+
+        if not blob:
+            return {"error": "image data was empty"}
+
+        session = self._session(params)
+        model = str((session.init_info or {}).get("model") or "")
+        if not _vision_ok(model):
+            # Sending it anyway is a hard 400 from the provider that kills the
+            # turn; saying which model cannot read it is far more use than
+            # "Failed to deserialize the JSON body".
+            return {"error": f"{model} cannot read images — switch to a vision model first."}
+
+        name = str(params.get("name") or "pasted-image.png")
+        suffix = os.path.splitext(name)[1] or ".png"
+        handle, path = tempfile.mkstemp(prefix="clawcodex-paste-", suffix=suffix)
+        try:
+            with os.fdopen(handle, "wb") as fh:
+                fh.write(blob)
+            result = await session.control_query(
+                "attach_image", {"path": path, "placeholder": True}
+            )
+        finally:
+            # The control reads the file into memory, so the copy on disk is
+            # dead the moment it returns — including when it failed.
+            try:
+                os.unlink(path)
+            except OSError:
+                logger.debug("image.attach: could not remove %s", path)
+
+        if not isinstance(result, dict):
+            return {"error": "no response from the session"}
+        if result.get("attached") is not True:
+            return {"error": str(result.get("error") or "the session refused the image")}
+        return {
+            "attached": True,
+            "id": result.get("id"),
+            "name": result.get("name") or name,
+        }
 
     async def fs_search_files(self, params: dict[str, Any]) -> dict[str, Any]:
         """Workspace files matching ``query``, for the composer's @ mentions.

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -599,3 +599,135 @@ def test_auto_title_survives_a_saved_file_it_cannot_stamp(tmp_path) -> None:
 
     assert title == "Run the tests"
     assert ("session.title", {"title": title}) in events
+
+
+# ── image attach ──────────────────────────────────────────────────────────────
+#
+# The agent's attach_image control reads a path off the machine it runs on,
+# which a browser cannot produce. The gateway lands the bytes in a temp file so
+# the agent side stays exactly as the TUI uses it.
+
+
+def _attach(
+    reply: Any, params: dict[str, Any], model: str = "claude-sonnet-4-6"
+) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    from src.server.desktop_gateway_methods import GatewayConnection
+
+    seen: list[dict[str, Any]] = []
+
+    class _Session:
+        init_info = {"model": model}
+
+        async def control_query(self, subtype: str, args: dict[str, Any]) -> Any:
+            # Record what the control actually saw, contents included: the file
+            # is gone by the time the caller could look.
+            path = args.get("path")
+            body = b""
+            if isinstance(path, str) and os.path.exists(path):
+                with open(path, "rb") as fh:
+                    body = fh.read()
+            seen.append({"subtype": subtype, **args, "_body": body, "_existed": bool(body)})
+            return reply
+
+    connection = GatewayConnection.__new__(GatewayConnection)
+    connection._session = lambda p: _Session()  # type: ignore[method-assign]
+    return asyncio.run(GatewayConnection.image_attach(connection, params)), seen
+
+
+ONE_PIXEL_B64 = (
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=="
+)
+OK_REPLY = {"attached": True, "id": 1, "name": "shot.png"}
+
+
+def test_attach_writes_the_bytes_where_the_control_can_read_them() -> None:
+    result, seen = _attach(OK_REPLY, {"data": ONE_PIXEL_B64, "name": "shot.png"})
+
+    assert result == {"attached": True, "id": 1, "name": "shot.png"}
+    assert seen[0]["_existed"] is True
+    assert seen[0]["_body"].startswith(b"\x89PNG")
+
+
+def test_attach_asks_for_the_placeholder_contract() -> None:
+    # placeholder=True is what makes the [Image #N] chip authoritative, so
+    # deleting it in the composer un-attaches the image.
+    _result, seen = _attach(OK_REPLY, {"data": ONE_PIXEL_B64})
+
+    assert seen[0]["placeholder"] is True
+
+
+def test_attach_accepts_the_data_url_a_browser_paste_produces() -> None:
+    result, seen = _attach(OK_REPLY, {"data": f"data:image/png;base64,{ONE_PIXEL_B64}"})
+
+    assert result["attached"] is True
+    assert seen[0]["_body"].startswith(b"\x89PNG")
+
+
+def test_attach_removes_the_temp_file_afterwards() -> None:
+    _result, seen = _attach(OK_REPLY, {"data": ONE_PIXEL_B64})
+
+    # The control reads the file into memory, so the copy on disk is dead the
+    # moment it returns.
+    assert not os.path.exists(seen[0]["path"])
+
+
+def test_attach_removes_the_temp_file_even_when_the_control_refuses() -> None:
+    _result, seen = _attach({"error": "too many images"}, {"data": ONE_PIXEL_B64})
+
+    assert not os.path.exists(seen[0]["path"])
+
+
+@pytest.mark.parametrize(
+    "params", [{}, {"data": ""}, {"data": 5}, {"data": "not base64!!"}, {"data": "===="}]
+)
+def test_attach_rejects_data_it_cannot_decode(params: dict[str, Any]) -> None:
+    result, seen = _attach(OK_REPLY, params)
+
+    assert "error" in result
+    assert result.get("attached") is not True
+    # Nothing reached the session, so nothing was queued for the next prompt.
+    assert seen == []
+
+
+def test_attach_reports_a_refusal_rather_than_claiming_success() -> None:
+    result, _seen = _attach({"error": "too many images"}, {"data": ONE_PIXEL_B64})
+
+    assert result.get("attached") is not True
+    assert "too many images" in result["error"]
+
+
+def test_attach_reports_a_session_that_did_not_answer() -> None:
+    result, _seen = _attach(None, {"data": ONE_PIXEL_B64})
+
+    assert result.get("attached") is not True
+
+
+def test_attach_refuses_a_model_that_cannot_read_images() -> None:
+    # deepseek-v4-pro answers a request carrying an image with a hard 400 that
+    # kills the turn ("Failed to deserialize the JSON body"). Naming the model
+    # is far more use than passing that through.
+    result, seen = _attach(OK_REPLY, {"data": ONE_PIXEL_B64}, model="deepseek-v4-pro")
+
+    assert result.get("attached") is not True
+    assert "deepseek-v4-pro" in result["error"]
+    assert "cannot read images" in result["error"]
+    # Nothing was queued, so the next prompt is unaffected.
+    assert seen == []
+
+
+def test_attach_allows_a_model_the_table_has_never_heard_of() -> None:
+    # supports_vision' own rule: an unknown id is assumed capable, because a
+    # real API error beats a wrong refusal.
+    result, _seen = _attach(OK_REPLY, {"data": ONE_PIXEL_B64}, model="some-new-model-9000")
+
+    assert result["attached"] is True
+
+
+def test_vision_flag_follows_the_model() -> None:
+    from src.server.desktop_gateway_methods import _vision_ok
+
+    assert _vision_ok("deepseek-v4-pro") is False
+    assert _vision_ok("some-new-model-9000") is True
+    # An absent model is not evidence of anything.
+    assert _vision_ok("") is True
+    assert _vision_ok(None) is True

--- a/ui-web/src/conversation/ConversationRoot.tsx
+++ b/ui-web/src/conversation/ConversationRoot.tsx
@@ -171,6 +171,7 @@ export function ConversationRoot() {
       sessionModel={transcript.info.model}
       sessionProvider={transcript.info.provider}
       usage={usage}
+      vision={transcript.info.vision}
     />
   )
 

--- a/ui-web/src/conversation/InputBar.module.css
+++ b/ui-web/src/conversation/InputBar.module.css
@@ -245,3 +245,91 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+/* Attached images. The strip is a view of the draft, not a second source of
+   truth — a thumbnail is here because its [Image #N] chip is still in the
+   text, and removing either removes both. */
+.attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px 14px 0;
+}
+
+.thumb {
+  position: relative;
+  width: 56px;
+  height: 56px;
+  overflow: hidden;
+  border: 1px solid var(--cc-alias-border-l2);
+  border-radius: 10px;
+  background: var(--cc-alias-interactive-bg-hover);
+}
+
+.thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.thumbRemove {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--cc-alias-bg-mask-2);
+  color: var(--cc-alias-label-primary-foreground);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.thumb:hover .thumbRemove,
+.thumbRemove:focus-visible {
+  opacity: 1;
+}
+
+/* The number that ties the thumbnail to its [Image #N] chip in the text. */
+.thumbTag {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 0 4px;
+  border-radius: 0 6px 0 0;
+  background: var(--cc-alias-bg-mask-2);
+  color: var(--cc-alias-label-primary-foreground);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+  line-height: 14px;
+}
+
+.attachButton {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--cc-alias-label-tertiary);
+  cursor: pointer;
+}
+
+.attachButton:hover {
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-primary);
+}
+
+.hiddenPicker {
+  display: none;
+}

--- a/ui-web/src/conversation/InputBar.tsx
+++ b/ui-web/src/conversation/InputBar.tsx
@@ -14,10 +14,16 @@ import type {
   EffortOptionsResult,
   ModelOptionsResult,
 } from '../gateway/protocol.ts'
-import { searchFiles } from '../state/actions.ts'
+import { attachImage, searchFiles } from '../state/actions.ts'
 import { $commands, $notice } from '../state/store.ts'
-import { ArrowUpIcon, StopIcon } from '../ui/icons.tsx'
+import { ArrowUpIcon, PlusIcon, StopIcon, XIcon } from '../ui/icons.tsx'
 import { ContextMeter } from './ContextMeter.tsx'
+import {
+  insertPlaceholder,
+  liveAttachments,
+  removePlaceholder,
+  type Attachment,
+} from './attachments.ts'
 import { applyMention, mentionAt, type MentionToken } from './mentions.ts'
 import { EffortSelect } from './EffortSelect.tsx'
 import { ModelSelect } from './ModelSelect.tsx'
@@ -29,6 +35,8 @@ export interface InputBarProps {
   draft: string
   effort: EffortOptionsResult
   hero?: boolean
+  /** False when the session's model would 400 on an image. */
+  vision?: boolean
   models: ModelOptionsResult
   onApprovalModeChange: (mode: ApprovalMode) => void
   onDraftChange: (text: string) => void
@@ -68,6 +76,7 @@ export function InputBar({
   sessionModel,
   sessionProvider,
   usage,
+  vision = true,
 }: InputBarProps) {
   const commands = useStore($commands)
   const notice = useStore($notice)
@@ -145,6 +154,55 @@ export function InputBar({
       textarea.current?.focus()
     },
     [onDraftChange],
+  )
+
+  // Every image the session has accepted this composer session. What actually
+  // SENDS is whatever the draft still claims — see attachments.ts.
+  const [attachments, setAttachments] = useState<Attachment[]>([])
+  const picker = useRef<HTMLInputElement | null>(null)
+
+  const shown = useMemo(() => liveAttachments(draft, attachments), [attachments, draft])
+
+  // Object URLs outlive the component unless revoked, and a long session can
+  // paste a lot of screenshots.
+  useEffect(
+    () => () => {
+      for (const item of attachments) URL.revokeObjectURL(item.url)
+    },
+    [attachments],
+  )
+
+  const attach = useCallback(
+    async (file: File | Blob, name: string) => {
+      const id = await attachImage(file, name)
+
+      if (id === null) return
+
+      const element = textarea.current
+      const caret = element === null ? draft.length : element.selectionStart
+      const next = insertPlaceholder(draft, caret, id)
+
+      setAttachments(current => [...current, { id, name, url: URL.createObjectURL(file) }])
+      onDraftChange(next.text)
+
+      requestAnimationFrame(() => {
+        const live = textarea.current
+
+        if (live === null) return
+
+        live.focus()
+        live.setSelectionRange(next.caret, next.caret)
+      })
+    },
+    [draft, onDraftChange],
+  )
+
+  const dropAttachment = useCallback(
+    (id: number) => {
+      onDraftChange(removePlaceholder(draft, id))
+      textarea.current?.focus()
+    },
+    [draft, onDraftChange],
   )
 
   const acceptFile = useCallback(
@@ -324,10 +382,67 @@ export function InputBar({
             ))}
           </div>
         )}
+        {shown.length > 0 && (
+          <div className={css.attachments}>
+            {shown.map(item => (
+              <div className={css.thumb} key={item.id}>
+                <img alt={item.name} src={item.url} />
+                <button
+                  aria-label={`Remove ${item.name}`}
+                  className={css.thumbRemove}
+                  onClick={() => {
+                    dropAttachment(item.id)
+                  }}
+                  title="Remove this image"
+                  type="button"
+                >
+                  <XIcon size={10} />
+                </button>
+                <span className={css.thumbTag}>#{item.id}</span>
+              </div>
+            ))}
+          </div>
+        )}
         <div className={css.scroll}>
           <textarea
             aria-label="Message ClawCodex"
             className={css.input}
+            onDragOver={event => {
+              if (vision && event.dataTransfer.types.includes('Files')) event.preventDefault()
+            }}
+            onDrop={event => {
+              if (!vision) return
+
+              const file = [...event.dataTransfer.files].find(item =>
+                item.type.startsWith('image/'),
+              )
+
+              if (file === undefined) return
+
+              event.preventDefault()
+              void attach(file, file.name)
+            }}
+            onPaste={event => {
+              // A model that cannot read images must not swallow the paste —
+              // letting it through as text is better than attaching something
+              // the turn will 400 on.
+              if (!vision) return
+
+              // Only take over when an image is actually on the clipboard; a
+              // normal text paste must keep working.
+              const item = [...event.clipboardData.items].find(entry =>
+                entry.type.startsWith('image/'),
+              )
+
+              if (item === undefined) return
+
+              const file = item.getAsFile()
+
+              if (file === null) return
+
+              event.preventDefault()
+              void attach(file, file.name === '' ? 'pasted-image.png' : file.name)
+            }}
             onChange={event => {
               onDraftChange(event.target.value)
               syncMention(event.target)
@@ -348,6 +463,35 @@ export function InputBar({
         </div>
         <div className={css.row}>
           <div className={css.modes}>
+            {vision && (
+              <>
+            <input
+              accept="image/*"
+              className={css.hiddenPicker}
+              onChange={event => {
+                const file = event.target.files?.[0]
+
+                if (file !== undefined) void attach(file, file.name)
+                // Clear it, or picking the same file twice is inert.
+                event.target.value = ''
+              }}
+              ref={picker}
+              tabIndex={-1}
+              type="file"
+            />
+            <button
+              aria-label="Attach an image"
+              className={css.attachButton}
+              onClick={() => {
+                picker.current?.click()
+              }}
+              title="Attach an image"
+              type="button"
+            >
+              <PlusIcon size={14} />
+            </button>
+              </>
+            )}
             <PermissionSelect
               onChange={onApprovalModeChange}
               value={approvalMode ?? 'manual'}

--- a/ui-web/src/conversation/attachments.test.ts
+++ b/ui-web/src/conversation/attachments.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  insertPlaceholder,
+  isAttached,
+  liveAttachments,
+  placeholderFor,
+  removePlaceholder,
+  type Attachment,
+} from './attachments.ts'
+
+const shot = (id: number): Attachment => ({ id, name: `shot-${String(id)}.png`, url: `blob:${String(id)}` })
+
+describe('placeholderFor', () => {
+  it('matches the chip the backend looks for', () => {
+    // Anything else and the image is silently dropped at submit.
+    expect(placeholderFor(1)).toBe('[Image #1]')
+    expect(placeholderFor(12)).toBe('[Image #12]')
+  })
+})
+
+describe('isAttached', () => {
+  it('follows the draft, not a separate list', () => {
+    expect(isAttached('look at [Image #1] please', 1)).toBe(true)
+    expect(isAttached('look at this please', 1)).toBe(false)
+  })
+
+  it('does not confuse #1 with #12', () => {
+    expect(isAttached('see [Image #12]', 1)).toBe(false)
+  })
+})
+
+describe('liveAttachments', () => {
+  it('keeps only what the draft still claims', () => {
+    // Deleting the chip is the un-attach gesture; the strip has to agree.
+    const kept = liveAttachments('a [Image #2] b', [shot(1), shot(2)])
+
+    expect(kept.map(item => item.id)).toEqual([2])
+  })
+
+  it('orders by where the chips appear, not by id', () => {
+    const kept = liveAttachments('[Image #3] then [Image #1]', [shot(1), shot(3)])
+
+    expect(kept.map(item => item.id)).toEqual([3, 1])
+  })
+
+  it('is empty for a draft that mentions none of them', () => {
+    expect(liveAttachments('plain text', [shot(1)])).toEqual([])
+  })
+})
+
+describe('insertPlaceholder', () => {
+  it('inserts at the caret and reports where it lands', () => {
+    const result = insertPlaceholder('', 0, 1)
+
+    expect(result.text).toBe('[Image #1] ')
+    expect(result.caret).toBe(result.text.length)
+  })
+
+  it('spaces the chip off the preceding word', () => {
+    // "see this[Image #1]" reads badly and is harder to delete cleanly —
+    // and deleting it is the un-attach gesture.
+    expect(insertPlaceholder('see this', 8, 1).text).toBe('see this [Image #1] ')
+  })
+
+  it('does not double the space when there already is one', () => {
+    expect(insertPlaceholder('see this ', 9, 1).text).toBe('see this [Image #1] ')
+  })
+
+  it('inserts mid-draft without disturbing the rest', () => {
+    expect(insertPlaceholder('before after', 6, 2).text).toBe('before [Image #2] after')
+  })
+
+  it('clamps a caret outside the draft', () => {
+    expect(insertPlaceholder('abc', 99, 1).text).toBe('abc [Image #1] ')
+    expect(insertPlaceholder('abc', -4, 1).text).toBe('[Image #1] abc')
+  })
+})
+
+describe('removePlaceholder', () => {
+  it('drops the chip', () => {
+    expect(removePlaceholder('[Image #1] hello', 1)).toBe('hello')
+  })
+
+  it('collapses the space the chip leaves behind', () => {
+    expect(removePlaceholder('a [Image #1] b', 1)).toBe('a b')
+  })
+
+  it('leaves a draft that never had the chip alone', () => {
+    expect(removePlaceholder('a b', 1)).toBe('a b')
+  })
+
+  it('removes only the chip asked for', () => {
+    expect(removePlaceholder('[Image #1] [Image #2]', 1)).toBe('[Image #2]')
+  })
+})

--- a/ui-web/src/conversation/attachments.ts
+++ b/ui-web/src/conversation/attachments.ts
@@ -1,0 +1,84 @@
+/**
+ * Image attachments, tracked through the draft text.
+ *
+ * The backend queues an attached image and drains it into the next prompt —
+ * but only if its `[Image #N]` chip is still in the text at submit. That is
+ * the agent's own contract (`_drain_pending_images`: *"An image whose
+ * [Image #N] chip is gone from the text is DROPPED. That is how the chip
+ * doubles as un-attach"*), and it is why the draft, not a separate list, is
+ * the source of truth for what will actually be sent.
+ */
+
+export interface Attachment {
+  /** The number the backend assigned; the `[Image #N]` in the text. */
+  id: number
+  name: string
+  /** Object URL for the thumbnail, revoked when the attachment goes. */
+  url: string
+}
+
+/** The chip text for an attachment, exactly as the backend matches it. */
+export function placeholderFor(id: number): string {
+  return `[Image #${String(id)}]`
+}
+
+/** Whether the draft still claims this attachment. */
+export function isAttached(draft: string, id: number): boolean {
+  return draft.includes(placeholderFor(id))
+}
+
+/**
+ * The attachments the draft still claims, in the order their chips appear.
+ *
+ * Ordering by position rather than by id keeps the thumbnail strip matching
+ * what the reader sees in their own text after they have moved a chip around.
+ */
+export function liveAttachments(draft: string, all: Attachment[]): Attachment[] {
+  return all
+    .filter(item => isAttached(draft, item.id))
+    .sort((a, b) => draft.indexOf(placeholderFor(a.id)) - draft.indexOf(placeholderFor(b.id)))
+}
+
+/**
+ * Insert a chip at `caret`, and report where the caret lands.
+ *
+ * Spacing is deliberate: a chip welded to the preceding word ("see this[Image
+ * #1]") reads badly and, worse, is harder to delete cleanly — and deleting it
+ * is the un-attach gesture.
+ */
+export function insertPlaceholder(
+  draft: string,
+  caret: number,
+  id: number,
+): { caret: number; text: string } {
+  const at = Math.max(0, Math.min(caret, draft.length))
+  const before = draft.slice(0, at)
+  const after = draft.slice(at)
+  const lead = before === '' || /\s$/.test(before) ? '' : ' '
+  // A trailing space only where one is wanted: at the end of the draft it
+  // leaves the caret ready for the next word, but before existing text it
+  // would double the space already there.
+  const trail = after === '' || !/^\s/.test(after) ? ' ' : ''
+  const insertion = `${lead}${placeholderFor(id)}${trail}`
+
+  return { caret: at + insertion.length, text: before + insertion + after }
+}
+
+/** Drop the chip for `id` from the draft, collapsing the space it leaves. */
+export function removePlaceholder(draft: string, id: number): string {
+  const chip = placeholderFor(id)
+  const at = draft.indexOf(chip)
+
+  if (at < 0) return draft
+
+  let head = draft.slice(0, at)
+  let tail = draft.slice(at + chip.length)
+
+  // Close the gap the chip leaves. At an edge that means dropping the orphaned
+  // space entirely; in the middle it means collapsing two spaces into one.
+  if (head === '') tail = tail.replace(/^\s+/, '')
+  else if (tail === '') head = head.replace(/\s+$/, '')
+  else if (/\s$/.test(head) && /^\s/.test(tail)) tail = tail.replace(/^\s/, '')
+
+  return head + tail
+}

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -28,6 +28,8 @@ export interface SessionInfoPayload {
   model?: string
   provider?: string
   reasoning_effort?: string
+  /** Whether the session's model accepts image input; false hides the attach control. */
+  vision?: boolean
   running?: boolean
   stored_session_id?: string
 }

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -602,6 +602,59 @@ export async function searchFiles(query: string, limit = 12): Promise<string[]> 
   }
 }
 
+/**
+ * Send an image to the session; the reply's id becomes its `[Image #N]` chip.
+ *
+ * Returns null on any failure, having already said why — the composer has
+ * nothing useful to do with the error beyond not inserting a chip for an image
+ * that is not there.
+ */
+export async function attachImage(file: Blob, name: string): Promise<number | null> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) {
+    notice('Start a session before attaching an image.', 'error')
+
+    return null
+  }
+
+  try {
+    const data = await blobToBase64(file)
+    const result = await gateway().request<{ attached?: boolean; error?: string; id?: number }>(
+      'image.attach',
+      { data, name, session_id: sessionId },
+    )
+
+    if (result.attached !== true || typeof result.id !== 'number') {
+      notice(result.error ?? 'Could not attach that image', 'error')
+
+      return null
+    }
+
+    return result.id
+  } catch (error) {
+    notice(errorText(error), 'error')
+
+    return null
+  }
+}
+
+/** Blob to bare base64 (FileReader hands back a data: URL). */
+async function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+
+    reader.onerror = () => {
+      reject(new Error('could not read the image'))
+    }
+    reader.onload = () => {
+      const result = typeof reader.result === 'string' ? reader.result : ''
+      resolve(result.slice(result.indexOf(',') + 1))
+    }
+    reader.readAsDataURL(blob)
+  })
+}
+
 /* ── model + catalogs ────────────────────────────────────────────────────── */
 
 export async function refreshModels(): Promise<void> {


### PR DESCRIPTION
There was no way to show the agent a screenshot from a browser — the most common thing anyone wants to do when the subject is a UI.

## Bridging, not rewriting

The agent's `attach_image` control reads a path off the machine it runs on, which a browser cannot produce. So the gateway bridges it: the bytes come over the socket, land in a temp file the control reads, and the file is removed the moment it returns — including when it failed. **The agent side is untouched.**

## The draft is the source of truth

`placeholder: True` is the important part. It tells the agent this client renders an `[Image #N]` chip in the prompt text, which makes the chip authoritative:

> *"An image whose `[Image #N]` chip is gone from the text is DROPPED. That is how the chip doubles as un-attach."* — `_drain_pending_images`

So the thumbnail strip is a **view of the draft**, not a second list that could disagree with it. Deleting the chip text removes the thumbnail; removing the thumbnail deletes the chip text; the number on the thumbnail ties the two together. Same contract the TUI composer already uses.

## A model that can't see doesn't get the control

Sending an image to `deepseek-v4-pro` is a hard 400 that kills the turn:

```
Error code: 400 - Failed to deserialize the JSON body into the target type: messages[3]: unknown …
```

That is a terrible way to find out. `session.info` now carries a `vision` flag from `supports_vision`, republished on every model switch, and the composer hides the `+` button and lets paste and drop fall through as ordinary text. The RPC refuses too, naming the model — the client is a courtesy, the RPC is the guard.

Unknown model ids stay permissive, which is `supports_vision`' own documented rule: *"a model absent from the table is assumed capable, and a real API error is a better outcome than a wrong refusal."*

## Testing

15 new specs for the chip/draft logic, 11 new backend specs (byte round-trip, data-URL form, temp-file cleanup on both paths, malformed data, the vision gate). Full suites green: 680 server, 243 web. `tsc` clean, bundle builds.

Verified live in the browser:

| | |
|---|---|
| paste a PNG | draft becomes `[Image #1] `, thumbnail appears tagged `#1` |
| delete the chip text | thumbnail disappears |
| `gpt-5.6` session | `+` button present |
| `deepseek-v4-pro` session | `+` button absent, paste inert |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
