### PR TITLE
feat(web): a plan you can read before approving it

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -520,7 +520,9 @@ class DesktopSession:
              "request": {"subtype": subtype, **params}}
         )
 
-    async def respond_approval(self, choice: str) -> dict[str, Any]:
+    async def respond_approval(
+        self, choice: str, *, updates: list[dict[str, Any]] | None = None
+    ) -> dict[str, Any]:
         rid = self._last_ask_id
         request = self._pending_asks.pop(rid, None) if rid else None
         self._last_ask_id = None
@@ -535,7 +537,13 @@ class DesktopSession:
             "behavior": "allow",
             "updatedInput": request.get("input") or {},
         }
-        if choice in ("session", "always"):
+        if updates:
+            # Explicit updates come from a dialog that composed them itself —
+            # the plan review's "auto-accept edits" is a setMode the ask
+            # carries no suggestion for, so it cannot be picked from the list
+            # below.
+            reply["chosen_updates"] = updates
+        elif choice in ("session", "always"):
             wanted = "session" if choice == "session" else "always"
             chosen = [
                 s for s in (request.get("suggestions") or [])
@@ -840,6 +848,7 @@ class GatewayConnection:
             "fs.list_directory": self.fs_list_directory,
             "fs.search_files": self.fs_search_files,
             "image.attach": self.image_attach,
+            "plan.get": self.plan_get,
             "slash.exec": self.slash_exec,
             "command.dispatch": self.command_dispatch,
             "setup.status": self.setup_status,
@@ -1115,7 +1124,11 @@ class GatewayConnection:
         return {"ok": True}
 
     async def approval_respond(self, params: dict[str, Any]) -> dict[str, Any]:
-        return await self._session(params).respond_approval(str(params.get("choice") or "deny"))
+        raw = params.get("updates")
+        updates = [u for u in raw if isinstance(u, dict)] if isinstance(raw, list) else None
+        return await self._session(params).respond_approval(
+            str(params.get("choice") or "deny"), updates=updates
+        )
 
     async def question_respond(self, params: dict[str, Any]) -> dict[str, Any]:
         raw = params.get("answers")
@@ -1127,6 +1140,27 @@ class GatewayConnection:
     async def permission_cycle(self, params: dict[str, Any]) -> dict[str, Any]:
         result = await self._session(params).control_query("cycle_permission_mode", {})
         return result or {}
+
+    async def plan_get(self, params: dict[str, Any]) -> dict[str, Any]:
+        """The session's current plan text.
+
+        ExitPlanMode is a V2 tool: the plan lives in the session plan FILE, not
+        in the tool input, so an ``approval.request`` for it carries no plan to
+        show. The client fetches it when that ask arrives.
+
+        Fetched rather than folded into the ask because the ask is routed from
+        the pump, and a control query issued there would wait on a response
+        that same pump has to deliver.
+        """
+        result = await self._session(params).control_query("plan", {})
+        if not isinstance(result, dict) or result.get("ok") is False:
+            return {"plan": "", "mode": ""}
+        plan = result.get("plan")
+        return {
+            "mode": str(result.get("mode") or ""),
+            "path": str(result.get("plan_file_path") or ""),
+            "plan": plan if isinstance(plan, str) else "",
+        }
 
     async def image_attach(self, params: dict[str, Any]) -> dict[str, Any]:
         """Attach a pasted or dropped image to the next prompt.

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -731,3 +731,92 @@ def test_vision_flag_follows_the_model() -> None:
     # An absent model is not evidence of anything.
     assert _vision_ok("") is True
     assert _vision_ok(None) is True
+
+
+# ── plan review ───────────────────────────────────────────────────────────────
+#
+# ExitPlanMode is a V2 tool: the plan lives in the session plan FILE, not the
+# tool input, so the ask carries nothing to show and the client fetches it.
+
+
+def _plan_get(reply: Any) -> dict[str, Any]:
+    from src.server.desktop_gateway_methods import GatewayConnection
+
+    connection = GatewayConnection.__new__(GatewayConnection)
+    connection._session = lambda p: _Queryable(reply)  # type: ignore[method-assign]
+    return asyncio.run(GatewayConnection.plan_get(connection, {}))
+
+
+def test_plan_get_returns_the_plan_text() -> None:
+    result = _plan_get(
+        {"ok": True, "plan": "## Steps\n1. do it", "mode": "plan", "plan_file_path": "/p.md"}
+    )
+
+    assert result == {"mode": "plan", "path": "/p.md", "plan": "## Steps\n1. do it"}
+
+
+def test_plan_get_reports_an_absent_plan_as_empty_not_missing() -> None:
+    # get_plan returns None when the file does not exist; the panel renders its
+    # own "no plan" state rather than being handed a null.
+    assert _plan_get({"ok": True, "plan": None})["plan"] == ""
+
+
+@pytest.mark.parametrize("reply", [None, {"ok": False, "error": "boom"}, "nonsense"])
+def test_plan_get_degrades_to_empty_rather_than_raising(reply: Any) -> None:
+    # A failed fetch must still leave the approval answerable.
+    assert _plan_get(reply)["plan"] == ""
+
+
+def test_approval_respond_forwards_explicit_updates() -> None:
+    # ExitPlanMode's ask carries no suggestions, so the plan dialog composes
+    # its own setMode; without this it could not be sent at all.
+    session, agent, _ = _session()
+    asyncio.run(
+        session._route_ask(
+            {"request_id": "ask-1", "request": {"subtype": "can_use_tool", "input": {}}}
+        )
+    )
+
+    updates = [{"type": "setMode", "destination": "session", "mode": "acceptEdits"}]
+    asyncio.run(session.respond_approval("allow", updates=updates))
+
+    assert agent.replies[0]["response"]["chosen_updates"] == updates
+
+
+def test_explicit_updates_beat_the_suggestion_list() -> None:
+    session, agent, _ = _session()
+    asyncio.run(
+        session._route_ask(
+            {
+                "request_id": "ask-1",
+                "request": {
+                    "subtype": "can_use_tool",
+                    "input": {},
+                    "suggestions": [{"type": "addRules", "destination": "session"}],
+                },
+            }
+        )
+    )
+
+    updates = [{"type": "setMode", "destination": "session", "mode": "default"}]
+    asyncio.run(session.respond_approval("session", updates=updates))
+
+    assert agent.replies[0]["response"]["chosen_updates"] == updates
+
+
+def test_a_plain_approval_still_uses_its_suggestions() -> None:
+    # The explicit path must not disturb the ordinary allow-for-session flow.
+    session, agent, _ = _session()
+    suggestion = {"type": "addRules", "destination": "session"}
+    asyncio.run(
+        session._route_ask(
+            {
+                "request_id": "ask-1",
+                "request": {"subtype": "can_use_tool", "input": {}, "suggestions": [suggestion]},
+            }
+        )
+    )
+
+    asyncio.run(session.respond_approval("session"))
+
+    assert agent.replies[0]["response"]["chosen_updates"] == [suggestion]

--- a/ui-web/src/conversation/ConversationRoot.tsx
+++ b/ui-web/src/conversation/ConversationRoot.tsx
@@ -8,6 +8,8 @@ import {
   interrupt,
   renameSession,
   respondApproval,
+  fetchPlan,
+  respondPlan,
   respondQuestion,
   retryLastTurn,
   setApprovalMode,
@@ -41,6 +43,7 @@ import { ApprovalPanel } from './ApprovalPanel.tsx'
 import { ChatView } from './ChatView.tsx'
 import { HeroShell } from './HeroShell.tsx'
 import { InputBar } from './InputBar.tsx'
+import { PlanReviewPanel } from './PlanReviewPanel.tsx'
 import { QuestionComposer } from './QuestionComposer.tsx'
 import { QueueDock } from './QueueDock.tsx'
 import css from './ConversationRoot.module.css'
@@ -76,6 +79,8 @@ export function ConversationRoot() {
   const stats = useMemo(() => trajectoryStats(trajectory), [trajectory])
 
   const [draft, setDraft] = useState('')
+  // null while in flight, so the panel can say "loading" rather than "no plan".
+  const [plan, setPlan] = useState<string | null>(null)
   const [atBottom, setAtBottom] = useState(true)
   const scroller = useRef<HTMLDivElement | null>(null)
   const seat = useRef<HTMLDivElement | null>(null)
@@ -144,6 +149,28 @@ export function ConversationRoot() {
     [workspace],
   )
 
+  // ExitPlanMode's ask carries no plan — the plan is a session FILE — so it is
+  // fetched when that ask arrives, and cleared when it goes.
+  const planAsk = transcript.approval?.tool_name === 'ExitPlanMode'
+
+  useEffect(() => {
+    if (!planAsk) {
+      setPlan(null)
+
+      return
+    }
+
+    let live = true
+
+    void fetchPlan().then(text => {
+      if (live) setPlan(text)
+    })
+
+    return () => {
+      live = false
+    }
+  }, [planAsk])
+
   const composer = (
     <InputBar
       // The session's mode when there is one, otherwise the choice being held
@@ -183,7 +210,17 @@ export function ConversationRoot() {
    * once the tool is allowed or denied.
    */
   const seatPanel =
-    transcript.approval !== undefined ? (
+    planAsk ? (
+      <PlanReviewPanel
+        onApprove={approval => {
+          void respondPlan(approval)
+        }}
+        onReject={() => {
+          void respondPlan('reject')
+        }}
+        plan={plan}
+      />
+    ) : transcript.approval !== undefined ? (
       <ApprovalPanel
         onRespond={choice => {
           void respondApproval(choice)

--- a/ui-web/src/conversation/PlanReviewPanel.module.css
+++ b/ui-web/src/conversation/PlanReviewPanel.module.css
@@ -1,0 +1,66 @@
+/* Composer takeover for the plan-mode exit. Same footprint as the permission
+   ask and the question composer; a taller body, because the thing being
+   decided is a document rather than a line. */
+
+.root {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 8px calc(var(--cc-composer-side-clearance) + 16px) 12px;
+}
+
+.card {
+  width: 100%;
+  max-width: var(--cc-chat-content-width);
+  overflow: hidden;
+  border: 1px solid var(--cc-alias-border-l2);
+  border-radius: 20px;
+  background: var(--cc-specific-input-major);
+  box-shadow: var(--cc-shadow-lv2);
+  --cc-scrollbar-thumb: var(--cc-alias-scrollbar-bg-l2);
+  --cc-scrollbar-thumb-hover: var(--cc-alias-scrollbar-hover-l2);
+}
+
+.strip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-secondary);
+  font-size: 13px;
+  line-height: 18px;
+}
+
+/* A plan is the one takeover whose content is meant to be read in full, so it
+   gets more room than the others before it starts scrolling. */
+.body {
+  box-sizing: border-box;
+  max-height: calc(var(--cc-composer-text-max-height) + 80px);
+  padding: 4px 16px;
+  overflow-y: auto;
+}
+
+.plan {
+  font-size: 14px;
+  line-height: 22px;
+}
+
+.settling {
+  padding: 16px 0;
+  color: var(--cc-alias-label-caption);
+  font-size: 13px;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px 12px;
+}
+
+/* Pushes the two approve buttons right, away from "Keep planning" — the
+   destructive-ish choice should not sit under the cursor that just declined. */
+.spacer {
+  flex: 1;
+}

--- a/ui-web/src/conversation/PlanReviewPanel.test.tsx
+++ b/ui-web/src/conversation/PlanReviewPanel.test.tsx
@@ -1,0 +1,101 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { PlanReviewPanel, updatesFor } from './PlanReviewPanel.tsx'
+
+afterEach(cleanup)
+
+const PLAN = '## Steps\n\n1. Rename the thing\n2. Update its callers'
+
+describe('updatesFor', () => {
+  it('maps "edit freely" to acceptEdits', () => {
+    expect(updatesFor('auto')).toEqual([
+      { destination: 'session', mode: 'acceptEdits', type: 'setMode' },
+    ])
+  })
+
+  it('maps "ask before edits" to default', () => {
+    expect(updatesFor('manual')).toEqual([
+      { destination: 'session', mode: 'default', type: 'setMode' },
+    ])
+  })
+
+  it('never offers bypassPermissions', () => {
+    // Turning off every check is guarded by its own confirmation in the
+    // approval-mode picker; a plan dialog must not smuggle it in.
+    const modes = [...updatesFor('auto'), ...updatesFor('manual')].map(u => u.mode)
+
+    expect(modes).not.toContain('bypassPermissions')
+  })
+})
+
+describe('PlanReviewPanel', () => {
+  it('renders the plan as markdown', () => {
+    render(<PlanReviewPanel onApprove={vi.fn()} onReject={vi.fn()} plan={PLAN} />)
+
+    expect(screen.getByRole('heading', { name: 'Steps' })).toBeTruthy()
+    expect(screen.getByText('Rename the thing')).toBeTruthy()
+  })
+
+  it('says it is still loading rather than showing an empty plan', () => {
+    // "No plan" and "not fetched yet" are different, and only one of them is
+    // a reason to hesitate.
+    render(<PlanReviewPanel onApprove={vi.fn()} onReject={vi.fn()} plan={null} />)
+
+    expect(screen.getByText(/Loading the plan/)).toBeTruthy()
+  })
+
+  it('explains an empty plan instead of showing a blank card', () => {
+    render(<PlanReviewPanel onApprove={vi.fn()} onReject={vi.fn()} plan="   " />)
+
+    expect(screen.getByText(/wrote no plan file/)).toBeTruthy()
+    // The decision is still the user's to make.
+    expect(screen.getByRole('button', { name: 'Approve, edit freely' })).toBeTruthy()
+  })
+
+  it('offers both approvals and the way out', () => {
+    render(<PlanReviewPanel onApprove={vi.fn()} onReject={vi.fn()} plan={PLAN} />)
+
+    expect(screen.getByRole('button', { name: 'Keep planning' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Approve, ask before edits' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Approve, edit freely' })).toBeTruthy()
+  })
+
+  it('reports which approval was chosen', () => {
+    const onApprove = vi.fn()
+    render(<PlanReviewPanel onApprove={onApprove} onReject={vi.fn()} plan={PLAN} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve, ask before edits' }))
+    expect(onApprove).toHaveBeenCalledWith('manual')
+  })
+
+  it('reports the free-editing approval separately', () => {
+    const onApprove = vi.fn()
+    render(<PlanReviewPanel onApprove={onApprove} onReject={vi.fn()} plan={PLAN} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve, edit freely' }))
+    expect(onApprove).toHaveBeenCalledWith('auto')
+  })
+
+  it('keeps planning on Escape', () => {
+    // The safe end of the decision: the agent stays read-only.
+    const onReject = vi.fn()
+    render(<PlanReviewPanel onApprove={vi.fn()} onReject={onReject} plan={PLAN} />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onReject).toHaveBeenCalled()
+  })
+
+  it('cannot be approved twice by a double click', () => {
+    // Both answers resolve the same parked ask; the second is a reply to
+    // something that is no longer waiting.
+    const onApprove = vi.fn()
+    render(<PlanReviewPanel onApprove={onApprove} onReject={vi.fn()} plan={PLAN} />)
+
+    const button = screen.getByRole('button', { name: 'Approve, edit freely' })
+    fireEvent.click(button)
+    fireEvent.click(button)
+
+    expect(onApprove).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui-web/src/conversation/PlanReviewPanel.tsx
+++ b/ui-web/src/conversation/PlanReviewPanel.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useState } from 'react'
+
+import { Button } from '../ui/primitives/Button.tsx'
+import { Markdown } from '../ui/markdown/Markdown.tsx'
+import { ListIcon } from '../ui/icons.tsx'
+import css from './PlanReviewPanel.module.css'
+
+/** What approving a plan does to the permission mode. */
+export type PlanApproval = 'auto' | 'manual'
+
+/** The `setMode` update each choice sends as `chosen_updates`. */
+export function updatesFor(approval: PlanApproval): { destination: string; mode: string; type: string }[] {
+  return [
+    {
+      destination: 'session',
+      // `acceptEdits` lets file edits through and still asks about shell and
+      // everything else; `default` asks about all of it. Neither is
+      // bypassPermissions — turning off every check is a decision the
+      // approval-mode picker guards behind its own confirmation, and a plan
+      // dialog is not the place to smuggle it in.
+      mode: approval === 'auto' ? 'acceptEdits' : 'default',
+      type: 'setMode',
+    },
+  ]
+}
+
+export interface PlanReviewPanelProps {
+  /** null while the plan is still being fetched. */
+  plan: string | null
+  onApprove: (approval: PlanApproval) => void
+  onReject: () => void
+}
+
+/**
+ * The plan-mode exit, as a composer takeover.
+ *
+ * ExitPlanMode is a V2 tool — the plan lives in the session plan FILE, not the
+ * tool input — so the generic approval had nothing to show and rendered as
+ * "Use ExitPlanMode" over a blank card. Approving a plan you cannot read is
+ * not approval.
+ *
+ * The two approve buttons are the mode choice the TUI's dialog offers, and
+ * they are the point of the dialog: the plan is agreed either way, the
+ * question is whether the edits that follow need watching.
+ */
+export function PlanReviewPanel({ onApprove, onReject, plan }: PlanReviewPanelProps) {
+  const [busy, setBusy] = useState(false)
+
+  // Escape keeps planning. It is the safe end of this decision — the agent
+  // stays read-only — which is what a dismiss gesture should map to.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onReject()
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [onReject])
+
+  const approve = (approval: PlanApproval) => {
+    setBusy(true)
+    onApprove(approval)
+  }
+
+  return (
+    <div className={css.root}>
+      <section aria-labelledby="plan-review-title" className={css.card} role="dialog">
+        <div className={css.strip}>
+          <ListIcon size={14} />
+          <span id="plan-review-title">Ready to implement</span>
+        </div>
+
+        <div className={css.body}>
+          {plan === null ? (
+            <div className={css.settling}>Loading the plan…</div>
+          ) : plan.trim() === '' ? (
+            // Saying so beats an empty card that looks like a rendering
+            // failure — and the decision is still the user's to make.
+            <div className={css.settling}>
+              The agent wrote no plan file. Approving will leave plan mode anyway.
+            </div>
+          ) : (
+            <Markdown className={css.plan} text={plan} />
+          )}
+        </div>
+
+        <div className={css.actions}>
+          <Button disabled={busy} onClick={onReject} size="sm" variant="outline">
+            Keep planning
+          </Button>
+          <span className={css.spacer} />
+          <Button
+            disabled={busy}
+            onClick={() => {
+              approve('manual')
+            }}
+            size="sm"
+            variant="outline"
+          >
+            Approve, ask before edits
+          </Button>
+          <Button
+            disabled={busy}
+            onClick={() => {
+              approve('auto')
+            }}
+            size="sm"
+            variant="primary"
+          >
+            Approve, edit freely
+          </Button>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -50,6 +50,7 @@ import {
   emptyTrajectory,
   recordPrompt,
 } from './trajectory.ts'
+import { updatesFor } from '../conversation/PlanReviewPanel.tsx'
 import {
   appendUserMessage,
   applyEvent,
@@ -522,6 +523,52 @@ export async function respondQuestion(
 
   try {
     await gateway().request('question.respond', { action, answers, session_id: sessionId })
+  } catch (error) {
+    notice(errorText(error), 'error')
+  }
+}
+
+/** The session's plan text, for the plan-review takeover. */
+export async function fetchPlan(): Promise<string> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) return ''
+
+  try {
+    const result = await gateway().request<{ plan?: string }>('plan.get', {
+      session_id: sessionId,
+    })
+
+    return result.plan ?? ''
+  } catch {
+    // The panel shows its empty state; the decision is still available.
+    return ''
+  }
+}
+
+/**
+ * Approve the plan-mode exit, choosing what happens to the permission mode.
+ *
+ * The mode rides as an explicit `setMode` update rather than one of the ask's
+ * suggestions, because ExitPlanMode's ask carries none — the dialog is
+ * expected to compose it (`_exit_plan_mode_call`: "The dialog path already
+ * applied its setMode via chosen_updates BEFORE this runs").
+ */
+export async function respondPlan(
+  approval: 'auto' | 'manual' | 'reject',
+): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) return
+
+  $transcript.set(clearApproval($transcript.get()))
+
+  try {
+    await gateway().request('approval.respond', {
+      choice: approval === 'reject' ? 'deny' : 'allow',
+      session_id: sessionId,
+      ...(approval === 'reject' ? {} : { updates: updatesFor(approval) }),
+    })
   } catch (error) {
     notice(errorText(error), 'error')
   }


### PR DESCRIPTION
Plan-mode exit surfaced as a generic **"Use ExitPlanMode"** approval over a blank card.

ExitPlanMode is a V2 tool — *"the plan lives in the session plan FILE, not in the tool input"* — so the ask genuinely carries nothing to show. Approving a plan you cannot read is not approval.

`plan.get` fetches it (the `plan` control already returned exactly this and was wired to nothing on this surface), and the ask is replaced by a takeover that renders the plan as markdown.

**Fetched on the ask rather than folded into it:** the ask is routed from the pump, and a control query issued there would wait on a response that same pump has to deliver.

## The two approve buttons are the point

They are the mode choice the TUI's dialog offers. The plan is agreed either way; the question is whether the edits that follow need watching.

| button | update |
|---|---|
| Approve, ask before edits | `setMode default` |
| Approve, edit freely | `setMode acceptEdits` |
| Keep planning | deny — agent stays read-only |

**Neither is `bypassPermissions`.** Turning off every check is a decision the approval-mode picker guards behind its own confirmation, and a plan dialog is not the place to smuggle it in.

The mode rides as an explicit `chosen_updates` because ExitPlanMode's ask carries no suggestions to pick from — the dialog is expected to compose it:

> *"The dialog path already applied its setMode via chosen_updates BEFORE this runs"* — `_exit_plan_mode_call`

`approval.respond` grew an optional `updates` param for that. The ordinary allow-for-session path is untouched and still reads its suggestions (covered by a test).

Escape keeps planning, which is the safe end of the decision.

## Testing

11 new panel specs, 6 new backend specs. Full suites green: 688 server, 254 web. `tsc` clean, bundle builds.

Verified live against a plan-mode DeepSeek session:
- The plan file rendered as headed markdown — Context / Steps / Verification, inline code intact.
- "Approve, ask before edits" left plan mode, and the very next shell command (`mv note.txt readme.txt`) raised its own permission ask.
- The approval chip settled on **"Ask every time"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
