### PR TITLE
feat(web): name the provider alongside the model

### DIFF
--- a/ui-web/src/conversation/ModelSelect.test.ts
+++ b/ui-web/src/conversation/ModelSelect.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ModelOptionsResult } from '../gateway/protocol.ts'
-import { buildModelMenu, selectedModelId } from './ModelSelect.tsx'
+import { buildModelMenu, qualifiedModel, selectedModelId } from './ModelSelect.tsx'
 
 const CATALOG: ModelOptionsResult = {
   providers: [
@@ -116,5 +116,28 @@ describe('provider identity', () => {
     const { choices } = buildModelMenu(CATALOG)
 
     expect([...choices.values()][0]).toEqual({ model: 'deepseek-v4-pro', provider: 'deepseek' })
+  })
+})
+
+describe('qualifiedModel', () => {
+  it('names the provider alongside the model', () => {
+    // The same id comes from more than one provider, with different keys and
+    // different bills; a bare name does not say which is running.
+    expect(qualifiedModel('deepseek-v4-pro', 'deepseek')).toBe('deepseek:deepseek-v4-pro')
+    expect(qualifiedModel('deepseek/deepseek-v4-pro', 'openrouter')).toBe(
+      'openrouter:deepseek/deepseek-v4-pro',
+    )
+  })
+
+  it('stays bare rather than showing a dangling colon', () => {
+    // An unqualified name is incomplete; a separator with nothing after it is
+    // broken.
+    expect(qualifiedModel('deepseek-v4-pro')).toBe('deepseek-v4-pro')
+    expect(qualifiedModel('deepseek-v4-pro', '')).toBe('deepseek-v4-pro')
+  })
+
+  it('falls back to a placeholder when there is no model at all', () => {
+    expect(qualifiedModel('')).toBe('Model')
+    expect(qualifiedModel('', 'deepseek')).toBe('Model')
   })
 })

--- a/ui-web/src/conversation/ModelSelect.tsx
+++ b/ui-web/src/conversation/ModelSelect.tsx
@@ -47,6 +47,18 @@ export function buildModelMenu(models: ModelOptionsResult): {
   return { choices, items }
 }
 
+/**
+ * How a model is named wherever it appears: `provider:model`.
+ *
+ * Bare until a provider is known, rather than showing a lone colon — an
+ * unqualified name is incomplete, but a dangling separator is broken.
+ */
+export function qualifiedModel(model: string, provider?: string): string {
+  if (model === '') return 'Model'
+
+  return provider === undefined || provider === '' ? model : `${provider}:${model}`
+}
+
 /** The row to check: the exact pair when the catalog has it, else the model. */
 export function selectedModelId(
   choices: Map<string, ModelChoice>,
@@ -114,7 +126,11 @@ export function ModelSelect({
     [choices, onChange],
   )
 
-  const label = currentModel === '' ? 'Model' : currentModel
+  // Qualified, because the same model id is offered by several providers —
+  // `deepseek-v4-pro` comes from both deepseek and openrouter, and they are
+  // different choices with different keys and different bills. A bare model
+  // name does not say which one is running.
+  const label = qualifiedModel(currentModel, currentProvider)
 
   return (
     <Menu
@@ -129,7 +145,7 @@ export function ModelSelect({
           onClick={() => {
             setOpen(value => !value)
           }}
-          title={currentProvider === '' ? label : `${currentProvider} · ${label}`}
+          title={`Model: ${label}`}
           type="button"
         >
           <span className={css.triggerLabel}>{label}</span>

--- a/ui-web/src/trajectory/RunStatsBar.test.tsx
+++ b/ui-web/src/trajectory/RunStatsBar.test.tsx
@@ -44,7 +44,7 @@ describe('RunStatsBar', () => {
     // A fresh session still says what it is about to run on.
     render(<RunStatsBar model="deepseek-v4-pro" provider="deepseek" stats={EMPTY} />)
 
-    expect(screen.getByText('deepseek · deepseek-v4-pro')).toBeTruthy()
+    expect(screen.getByText('deepseek:deepseek-v4-pro')).toBeTruthy()
     expect(text()).not.toMatch(/turn|LLM|tok/)
   })
 

--- a/ui-web/src/trajectory/RunStatsBar.tsx
+++ b/ui-web/src/trajectory/RunStatsBar.tsx
@@ -1,3 +1,4 @@
+import { qualifiedModel } from '../conversation/ModelSelect.tsx'
 import { formatMs, formatTokens, type TrajectoryStats } from '../state/trajectory.ts'
 import css from './RunStatsBar.module.css'
 
@@ -31,9 +32,7 @@ export function RunStatsBar({ model, provider, stats }: RunStatsBarProps) {
     <div className={css.root}>
       {named && (
         <span className={css.group}>
-          <span className={css.model}>
-            {provider === undefined || provider === '' ? model : `${provider} · ${model}`}
-          </span>
+          <span className={css.model}>{qualifiedModel(model ?? '', provider)}</span>
         </span>
       )}
 


### PR DESCRIPTION
A bare model name does not say what is running. The same id is offered by more than one provider — `deepseek-v4-pro` comes from deepseek *and* from openrouter — and those are different choices with different keys and different bills.

The wrong-provider bug in #856 was invisible on screen for exactly this reason: the chip said `deepseek-v4-flash` while the session ran on Anthropic.

The composer chip and the run stats bar now both read `provider:model`:

```
deepseek:deepseek-v4-pro
```

Through **one helper**, so the two cannot drift into different formats for the same fact. It replaces the stats bar's `provider · model`, which had the further problem of using the same separator as the bar's own group divider.

Bare until a provider is known, rather than a dangling colon — an unqualified name is incomplete, but a separator with nothing after it is broken.

Menu items stay unqualified: they sit under a provider heading that already says which one, and repeating it on every row would be noise.

## Testing

3 new helper specs. Full suite green: 260 web tests, `tsc` clean, bundle builds. Verified live — chip and stats bar both read `deepseek:deepseek-v4-pro`, and the label already ellipsises, so the longer string cannot push the other chips out of the row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
