### PR TITLE
fix(web): the welcome screen named the wrong model

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -1319,7 +1319,19 @@ class GatewayConnection:
         # first prompt), or the session couldn't answer — enumerate the whole
         # registry directly from config. The catalog is session-independent;
         # it only needs the default provider + its model list.
-        return await asyncio.to_thread(_catalog_from_config)
+        catalog = await asyncio.to_thread(_catalog_from_config)
+        # …but what the FIRST session will actually run on is what `serve` was
+        # launched with, not the config default. Without this the composer
+        # advertises one model on the welcome screen and silently switches to
+        # another the moment a session starts.
+        config = self.state.agent_config
+        model = _clean(getattr(config, "model", None)) if config is not None else ""
+        provider = _clean(getattr(config, "provider_name", None)) if config is not None else ""
+        if model:
+            catalog["model"] = model
+        if provider:
+            catalog["provider"] = provider
+        return catalog
 
     def _first_session(self, params: dict[str, Any]) -> DesktopSession | None:
         session_id = str(params.get("session_id") or "")

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -820,3 +820,68 @@ def test_a_plain_approval_still_uses_its_suggestions() -> None:
     asyncio.run(session.respond_approval("session"))
 
     assert agent.replies[0]["response"]["chosen_updates"] == [suggestion]
+
+
+# ── the welcome screen's model chip ───────────────────────────────────────────
+
+
+def _model_options(agent_config: Any, catalog: dict[str, Any] | None = None) -> dict[str, Any]:
+    import src.server.desktop_gateway_methods as mod
+
+    connection = mod.GatewayConnection.__new__(mod.GatewayConnection)
+    connection._first_session = lambda p: None  # type: ignore[method-assign]
+
+    class _State:
+        pass
+
+    state = _State()
+    state.agent_config = agent_config
+    connection.state = state  # type: ignore[attr-defined]
+
+    base = catalog if catalog is not None else {
+        "model": "claude-sonnet-4-6",
+        "provider": "anthropic",
+        "providers": [],
+    }
+    original = mod._catalog_from_config
+    mod._catalog_from_config = lambda: dict(base)
+    try:
+        return asyncio.run(mod.GatewayConnection.model_options(connection, {}))
+    finally:
+        mod._catalog_from_config = original
+
+
+class _ServeConfig:
+    def __init__(self, model: str = "", provider_name: str = "") -> None:
+        self.model = model
+        self.provider_name = provider_name
+
+
+def test_welcome_chip_names_the_model_serve_was_launched_with() -> None:
+    # Otherwise the composer advertises the config default on the welcome
+    # screen and silently switches the moment a session starts.
+    result = _model_options(_ServeConfig(model="deepseek-v4-pro", provider_name="deepseek"))
+
+    assert result["model"] == "deepseek-v4-pro"
+    assert result["provider"] == "deepseek"
+
+
+def test_welcome_chip_falls_back_to_config_when_serve_overrode_nothing() -> None:
+    result = _model_options(_ServeConfig())
+
+    assert result["model"] == "claude-sonnet-4-6"
+    assert result["provider"] == "anthropic"
+
+
+def test_welcome_chip_survives_a_state_with_no_agent_config() -> None:
+    # Tests inject a bare spawn with no config; the catalog still answers.
+    result = _model_options(None)
+
+    assert result["model"] == "claude-sonnet-4-6"
+
+
+def test_a_serve_model_without_a_provider_still_names_the_model() -> None:
+    result = _model_options(_ServeConfig(model="deepseek-v4-pro"))
+
+    assert result["model"] == "deepseek-v4-pro"
+    assert result["provider"] == "anthropic"


### PR DESCRIPTION
Launching `clawcodex serve --provider deepseek --model deepseek-v4-pro` and opening the web UI showed **`claude-sonnet-4-6`** on the composer chip. Sending the first message silently swapped it to `deepseek-v4-pro` — so the chip had been naming a model that was never going to run.

`model.options` falls back to a config-only catalog when no session exists yet. That is right for *enumerating providers*, but wrong for the *current selection*: what the first session will actually run on is what `serve` was launched with. The gateway state already holds it as `agent_config`, so the fallback now stamps it over the config default.

Found by using the app rather than reading it — the chip is only wrong **before the first session**, so it looks correct in every screenshot taken after one.

## Testing

4 new backend specs, covering the override, the no-override fallback, a state with no `agent_config` (which tests inject), and a model without a provider. Full suite green: 692 server.

Verified live on a fresh backend: chip reads `deepseek-v4-pro`, tooltip `deepseek · deepseek-v4-pro`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
