### PR TITLE
fix: /bg never listed anything

### DIFF
--- a/src/server/desktop_slash.py
+++ b/src/server/desktop_slash.py
@@ -25,6 +25,17 @@ def _out(text: str) -> dict[str, Any]:
     return {"output": text, "type": "exec"}
 
 
+def _bg_row(task: dict[str, Any]) -> str:
+    """One background task as a line: id, status, and what it is running."""
+    status = str(task.get("status") or "?")
+    code = task.get("exit_code")
+    # An exit code is the whole story for a finished task and noise for a
+    # running one.
+    if status != "running" and isinstance(code, int):
+        status = f"{status} ({code})"
+    return f"{task.get('id', '?')}  {status}  {task.get('command', '')}".rstrip()
+
+
 def _num(arg: str | None, default: int = 1) -> int:
     try:
         return int(str(arg).strip()) if arg else default
@@ -139,10 +150,18 @@ async def dispatch_slash(control: ControlQuery, name: str, arg: str | None) -> d
                 r = await control("bg_agent", {"command": arg})
                 r = r if isinstance(r, dict) else {}
                 return _out(f"Started background agent {r.get('id', '')}.")
-            r = await control("bg_run", {"action": "list"})
+            # bg_list, not bg_run: bg_run REQUIRES a command and answers
+            # "usage: /bg <command>" without one, so the old call reported
+            # zero tasks however many were actually running.
+            r = await control("bg_list", {})
             r = r if isinstance(r, dict) else {}
-            procs = r.get("processes") or r.get("tasks") or []
-            return _out(f"{len(procs)} background task(s).")
+            tasks = [t for t in (r.get("tasks") or []) if isinstance(t, dict)]
+            if not tasks:
+                return _out("No background tasks.")
+            # Listed rather than counted: "3 background task(s)" tells you
+            # something is running but not what, whether it finished, or the
+            # id you would need to kill it.
+            return _out("\n".join(_bg_row(t) for t in tasks))
 
         if name == "version":
             from src import __version__

--- a/tests/server/test_desktop_slash.py
+++ b/tests/server/test_desktop_slash.py
@@ -149,3 +149,92 @@ def test_catalog_from_config_shows_only_configured() -> None:
     if current is not None:
         assert len(current["models"]) >= 1
 
+
+
+# ─── /bg listing ─────────────────────────────────────────────────────────────
+#
+# The list path used to call `bg_run` with `{"action": "list"}`. bg_run REQUIRES
+# a command and answers "usage: /bg <command>" without one, so `/bg` reported
+# zero tasks however many were actually running.
+
+
+def _bg_control(reply: dict, seen: list) -> object:
+    async def control(subtype: str, params: dict) -> dict:
+        seen.append((subtype, params))
+        return reply
+
+    return control
+
+
+@pytest.mark.asyncio
+async def test_bg_lists_via_bg_list_not_bg_run() -> None:
+    seen: list = []
+    reply = {
+        "ok": True,
+        "tasks": [{"id": "abc123", "command": "sleep 30", "status": "running", "exit_code": None}],
+    }
+
+    res = await dispatch_slash(_bg_control(reply, seen), "bg", None)
+
+    assert seen[0][0] == "bg_list"
+    assert "abc123" in res["output"]
+    assert "sleep 30" in res["output"]
+
+
+@pytest.mark.asyncio
+async def test_bg_lists_every_task_rather_than_counting_them() -> None:
+    # "3 background task(s)" says something is running but not what, whether it
+    # finished, or the id you would need to kill it.
+    seen: list = []
+    reply = {
+        "ok": True,
+        "tasks": [
+            {"id": "one", "command": "npm test", "status": "running", "exit_code": None},
+            {"id": "two", "command": "make build", "status": "exited", "exit_code": 0},
+        ],
+    }
+
+    res = await dispatch_slash(_bg_control(reply, seen), "bg", None)
+    lines = res["output"].splitlines()
+
+    assert len(lines) == 2
+    assert "npm test" in lines[0]
+    assert "make build" in lines[1]
+
+
+@pytest.mark.asyncio
+async def test_bg_shows_the_exit_code_of_a_finished_task_only() -> None:
+    # The code is the whole story for a finished task and noise for a live one.
+    seen: list = []
+    reply = {
+        "ok": True,
+        "tasks": [
+            {"id": "one", "command": "a", "status": "running", "exit_code": None},
+            {"id": "two", "command": "b", "status": "exited", "exit_code": 1},
+        ],
+    }
+
+    res = await dispatch_slash(_bg_control(reply, seen), "bg", None)
+    lines = res["output"].splitlines()
+
+    assert "(1)" in lines[1]
+    assert "(" not in lines[0]
+
+
+@pytest.mark.asyncio
+async def test_bg_says_so_when_there_is_nothing_running() -> None:
+    seen: list = []
+
+    res = await dispatch_slash(_bg_control({"ok": True, "tasks": []}, seen), "bg", None)
+
+    assert res["output"] == "No background tasks."
+
+
+@pytest.mark.asyncio
+async def test_bg_with_an_argument_still_starts_an_agent() -> None:
+    seen: list = []
+
+    res = await dispatch_slash(_bg_control({"ok": True, "id": "xyz"}, seen), "bg", "review the diff")
+
+    assert seen[0][0] == "bg_agent"
+    assert "xyz" in res["output"]


### PR DESCRIPTION
`/bg` with no argument always reported **"0 background task(s)"**, however many were running.

The list path called `bg_run` with `{"action": "list"}` — but `bg_run` **requires** a command and answers `usage: /bg <command>` without one. So the reply carried an error and no tasks, and the caller read that as an empty list.

Measured against one genuinely running task:

```
bg_run   -> ok=False  "usage: /bg <command>"
bg_list  -> ok=True   1 task
```

This is shared slash dispatch (`desktop_slash.dispatch_slash`, behind both `slash.exec` and `command.dispatch`), so it was broken for **every gateway client**, not just the web.

## Also: it lists rather than counts

A count tells you something is happening, but not what, whether it finished, or the id you would need to kill it:

```
6bb8e8a3  running   sleep 30
1de764a4  done (0)  true
```

The exit code shows only on a task that has finished — it is the whole story there and noise on a live one.

## Testing

5 new specs on the dispatch path (calls `bg_list`; lists every task; exit code on finished only; the empty case; `/bg <prompt>` still starts an agent). Full suite green: 702 server.

Verified end to end through the real `dispatch_slash` → `_do_bgtask` → `BackgroundTasks`: two tasks started, one left running, one allowed to exit, both listed correctly. The web reaches this through `slash.exec`, which I confirmed separately works by running `/context` in the browser.

## Context

I went looking for this while scoping a background-jobs *view* for the web — the reference has one, and `/bg` work has no visible home there. Turns out the more useful fix was that the command meant to show it never worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
