### PR TITLE
fix(web): picking a model ran the session on the wrong provider

### DIFF
--- a/ui-web/src/conversation/ModelSelect.test.ts
+++ b/ui-web/src/conversation/ModelSelect.test.ts
@@ -11,6 +11,14 @@ const CATALOG: ModelOptionsResult = {
   ],
 }
 
+/** The real shape: a display name beside the id the backend answers to. */
+const SLUGGED: ModelOptionsResult = {
+  providers: [
+    { models: ['deepseek-v4-flash'], name: 'DeepSeek', slug: 'deepseek' },
+    { models: ['claude-sonnet-4-6'], name: 'Anthropic Claude', slug: 'anthropic' },
+  ],
+}
+
 describe('buildModelMenu', () => {
   it('groups models under their provider', () => {
     const { items } = buildModelMenu(CATALOG)
@@ -82,5 +90,31 @@ describe('selectedModelId', () => {
   it('marks nothing when the model is unknown or absent', () => {
     expect(selectedModelId(choices, 'gpt-9', 'openai')).toBeUndefined()
     expect(selectedModelId(choices, '', '')).toBeUndefined()
+  })
+})
+
+describe('provider identity', () => {
+  it('sends the slug, not the display name', () => {
+    // "Unknown provider: DeepSeek" — the backend answers to "deepseek".
+    const { choices } = buildModelMenu(SLUGGED)
+
+    expect([...choices.values()]).toEqual([
+      { model: 'deepseek-v4-flash', provider: 'deepseek' },
+      { model: 'claude-sonnet-4-6', provider: 'anthropic' },
+    ])
+  })
+
+  it('still shows the display name as the heading', () => {
+    const { items } = buildModelMenu(SLUGGED)
+    const headings = items.filter(entry => 'text' in entry).map(entry => (entry as { text: string }).text)
+
+    expect(headings).toEqual(['DeepSeek', 'Anthropic Claude'])
+  })
+
+  it('falls back to the name when a row carries no slug', () => {
+    // Which is the shape every existing fixture uses.
+    const { choices } = buildModelMenu(CATALOG)
+
+    expect([...choices.values()][0]).toEqual({ model: 'deepseek-v4-pro', provider: 'deepseek' })
   })
 })

--- a/ui-web/src/conversation/ModelSelect.tsx
+++ b/ui-web/src/conversation/ModelSelect.tsx
@@ -36,7 +36,10 @@ export function buildModelMenu(models: ModelOptionsResult): {
 
     for (const model of list) {
       const id = `m${choices.size}`
-      choices.set(id, { model, provider: provider.name })
+      // The SLUG, not the display name: the backend answers to "deepseek" and
+      // rejects "DeepSeek" outright. Falls back to the name for a catalog row
+      // that carries no slug, which is what the shape was before.
+      choices.set(id, { model, provider: provider.slug ?? provider.name })
       items.push({ id, label: model })
     }
   }

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -210,8 +210,15 @@ export interface ModelOption {
   auth_type?: string
   is_current?: boolean
   models?: string[]
+  /** Display name — "DeepSeek", "Anthropic Claude", "Moonshot / Kimi". */
   name: string
   label?: string
+  /**
+   * The id the backend answers to — "deepseek", not "DeepSeek". Sending the
+   * display name back gets "Unknown provider: DeepSeek", so the menu shows
+   * `name` and sends `slug`.
+   */
+  slug?: string
 }
 
 export interface ModelOptionsResult {

--- a/ui-web/src/state/actions.test.ts
+++ b/ui-web/src/state/actions.test.ts
@@ -13,12 +13,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { GatewayClient } from '../gateway/client.ts'
 import {
   createSession,
+  setModel,
   dequeue,
   setGatewayClient,
   start,
   submitPrompt,
 } from './actions.ts'
-import { $queue, $sessionId, $transcript } from './store.ts'
+import { $queue, $sessionId, $sessionLoading, $transcript } from './store.ts'
 import { emptyTranscript, type AssistantNode } from './transcript.ts'
 
 /** Answers every RPC from a canned table and lets tests push events. */
@@ -264,5 +265,51 @@ describe('createSession', () => {
 
     expect($sessionId.get()).toBe('S2')
     expect($transcript.get().nodes).toEqual([])
+  })
+
+  it('spawns on the model picked before there was a session', async () => {
+    // The bug this covers: `setModel` with no session stores the choice and
+    // says it "rides the next session.create", but nothing carried it — so
+    // picking a deepseek model spawned the session on the config default
+    // provider (anthropic), which then 400s on the first turn.
+    const gateway = await connect()
+
+    await setModel('deepseek-v4-flash', 'deepseek')
+    await createSession({ cwd: '/repo' })
+    await settle()
+
+    const create = gateway.sent.find(frame => frame.method === 'session.create')
+
+    expect(create?.params).toMatchObject({
+      cwd: '/repo',
+      model: 'deepseek-v4-flash',
+      provider: 'deepseek',
+    })
+  })
+
+  it('lets an explicit option win over the picked model', async () => {
+    // A caller naming a model means it.
+    const gateway = await connect()
+
+    await setModel('deepseek-v4-flash', 'deepseek')
+    await createSession({ model: 'gpt-5.6-luna', provider: 'openai' })
+    await settle()
+
+    const create = gateway.sent.find(frame => frame.method === 'session.create')
+
+    expect(create?.params).toMatchObject({ model: 'gpt-5.6-luna', provider: 'openai' })
+  })
+
+  it('clears the loading flag when the create fails', async () => {
+    // Otherwise a failed create leaves "Loading session…" over an empty
+    // transcript with no way back to the composer.
+    const gateway = await connect()
+
+    $sessionLoading.set(true)
+    gateway.failing.add('session.create')
+    await createSession()
+    await settle()
+
+    expect($sessionLoading.get()).toBe(false)
   })
 })

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -217,9 +217,19 @@ export async function createSession(options: SessionSpawnOptions = {}): Promise<
 
   const params: Record<string, unknown> = { capabilities: CAPABILITIES }
 
+  // A model chosen before there was a session lives in $models, because
+  // `setModel` has nowhere else to put it. Reading it here is what makes that
+  // choice ride the create — without this the picker on the welcome screen
+  // changed the chip and nothing else, and the session spawned on the config
+  // default provider instead. Explicit options still win: a caller naming a
+  // model means it.
+  const selected = $models.get()
+  const provider = options.provider ?? selected.provider
+  const model = options.model ?? selected.model
+
   if (options.cwd !== undefined && options.cwd !== '') params.cwd = options.cwd
-  if (options.provider !== undefined && options.provider !== '') params.provider = options.provider
-  if (options.model !== undefined && options.model !== '') params.model = options.model
+  if (provider !== undefined && provider !== '') params.provider = provider
+  if (model !== undefined && model !== '') params.model = model
   if (options.effort !== undefined && options.effort !== '') params.reasoning_effort = options.effort
 
   try {
@@ -229,6 +239,12 @@ export async function createSession(options: SessionSpawnOptions = {}): Promise<
     await applyPendingApprovalMode()
   } catch (error) {
     notice(`Could not start a session: ${errorText(error)}`, 'error')
+  } finally {
+    // A create that fails must not leave a "Loading session…" spinner over an
+    // empty transcript: the composer is still usable, and the hero is the
+    // honest place to land. Resume owns this flag too, so clearing it here
+    // covers a create that interleaves with one.
+    $sessionLoading.set(false)
   }
 }
 


### PR DESCRIPTION
Reported from a relaunch: choosing `deepseek-v4-flash` on the welcome screen and sending a prompt spawned the session on **Anthropic**, which then 400'd. Two defects in a row, one hiding the other.

## 1. The choice never left the client

`setModel` with no session stores it in `$models`, and its own comment says it *"rides the next `session.create`"* — but `createSession` only read its `options` argument, and `ConversationRoot` passes `{ cwd }` alone. So the picker changed the chip and nothing else, and the session spawned on the config default provider.

`createSession` now falls back to the stored selection. An explicit option still wins — a caller naming a model means it.

## 2. The provider was sent as its display name

With (1) fixed the session refused to start at all:

```
agent-server failed to start: Unknown provider: DeepSeek
```

The catalog carries **both**:

```python
{'slug': 'deepseek', 'name': 'DeepSeek', 'models': [...]}
```

…and the menu was using `name` for the value as well as the heading. It now shows `name` and sends `slug`, falling back to the name for a row carrying neither (which is the shape every existing fixture uses).

## Also: the stuck spinner

The report came with a screenshot of **"Loading session…"** spinning above **"Could not start a session: request timed out after 120s"**. A failed create must land on the composer, not a spinner with no way back — `createSession` now clears the loading flag in a `finally`, as `resumeSession` already did.

The 120s timeout itself was downstream of (1): the session was spawning on a provider that is failing on that machine, and its retries outran the client's request timeout.

## Testing

3 new action specs, 3 new picker specs. **The regression test was verified against the old code** — it fails there and passes here. Full suite green: 260 web tests, `tsc` clean, bundle builds.

Verified live end to end:

| | |
|---|---|
| pick `deepseek-v4-flash` on the hero, send a prompt | replies `ALPHA`, ran on `deepseek · deepseek-v4-flash` |
| switch to `deepseek-v4-pro` mid-session | replies `BETA`, ran on `deepseek · deepseek-v4-pro` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
