### PR TITLE
feat(web): a settings page, starting with providers and keys

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -849,6 +849,9 @@ class GatewayConnection:
             "fs.search_files": self.fs_search_files,
             "image.attach": self.image_attach,
             "plan.get": self.plan_get,
+            "provider.list": self.provider_list,
+            "provider.save_key": self.provider_save_key,
+            "provider.disconnect": self.provider_disconnect,
             "slash.exec": self.slash_exec,
             "command.dispatch": self.command_dispatch,
             "setup.status": self.setup_status,
@@ -1142,6 +1145,79 @@ class GatewayConnection:
     async def permission_cycle(self, params: dict[str, Any]) -> dict[str, Any]:
         result = await self._session(params).control_query("cycle_permission_mode", {})
         return result or {}
+
+    async def provider_list(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Every provider ClawCodex knows, configured or not.
+
+        Deliberately NOT ``model.options``, which filters to the configured
+        ones: that is right for a picker (you cannot run on a provider you have
+        no key for) and wrong for settings, where the whole point is adding a
+        key to one you have not set up yet.
+
+        Carries no secrets — the catalog reports ``authenticated`` and the
+        environment variable a key could come from, never the key itself.
+        """
+        session = self._first_session(params)
+        if session is not None:
+            result = await session.control_query("list_model_providers", {})
+            if isinstance(result, dict) and result.get("providers"):
+                return {
+                    "current": result.get("provider") or "",
+                    "providers": result["providers"],
+                }
+        catalog = await asyncio.to_thread(_catalog_from_config)
+        return {
+            "current": catalog.get("provider") or "",
+            "providers": catalog.get("providers") or [],
+        }
+
+    async def provider_save_key(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Store an API key for a provider, where `clawcodex login` stores it.
+
+        Needs a live session because the control lives on the agent: the reply
+        is the provider's refreshed catalog row, so the client can show the new
+        state without a second round trip — and without ever being handed the
+        key back.
+        """
+        session = self._first_session(params)
+        if session is None:
+            return {"ok": False, "error": "start a session before changing providers"}
+        result = await session.control_query(
+            "save_provider_key",
+            {"slug": _clean(params.get("slug")), "api_key": str(params.get("api_key") or "")},
+        )
+        if not isinstance(result, dict):
+            return {"ok": False, "error": "no response from the session"}
+        return {
+            "error": str(result.get("error") or ""),
+            "ok": result.get("ok") is not False,
+            "provider": result.get("provider"),
+        }
+
+    async def provider_disconnect(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Clear a provider's stored credentials.
+
+        The agent refuses the ACTIVE provider — this session holds a
+        constructed provider instance, and pulling its key would leave the next
+        turn firing at an endpoint it can no longer authenticate against — and
+        reports honestly when the key lives in the real shell environment,
+        where nothing here can remove it. Both are passed through rather than
+        smoothed into a generic failure.
+        """
+        session = self._first_session(params)
+        if session is None:
+            return {"ok": False, "error": "start a session before changing providers"}
+        result = await session.control_query(
+            "disconnect_provider", {"slug": _clean(params.get("slug"))}
+        )
+        if not isinstance(result, dict):
+            return {"ok": False, "error": "no response from the session"}
+        return {
+            "error": str(result.get("error") or ""),
+            "message": str(result.get("message") or ""),
+            "ok": result.get("ok") is not False,
+            "provider": result.get("provider"),
+        }
 
     async def plan_get(self, params: dict[str, Any]) -> dict[str, Any]:
         """The session's current plan text.

--- a/ui-web/src/App.tsx
+++ b/ui-web/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 
 import { ConversationRoot } from './conversation/ConversationRoot.tsx'
 import { DetailsPanel } from './details/DetailsPanel.tsx'
+import { SettingsOverlay } from './settings/SettingsOverlay.tsx'
 import { AppFrame } from './layout/AppFrame.tsx'
 import { Sidebar } from './sidebar/Sidebar.tsx'
 import { createSession, start } from './state/actions.ts'
@@ -106,10 +107,15 @@ export function App() {
   if (phase !== 'ready') return <BootScreen error={phase === 'failed' ? error : ''} />
 
   return (
-    <AppFrame
-      conversation={<ConversationRoot />}
-      details={detailsWidth === 0 ? null : <DetailsPanel />}
-      sidebar={state => <Sidebar collapsed={state.collapsed} />}
-    />
+    <>
+      <AppFrame
+        conversation={<ConversationRoot />}
+        details={detailsWidth === 0 ? null : <DetailsPanel />}
+        sidebar={state => <Sidebar collapsed={state.collapsed} />}
+      />
+      {/* Outside the frame: it covers the whole app, including the sidebar
+          it is opened from. */}
+      <SettingsOverlay />
+    </>
   )
 }

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -209,6 +209,9 @@ export interface ModelOption {
   authenticated?: boolean
   auth_type?: string
   is_current?: boolean
+  /** The environment variable a key could come from, e.g. DEEPSEEK_API_KEY. */
+  key_env?: string
+  total_models?: number
   models?: string[]
   /** Display name — "DeepSeek", "Anthropic Claude", "Moonshot / Kimi". */
   name: string
@@ -219,6 +222,19 @@ export interface ModelOption {
    * `name` and sends `slug`.
    */
   slug?: string
+}
+
+/** `provider.list` — every provider, configured or not. Carries no secrets. */
+export interface ProviderListResult {
+  current?: string
+  providers?: ModelOption[]
+}
+
+export interface ProviderMutationResult {
+  error?: string
+  message?: string
+  ok?: boolean
+  provider?: ModelOption
 }
 
 export interface ModelOptionsResult {

--- a/ui-web/src/settings/ProvidersSection.test.tsx
+++ b/ui-web/src/settings/ProvidersSection.test.tsx
@@ -1,0 +1,188 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ModelOption } from '../gateway/protocol.ts'
+import { ProvidersSection, credentialState, orderProviders, takesKey } from './ProvidersSection.tsx'
+
+afterEach(cleanup)
+
+const DEEPSEEK: ModelOption = {
+  authenticated: true,
+  auth_type: 'api_key',
+  is_current: true,
+  key_env: 'DEEPSEEK_API_KEY',
+  name: 'DeepSeek',
+  slug: 'deepseek',
+  total_models: 4,
+}
+const OPENAI: ModelOption = {
+  authenticated: true,
+  auth_type: 'api_key',
+  name: 'OpenAI',
+  slug: 'openai',
+  total_models: 9,
+}
+const GROQ: ModelOption = { authenticated: false, name: 'Groq', slug: 'groq', total_models: 3 }
+
+describe('orderProviders', () => {
+  it('puts the running provider first, then the configured ones', () => {
+    // The catalog knows ~30 providers and a user has set up two.
+    const order = orderProviders([GROQ, OPENAI, DEEPSEEK]).map(p => p.slug)
+
+    expect(order).toEqual(['deepseek', 'openai', 'groq'])
+  })
+
+  it('sorts the unconfigured rest by name', () => {
+    const zed: ModelOption = { authenticated: false, name: 'Zed', slug: 'zed' }
+    const ace: ModelOption = { authenticated: false, name: 'Ace', slug: 'ace' }
+
+    expect(orderProviders([zed, ace]).map(p => p.slug)).toEqual(['ace', 'zed'])
+  })
+
+  it('does not mutate the array it was given', () => {
+    const input = [GROQ, DEEPSEEK]
+
+    orderProviders(input)
+
+    expect(input[0]?.slug).toBe('groq')
+  })
+})
+
+describe('credentialState', () => {
+  it('distinguishes a key from a sign-in', () => {
+    // "Key set" invites Replace; "Signed in" does not mean the same thing.
+    expect(credentialState(DEEPSEEK)).toBe('Key set')
+    expect(credentialState({ ...OPENAI, auth_type: 'subscription' })).toBe('Signed in')
+    expect(credentialState({ ...OPENAI, auth_type: 'oauth' })).toBe('Signed in')
+  })
+
+  it('says so when there is nothing', () => {
+    expect(credentialState(GROQ)).toBe('No key')
+  })
+})
+
+describe('ProvidersSection', () => {
+  const props = { onDisconnect: vi.fn(), onSave: vi.fn().mockResolvedValue(true) }
+
+  it('marks the provider the session is running on', () => {
+    render(<ProvidersSection {...props} providers={[DEEPSEEK]} />)
+
+    expect(screen.getByText('Running')).toBeTruthy()
+  })
+
+  it('offers Add for an unconfigured provider and Replace for a configured one', () => {
+    render(<ProvidersSection {...props} providers={[DEEPSEEK, GROQ]} />)
+
+    expect(screen.getByRole('button', { name: 'Replace key' })).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Add key' })).toBeTruthy()
+  })
+
+  it('offers Disconnect only where there is something to disconnect', () => {
+    render(<ProvidersSection {...props} providers={[GROQ]} />)
+
+    expect(screen.queryByRole('button', { name: 'Disconnect' })).toBeNull()
+  })
+
+  it('names the environment variable a key could come from', () => {
+    // A key exported in the shell cannot be removed from here, and this is the
+    // only clue to where it came from.
+    render(<ProvidersSection {...props} providers={[DEEPSEEK]} />)
+
+    expect(screen.getByText('DEEPSEEK_API_KEY')).toBeTruthy()
+  })
+
+  it('masks the key field', () => {
+    // Settings pages get screen-shared.
+    render(<ProvidersSection {...props} providers={[GROQ]} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Add key' }))
+
+    expect(screen.getByLabelText('API key for Groq').getAttribute('type')).toBe('password')
+  })
+
+  it('sends the slug and the typed key', async () => {
+    const onSave = vi.fn().mockResolvedValue(true)
+    render(<ProvidersSection onDisconnect={vi.fn()} onSave={onSave} providers={[GROQ]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add key' }))
+    fireEvent.change(screen.getByLabelText('API key for Groq'), { target: { value: ' sk-abc ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onSave).toHaveBeenCalledWith('groq', 'sk-abc')
+  })
+
+  it('will not save an empty key', () => {
+    const onSave = vi.fn()
+    render(<ProvidersSection onDisconnect={vi.fn()} onSave={onSave} providers={[GROQ]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add key' }))
+    fireEvent.change(screen.getByLabelText('API key for Groq'), { target: { value: '   ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('clears the field after a save, so a secret is not left on screen', async () => {
+    const onSave = vi.fn().mockResolvedValue(false)
+    render(<ProvidersSection onDisconnect={vi.fn()} onSave={onSave} providers={[GROQ]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add key' }))
+    const field = screen.getByLabelText('API key for Groq')
+    fireEvent.change(field, { target: { value: 'sk-abc' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    // Even on failure: a failed save is a reason to retype, not to leave it up.
+    await waitFor(() => {
+      expect((screen.getByLabelText('API key for Groq') as HTMLInputElement).value).toBe('')
+    })
+  })
+
+  it('reports the provider to disconnect by slug', () => {
+    const onDisconnect = vi.fn()
+    render(<ProvidersSection onDisconnect={onDisconnect} onSave={vi.fn()} providers={[DEEPSEEK]} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }))
+
+    expect(onDisconnect).toHaveBeenCalledWith('deepseek')
+  })
+
+  it('says so when there is nothing to show', () => {
+    render(<ProvidersSection {...props} providers={[]} />)
+
+    expect(screen.getByText('No providers to show.')).toBeTruthy()
+  })
+})
+
+describe('providers that take no key', () => {
+  // ollama, sglang and vllm are local endpoints: auth_type "none". There is
+  // nothing to set and nothing to disconnect.
+  const OLLAMA: ModelOption = {
+    authenticated: true,
+    auth_type: 'none',
+    key_env: 'OLLAMA_API_KEY',
+    name: 'Ollama (local)',
+    slug: 'ollama',
+    total_models: 1,
+  }
+
+  it('knows which providers take one', () => {
+    expect(takesKey(OLLAMA)).toBe(false)
+    expect(takesKey(DEEPSEEK)).toBe(true)
+  })
+
+  it('says so rather than claiming a key is set', () => {
+    expect(credentialState(OLLAMA)).toBe('No key needed')
+  })
+
+  it('offers neither Add, Replace nor Disconnect', () => {
+    render(<ProvidersSection onDisconnect={vi.fn()} onSave={vi.fn()} providers={[OLLAMA]} />)
+
+    expect(screen.queryByRole('button', { name: /key/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Disconnect' })).toBeNull()
+  })
+
+  it('does not name an environment variable that is not used', () => {
+    render(<ProvidersSection onDisconnect={vi.fn()} onSave={vi.fn()} providers={[OLLAMA]} />)
+
+    expect(screen.queryByText('OLLAMA_API_KEY')).toBeNull()
+  })
+})

--- a/ui-web/src/settings/ProvidersSection.tsx
+++ b/ui-web/src/settings/ProvidersSection.tsx
@@ -1,0 +1,198 @@
+import { useState } from 'react'
+
+import type { ModelOption } from '../gateway/protocol.ts'
+import { Button } from '../ui/primitives/Button.tsx'
+import { CheckIcon, XIcon } from '../ui/icons.tsx'
+import css from './Settings.module.css'
+
+/**
+ * Order providers by how much the reader cares: the one running now, then the
+ * ones with credentials, then the rest alphabetically. The catalog knows ~30
+ * providers and a user has configured two of them.
+ */
+export function orderProviders(providers: ModelOption[]): ModelOption[] {
+  return [...providers].sort((a, b) => {
+    if ((a.is_current === true) !== (b.is_current === true)) return a.is_current === true ? -1 : 1
+    if ((a.authenticated === true) !== (b.authenticated === true)) {
+      return a.authenticated === true ? -1 : 1
+    }
+
+    return (a.name ?? '').localeCompare(b.name ?? '')
+  })
+}
+
+/**
+ * Whether this provider takes a key at all.
+ *
+ * Local endpoints — ollama, sglang, vllm — report `auth_type: "none"`. There
+ * is nothing to set and nothing to disconnect, so offering either would be
+ * offering something that cannot happen.
+ */
+export function takesKey(provider: ModelOption): boolean {
+  return provider.auth_type !== 'none'
+}
+
+/** What to tell the reader about a provider's credentials. */
+export function credentialState(provider: ModelOption): string {
+  if (!takesKey(provider)) return 'No key needed'
+  if (provider.authenticated !== true) return 'No key'
+  if (provider.auth_type === 'subscription' || provider.auth_type === 'oauth') return 'Signed in'
+
+  return 'Key set'
+}
+
+interface ProviderRowProps {
+  onDisconnect: (slug: string) => void
+  onSave: (slug: string, apiKey: string) => Promise<boolean>
+  provider: ModelOption
+}
+
+function ProviderRow({ onDisconnect, onSave, provider }: ProviderRowProps) {
+  const [editing, setEditing] = useState(false)
+  const [key, setKey] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const slug = provider.slug ?? provider.name
+  const keyed = takesKey(provider)
+  const configured = provider.authenticated === true
+
+  const save = async () => {
+    if (key.trim() === '') return
+
+    setBusy(true)
+
+    const ok = await onSave(slug, key.trim())
+
+    setBusy(false)
+
+    // Clear it either way: the field held a secret, and a failed save is a
+    // reason to retype rather than to leave it sitting on screen.
+    setKey('')
+    if (ok) setEditing(false)
+  }
+
+  return (
+    <div className={css.row}>
+      <div className={css.rowHead}>
+        <span className={css.rowName}>{provider.name}</span>
+        {provider.is_current === true && <span className={css.badge}>Running</span>}
+        <span className={[css.state, configured ? css.stateOn : ''].filter(Boolean).join(' ')}>
+          {configured && <CheckIcon size={11} />}
+          {credentialState(provider)}
+        </span>
+        <span className={css.rowSpacer} />
+        {!editing && keyed && (
+          <Button
+            onClick={() => {
+              setEditing(true)
+            }}
+            size="sm"
+            variant="outline"
+          >
+            {configured ? 'Replace key' : 'Add key'}
+          </Button>
+        )}
+        {!editing && keyed && configured && (
+          <Button
+            onClick={() => {
+              onDisconnect(slug)
+            }}
+            size="sm"
+            variant="ghost"
+          >
+            Disconnect
+          </Button>
+        )}
+      </div>
+
+      <div className={css.rowMeta}>
+        {provider.total_models !== undefined && provider.total_models > 0 && (
+          <span>
+            {provider.total_models} {provider.total_models === 1 ? 'model' : 'models'}
+          </span>
+        )}
+        {/* Naming the variable matters: a key exported in the shell cannot be
+            removed from here, and this is the only clue to where it came from. */}
+        {keyed && provider.key_env !== undefined && provider.key_env !== '' && (
+          <span className={css.env}>{provider.key_env}</span>
+        )}
+      </div>
+
+      {editing && (
+        <div className={css.keyRow}>
+          <input
+            aria-label={`API key for ${provider.name}`}
+            autoComplete="off"
+            className={css.keyInput}
+            onChange={event => {
+              setKey(event.target.value)
+            }}
+            onKeyDown={event => {
+              if (event.key === 'Enter') void save()
+              if (event.key === 'Escape') {
+                setKey('')
+                setEditing(false)
+              }
+            }}
+            placeholder={`Paste the ${provider.name} API key`}
+            // A password field: the key is a secret, and settings pages get
+            // screen-shared.
+            type="password"
+            value={key}
+          />
+          <Button disabled={busy || key.trim() === ''} onClick={() => void save()} size="sm" variant="primary">
+            Save
+          </Button>
+          <button
+            aria-label="Cancel"
+            className={css.cancel}
+            onClick={() => {
+              setKey('')
+              setEditing(false)
+            }}
+            type="button"
+          >
+            <XIcon size={12} />
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export interface ProvidersSectionProps {
+  onDisconnect: (slug: string) => void
+  onSave: (slug: string, apiKey: string) => Promise<boolean>
+  providers: ModelOption[]
+}
+
+/**
+ * Providers and their credentials.
+ *
+ * The one thing that could not be done from the web at all: a broken or
+ * missing key meant hand-editing `~/.clawcodex/config.json`. Keys are written
+ * where `clawcodex login` writes them, so a key set here survives a restart
+ * and the two paths agree.
+ */
+export function ProvidersSection({ onDisconnect, onSave, providers }: ProvidersSectionProps) {
+  if (providers.length === 0) {
+    return <div className={css.empty}>No providers to show.</div>
+  }
+
+  return (
+    <div className={css.section}>
+      <p className={css.blurb}>
+        Keys are stored where <code>clawcodex login</code> stores them, so they survive a
+        restart. A key exported in your shell cannot be removed from here.
+      </p>
+      {orderProviders(providers).map(provider => (
+        <ProviderRow
+          key={provider.slug ?? provider.name}
+          onDisconnect={onDisconnect}
+          onSave={onSave}
+          provider={provider}
+        />
+      ))}
+    </div>
+  )
+}

--- a/ui-web/src/settings/Settings.module.css
+++ b/ui-web/src/settings/Settings.module.css
@@ -1,0 +1,230 @@
+/* Settings, as a takeover over the whole app. Colors ride the alias tokens. */
+
+.scrim {
+  position: fixed;
+  z-index: 40;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  background: var(--cc-alias-bg-mask-2);
+}
+
+.panel {
+  display: flex;
+  width: min(920px, 100%);
+  max-height: min(720px, 100%);
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--cc-alias-border-l2);
+  border-radius: 18px;
+  background: var(--cc-alias-bg-layer-1);
+  box-shadow: var(--cc-shadow-lv3, var(--cc-shadow-lv2));
+  --cc-scrollbar-thumb: var(--cc-alias-scrollbar-bg-l2);
+  --cc-scrollbar-thumb-hover: var(--cc-alias-scrollbar-hover-l2);
+}
+
+.head {
+  display: flex;
+  flex: none;
+  align-items: center;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--cc-alias-border-l2);
+}
+
+.title {
+  flex: 1;
+  color: var(--cc-alias-label-primary);
+  font-size: 15px;
+  font-weight: 500;
+}
+
+.close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--cc-alias-label-tertiary);
+  cursor: pointer;
+}
+
+.close:hover {
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-primary);
+}
+
+.body {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+}
+
+.nav {
+  display: flex;
+  flex: none;
+  width: 168px;
+  flex-direction: column;
+  gap: 2px;
+  padding: 12px 8px;
+  border-right: 1px solid var(--cc-alias-border-l2);
+}
+
+.navItem {
+  padding: 7px 10px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--cc-alias-label-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+}
+
+.navItem:hover {
+  background: var(--cc-alias-interactive-bg-hover);
+}
+
+.navItemOn,
+.navItemOn:hover {
+  background: var(--cc-alias-interactive-bg-active);
+  color: var(--cc-alias-label-primary);
+}
+
+.content {
+  min-width: 0;
+  flex: 1;
+  padding: 16px 20px;
+  overflow-y: auto;
+}
+
+.section {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.blurb {
+  margin: 0 0 4px;
+  color: var(--cc-alias-label-tertiary);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.blurb code {
+  font-family: var(--cc-font-family-code);
+}
+
+.empty {
+  padding: 24px 0;
+  color: var(--cc-alias-label-caption);
+  font-size: 13px;
+}
+
+/* ── one provider ────────────────────────────────────────────────────────── */
+
+.row {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  border: 1px solid var(--cc-alias-border-l2);
+  border-radius: 12px;
+}
+
+.rowHead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.rowName {
+  color: var(--cc-alias-label-primary);
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.rowSpacer {
+  flex: 1;
+}
+
+.badge {
+  padding: 0 7px;
+  border-radius: 999px;
+  background: var(--cc-alias-interactive-bg-active);
+  color: var(--cc-alias-label-secondary);
+  font-size: 10px;
+  line-height: 17px;
+}
+
+.state {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--cc-alias-label-caption);
+  font-size: 12px;
+}
+
+.stateOn {
+  color: var(--cc-alias-label-secondary);
+}
+
+.rowMeta {
+  display: flex;
+  gap: 10px;
+  color: var(--cc-alias-label-caption);
+  font-size: 11px;
+}
+
+.env {
+  font-family: var(--cc-font-family-code);
+}
+
+.keyRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.keyInput {
+  min-width: 0;
+  flex: 1;
+  padding: 7px 10px;
+  border: 1px solid var(--cc-alias-border-l2);
+  border-radius: 9px;
+  background: transparent;
+  color: var(--cc-alias-label-primary);
+  font: inherit;
+  font-size: 13px;
+}
+
+.keyInput:focus {
+  border-color: var(--cc-alias-label-tertiary);
+  outline: none;
+}
+
+.cancel {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--cc-alias-label-tertiary);
+  cursor: pointer;
+}
+
+.cancel:hover {
+  background: var(--cc-alias-interactive-bg-hover);
+}

--- a/ui-web/src/settings/SettingsOverlay.tsx
+++ b/ui-web/src/settings/SettingsOverlay.tsx
@@ -1,0 +1,108 @@
+import { useStore } from '@nanostores/react'
+import { useEffect } from 'react'
+
+import { disconnectProvider, refreshProviders, saveProviderKey } from '../state/actions.ts'
+import { $providers, $settingsTab } from '../state/store.ts'
+import { XIcon } from '../ui/icons.tsx'
+import { ProvidersSection } from './ProvidersSection.tsx'
+import css from './Settings.module.css'
+
+const TABS = [{ id: 'providers', label: 'Providers' }] as const
+
+/**
+ * Settings, as a full-screen takeover.
+ *
+ * Over the app rather than beside it: the three-column layout already gives up
+ * the details pane on a narrow window, and settings is a place you go, finish,
+ * and leave — not something to read alongside a conversation.
+ */
+export function SettingsOverlay() {
+  const tab = useStore($settingsTab)
+  const providers = useStore($providers)
+
+  const open = tab !== null
+
+  // Re-read on every open: a key may have been set from the CLI, or another
+  // window, since this was last looked at.
+  useEffect(() => {
+    if (open) void refreshProviders()
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') $settingsTab.set(null)
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  if (!open) return null
+
+  return (
+    <div
+      className={css.scrim}
+      onClick={() => {
+        $settingsTab.set(null)
+      }}
+    >
+      <div
+        aria-label="Settings"
+        className={css.panel}
+        onClick={event => {
+          event.stopPropagation()
+        }}
+        role="dialog"
+      >
+        <div className={css.head}>
+          <span className={css.title}>Settings</span>
+          <button
+            aria-label="Close settings"
+            className={css.close}
+            onClick={() => {
+              $settingsTab.set(null)
+            }}
+            type="button"
+          >
+            <XIcon size={14} />
+          </button>
+        </div>
+
+        <div className={css.body}>
+          <nav className={css.nav}>
+            {TABS.map(entry => (
+              <button
+                aria-current={tab === entry.id}
+                className={[css.navItem, tab === entry.id ? css.navItemOn : '']
+                  .filter(Boolean)
+                  .join(' ')}
+                key={entry.id}
+                onClick={() => {
+                  $settingsTab.set(entry.id)
+                }}
+                type="button"
+              >
+                {entry.label}
+              </button>
+            ))}
+          </nav>
+
+          <div className={css.content}>
+            <ProvidersSection
+              onDisconnect={slug => {
+                void disconnectProvider(slug)
+              }}
+              onSave={saveProviderKey}
+              providers={providers.providers ?? []}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui-web/src/sidebar/Sidebar.tsx
+++ b/ui-web/src/sidebar/Sidebar.tsx
@@ -5,7 +5,14 @@ import type { ProjectNode, SessionRow } from '../gateway/protocol.ts'
 import { createSession, resumeSession } from '../state/actions.ts'
 import { toggleSidebar } from '../state/layout.ts'
 import { BrandMark } from '../ui/BrandMark.tsx'
-import { $connection, $projects, $sessionId, $storedSessionId, $workspace } from '../state/store.ts'
+import {
+  $connection,
+  $projects,
+  $sessionId,
+  $settingsTab,
+  $storedSessionId,
+  $workspace,
+} from '../state/store.ts'
 import { $themePreference, cycleTheme } from '../state/theme.ts'
 import {
   ChevronDownIcon,
@@ -16,6 +23,7 @@ import {
   PanelLeftIcon,
   PlusIcon,
   SearchIcon,
+  SettingsIcon,
   SunIcon,
   XIcon,
 } from '../ui/icons.tsx'
@@ -257,6 +265,17 @@ export function Sidebar({ collapsed }: SidebarProps) {
           type="button"
         >
           <ThemeIcon size={16} />
+        </button>
+        <button
+          aria-label="Settings"
+          className={css.iconButton}
+          onClick={() => {
+            $settingsTab.set('providers')
+          }}
+          title="Settings"
+          type="button"
+        >
+          <SettingsIcon size={16} />
         </button>
         {!collapsed && (
           <>

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -19,6 +19,8 @@ import type {
   EffortOptionsResult,
   FileSearchResult,
   ModelOptionsResult,
+  ProviderListResult,
+  ProviderMutationResult,
   ProjectsTreeResult,
   SessionResumeResult,
   SlashResult,
@@ -34,6 +36,7 @@ import {
   $models,
   $notice,
   $pendingApprovalMode,
+  $providers,
   $projects,
   $projectsLoading,
   $queue,
@@ -721,6 +724,100 @@ async function blobToBase64(blob: Blob): Promise<string> {
     }
     reader.readAsDataURL(blob)
   })
+}
+
+/* ── providers (settings) ────────────────────────────────────────────────── */
+
+export async function refreshProviders(): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  try {
+    $providers.set(
+      await gateway().request<ProviderListResult>(
+        'provider.list',
+        sessionId === null ? {} : { session_id: sessionId },
+      ),
+    )
+  } catch (error) {
+    notice(errorText(error), 'error')
+  }
+}
+
+/**
+ * Store an API key for a provider.
+ *
+ * The key goes one way. Nothing echoes it back — the reply is the provider's
+ * refreshed catalog row, which reports `authenticated` and never the secret —
+ * so the caller can clear its field the moment this returns.
+ */
+export async function saveProviderKey(slug: string, apiKey: string): Promise<boolean> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) {
+    notice('Start a session before changing providers.', 'error')
+
+    return false
+  }
+
+  try {
+    const result = await gateway().request<ProviderMutationResult>('provider.save_key', {
+      api_key: apiKey,
+      session_id: sessionId,
+      slug,
+    })
+
+    if (result.ok === false) {
+      notice(result.error === undefined || result.error === '' ? 'Could not save that key' : result.error, 'error')
+
+      return false
+    }
+
+    notice(`Saved the ${slug} key.`)
+    await refreshProviders()
+    await refreshModels()
+
+    return true
+  } catch (error) {
+    notice(errorText(error), 'error')
+
+    return false
+  }
+}
+
+/**
+ * Clear a provider's stored credentials.
+ *
+ * The agent refuses the provider this session is running on, and says so when
+ * the key lives in the shell environment where nothing here can remove it.
+ * Both come back as their own message rather than a generic failure.
+ */
+export async function disconnectProvider(slug: string): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) {
+    notice('Start a session before changing providers.', 'error')
+
+    return
+  }
+
+  try {
+    const result = await gateway().request<ProviderMutationResult>('provider.disconnect', {
+      session_id: sessionId,
+      slug,
+    })
+
+    if (result.ok === false) {
+      notice(result.error === undefined || result.error === '' ? 'Could not disconnect' : result.error, 'error')
+
+      return
+    }
+
+    notice(result.message === undefined || result.message === '' ? `Disconnected ${slug}.` : result.message)
+    await refreshProviders()
+    await refreshModels()
+  } catch (error) {
+    notice(errorText(error), 'error')
+  }
 }
 
 /* ── model + catalogs ────────────────────────────────────────────────────── */

--- a/ui-web/src/state/store.ts
+++ b/ui-web/src/state/store.ts
@@ -14,6 +14,7 @@ import type {
   ContextUsageResult,
   EffortOptionsResult,
   ModelOptionsResult,
+  ProviderListResult,
   ProjectNode,
 } from '../gateway/protocol.ts'
 import { emptyTrajectory, type TrajectoryState } from './trajectory.ts'
@@ -64,6 +65,9 @@ export const $workspace = atom<string>('')
 export const $models = atom<ModelOptionsResult>({})
 /** Effort ladder for the running model; `supported: false` hides the chip. */
 export const $effort = atom<EffortOptionsResult>({ supported: false })
+/** Settings overlay: null when closed, else the section on show. */
+export const $settingsTab = atom<'general' | 'providers' | null>(null)
+export const $providers = atom<ProviderListResult>({})
 export const $commands = atom<CommandEntry[]>([])
 export const $contextUsage = atom<ContextUsageResult | null>(null)
 


### PR DESCRIPTION
The one thing the web could not do **at all**: fix a broken or missing provider key. That meant hand-editing `~/.clawcodex/config.json` — which is exactly the situation you land in when your default provider stops authenticating.

Stage 1 of a config page, ported by *feature* from the reference's `ui-settings-models`; the slot-based mechanism doesn't transfer, the product does.

A takeover reached from the sidebar foot. **Over** the app rather than beside it: the three-column layout already gives up its details pane on a narrow window, and settings is a place you go, finish and leave — not something to read alongside a conversation.

## Providers

Ordered by how much the reader cares: the one running now, then the ones with credentials, then the other twenty alphabetically.

- **`provider.list` deliberately does not filter to configured providers** the way `model.options` does. That filter is right for a picker — you cannot run on a provider you have no key for — and wrong here, where the whole point is adding a key to one you have *not* set up yet.
- **Keys go one way.** Nothing echoes them back: the reply is the provider's refreshed catalog row, which reports `authenticated` and never the secret. The field is a password input, and it is cleared on save — including a **failed** save, which is a reason to retype rather than to leave a key sitting on a screen that gets shared.
- **`auth_type: "none"` providers** (ollama, sglang, vllm — local endpoints) offer neither Add, Replace nor Disconnect, and say *"No key needed"*. There is nothing to set, so offering it would be offering something that cannot happen.
- **The environment variable is named on each row**, because a key exported in your shell cannot be removed from here, and that is the only clue to where it came from.
- **The agent's refusals pass through verbatim** rather than becoming a generic failure.

## Testing

19 new specs. Full suites green: 702 server, 282 web. `tsc` clean, bundle builds.

Verified live end to end:

| | |
|---|---|
| add a key to an unconfigured provider | "No key" → "Key set", Replace + Disconnect appear, key reaches `config.json` |
| disconnect the **running** provider | refused: *"'deepseek' is the active provider — switch to another provider before disconnecting it"*, key left in place |

## Next

Stage 2 is the General section — theme, response language (`set_language`), output style (`set_output_style`), default approval mode — so those are discoverable without knowing the slash commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
