### PR TITLE
fix(web): resuming a session lost its title

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -1033,6 +1033,8 @@ class GatewayConnection:
             if stored is not None:
                 response["messages"] = stored["messages"]
                 response["message_count"] = stored["message_count"]
+                if stored.get("title"):
+                    response["title"] = stored["title"]
         elif wanted and omit:
             response["messages_omitted"] = True
         return response

--- a/src/server/desktop_sessions.py
+++ b/src/server/desktop_sessions.py
@@ -102,7 +102,7 @@ def _display_kind(role: str, content: Any) -> str | None:
 
 
 def load_session_messages(sessions_dir: Path, session_id: str) -> dict[str, Any] | None:
-    """Transcript for one saved session: ``{messages, message_count}``.
+    """Transcript for one saved session: ``{messages, message_count, title}``.
 
     Messages pass through in their stored shape (string or content-block list)
     — the renderer already narrows both, live and rehydrated.
@@ -126,10 +126,15 @@ def load_session_messages(sessions_dir: Path, session_id: str) -> dict[str, Any]
         if kind:
             message["display_kind"] = kind
         messages.append(message)
+    # The stored name, so a resumed session keeps the title it was given —
+    # the sidebar reads it from this same file, and a header that disagreed
+    # with the row the user just clicked is its own small confusion.
+    name = data.get("name")
     return {
         "messages": messages,
         "message_count": len(messages),
         "session_id": str(data.get("session_id") or safe),
+        "title": str(name) if isinstance(name, str) and name.strip() else "",
     }
 
 

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -885,3 +885,39 @@ def test_a_serve_model_without_a_provider_still_names_the_model() -> None:
 
     assert result["model"] == "deepseek-v4-pro"
     assert result["provider"] == "anthropic"
+
+
+# ── resumed titles ────────────────────────────────────────────────────────────
+
+
+def _saved(tmp_path, **extra: Any) -> str:
+    import json
+
+    session_id = "ds_resume_me"
+    payload = {
+        "session_id": session_id,
+        "conversation": {"messages": [{"role": "user", "content": "hello"}]},
+        **extra,
+    }
+    (tmp_path / f"{session_id}.json").write_text(json.dumps(payload))
+    return session_id
+
+
+def test_a_saved_session_reports_its_stored_title(tmp_path) -> None:
+    # The sidebar reads the name from this same file; a header that disagreed
+    # with the row the user just clicked is its own small confusion.
+    from src.server.desktop_sessions import load_session_messages
+
+    session_id = _saved(tmp_path, name="Count slowly from 1 to 40")
+
+    assert load_session_messages(tmp_path, session_id)["title"] == "Count slowly from 1 to 40"
+
+
+@pytest.mark.parametrize("extra", [{}, {"name": ""}, {"name": "   "}, {"name": 7}])
+def test_a_session_with_no_usable_name_reports_no_title(tmp_path, extra: dict[str, Any]) -> None:
+    # Empty rather than absent, so the client's check is one shape not four.
+    from src.server.desktop_sessions import load_session_messages
+
+    session_id = _saved(tmp_path, **extra)
+
+    assert load_session_messages(tmp_path, session_id)["title"] == ""

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -201,6 +201,8 @@ export interface SessionResumeResult extends SessionCreateResult {
   messages?: StoredMessage[]
   messages_omitted?: boolean
   resumed?: string
+  /** The stored name, so the header keeps the title the sidebar row showed. */
+  title?: string
 }
 
 export interface ModelOption {

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -249,6 +249,11 @@ export async function resumeSession(storedId: string, cwd?: string): Promise<voi
 
     adoptSession(result)
 
+    // Without this the header falls back to its "Untitled session"
+    // placeholder while the sidebar row the user just clicked keeps showing
+    // the real name.
+    if (result.title !== undefined && result.title !== '') $sessionTitle.set(result.title)
+
     if (result.messages !== undefined && result.messages.length > 0) {
       $transcript.set({
         ...$transcript.get(),


### PR DESCRIPTION
Clicking a session in the sidebar replayed the conversation but left the header on its **"Untitled session"** placeholder — so the row said `Count slowly from 1 to 40` and the header, for the same conversation, said nothing.

`session.resume` returned no title, even though the stored file it reads the messages from carries one. It now returns it, and the client applies it the way it already applies a rename.

Empty string rather than an absent key for a session with no usable name, so the client's check is one shape instead of four.

Found during a pass over surfaces I had not exercised: resume, interrupt, the queue, slash commands, the details panel. This was the one thing broken. (The details panel and the slash palette both work; two earlier readings that looked like bugs were my own bad test selectors.)

## Testing

5 new backend specs — the stored title, and the four shapes of "no usable name". Full suites green: 697 server, 254 web. `tsc` clean, bundle builds.

Verified live: filtering to a stored session and clicking it replays the transcript **and** fills the header with the same name the row showed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
