### PR TITLE
fix: CLAWCODEX_CONFIG_DIR did not move config.json

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -20,13 +20,24 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Optional
 
+from src.utils.clawcodex_dirs import get_user_config_dir
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Paths
 # ---------------------------------------------------------------------------
 
-GLOBAL_CONFIG_DIR = Path.home() / ".clawcodex"
+# One definition of the user config root, shared with everything else that
+# resolves it. This used to be a bare ``Path.home() / ".clawcodex"``, which
+# meant ``$CLAWCODEX_CONFIG_DIR`` moved sessions, memories, skills and projects
+# but NOT config.json or history.jsonl — so an isolated profile silently read
+# and wrote the real user's credentials.
+#
+# Evaluated at import, exactly as before, so a process that does not set the
+# variable resolves to ~/.clawcodex as it always did. Tests that re-point these
+# by monkeypatching the module attribute are unaffected.
+GLOBAL_CONFIG_DIR = get_user_config_dir()
 GLOBAL_CONFIG_FILE = GLOBAL_CONFIG_DIR / "config.json"
 HISTORY_FILE = GLOBAL_CONFIG_DIR / "history.jsonl"
 

--- a/tests/test_config_dir_override.py
+++ b/tests/test_config_dir_override.py
@@ -1,0 +1,51 @@
+"""``$CLAWCODEX_CONFIG_DIR`` has to cover config.json too.
+
+``clawcodex_dirs`` documents the variable as the user config root and honors it
+for sessions, memories, skills and projects. ``config.py`` used to hardcode
+``Path.home() / ".clawcodex"`` beside it, so an isolated profile moved
+everything EXCEPT the file holding the user's API keys — silently, with no
+error and no warning.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _resolve(env_dir: str | None) -> str:
+    """Import config in a fresh interpreter and report where it points.
+
+    A subprocess because these are import-time constants: re-importing in this
+    process would not re-evaluate them.
+    """
+    env = {"PATH": "/usr/bin:/bin", "HOME": str(Path.home())}
+    if env_dir is not None:
+        env["CLAWCODEX_CONFIG_DIR"] = env_dir
+    result = subprocess.run(
+        [sys.executable, "-c", "from src.config import GLOBAL_CONFIG_FILE; print(GLOBAL_CONFIG_FILE)"],
+        capture_output=True, text=True, cwd=str(REPO), env=env, timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.strip()
+
+
+def test_config_file_follows_the_override(tmp_path) -> None:
+    assert _resolve(str(tmp_path)) == str(tmp_path / "config.json")
+
+
+def test_config_file_defaults_to_the_home_directory() -> None:
+    # Unset, nothing changes: this is what every ordinary run gets.
+    assert _resolve(None) == str(Path.home() / ".clawcodex" / "config.json")
+
+
+def test_the_override_agrees_with_the_dirs_helper(tmp_path, monkeypatch) -> None:
+    # One root, not two that can disagree — which is how the bug arose.
+    monkeypatch.setenv("CLAWCODEX_CONFIG_DIR", str(tmp_path))
+    from src.utils.clawcodex_dirs import get_user_config_dir
+
+    assert get_user_config_dir() == tmp_path
+    assert _resolve(str(tmp_path)).startswith(str(tmp_path))


### PR DESCRIPTION
`clawcodex_dirs` documents `$CLAWCODEX_CONFIG_DIR` as the user config root and honors it for sessions, memories, skills and projects. `config.py` had a **second, hardcoded definition** beside it:

```python
GLOBAL_CONFIG_DIR = Path.home() / ".clawcodex"
```

So an isolated profile moved everything *except* the file holding the user's API keys. Silently — no error, no warning, and `get_user_config_dir()` reporting the override the whole time.

## How it was found

I set the variable to a throwaway directory specifically to keep a settings test off a real config, typed a fake key into the UI, and it landed in `~/.clawcodex/config.json`. Anyone using this variable to isolate a profile, a CI run, or a test is reading and writing their real credentials.

## The fix

One definition, taken from the same helper everything else uses. Still evaluated at import, exactly as before, so:

- a process that does not set the variable resolves to `~/.clawcodex` as it always did, and
- tests that re-point these by monkeypatching the module attribute are unaffected.

## Testing

3 new specs, run in a **subprocess** — these are import-time constants, so re-importing in-process would not re-evaluate them. **Verified against the old code**, where two of the three fail.

Full suite: 10223 passed, 1 failed — `TestBuildAppSmoke::test_pip_install_editable`, which shells out to `pip install -e . --quiet` under a 60s timeout and never touches config resolution. I believe that to be environmental rather than caused by a path constant, and I am letting CI arbitrate rather than assert it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
