### PR TITLE
feat(web): close the chat-rendering gap with the DeepSeek Harness client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   adapted from the MIT-licensed DeepSeek Harness web client; see
   `ui-web/README.md`.
 
+- **Web chat rendering at reference-client fidelity (`ui-web/`).** A
+  side-by-side pass against the DeepSeek Harness client, closing every gap in
+  what the transcript shows: terminal output renders its ANSI colors (SGR incl.
+  256/truecolor, `\r` progress-bar overwrite) instead of escape-glyph salad;
+  math is tokenized in the markdown grammar so `$$\int x\,dx$$` survives
+  marked's own escapes; task lists draw a checkbox without the literal `[x]`;
+  links keep http/https/mailto only and images must be absolute http(s) (lazy,
+  no referrer); streaming freezes settled blocks and highlights each fence
+  once, at seal, instead of re-lexing the whole reply per delta; long
+  terminal/diff/read/web cards fold their middle and keep the tail (the exit
+  error is the point); resumed sessions keep their diffs (reconstructed from
+  the stored edit arguments), match/file counts and read summaries; the todo
+  row reports `2/6 done · <active item>`; unknown tools disclose an IN/OUT
+  card; web tools link their URLs; a turn-fatal error paints once, not as
+  bubble and notice; and the flow re-pins to the bottom when content grows
+  after layout (async highlight, image loads, card expansion).
+
 - **Native Windows support for the CLI.** ClawCodex now runs first-class on
   Windows 10/11 — PowerShell, cmd, and Windows Terminal — with no WSL
   required. The port follows the playbook of a reference Windows-supporting

--- a/ui-web/src/conversation/ChatView.module.css
+++ b/ui-web/src/conversation/ChatView.module.css
@@ -26,6 +26,11 @@
   min-width: 0;
 }
 
+/* A row whose renderer produced nothing must not spend the column gap. */
+.item:empty {
+  display: none;
+}
+
 /* Turn activity keeps a loader's one-line footprint. A pale accent band sweeps
    left to right across the words; reduced motion keeps it static. */
 .turnStatus {

--- a/ui-web/src/conversation/ConversationRoot.tsx
+++ b/ui-web/src/conversation/ConversationRoot.tsx
@@ -84,6 +84,7 @@ export function ConversationRoot() {
   const [atBottom, setAtBottom] = useState(true)
   const scroller = useRef<HTMLDivElement | null>(null)
   const seat = useRef<HTMLDivElement | null>(null)
+  const flow = useRef<HTMLDivElement | null>(null)
 
   // A replay in flight is NOT the empty state: showing the hero over a
   // conversation that is about to land reads as "your session is gone".
@@ -109,6 +110,29 @@ export function ConversationRoot() {
     const distance = element.scrollHeight - element.scrollTop - element.clientHeight
     setAtBottom(distance <= STICK_THRESHOLD)
   }, [])
+
+  // Content grows without the node list changing — a highlight lands, an
+  // image loads, a card is expanded. While the reader is at the bottom, any
+  // such growth re-pins; otherwise it would leak the flow past the fold one
+  // async paint at a time.
+  useEffect(() => {
+    if (!atBottom) return
+
+    const element = flow.current
+    const scrollerEl = scroller.current
+
+    if (element === null || scrollerEl === null) return
+
+    const observer = new ResizeObserver(() => {
+      scrollerEl.scrollTop = scrollerEl.scrollHeight
+    })
+
+    observer.observe(element)
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [atBottom, hero, tab])
 
   // The back-to-bottom control clears the live composer height, which grows
   // with the draft. Measured rather than assumed so the button never overlaps.
@@ -360,7 +384,7 @@ export function ConversationRoot() {
           />
         ) : (
           <>
-            <div className={css.flow}>
+            <div className={css.flow} ref={flow}>
               {loading && transcript.nodes.length === 0 ? (
                 <div className={css.settling}>Loading session…</div>
               ) : (

--- a/ui-web/src/conversation/ReasoningRow.tsx
+++ b/ui-web/src/conversation/ReasoningRow.tsx
@@ -24,7 +24,9 @@ function ReasoningRowImpl({ node }: ReasoningRowProps) {
   const [expanded, setExpanded] = useState(false)
   const live = !node.sealed
   const flat = node.text.replace(/\s+/g, ' ').trim()
-  const summary = live ? flat.slice(-TAIL) : flat
+  // Live, the summary follows the newest words; sealed, it opens with the
+  // first ones — the thought's own topic sentence.
+  const summary = live ? flat.slice(-TAIL) : (node.text.split('\n').find(line => line.trim() !== '') ?? '').trim()
 
   return (
     <DisclosureRow

--- a/ui-web/src/conversation/ToolRow.tsx
+++ b/ui-web/src/conversation/ToolRow.tsx
@@ -13,11 +13,21 @@ import {
 } from '../ui/icons.tsx'
 import { DiffBlock } from '../ui/primitives/DiffBlock.tsx'
 import { DisclosureRow } from '../ui/primitives/DisclosureRow.tsx'
+import { IoCard } from '../ui/primitives/IoCard.tsx'
 import { OutputBlock } from '../ui/primitives/OutputBlock.tsx'
 import { ReadBlock } from '../ui/primitives/ReadBlock.tsx'
 import { TerminalBlock } from '../ui/primitives/TerminalBlock.tsx'
+import { WebBlock } from '../ui/primitives/WebBlock.tsx'
 import type { ToolNode } from '../state/transcript.ts'
-import { describeTool, genericBodyText, type ToolIconName } from './tool-view.ts'
+import {
+  describeTool,
+  formatArgs,
+  genericBodyText,
+  readTodos,
+  synthesizeDiff,
+  type ToolIconName,
+  type TodoEntry,
+} from './tool-view.ts'
 import css from './ToolRow.module.css'
 
 const ICON_COMPONENTS: Record<ToolIconName, (props: { size?: number }) => ReactNode> = {
@@ -30,28 +40,6 @@ const ICON_COMPONENTS: Record<ToolIconName, (props: { size?: number }) => ReactN
   search: SearchIcon,
   terminal: TerminalIcon,
   tool: WrenchIcon,
-}
-
-interface TodoEntry {
-  content: string
-  status: string
-}
-
-function readTodos(args: Record<string, unknown>): TodoEntry[] {
-  const raw = args.todos
-
-  if (!Array.isArray(raw)) return []
-
-  return raw.flatMap(entry => {
-    if (entry === null || typeof entry !== 'object') return []
-
-    const record = entry as Record<string, unknown>
-    const content = typeof record.content === 'string' ? record.content : ''
-
-    if (content === '') return []
-
-    return [{ content, status: typeof record.status === 'string' ? record.status : 'pending' }]
-  })
 }
 
 function TodoBody({ todos }: { todos: TodoEntry[] }) {
@@ -84,8 +72,8 @@ export interface ToolRowProps {
 
 /**
  * One tool call in the flow: a 24px title row that discloses the call's own
- * card — a terminal transcript, a diff, a numbered file window, or the generic
- * output card.
+ * card — a terminal transcript, a diff, a numbered file window, a web card
+ * with followable links, or the generic IN/OUT card.
  *
  * A running call shows its row (with the sweep) and no body: there is nothing
  * to disclose yet, and reserving space for a card that has not arrived makes
@@ -100,20 +88,39 @@ function ToolRowImpl({ node, workspace }: ToolRowProps) {
 
   const todos = view.body === 'todo' ? readTodos(node.args) : []
   const generic = genericBodyText(node)
+  const diff = view.body === 'diff' ? synthesizeDiff(node) : undefined
 
   let body: ReactNode
 
   if (running) {
     body = undefined
   } else if (failed) {
-    body = (
-      <OutputBlock
-        className={css.body}
-        label="error"
-        text={node.error ?? 'Tool execution failed'}
-        tone="error"
-      />
-    )
+    // A failed terminal keeps its terminal shape — the error text is what the
+    // command printed. Everything else shows the exchange, arguments first:
+    // for an unknown tool they are the only record of what was asked.
+    const command = typeof node.args.command === 'string' ? node.args.command : ''
+
+    if (node.name === 'terminal' && command !== '') {
+      body = (
+        <TerminalBlock
+          className={[css.body, css.terminalBody].join(' ')}
+          command={command}
+          output={node.error ?? 'Tool execution failed'}
+          state="error"
+        />
+      )
+    } else {
+      const input = formatArgs(node.args)
+
+      body = (
+        <IoCard
+          className={css.body}
+          input={input === '' ? undefined : input}
+          output={node.error ?? 'Tool execution failed'}
+          tone="error"
+        />
+      )
+    }
   } else if (view.body === 'terminal') {
     body = (
       <TerminalBlock
@@ -123,12 +130,32 @@ function ToolRowImpl({ node, workspace }: ToolRowProps) {
         state="done"
       />
     )
-  } else if (view.body === 'diff' && node.result?.inline_diff !== undefined) {
-    body = <DiffBlock className={css.body} diff={node.result.inline_diff} />
+  } else if (view.body === 'diff' && diff !== undefined) {
+    body = <DiffBlock className={css.body} diff={diff} />
   } else if (view.body === 'read' && node.result?.content !== undefined) {
     body = <ReadBlock className={css.body} content={node.result.content} label={view.path} />
   } else if (view.body === 'todo' && todos.length > 0) {
     body = <TodoBody todos={todos} />
+  } else if (view.body === 'web' && generic !== '') {
+    body = (
+      <WebBlock
+        className={css.body}
+        text={generic}
+        url={typeof node.args.url === 'string' ? node.args.url : undefined}
+      />
+    )
+  } else if (view.body === 'io') {
+    const input = formatArgs(node.args)
+
+    if (input !== '' || generic !== '') {
+      body = (
+        <IoCard
+          className={css.body}
+          input={input === '' ? undefined : input}
+          output={generic}
+        />
+      )
+    }
   } else if (generic !== '') {
     body = <OutputBlock className={css.body} label="output" text={generic} />
   }

--- a/ui-web/src/conversation/tool-view.test.ts
+++ b/ui-web/src/conversation/tool-view.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ToolNode } from '../state/transcript.ts'
-import { describeTool, genericBodyText, shortPath } from './tool-view.ts'
+import {
+  describeTool,
+  formatArgs,
+  genericBodyText,
+  shortPath,
+  synthesizeDiff,
+  todoSummary,
+} from './tool-view.ts'
 
 function tool(overrides: Partial<ToolNode> = {}): ToolNode {
   return {
@@ -93,11 +100,136 @@ describe('describeTool', () => {
     expect(view.body).toBe('output')
   })
 
-  it('falls back to a generic row for an unknown tool', () => {
+  it('falls back to an IN/OUT row for an unknown tool', () => {
     const view = describeTool(tool({ context: 'Explore the repo', name: 'Task', state: 'running' }))
 
-    expect(view).toMatchObject({ body: 'output', icon: 'tool', title: 'Task' })
+    expect(view).toMatchObject({ body: 'io', icon: 'tool', title: 'Task' })
     expect(view.summary).toBe('Explore the repo')
+  })
+
+  it('summarises todos as progress plus the live item', () => {
+    const view = describeTool(
+      tool({
+        args: {
+          todos: [
+            { activeForm: 'Mapping the code', content: 'Map the code', status: 'completed' },
+            { activeForm: 'Porting the polish', content: 'Port the polish', status: 'in_progress' },
+            { content: 'Run QA', status: 'pending' },
+          ],
+        },
+        name: 'todo',
+        result: { message: 'Todos have been modified successfully.' },
+      }),
+    )
+
+    expect(view.body).toBe('todo')
+    expect(view.summary).toBe('1/3 done · Porting the polish')
+  })
+
+  it('gives web tools a web card', () => {
+    expect(describeTool(tool({ args: { query: 'x' }, name: 'web_search' })).body).toBe('web')
+    expect(describeTool(tool({ args: { url: 'https://a.io' }, name: 'web_extract' })).body).toBe(
+      'web',
+    )
+  })
+
+  it('synthesizes a diff for a rehydrated edit with no inline_diff', () => {
+    const view = describeTool(
+      tool({
+        args: { file_path: '/repo/a.ts', new_string: 'const b = 2', old_string: 'const a = 1' },
+        name: 'edit_file',
+        result: { message: 'The file /repo/a.ts has been updated successfully.' },
+      }),
+      '/repo',
+    )
+
+    expect(view.body).toBe('diff')
+    expect(view.summary).toBe('')
+  })
+})
+
+describe('synthesizeDiff', () => {
+  it('prefers the diff the gateway sent', () => {
+    const diff = '--- a\n+++ a\n@@ -1 +1 @@\n-x\n+y'
+
+    expect(synthesizeDiff(tool({ name: 'edit_file', result: { inline_diff: diff } }))).toBe(diff)
+  })
+
+  it('reconstructs an edit from old_string and new_string', () => {
+    const node = tool({
+      args: { file_path: '/repo/a.ts', new_string: 'two\nlines', old_string: 'one line' },
+      name: 'edit_file',
+    })
+
+    expect(synthesizeDiff(node)).toBe('+++ /repo/a.ts\n-one line\n+two\n+lines')
+  })
+
+  it('reconstructs a MultiEdit as gap-separated hunks', () => {
+    const node = tool({
+      args: {
+        edits: [
+          { new_string: 'b', old_string: 'a' },
+          { new_string: 'd', old_string: 'c' },
+        ],
+        file_path: '/repo/a.ts',
+      },
+      name: 'edit_file',
+    })
+
+    expect(synthesizeDiff(node)).toBe('+++ /repo/a.ts\n-a\n+b\n@@\n-c\n+d')
+  })
+
+  it('reconstructs a write as pure additions', () => {
+    const node = tool({
+      args: { content: 'alpha\nbeta\n', file_path: '/repo/notes.md' },
+      name: 'write_file',
+    })
+
+    expect(synthesizeDiff(node)).toBe('+++ /repo/notes.md\n+alpha\n+beta')
+  })
+
+  it('declines when the arguments carry no mutation', () => {
+    expect(synthesizeDiff(tool({ name: 'edit_file' }))).toBeUndefined()
+    expect(synthesizeDiff(tool({ name: 'write_file' }))).toBeUndefined()
+  })
+
+  it('declines for a failed call: nothing was written', () => {
+    const node = tool({
+      args: { new_string: 'b', old_string: 'a' },
+      error: 'Error: not found',
+      name: 'edit_file',
+    })
+
+    expect(synthesizeDiff(node)).toBeUndefined()
+  })
+})
+
+describe('formatArgs', () => {
+  it('renders scalar arguments as key: value lines', () => {
+    expect(formatArgs({ description: 'Audit the store', subagent_type: 'Explore' })).toBe(
+      'description: Audit the store\nsubagent_type: Explore',
+    )
+  })
+
+  it('indents multi-line and structured values under their key', () => {
+    expect(formatArgs({ prompt: 'line one\nline two' })).toBe('prompt:\n  line one\n  line two')
+    expect(formatArgs({ flags: [1, 2] })).toBe('flags:\n  [\n   1,\n   2\n  ]')
+  })
+
+  it('returns empty for no arguments', () => {
+    expect(formatArgs({})).toBe('')
+  })
+})
+
+describe('todoSummary', () => {
+  it('is empty without todos', () => {
+    expect(todoSummary({})).toBe('')
+  })
+
+  it('shows progress alone when nothing is in flight', () => {
+    expect(
+      todoSummary({ todos: [{ content: 'a', status: 'completed' }, { content: 'b', status: 'pending' }] }),
+    ).toBe('1/2 done')
   })
 })
 

--- a/ui-web/src/conversation/tool-view.ts
+++ b/ui-web/src/conversation/tool-view.ts
@@ -15,7 +15,7 @@
 import type { ToolResult } from '../gateway/protocol.ts'
 import type { ToolNode } from '../state/transcript.ts'
 
-export type ToolBodyKind = 'diff' | 'none' | 'output' | 'read' | 'terminal' | 'todo'
+export type ToolBodyKind = 'diff' | 'io' | 'none' | 'output' | 'read' | 'terminal' | 'todo' | 'web'
 
 export type ToolIconName =
   | 'edit'
@@ -35,6 +35,49 @@ export interface ToolView {
   path?: string
   summary: string
   title: string
+}
+
+export interface TodoEntry {
+  active: string
+  content: string
+  status: string
+}
+
+/** The `todos` argument, defensively: content-less or malformed entries drop. */
+export function readTodos(args: Record<string, unknown>): TodoEntry[] {
+  const raw = args.todos
+
+  if (!Array.isArray(raw)) return []
+
+  return raw.flatMap(entry => {
+    if (entry === null || typeof entry !== 'object') return []
+
+    const record = entry as Record<string, unknown>
+    const content = typeof record.content === 'string' ? record.content : ''
+
+    if (content === '') return []
+
+    return [
+      {
+        active: typeof record.activeForm === 'string' ? record.activeForm : content,
+        content,
+        status: typeof record.status === 'string' ? record.status : 'pending',
+      },
+    ]
+  })
+}
+
+/** `2/6 done · Porting the reference polish` — progress plus the live item. */
+export function todoSummary(args: Record<string, unknown>): string {
+  const todos = readTodos(args)
+
+  if (todos.length === 0) return ''
+
+  const done = todos.filter(todo => todo.status === 'completed').length
+  const active = todos.find(todo => todo.status === 'in_progress')
+  const progress = `${done}/${todos.length} done`
+
+  return active === undefined ? progress : `${progress} · ${active.active}`
 }
 
 const TITLES: Record<string, string> = {
@@ -98,10 +141,10 @@ function argPath(args: Record<string, unknown>): string {
   )
 }
 
-function countLabel(count: number | undefined, singular: string): string {
+function countLabel(count: number | undefined, singular: string, plural = `${singular}s`): string {
   if (count === undefined) return ''
 
-  return `${count} ${count === 1 ? singular : `${singular}s`}`
+  return `${count} ${count === 1 ? singular : plural}`
 }
 
 /** Summary for a finished call, from whichever result field its family uses. */
@@ -113,7 +156,7 @@ function resultSummary(name: string, result: ToolResult | undefined): string {
       return countLabel(num(result.file_count), 'file')
 
     case 'search_files':
-      return countLabel(num(result.match_count), 'match')
+      return countLabel(num(result.match_count), 'match', 'matches')
 
     case 'web_search': {
       const count = countLabel(num(result.result_count), 'result')
@@ -127,6 +170,60 @@ function resultSummary(name: string, result: ToolResult | undefined): string {
     default:
       return str(result.context) || firstLine(str(result.output) || str(result.message))
   }
+}
+
+/**
+ * The diff a mutation row shows.
+ *
+ * Live events carry the server's `inline_diff` (built from the agent's
+ * structuredPatch). A REHYDRATED session has no display envelope — but the
+ * stored `tool_use` arguments still hold the whole mutation (`old_string` /
+ * `new_string`, a MultiEdit's `edits`, a Write's `content`), so the diff is
+ * reconstructed from those rather than degrading to "file updated" prose.
+ */
+export function synthesizeDiff(node: ToolNode): string | undefined {
+  const stored = node.result?.inline_diff
+
+  if (stored !== undefined && stored !== '') return stored
+  if (node.error !== undefined) return undefined
+
+  const args = node.args
+  const path = argPath(args) || str(node.result?.path) || 'file'
+
+  const hunk = (oldText: string, newText: string): string[] => [
+    ...(oldText === '' ? [] : oldText.replace(/\n$/, '').split('\n').map(line => `-${line}`)),
+    ...(newText === '' ? [] : newText.replace(/\n$/, '').split('\n').map(line => `+${line}`)),
+  ]
+
+  if (node.name === 'edit_file') {
+    const edits = Array.isArray(args.edits)
+      ? (args.edits as { new_string?: unknown; old_string?: unknown }[])
+      : []
+
+    if (edits.length > 0) {
+      const body = edits.flatMap((edit, index) => {
+        const lines = hunk(str(edit.old_string), str(edit.new_string))
+
+        return index === 0 ? lines : ['@@', ...lines]
+      })
+
+      return body.length === 0 ? undefined : [`+++ ${path}`, ...body].join('\n')
+    }
+
+    const body = hunk(str(args.old_string), str(args.new_string))
+
+    return body.length === 0 ? undefined : [`+++ ${path}`, ...body].join('\n')
+  }
+
+  if (node.name === 'write_file') {
+    const content = str(args.content)
+
+    if (content === '') return undefined
+
+    return [`+++ ${path}`, ...hunk('', content)].join('\n')
+  }
+
+  return undefined
 }
 
 export function describeTool(node: ToolNode, workspace?: string): ToolView {
@@ -166,24 +263,33 @@ export function describeTool(node: ToolNode, workspace?: string): ToolView {
     case 'edit_file':
     case 'write_file': {
       const path = argPath(args) || str(node.result?.path)
+      const diff = synthesizeDiff(node)
 
       return {
-        body: node.result?.inline_diff === undefined ? 'output' : 'diff',
+        body: diff === undefined ? 'output' : 'diff',
         icon,
         path: shortPath(path, workspace),
-        summary: node.result?.inline_diff === undefined ? resultSummary(name, node.result) : '',
+        summary: diff === undefined ? resultSummary(name, node.result) : '',
         title,
       }
     }
 
-    case 'todo':
-      return { body: 'todo', icon, summary: resultSummary(name, node.result), title }
+    case 'todo': {
+      const summary = todoSummary(args)
+
+      return {
+        body: 'todo',
+        icon,
+        summary: summary === '' ? resultSummary(name, node.result) : summary,
+        title,
+      }
+    }
 
     case 'web_search':
-      return { body: 'output', icon, summary: str(args.query) || str(node.context), title }
+      return { body: 'web', icon, summary: str(args.query) || str(node.context), title }
 
     case 'web_extract':
-      return { body: 'output', icon, summary: str(args.url) || str(node.context), title }
+      return { body: 'web', icon, summary: str(args.url) || str(node.context), title }
 
     case 'clarify':
       return { body: 'output', icon, summary: str(node.context), title }
@@ -194,7 +300,9 @@ export function describeTool(node: ToolNode, workspace?: string): ToolView {
           ? str(node.context) || str(args.description) || str(args.pattern)
           : resultSummary(name, node.result) || str(node.context)
 
-      return { body: 'output', icon, summary, title }
+      // Unknown tools (Task, MCP…) disclose both sides of the exchange: the
+      // arguments are the only record of what was asked.
+      return { body: 'io', icon, summary, title }
     }
   }
 }
@@ -208,4 +316,39 @@ export function genericBodyText(node: ToolNode): string {
   if (result === undefined) return ''
 
   return str(result.output) || str(result.content) || str(result.message) || ''
+}
+
+/**
+ * Tool arguments as readable `key: value` lines for the IN side of a generic
+ * card — friendlier than JSON-escaped strings for the prompt-sized values a
+ * Task or MCP call carries. Multi-line and structured values indent under
+ * their key.
+ */
+export function formatArgs(args: Record<string, unknown>): string {
+  const lines: string[] = []
+
+  for (const [key, value] of Object.entries(args)) {
+    if (value === undefined) continue
+
+    let text: string
+
+    if (typeof value === 'string') {
+      text = value
+    } else {
+      try {
+        text = JSON.stringify(value, null, 1) ?? String(value)
+      } catch {
+        text = String(value)
+      }
+    }
+
+    if (text.includes('\n')) {
+      lines.push(`${key}:`)
+      lines.push(...text.split('\n').map(line => `  ${line}`))
+    } else {
+      lines.push(`${key}: ${text}`)
+    }
+  }
+
+  return lines.join('\n')
 }

--- a/ui-web/src/gateway/tool-vocabulary.test.ts
+++ b/ui-web/src/gateway/tool-vocabulary.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+
+import { renderToolName, renderToolResult } from './tool-vocabulary.ts'
+
+describe('renderToolName', () => {
+  it('maps the ClawCodex vocabulary onto the renderer names', () => {
+    expect(renderToolName('Read')).toBe('read_file')
+    expect(renderToolName('Bash')).toBe('terminal')
+    expect(renderToolName('Grep')).toBe('search_files')
+  })
+
+  it('passes unknown tools through unchanged', () => {
+    expect(renderToolName('Task')).toBe('Task')
+    expect(renderToolName('mcp__linear__create_issue')).toBe('mcp__linear__create_issue')
+  })
+})
+
+describe('renderToolResult', () => {
+  it('summarises a numbered read like the live gateway does', () => {
+    const result = renderToolResult('Read', '1\tconst a = 1\n2\tconst b = 2')
+
+    expect(result.content).toBe('1\tconst a = 1\n2\tconst b = 2')
+    expect(result.context).toBe('Read 2 lines')
+  })
+
+  it('leaves an un-numbered read without a line summary', () => {
+    expect(renderToolResult('Read', 'binary blob').context).toBeUndefined()
+  })
+
+  it('counts matches for a resumed search', () => {
+    const result = renderToolResult('Grep', 'a.ts:1:x\nb.ts:2:y\n')
+
+    expect(result.match_count).toBe(2)
+    expect(result.output).toContain('a.ts:1:x')
+  })
+
+  it('counts files for a resumed glob', () => {
+    expect(renderToolResult('Glob', 'a.ts\nb.ts\nc.ts').file_count).toBe(3)
+  })
+
+  it('keeps terminal output on the output field', () => {
+    expect(renderToolResult('Bash', 'ok')).toEqual({ output: 'ok' })
+  })
+
+  it('returns nothing for empty output', () => {
+    expect(renderToolResult('Bash', '')).toEqual({})
+  })
+})

--- a/ui-web/src/gateway/tool-vocabulary.ts
+++ b/ui-web/src/gateway/tool-vocabulary.ts
@@ -45,15 +45,44 @@ export function renderToolName(name: string): string {
   return RENDER_TOOL_NAMES[name.trim().toLowerCase()] ?? name
 }
 
+const NUMBERED_LINE = /^\s*\d+\t/
+
+function nonEmptyLines(text: string): number {
+  return text.split('\n').filter(line => line.trim() !== '').length
+}
+
 /** Tool output text → the result object the matching card knows how to read. */
 export function renderToolResult(name: string, text: string): ToolResult {
   const render = renderToolName(name)
 
   if (text === '') return {}
 
-  if (render === 'read_file' || render === 'web_extract') return { content: text }
+  if (render === 'read_file') {
+    // The live gateway summarises a numbered read as "Read N lines"; a resumed
+    // row deserves the same summary, not a blank one.
+    const lines = text.split('\n').filter(line => line !== '')
+    const first = lines[0]
+
+    if (first !== undefined && NUMBERED_LINE.test(first)) {
+      return {
+        content: text,
+        context: `Read ${lines.length} ${lines.length === 1 ? 'line' : 'lines'}`,
+      }
+    }
+
+    return { content: text }
+  }
+
+  if (render === 'web_extract') return { content: text }
   if (render === 'terminal') return { output: text }
   if (render === 'edit_file' || render === 'write_file') return { message: text }
+
+  // Counts, mirroring the live translate layer, so a resumed Search/List row
+  // keeps its "N matches" summary.
+  if (render === 'list_files') return { context: text, file_count: nonEmptyLines(text), output: text }
+  if (render === 'search_files') {
+    return { context: text, match_count: nonEmptyLines(text), output: text }
+  }
 
   // No dedicated card: the generic path prefers `context`, and `output` feeds
   // the copy affordance.

--- a/ui-web/src/state/transcript.test.ts
+++ b/ui-web/src/state/transcript.test.ts
@@ -222,6 +222,28 @@ describe('turn state', () => {
     expect(state.running).toBe(false)
   })
 
+  it('shows a replayed turn error once, not as bubble AND notice', () => {
+    // The backend often streams the failure text as interim prose before the
+    // result frame names the same words as the turn's error.
+    const boom = 'Error code: 400 - invalid_request_error'
+    const state = fold([
+      event('message.interim', { text: boom }),
+      event('message.complete', { error: boom, status: 'error', text: boom }),
+    ])
+
+    expect(state.nodes.map(n => n.kind)).toEqual(['notice'])
+    expect(state.nodes[0]).toMatchObject({ body: boom, tone: 'error' })
+  })
+
+  it('keeps real streamed prose alongside the error notice', () => {
+    const state = fold([
+      event('message.delta', { text: 'Half an answer' }),
+      event('message.complete', { error: 'overloaded', status: 'error' }),
+    ])
+
+    expect(state.nodes.map(n => n.kind)).toEqual(['assistant', 'notice'])
+  })
+
   it('drops an empty trailing bubble instead of painting one', () => {
     const state = fold([
       event('message.delta', { text: '' }),

--- a/ui-web/src/state/transcript.ts
+++ b/ui-web/src/state/transcript.ts
@@ -352,6 +352,21 @@ export function applyEvent(state: TranscriptState, event: GatewayEvent): Transcr
       }
 
       if (payload.status === 'error') {
+        // A turn-fatal error is often replayed as interim prose before the
+        // result frame arrives, leaving the same words in a bubble AND in
+        // this notice. One row carrying the failure is enough.
+        const errorText = (payload.error ?? '').trim()
+        const last = nodes[nodes.length - 1]
+
+        if (
+          errorText !== '' &&
+          last !== undefined &&
+          last.kind === 'assistant' &&
+          last.text.trim() === errorText
+        ) {
+          nodes = nodes.slice(0, -1)
+        }
+
         nodes = [
           ...nodes,
           {

--- a/ui-web/src/styles/tokens.css
+++ b/ui-web/src/styles/tokens.css
@@ -184,6 +184,27 @@
   --cc-specific-sidebar-nav-item-hover: var(--cc-static-ink-75);
   --cc-specific-tip: var(--cc-static-ink-60);
 
+  /* ── ANSI palette (light) ──────────────────────────────────────────────── */
+  /* Terminal output colors, tuned to stay readable on the light card surface
+     (the classic palette's yellow and white vanish on white). Hues follow the
+     static palette family above, so a red FAIL and a red error state match. */
+  --cc-ansi-0: rgb(55, 65, 81);
+  --cc-ansi-1: rgb(220, 38, 38);
+  --cc-ansi-2: rgb(21, 128, 61);
+  --cc-ansi-3: rgb(161, 98, 7);
+  --cc-ansi-4: rgb(37, 99, 235);
+  --cc-ansi-5: rgb(147, 51, 234);
+  --cc-ansi-6: rgb(14, 116, 144);
+  --cc-ansi-7: rgb(107, 114, 128);
+  --cc-ansi-8: rgb(107, 114, 128);
+  --cc-ansi-9: rgb(239, 68, 68);
+  --cc-ansi-10: rgb(22, 163, 74);
+  --cc-ansi-11: rgb(202, 138, 4);
+  --cc-ansi-12: rgb(59, 130, 246);
+  --cc-ansi-13: rgb(168, 85, 247);
+  --cc-ansi-14: rgb(6, 182, 212);
+  --cc-ansi-15: rgb(156, 163, 175);
+
   /* ── shadows ───────────────────────────────────────────────────────────── */
   --cc-shadow-lv1: 0 2px 4px 0 rgba(0, 0, 0, 0.05);
   --cc-shadow-lv2: 0 4px 12px 0 rgba(0, 0, 0, 0.02), 0 2px 8px 0 rgba(0, 0, 0, 0.04);
@@ -283,4 +304,22 @@
   --cc-specific-sidebar-nav-item-active-accent: var(--cc-static-ink-800);
   --cc-specific-sidebar-nav-item-hover: var(--cc-static-ink-850);
   --cc-specific-tip: var(--cc-static-ink-800);
+
+  /* ANSI palette, brightened for the dark card surface. */
+  --cc-ansi-0: rgb(107, 114, 128);
+  --cc-ansi-1: rgb(248, 113, 113);
+  --cc-ansi-2: rgb(74, 222, 128);
+  --cc-ansi-3: rgb(250, 204, 21);
+  --cc-ansi-4: rgb(96, 165, 250);
+  --cc-ansi-5: rgb(192, 132, 252);
+  --cc-ansi-6: rgb(34, 211, 238);
+  --cc-ansi-7: rgb(209, 213, 219);
+  --cc-ansi-8: rgb(156, 163, 175);
+  --cc-ansi-9: rgb(252, 165, 165);
+  --cc-ansi-10: rgb(134, 239, 172);
+  --cc-ansi-11: rgb(253, 224, 71);
+  --cc-ansi-12: rgb(147, 197, 253);
+  --cc-ansi-13: rgb(216, 180, 254);
+  --cc-ansi-14: rgb(103, 232, 249);
+  --cc-ansi-15: rgb(249, 250, 251);
 }

--- a/ui-web/src/ui/ansi.test.ts
+++ b/ui-web/src/ui/ansi.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasAnsi, parseAnsi, stripAnsi, type AnsiLine } from './ansi.ts'
+
+function textOf(line: AnsiLine): string {
+  return line.map(span => span.text).join('')
+}
+
+describe('parseAnsi', () => {
+  it('passes plain text through untouched', () => {
+    expect(parseAnsi('hello\nworld')).toEqual([[{ text: 'hello' }], [{ text: 'world' }]])
+  })
+
+  it('colors a span and resets', () => {
+    const [line] = parseAnsi('\x1b[32mPASS\x1b[0m tests')
+
+    expect(line).toEqual([{ fg: 2, text: 'PASS' }, { text: ' tests' }])
+  })
+
+  it('treats an empty SGR as a reset', () => {
+    const [line] = parseAnsi('\x1b[31mred\x1b[mplain')
+
+    expect(line).toEqual([{ fg: 1, text: 'red' }, { text: 'plain' }])
+  })
+
+  it('combines bold with color and clears bold on 22', () => {
+    const [line] = parseAnsi('\x1b[1;31mfail\x1b[22m still red')
+
+    expect(line).toEqual([
+      { bold: true, fg: 1, text: 'fail' },
+      { fg: 1, text: ' still red' },
+    ])
+  })
+
+  it('maps bright colors to the high palette', () => {
+    const [line] = parseAnsi('\x1b[90mdim gray\x1b[0m')
+
+    expect(line).toEqual([{ fg: 8, text: 'dim gray' }])
+  })
+
+  it('carries style across lines until reset', () => {
+    const lines = parseAnsi('\x1b[33mone\ntwo\x1b[0m\nthree')
+
+    expect(lines).toEqual([
+      [{ fg: 3, text: 'one' }],
+      [{ fg: 3, text: 'two' }],
+      [{ text: 'three' }],
+    ])
+  })
+
+  it('resolves 256-color and truecolor forms to CSS', () => {
+    const [line] = parseAnsi('\x1b[38;5;196mred\x1b[0m \x1b[38;2;10;20;30mrgb\x1b[0m')
+
+    expect(line?.[0]).toEqual({ fg: 'rgb(255, 0, 0)', text: 'red' })
+    expect(line?.[2]).toEqual({ fg: 'rgb(10, 20, 30)', text: 'rgb' })
+  })
+
+  it('keeps low 256-color indexes on the palette', () => {
+    const [line] = parseAnsi('\x1b[38;5;4mblue\x1b[0m')
+
+    expect(line).toEqual([{ fg: 4, text: 'blue' }])
+  })
+
+  it('applies background colors', () => {
+    const [line] = parseAnsi('\x1b[41mon red\x1b[49m off')
+
+    expect(line).toEqual([{ bg: 1, text: 'on red' }, { text: ' off' }])
+  })
+
+  it('strips cursor movement and OSC sequences', () => {
+    expect(textOf(parseAnsi('\x1b[2Kcleared \x1b]0;title\x07line')[0] ?? [])).toBe('cleared line')
+  })
+
+  it('ignores unknown SGR codes without dropping text', () => {
+    const [line] = parseAnsi('\x1b[5;7mtext\x1b[0m')
+
+    expect(line).toEqual([{ text: 'text' }])
+  })
+
+  it('emulates carriage-return overwrite for progress bars', () => {
+    const lines = parseAnsi('progress 10%\rprogress 50%\rdone!\nnext')
+
+    expect(lines.map(textOf)).toEqual(['done!', 'next'])
+  })
+
+  it('does not treat CRLF as an overwrite', () => {
+    expect(parseAnsi('one\r\ntwo').map(textOf)).toEqual(['one', 'two'])
+  })
+
+  it('drops a trailing newline like a terminal does', () => {
+    expect(parseAnsi('one\n').map(textOf)).toEqual(['one'])
+  })
+
+  it('keeps interior blank lines', () => {
+    expect(parseAnsi('one\n\ntwo').map(textOf)).toEqual(['one', '', 'two'])
+  })
+
+  it('survives a malformed extended color without smearing', () => {
+    const [line] = parseAnsi('\x1b[38;5m?\x1b[0m ok')
+
+    expect(textOf(line ?? [])).toBe('? ok')
+  })
+})
+
+describe('stripAnsi', () => {
+  it('yields the visible text alone', () => {
+    expect(stripAnsi('\x1b[32mPASS\x1b[0m 12 tests\n\x1b[31mFAIL\x1b[0m 1 test')).toBe(
+      'PASS 12 tests\nFAIL 1 test',
+    )
+  })
+})
+
+describe('hasAnsi', () => {
+  it('detects escapes and carriage returns', () => {
+    expect(hasAnsi('plain')).toBe(false)
+    expect(hasAnsi('a\x1b[32mb')).toBe(true)
+    expect(hasAnsi('a\rb')).toBe(true)
+  })
+})

--- a/ui-web/src/ui/ansi.ts
+++ b/ui-web/src/ui/ansi.ts
@@ -1,0 +1,226 @@
+/**
+ * ANSI SGR → styled spans, for terminal output.
+ *
+ * Shell tools stream what a terminal would show, escapes included; rendering
+ * them raw paints `␛[32m` glyph salad over every colored test run. This is the
+ * small, deliberate subset a transcript needs: SGR styling (colors, bold, dim,
+ * italic, underline), 256-color and truecolor forms, with every *other* escape
+ * (cursor movement, OSC titles) stripped rather than shown. Parsing never
+ * fails: unknown codes are ignored and the text always comes through.
+ *
+ * State carries across lines — `\x1b[31m` on line one colors every line until
+ * its reset — so a whole output is parsed in one pass, not line by line.
+ */
+
+export interface AnsiStyle {
+  /** 0–15 for the classic palette, or a CSS color for 256/truecolor forms. */
+  bg?: number | string
+  bold?: boolean
+  dim?: boolean
+  fg?: number | string
+  italic?: boolean
+  underline?: boolean
+}
+
+export interface AnsiSpan extends AnsiStyle {
+  text: string
+}
+
+/** One output line as styled runs; empty lines yield an empty array. */
+export type AnsiLine = AnsiSpan[]
+
+// SGR only: `\x1b[…m`. Every other CSI final byte is movement/erase noise in a
+// transcript, matched by the broader pattern below and dropped.
+const CSI_SGR = /^\x1b\[([0-9;]*)m/
+// Any CSI sequence (parameter, intermediate, final byte), OSC terminated by
+// BEL or ST, and the stray two-byte escapes some tools emit.
+const OTHER_ESCAPE = /^(?:\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)?|\x1b[@-_])/
+
+/** The xterm 256-color cube/grayscale, resolved to CSS. 0–15 stay palette ids. */
+function color256(index: number): number | string {
+  if (index < 0) return 7
+  if (index < 16) return index
+
+  if (index < 232) {
+    const cube = index - 16
+    const step = (value: number) => (value === 0 ? 0 : 55 + value * 40)
+    const r = step(Math.floor(cube / 36))
+    const g = step(Math.floor(cube / 6) % 6)
+    const b = step(cube % 6)
+
+    return `rgb(${r}, ${g}, ${b})`
+  }
+
+  if (index < 256) {
+    const gray = 8 + (index - 232) * 10
+
+    return `rgb(${gray}, ${gray}, ${gray})`
+  }
+
+  return 7
+}
+
+/**
+ * Apply one SGR parameter list to `style`, returning the next style.
+ * An empty parameter list (`\x1b[m`) is a reset, per the standard.
+ */
+function applySgr(params: string, style: AnsiStyle): AnsiStyle {
+  const next: AnsiStyle = { ...style }
+  const codes = params === '' ? [0] : params.split(';').map(part => Number.parseInt(part || '0', 10))
+
+  for (let i = 0; i < codes.length; i += 1) {
+    const code = codes[i] ?? 0
+
+    if (code === 0) {
+      delete next.bg
+      delete next.bold
+      delete next.dim
+      delete next.fg
+      delete next.italic
+      delete next.underline
+    } else if (code === 1) next.bold = true
+    else if (code === 2) next.dim = true
+    else if (code === 3) next.italic = true
+    else if (code === 4) next.underline = true
+    else if (code === 21 || code === 22) {
+      delete next.bold
+      delete next.dim
+    } else if (code === 23) delete next.italic
+    else if (code === 24) delete next.underline
+    else if (code >= 30 && code <= 37) next.fg = code - 30
+    else if (code === 39) delete next.fg
+    else if (code >= 40 && code <= 47) next.bg = code - 40
+    else if (code === 49) delete next.bg
+    else if (code >= 90 && code <= 97) next.fg = code - 90 + 8
+    else if (code >= 100 && code <= 107) next.bg = code - 100 + 8
+    else if (code === 38 || code === 48) {
+      // Extended color: `38;5;N` (256) or `38;2;R;G;B` (truecolor). Both
+      // consume their arguments even when the values are out of range, so a
+      // malformed sequence cannot smear into the codes after it.
+      const mode = codes[i + 1]
+
+      if (mode === 5) {
+        const value = color256(codes[i + 2] ?? 7)
+
+        if (code === 38) next.fg = value
+        else next.bg = value
+
+        i += 2
+      } else if (mode === 2) {
+        const [r, g, b] = [codes[i + 2] ?? 0, codes[i + 3] ?? 0, codes[i + 4] ?? 0]
+        const value = `rgb(${r}, ${g}, ${b})`
+
+        if (code === 38) next.fg = value
+        else next.bg = value
+
+        i += 4
+      }
+    }
+    // Anything else (blink, inverse, fonts…) is ignored on purpose.
+  }
+
+  return next
+}
+
+function isStyled(style: AnsiStyle): boolean {
+  return (
+    style.bg !== undefined ||
+    style.bold === true ||
+    style.dim === true ||
+    style.fg !== undefined ||
+    style.italic === true ||
+    style.underline === true
+  )
+}
+
+/**
+ * Parse terminal output into lines of styled spans.
+ *
+ * `\r` is honored the way a terminal honors it: text after a carriage return
+ * overwrites the line so far, which is what turns a progress bar's hundred
+ * frames into its final state instead of one endless line. CRLF is plain
+ * line ending, not an overwrite.
+ */
+export function parseAnsi(text: string): AnsiLine[] {
+  const lines: AnsiLine[] = []
+  let spans: AnsiSpan[] = []
+  let style: AnsiStyle = {}
+  let plain = ''
+
+  const flushText = () => {
+    if (plain === '') return
+
+    spans.push(isStyled(style) ? { ...style, text: plain } : { text: plain })
+    plain = ''
+  }
+
+  const endLine = () => {
+    flushText()
+    lines.push(spans)
+    spans = []
+  }
+
+  const source = text.replace(/\r+\n/g, '\n').replace(/\n$/, '')
+  let index = 0
+
+  while (index < source.length) {
+    const char = source[index] as string
+
+    if (char === '\x1b') {
+      const rest = source.slice(index)
+      const sgr = CSI_SGR.exec(rest)
+
+      if (sgr !== null) {
+        flushText()
+        style = applySgr(sgr[1] ?? '', style)
+        index += sgr[0].length
+        continue
+      }
+
+      const other = OTHER_ESCAPE.exec(rest)
+
+      if (other !== null) {
+        index += other[0].length
+        continue
+      }
+
+      // A bare escape with no recognizable sequence: drop the byte alone.
+      index += 1
+      continue
+    }
+
+    if (char === '\n') {
+      endLine()
+      index += 1
+      continue
+    }
+
+    if (char === '\r') {
+      // Overwrite: everything accumulated on this line so far is what the
+      // progress bar painted over.
+      spans = []
+      plain = ''
+      index += 1
+      continue
+    }
+
+    plain += char
+    index += 1
+  }
+
+  endLine()
+
+  return lines
+}
+
+/** True when the text carries any escape worth parsing. */
+export function hasAnsi(text: string): boolean {
+  return text.includes('\x1b') || text.includes('\r')
+}
+
+/** The text alone — what a copy affordance should yield. */
+export function stripAnsi(text: string): string {
+  return parseAnsi(text)
+    .map(line => line.map(span => span.text).join(''))
+    .join('\n')
+}

--- a/ui-web/src/ui/linkify.test.tsx
+++ b/ui-web/src/ui/linkify.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { linkifyText } from './linkify.tsx'
+
+afterEach(cleanup)
+
+function renderLine(text: string) {
+  return render(<div>{linkifyText(text)}</div>)
+}
+
+describe('linkifyText', () => {
+  it('leaves plain text untouched', () => {
+    const { container } = renderLine('nothing to see here')
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.textContent).toBe('nothing to see here')
+  })
+
+  it('turns a bare URL into a safe external link', () => {
+    const { container } = renderLine('see https://react.dev/blog for details')
+    const anchor = container.querySelector('a')
+
+    expect(anchor?.getAttribute('href')).toBe('https://react.dev/blog')
+    expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer')
+    expect(anchor?.getAttribute('target')).toBe('_blank')
+    expect(container.textContent).toBe('see https://react.dev/blog for details')
+  })
+
+  it('keeps trailing punctuation out of the address', () => {
+    const { container } = renderLine('read https://example.com/docs.')
+
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('https://example.com/docs')
+    expect(container.textContent).toBe('read https://example.com/docs.')
+  })
+
+  it('links every URL on the line', () => {
+    const { container } = renderLine('https://a.io and https://b.io')
+
+    expect(container.querySelectorAll('a')).toHaveLength(2)
+  })
+
+  it('ignores non-http protocols', () => {
+    const { container } = renderLine('ftp://files.example.com and javascript:alert(1)')
+
+    expect(container.querySelector('a')).toBeNull()
+  })
+})

--- a/ui-web/src/ui/linkify.tsx
+++ b/ui-web/src/ui/linkify.tsx
@@ -1,0 +1,48 @@
+import { Fragment, type ReactNode } from 'react'
+
+/**
+ * Bare http(s) URLs in plain text → anchors, for tool output that carries
+ * references (web search results, fetch citations). Everything else passes
+ * through as text. Only absolute http(s) URLs qualify — the same policy the
+ * markdown renderer applies to authored links.
+ */
+const URL_PATTERN = /https?:\/\/[^\s<>"')\]]+/g
+
+/** Trailing punctuation reads as prose, not as part of the address. */
+const TRAILING_PUNCTUATION = /[.,;:!?]+$/
+
+export function linkifyText(text: string, keyBase = 'link'): ReactNode {
+  if (!text.includes('http')) return text
+
+  const nodes: ReactNode[] = []
+  let last = 0
+  let count = 0
+
+  for (const match of text.matchAll(URL_PATTERN)) {
+    const start = match.index
+
+    let url = match[0]
+    const trimmed = TRAILING_PUNCTUATION.exec(url)
+
+    if (trimmed !== null) url = url.slice(0, -trimmed[0].length)
+    if (url.length < 'http://x'.length) continue
+
+    if (start > last) nodes.push(text.slice(last, start))
+
+    nodes.push(
+      <a href={url} key={`${keyBase}-${count}`} rel="noopener noreferrer" target="_blank">
+        {url}
+      </a>,
+    )
+
+    count += 1
+    last = start + url.length
+  }
+
+  if (nodes.length === 0) return text
+  if (last < text.length) nodes.push(text.slice(last))
+
+  return nodes.map((node, index) =>
+    typeof node === 'string' ? <Fragment key={`${keyBase}-t${index}`}>{node}</Fragment> : node,
+  )
+}

--- a/ui-web/src/ui/markdown/Markdown.module.css
+++ b/ui-web/src/ui/markdown/Markdown.module.css
@@ -197,6 +197,13 @@
   object-fit: contain;
 }
 
+/* Stand-in for an image whose source failed the safety check: the alt text,
+   set quietly apart from the prose. */
+.imageAlt {
+  color: var(--cc-alias-label-tertiary);
+  font-style: italic;
+}
+
 /* Display math gets its own scrollport: a long derivation must not widen the
    column. */
 .markdown :global(.katex-display-wrap) {

--- a/ui-web/src/ui/markdown/Markdown.test.tsx
+++ b/ui-web/src/ui/markdown/Markdown.test.tsx
@@ -1,94 +1,193 @@
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, render } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { Markdown } from './Markdown.tsx'
 
 afterEach(cleanup)
 
-describe('Markdown', () => {
-  it('renders headings, emphasis and links', () => {
-    const { container } = render(
-      <Markdown text={'# Title\n\nSome **bold** and [a link](https://example.com).'} />,
+describe('Markdown math', () => {
+  it('tokenizes display math whose TeX contains markdown escapes', async () => {
+    // `\,` lexes as a markdown escape; the old post-hoc regex never saw the
+    // delimiters as one span and printed the raw dollars.
+    const { container, findByText } = render(
+      <Markdown text={'$$\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}$$'} />,
     )
 
-    expect(screen.getByRole('heading', { level: 1 }).textContent).toBe('Title')
-    expect(container.querySelector('strong')?.textContent).toBe('bold')
-
-    const link = screen.getByRole('link', { name: 'a link' })
-    expect(link.getAttribute('href')).toBe('https://example.com')
-    // An external target without noopener hands the opened page a window
-    // handle back to this one.
-    expect(link.getAttribute('rel')).toBe('noopener noreferrer')
-    expect(link.getAttribute('target')).toBe('_blank')
+    expect(container.textContent).not.toContain('$$')
+    // KaTeX loads async; the raw TeX shows until it lands.
+    await findByText(/dx/, undefined, { timeout: 5000 })
   })
 
-  it('renders a fenced block as a code card with its language', () => {
-    const { container } = render(<Markdown text={'```ts\nconst a = 1\n```'} />)
+  it('renders single-dollar inline math', () => {
+    const { container } = render(<Markdown text="Euler: $e^{i\pi} + 1 = 0$ holds." />)
 
-    expect(container.textContent).toContain('const a = 1')
-    expect(container.textContent).toContain('typescript')
-    expect(screen.getByRole('button', { name: 'Copy' })).toBeTruthy()
+    expect(container.textContent).not.toContain('$')
+    expect(container.textContent).toContain('e^{i\\pi} + 1 = 0')
   })
 
-  it('renders a GFM table inside its own scrollport', () => {
-    const { container } = render(<Markdown text={'| a | b |\n| - | - |\n| 1 | 2 |'} />)
+  it('renders \\(...\\) and \\[...\\] delimiters', () => {
+    const { container } = render(<Markdown text={'Inline \\(a+b\\) and block:\n\n\\[a-b\\]'} />)
 
-    expect(container.querySelectorAll('th')).toHaveLength(2)
-    expect(container.querySelectorAll('td')).toHaveLength(2)
-    // A wide table must scroll itself rather than widen the transcript column.
-    const scroll = container.querySelector('table')?.parentElement
-    expect(scroll?.className).toMatch(/tableScroll/)
+    expect(container.textContent).toContain('a+b')
+    expect(container.textContent).toContain('a-b')
+    expect(container.textContent).not.toContain('\\(')
+    expect(container.textContent).not.toContain('\\[')
   })
 
-  it('renders task list items as checkboxes', () => {
-    const { container } = render(<Markdown text={'- [x] done\n- [ ] todo'} />)
+  it('leaves prices alone', () => {
+    const { container } = render(<Markdown text="It costs $5 and then $10 more." />)
+
+    expect(container.textContent).toContain('It costs $5 and then $10 more.')
+  })
+
+  it('leaves an unclosed dollar span literal', () => {
+    const { container } = render(<Markdown text="A lone $ sign stays." />)
+
+    expect(container.textContent).toContain('A lone $ sign stays.')
+  })
+})
+
+describe('Markdown task lists', () => {
+  it('draws the checkbox without the literal marker', () => {
+    const { container } = render(<Markdown text={'- [ ] open item\n- [x] done item'} />)
 
     const boxes = container.querySelectorAll('input[type="checkbox"]')
+
     expect(boxes).toHaveLength(2)
-    expect((boxes[0] as HTMLInputElement).checked).toBe(true)
-    expect((boxes[1] as HTMLInputElement).checked).toBe(false)
+    expect((boxes[1] as HTMLInputElement).checked).toBe(true)
+    expect(container.textContent).not.toContain('[ ]')
+    expect(container.textContent).not.toContain('[x]')
+    expect(container.textContent).toContain('open item')
+  })
+})
+
+describe('Markdown link safety', () => {
+  it('keeps https links, opening them in a new tab', () => {
+    const { container } = render(<Markdown text="[docs](https://example.com/docs)" />)
+    const anchor = container.querySelector('a')
+
+    expect(anchor?.getAttribute('href')).toBe('https://example.com/docs')
+    expect(anchor?.getAttribute('target')).toBe('_blank')
+    expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer')
   })
 
-  it('shows raw HTML as text instead of mounting it', () => {
-    // Model output is untrusted: a transcript is not a place markup executes.
-    const { container } = render(<Markdown text={'<img src=x onerror="alert(1)">'} />)
+  it('drops the anchor from a javascript: link but keeps its text', () => {
+    const { container } = render(<Markdown text="[click me](javascript:alert(1))" />)
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.textContent).toContain('click me')
+  })
+
+  it('drops the anchor from a data: link', () => {
+    const { container } = render(<Markdown text="[x](data:text/html,<script>1</script>)" />)
+
+    expect(container.querySelector('a')).toBeNull()
+  })
+
+  it('turns a backticked URL into a link around the code chip', () => {
+    const { container } = render(<Markdown text="See `https://example.com/api`." />)
+    const anchor = container.querySelector('a')
+
+    expect(anchor?.getAttribute('href')).toBe('https://example.com/api')
+    expect(anchor?.querySelector('code')?.textContent).toBe('https://example.com/api')
+  })
+
+  it('keeps a plain code chip for non-URL code', () => {
+    const { container } = render(<Markdown text="Call `fetch()` now." />)
+
+    expect(container.querySelector('a')).toBeNull()
+    expect(container.querySelector('code')?.textContent).toBe('fetch()')
+  })
+})
+
+describe('Markdown image safety', () => {
+  it('renders absolute http(s) images lazily and without a referrer', () => {
+    const { container } = render(<Markdown text="![alt text](https://example.com/x.png)" />)
+    const image = container.querySelector('img')
+
+    expect(image?.getAttribute('src')).toBe('https://example.com/x.png')
+    expect(image?.getAttribute('loading')).toBe('lazy')
+    expect(image?.getAttribute('referrerpolicy')).toBe('no-referrer')
+  })
+
+  it('shows alt text instead of a relative or data: image', () => {
+    const { container } = render(<Markdown text="![diagram](../secret.png)" />)
 
     expect(container.querySelector('img')).toBeNull()
-    expect(container.textContent).toContain('<img src=x onerror="alert(1)">')
+    expect(container.textContent).toContain('diagram')
+  })
+})
+
+describe('Markdown raw HTML', () => {
+  it('shows markup as source, never mounted', () => {
+    const { container } = render(<Markdown text={'<div onclick="alert(1)">boom</div>'} />)
+
+    expect(container.querySelector('div[onclick]')).toBeNull()
+    expect(container.textContent).toContain('<div onclick="alert(1)">')
+  })
+})
+
+describe('Markdown streaming', () => {
+  const DOC = [
+    '# Title',
+    '',
+    'First paragraph with **bold** text.',
+    '',
+    '```python',
+    'print("hi")',
+    '```',
+    '',
+    'Second paragraph.',
+    '',
+    '- item one',
+    '- item two',
+    '',
+    'Closing line.',
+  ].join('\n')
+
+  it('renders a growing document identically to the settled render', () => {
+    const streamed = render(<Markdown streaming text={DOC.slice(0, 10)} />)
+
+    // Feed the document in uneven chunks, as deltas would.
+    for (const cut of [25, 60, 61, 100, 140, DOC.length]) {
+      streamed.rerender(<Markdown streaming text={DOC.slice(0, cut)} />)
+    }
+
+    streamed.rerender(<Markdown text={DOC} />)
+
+    const settled = render(<Markdown text={DOC} />)
+
+    expect(streamed.container.textContent).toBe(settled.container.textContent)
+    expect(streamed.container.querySelectorAll('h1')).toHaveLength(1)
+    expect(streamed.container.querySelectorAll('li')).toHaveLength(2)
   })
 
-  it.each([
-    'It costs $5 and then $10 more.',
-    'A range of $5-$10 per seat.',
-    'Set $PATH and $HOME before running.',
-  ])('does not treat prose like %j as math', text => {
-    const { container } = render(<Markdown text={text} />)
+  it("keeps a frozen block's element identity across deltas", () => {
+    const first = render(<Markdown streaming text={DOC} />)
+    const heading = first.container.querySelector('h1')
 
-    expect(container.querySelector('.katex')).toBeNull()
-    expect(container.textContent).toBe(text)
+    first.rerender(<Markdown streaming text={DOC + '\n\nMore text.'} />)
+
+    // Same DOM node, not a re-created equal one: the frozen prefix is reused.
+    expect(first.container.querySelector('h1')).toBe(heading)
   })
 
-  it('still splits real inline math out of a sentence', () => {
-    const { container } = render(<Markdown text={'The area is $x^2$ exactly.'} />)
+  it('restarts cleanly when the text is rewritten', () => {
+    const view = render(<Markdown streaming text="Alpha beta" />)
 
-    // KaTeX loads lazily, so the TeX shows as code until it lands — either
-    // way the delimiters are gone and the expression is its own node.
-    expect(container.textContent).not.toContain('$')
-    expect(container.textContent).toContain('x^2')
+    view.rerender(<Markdown streaming text="Something else entirely" />)
+
+    expect(view.container.textContent).toContain('Something else entirely')
+    expect(view.container.textContent).not.toContain('Alpha')
   })
 
-  it('paints a caret only while the reply is streaming', () => {
-    const { container, rerender } = render(<Markdown streaming text="partial" />)
-    expect(container.querySelector('[class*=cursor]')).not.toBeNull()
+  it('shows the caret only while streaming', () => {
+    const view = render(<Markdown streaming text="Hello" />)
 
-    rerender(<Markdown text="partial" />)
-    expect(container.querySelector('[class*=cursor]')).toBeNull()
-  })
+    expect(view.container.querySelector('[aria-hidden]')).not.toBeNull()
 
-  it('renders an unterminated fence rather than failing', () => {
-    // Every streaming reply passes through this state on its way to a block.
-    const { container } = render(<Markdown streaming text={'```ts\nconst a ='} />)
+    view.rerender(<Markdown text="Hello" />)
 
-    expect(container.textContent).toContain('const a =')
+    expect(view.container.querySelector('[aria-hidden]')).toBeNull()
   })
 })

--- a/ui-web/src/ui/markdown/Markdown.tsx
+++ b/ui-web/src/ui/markdown/Markdown.tsx
@@ -6,10 +6,21 @@
  * and math become KaTeX — and it means no model output is ever passed to
  * `dangerouslySetInnerHTML`. React escapes every text node by construction, so
  * a reply containing `<script>` is text, not markup.
+ *
+ * Math lives in the GRAMMAR (marked tokenizer extensions), not in a regex pass
+ * over the finished tokens. The old post-hoc split broke on any TeX that
+ * marked also had an opinion about — `$$\int x\,dx$$` arrived as three tokens
+ * because `\,` lexed as an escape, and the delimiters could never reunite.
+ * A tokenizer sees the source before escapes exist.
+ *
+ * While a reply streams, blocks that can no longer change are FROZEN: their
+ * React elements are built once and reused, and only the trailing
+ * `UNSTABLE_TAIL` blocks are re-lexed per delta. Keys are absolute source
+ * offsets, so a block keeps its identity from first paint through seal.
  */
 
-import { marked, type Token, type Tokens } from 'marked'
-import { Fragment, memo, useMemo, type ReactNode } from 'react'
+import { Marked, type Token, type Tokens, type TokenizerAndRendererExtension } from 'marked'
+import { Fragment, memo, useMemo, useRef, type ReactNode } from 'react'
 
 import { CodeBlock } from '../primitives/CodeBlock.tsx'
 // Aliased: an unqualified `Math` here would shadow the global one for the
@@ -17,111 +28,158 @@ import { CodeBlock } from '../primitives/CodeBlock.tsx'
 import { Math as MathNode } from './Math.tsx'
 import css from './Markdown.module.css'
 
-/* ── math extraction ─────────────────────────────────────────────────────── */
+/* ── math grammar ────────────────────────────────────────────────────────── */
+
+interface MathToken {
+  display: boolean
+  raw: string
+  tex: string
+  type: 'math' | 'inlineMath'
+}
+
+// `$$…$$` and `\[…\]` opening a line: display math as its own block. The
+// close must be followed by end-of-line, so a paragraph does not lose its
+// tail to a greedy match.
+const BLOCK_DOLLARS = /^\$\$([\s\S]+?)\$\$ *(?:\n|$)/
+const BLOCK_BRACKETS = /^\\\[([\s\S]+?)\\\] *(?:\n|$)/
 
 /**
- * `$…$`, `\(…\)` inline and `$$…$$`, `\[…\]` display math.
+ * Inline forms. The single-`$` pattern carries the price guards, each earning
+ * its place against a real sentence:
  *
- * The single-`$` form needs guards or prices become equations. Three rules,
- * each earning its place against a real sentence:
- *
- *   - both delimiters hug non-space characters, and the body stays on one line
- *     and stays short — "it costs $5 and then $10 more." fails, because the
- *     body would end in a space;
+ *   - both delimiters hug non-space characters, and the body stays on one
+ *     line and stays short — "it costs $5 and then $10 more." fails, because
+ *     a body may not contain `$` and no closing candidate survives;
  *   - the closing `$` is not followed by a digit — "$5-$10" fails, because
  *     that closing delimiter is really a second price's opening one;
  *   - "$x^2$" passes both, which is the case the feature exists for.
  */
-const MATH_PATTERN =
-  /(\$\$[\s\S]+?\$\$|\\\[[\s\S]+?\\\]|\\\([\s\S]+?\\\)|\$[^\s$](?:[^\n$]{0,197}[^\s$])?\$(?![0-9]))/g
+const INLINE_DOLLARS = /^\$\$([\s\S]+?)\$\$/
+const INLINE_PARENS = /^\\\(([\s\S]+?)\\\)/
+const INLINE_BRACKETS = /^\\\[([\s\S]+?)\\\]/
+const INLINE_SINGLE = /^\$([^\s$](?:[^\n$]{0,197}[^\s$])?)\$(?![0-9])/
 
-interface MathPiece {
-  display: boolean
-  tex: string
-  type: 'math'
+const mathBlockExtension: TokenizerAndRendererExtension = {
+  name: 'math',
+  level: 'block',
+  start(src: string) {
+    const index = src.search(/\$\$|\\\[/)
+
+    return index === -1 ? undefined : index
+  },
+  tokenizer(src: string): MathToken | undefined {
+    const match = BLOCK_DOLLARS.exec(src) ?? BLOCK_BRACKETS.exec(src)
+
+    if (match === null) return undefined
+
+    return { display: true, raw: match[0], tex: (match[1] ?? '').trim(), type: 'math' }
+  },
 }
 
-interface TextPiece {
-  text: string
-  type: 'text'
-}
+const mathInlineExtension: TokenizerAndRendererExtension = {
+  name: 'inlineMath',
+  level: 'inline',
+  start(src: string) {
+    const index = src.search(/\$|\\\(|\\\[/)
 
-function splitMath(input: string): (MathPiece | TextPiece)[] {
-  if (!input.includes('$') && !input.includes('\\(') && !input.includes('\\[')) {
-    return [{ text: input, type: 'text' }]
-  }
+    return index === -1 ? undefined : index
+  },
+  tokenizer(src: string): MathToken | undefined {
+    const display = INLINE_DOLLARS.exec(src) ?? INLINE_BRACKETS.exec(src)
 
-  const pieces: (MathPiece | TextPiece)[] = []
-  let last = 0
-
-  for (const match of input.matchAll(MATH_PATTERN)) {
-    const index = match.index
-
-    if (index === undefined) continue
-
-    const raw = match[0]
-
-    if (index > last) pieces.push({ text: input.slice(last, index), type: 'text' })
-
-    if (raw.startsWith('$$')) {
-      pieces.push({ display: true, tex: raw.slice(2, -2), type: 'math' })
-    } else if (raw.startsWith('\\[')) {
-      pieces.push({ display: true, tex: raw.slice(2, -2), type: 'math' })
-    } else if (raw.startsWith('\\(')) {
-      pieces.push({ display: false, tex: raw.slice(2, -2), type: 'math' })
-    } else {
-      pieces.push({ display: false, tex: raw.slice(1, -1), type: 'math' })
+    if (display !== null) {
+      return { display: true, raw: display[0], tex: (display[1] ?? '').trim(), type: 'inlineMath' }
     }
 
-    last = index + raw.length
+    const inline = INLINE_PARENS.exec(src) ?? INLINE_SINGLE.exec(src)
+
+    if (inline !== null) {
+      return { display: false, raw: inline[0], tex: (inline[1] ?? '').trim(), type: 'inlineMath' }
+    }
+
+    return undefined
+  },
+}
+
+// One private instance so the extensions never leak into other users of the
+// shared `marked` singleton.
+const parser = new Marked({ gfm: true }, { extensions: [mathBlockExtension, mathInlineExtension] })
+
+function lex(text: string): Token[] {
+  try {
+    return parser.lexer(text)
+  } catch {
+    // A malformed document must still show its text.
+    return [{ raw: text, text, type: 'text' } as Token]
   }
-
-  if (last < input.length) pieces.push({ text: input.slice(last), type: 'text' })
-
-  return pieces
 }
 
-function renderTextWithMath(text: string, keyBase: string): ReactNode {
-  const pieces = splitMath(text)
+/* ── url safety ──────────────────────────────────────────────────────────── */
 
-  if (pieces.length === 1 && pieces[0]?.type === 'text') return pieces[0].text
+/**
+ * Model-authored URLs are untrusted. Links keep only protocols that navigate
+ * somewhere harmless; anything else (`javascript:`, `data:`, `vbscript:`,
+ * protocol-relative smuggling) renders as its text without an anchor.
+ */
+const SAFE_LINK = /^(?:https?:|mailto:)/i
 
-  return pieces.map((piece, index) =>
-    piece.type === 'math' ? (
-      <MathNode display={piece.display} key={`${keyBase}-m${index}`} tex={piece.tex} />
-    ) : (
-      <Fragment key={`${keyBase}-t${index}`}>{piece.text}</Fragment>
-    ),
-  )
-}
-
-/* ── token rendering ─────────────────────────────────────────────────────── */
-
-function renderInline(tokens: Token[] | undefined, keyBase: string): ReactNode {
-  if (tokens === undefined) return null
-
-  return tokens.map((token, index) => renderToken(token, `${keyBase}-${index}`))
-}
+/** Images additionally must be absolute http(s): a relative src would fetch
+    from this app's own origin, and `data:` bodies can be megabytes of noise. */
+const SAFE_IMAGE = /^https?:\/\//i
 
 function isExternal(href: string): boolean {
   return /^(https?:)?\/\//.test(href)
 }
 
-function renderToken(token: Token, key: string): ReactNode {
+const BARE_URL = /^https?:\/\/\S+$/i
+
+/* ── token rendering ─────────────────────────────────────────────────────── */
+
+interface RenderOptions {
+  /**
+   * False for the live tail of a streaming reply. An unsettled code fence
+   * renders plain — its text is still growing, and an async highlight of a
+   * stale prefix would lag the stream by one round trip, showing old code
+   * under a new banner.
+   */
+  settled: boolean
+}
+
+const SETTLED: RenderOptions = { settled: true }
+
+function renderInline(tokens: Token[] | undefined, keyBase: string, options: RenderOptions): ReactNode {
+  if (tokens === undefined) return null
+
+  return tokens.map((token, index) => renderToken(token, `${keyBase}-${index}`, options))
+}
+
+function renderToken(token: Token, key: string, options: RenderOptions): ReactNode {
   switch (token.type) {
     case 'space':
+      return null
+
+    case 'math':
+    case 'inlineMath': {
+      const math = token as unknown as MathToken
+
+      return <MathNode display={math.display} key={key} tex={math.tex} />
+    }
+
+    // The checkbox itself is drawn by `renderListItem`; marked's token would
+    // otherwise fall through to the default arm and print a literal `[x]`.
+    case 'checkbox':
       return null
 
     case 'text': {
       const text = token as Tokens.Text
 
       // An inline-token list means the text has nested emphasis/code/links;
-      // otherwise it is a leaf and only math can still be hiding in it.
+      // otherwise it is a leaf.
       if (text.tokens !== undefined && text.tokens.length > 0) {
-        return <Fragment key={key}>{renderInline(text.tokens, key)}</Fragment>
+        return <Fragment key={key}>{renderInline(text.tokens, key, options)}</Fragment>
       }
 
-      return <Fragment key={key}>{renderTextWithMath(text.text, key)}</Fragment>
+      return <Fragment key={key}>{text.text}</Fragment>
     }
 
     case 'escape':
@@ -130,33 +188,53 @@ function renderToken(token: Token, key: string): ReactNode {
     case 'paragraph': {
       const paragraph = token as Tokens.Paragraph
 
-      return <p key={key}>{renderInline(paragraph.tokens, key)}</p>
+      return <p key={key}>{renderInline(paragraph.tokens, key, options)}</p>
     }
 
     case 'heading': {
       const heading = token as Tokens.Heading
       const Tag = `h${clampHeadingDepth(heading.depth)}` as 'h1'
 
-      return <Tag key={key}>{renderInline(heading.tokens, key)}</Tag>
+      return <Tag key={key}>{renderInline(heading.tokens, key, options)}</Tag>
     }
 
     case 'strong':
-      return <strong key={key}>{renderInline((token as Tokens.Strong).tokens, key)}</strong>
+      return (
+        <strong key={key}>{renderInline((token as Tokens.Strong).tokens, key, options)}</strong>
+      )
 
     case 'em':
-      return <em key={key}>{renderInline((token as Tokens.Em).tokens, key)}</em>
+      return <em key={key}>{renderInline((token as Tokens.Em).tokens, key, options)}</em>
 
     case 'del':
-      return <del key={key}>{renderInline((token as Tokens.Del).tokens, key)}</del>
+      return <del key={key}>{renderInline((token as Tokens.Del).tokens, key, options)}</del>
 
-    case 'codespan':
-      return <code key={key}>{(token as Tokens.Codespan).text}</code>
+    case 'codespan': {
+      const code = (token as Tokens.Codespan).text
+
+      // A backticked URL is a *reference*, and readers expect to follow it.
+      if (BARE_URL.test(code)) {
+        return (
+          <a href={code} key={key} rel="noopener noreferrer" target="_blank">
+            <code>{code}</code>
+          </a>
+        )
+      }
+
+      return <code key={key}>{code}</code>
+    }
 
     case 'br':
       return <br key={key} />
 
     case 'link': {
       const link = token as Tokens.Link
+
+      // Unsafe protocol: the text stays, the affordance goes.
+      if (!SAFE_LINK.test(link.href)) {
+        return <Fragment key={key}>{renderInline(link.tokens, key, options)}</Fragment>
+      }
+
       const external = isExternal(link.href)
 
       return (
@@ -169,7 +247,7 @@ function renderToken(token: Token, key: string): ReactNode {
           target={external ? '_blank' : undefined}
           title={link.title ?? undefined}
         >
-          {renderInline(link.tokens, key)}
+          {renderInline(link.tokens, key, options)}
         </a>
       )
     }
@@ -177,19 +255,37 @@ function renderToken(token: Token, key: string): ReactNode {
     case 'image': {
       const image = token as Tokens.Image
 
-      return <img alt={image.text} key={key} src={image.href} title={image.title ?? undefined} />
+      if (!SAFE_IMAGE.test(image.href)) {
+        return (
+          <span className={css.imageAlt} key={key}>
+            {image.text || image.href}
+          </span>
+        )
+      }
+
+      return (
+        <img
+          alt={image.text}
+          decoding="async"
+          key={key}
+          loading="lazy"
+          referrerPolicy="no-referrer"
+          src={image.href}
+          title={image.title ?? undefined}
+        />
+      )
     }
 
     case 'code': {
       const code = token as Tokens.Code
 
-      return <CodeBlock code={code.text} key={key} language={code.lang} />
+      return <CodeBlock code={code.text} key={key} language={code.lang} settled={options.settled} />
     }
 
     case 'blockquote': {
       const quote = token as Tokens.Blockquote
 
-      return <blockquote key={key}>{renderBlocks(quote.tokens, key)}</blockquote>
+      return <blockquote key={key}>{renderBlocks(quote.tokens, key, options)}</blockquote>
     }
 
     case 'hr':
@@ -197,7 +293,9 @@ function renderToken(token: Token, key: string): ReactNode {
 
     case 'list': {
       const list = token as Tokens.List
-      const items = list.items.map((item, index) => renderListItem(item, `${key}-${index}`))
+      const items = list.items.map((item, index) =>
+        renderListItem(item, `${key}-${index}`, options),
+      )
 
       return list.ordered ? (
         <ol key={key} start={typeof list.start === 'number' ? list.start : undefined}>
@@ -218,7 +316,7 @@ function renderToken(token: Token, key: string): ReactNode {
               <tr>
                 {table.header.map((cell, index) => (
                   <th key={index} style={{ textAlign: table.align[index] ?? undefined }}>
-                    {renderInline(cell.tokens, `${key}-h${index}`)}
+                    {renderInline(cell.tokens, `${key}-h${index}`, options)}
                   </th>
                 ))}
               </tr>
@@ -228,7 +326,7 @@ function renderToken(token: Token, key: string): ReactNode {
                 <tr key={rowIndex}>
                   {row.map((cell, cellIndex) => (
                     <td key={cellIndex} style={{ textAlign: table.align[cellIndex] ?? undefined }}>
-                      {renderInline(cell.tokens, `${key}-r${rowIndex}c${cellIndex}`)}
+                      {renderInline(cell.tokens, `${key}-r${rowIndex}c${cellIndex}`, options)}
                     </td>
                   ))}
                 </tr>
@@ -252,25 +350,58 @@ function renderToken(token: Token, key: string): ReactNode {
   }
 }
 
-function renderListItem(item: Tokens.ListItem, key: string): ReactNode {
+function renderListItem(item: Tokens.ListItem, key: string, options: RenderOptions): ReactNode {
   if (item.task) {
     return (
       <li className={css.taskItem} key={key}>
         <input checked={item.checked === true} disabled readOnly type="checkbox" />
-        {renderBlocks(item.tokens, key)}
+        {renderBlocks(item.tokens, key, options)}
       </li>
     )
   }
 
-  return <li key={key}>{renderBlocks(item.tokens, key)}</li>
+  return <li key={key}>{renderBlocks(item.tokens, key, options)}</li>
 }
 
-function renderBlocks(tokens: Token[], keyBase: string): ReactNode {
-  return tokens.map((token, index) => renderToken(token, `${keyBase}-${index}`))
+function renderBlocks(tokens: Token[], keyBase: string, options: RenderOptions): ReactNode {
+  return tokens.map((token, index) => renderToken(token, `${keyBase}-${index}`, options))
 }
 
 function clampHeadingDepth(depth: number): number {
   return Math.min(6, Math.max(1, depth))
+}
+
+/* ── streaming: freeze settled blocks ────────────────────────────────────── */
+
+/**
+ * Trailing blocks that stay live. The LAST block is obviously still growing;
+ * one more is margin for constructs a later line can still reshape (a setext
+ * underline, a table's delimiter row, lazy list continuation). Everything
+ * before that is final by the block grammar and never re-lexed.
+ */
+const UNSTABLE_TAIL = 2
+
+interface StreamState {
+  /** Source prefix the frozen elements cover. */
+  frozenSource: string
+  frozenNodes: ReactNode[]
+}
+
+/** Top-level blocks keyed by ABSOLUTE source offset, stable across deltas. */
+function renderAbsolute(
+  tokens: Token[],
+  startOffset: number,
+  options: RenderOptions,
+): { length: number; nodes: ReactNode[] } {
+  const nodes: ReactNode[] = []
+  let offset = startOffset
+
+  for (const token of tokens) {
+    nodes.push(renderToken(token, `md-${offset}`, options))
+    offset += token.raw.length
+  }
+
+  return { length: offset - startOffset, nodes }
 }
 
 /* ── component ───────────────────────────────────────────────────────────── */
@@ -283,18 +414,57 @@ export interface MarkdownProps {
 }
 
 function MarkdownImpl({ className, streaming = false, text }: MarkdownProps) {
-  const tokens = useMemo(() => {
-    try {
-      return marked.lexer(text, { gfm: true })
-    } catch {
-      // A malformed document must still show its text.
-      return [{ raw: text, text, type: 'text' } as Token]
+  const stream = useRef<StreamState | null>(null)
+
+  const content = useMemo(() => {
+    if (!streaming) {
+      stream.current = null
+
+      // Absolute keys here too, so the one re-render at seal reconciles
+      // against the streamed blocks instead of remounting the whole reply.
+      return renderAbsolute(lex(text), 0, SETTLED).nodes
     }
-  }, [text])
+
+    let state = stream.current
+
+    // A rewind (retry, edit) is the only way the frozen prefix can change;
+    // starting over is correct and costs one full lex.
+    if (state === null || !text.startsWith(state.frozenSource)) {
+      state = { frozenNodes: [], frozenSource: '' }
+    }
+
+    const tailTokens = lex(text.slice(state.frozenSource.length))
+    const freezeCount = tailTokens.length - UNSTABLE_TAIL
+
+    if (freezeCount > 0) {
+      const frozen = renderAbsolute(
+        tailTokens.slice(0, freezeCount),
+        state.frozenSource.length,
+        SETTLED,
+      )
+
+      state = {
+        frozenNodes: [...state.frozenNodes, ...frozen.nodes],
+        frozenSource:
+          state.frozenSource +
+          text.slice(state.frozenSource.length, state.frozenSource.length + frozen.length),
+      }
+    }
+
+    stream.current = state
+
+    const live = renderAbsolute(
+      tailTokens.slice(Math.max(0, freezeCount)),
+      state.frozenSource.length,
+      { settled: false },
+    )
+
+    return [...state.frozenNodes, ...live.nodes]
+  }, [streaming, text])
 
   return (
     <div className={[css.markdown, className].filter(Boolean).join(' ')}>
-      {renderBlocks(tokens, 'md')}
+      {content}
       {streaming && <span aria-hidden="true" className={css.cursor} />}
     </div>
   )

--- a/ui-web/src/ui/primitives/AnsiText.module.css
+++ b/ui-web/src/ui/primitives/AnsiText.module.css
@@ -1,0 +1,44 @@
+/* ANSI palette roles. The values live in tokens.css (`--cc-ansi-*`) so light
+   and dark each pick tones readable on their own card surface. */
+
+.fg0 { color: var(--cc-ansi-0); }
+.fg1 { color: var(--cc-ansi-1); }
+.fg2 { color: var(--cc-ansi-2); }
+.fg3 { color: var(--cc-ansi-3); }
+.fg4 { color: var(--cc-ansi-4); }
+.fg5 { color: var(--cc-ansi-5); }
+.fg6 { color: var(--cc-ansi-6); }
+.fg7 { color: var(--cc-ansi-7); }
+.fg8 { color: var(--cc-ansi-8); }
+.fg9 { color: var(--cc-ansi-9); }
+.fg10 { color: var(--cc-ansi-10); }
+.fg11 { color: var(--cc-ansi-11); }
+.fg12 { color: var(--cc-ansi-12); }
+.fg13 { color: var(--cc-ansi-13); }
+.fg14 { color: var(--cc-ansi-14); }
+.fg15 { color: var(--cc-ansi-15); }
+
+.bg0 { background-color: var(--cc-ansi-0); }
+.bg1 { background-color: var(--cc-ansi-1); }
+.bg2 { background-color: var(--cc-ansi-2); }
+.bg3 { background-color: var(--cc-ansi-3); }
+.bg4 { background-color: var(--cc-ansi-4); }
+.bg5 { background-color: var(--cc-ansi-5); }
+.bg6 { background-color: var(--cc-ansi-6); }
+.bg7 { background-color: var(--cc-ansi-7); }
+.bg8 { background-color: var(--cc-ansi-8); }
+.bg9 { background-color: var(--cc-ansi-9); }
+.bg10 { background-color: var(--cc-ansi-10); }
+.bg11 { background-color: var(--cc-ansi-11); }
+.bg12 { background-color: var(--cc-ansi-12); }
+.bg13 { background-color: var(--cc-ansi-13); }
+.bg14 { background-color: var(--cc-ansi-14); }
+.bg15 { background-color: var(--cc-ansi-15); }
+
+.bold { font-weight: 600; }
+
+.dim { opacity: 0.65; }
+
+.italic { font-style: italic; }
+
+.underline { text-decoration: underline; }

--- a/ui-web/src/ui/primitives/AnsiText.tsx
+++ b/ui-web/src/ui/primitives/AnsiText.tsx
@@ -1,0 +1,45 @@
+import type { CSSProperties, ReactNode } from 'react'
+
+import type { AnsiLine, AnsiSpan } from '../ansi.ts'
+import css from './AnsiText.module.css'
+
+/**
+ * Styled runs of one parsed terminal line.
+ *
+ * Palette colors (0–15) resolve through the `--cc-ansi-*` tokens so both
+ * themes pick readable tones; 256/truecolor values arrive as CSS colors and
+ * are applied inline — they are the tool's own choice, not the theme's.
+ */
+function spanNode(span: AnsiSpan, key: number): ReactNode {
+  const classes: string[] = []
+  const style: CSSProperties = {}
+
+  if (typeof span.fg === 'number') classes.push(css[`fg${span.fg}`] ?? '')
+  else if (typeof span.fg === 'string') style.color = span.fg
+
+  if (typeof span.bg === 'number') classes.push(css[`bg${span.bg}`] ?? '')
+  else if (typeof span.bg === 'string') style.backgroundColor = span.bg
+
+  if (span.bold === true) classes.push(css.bold ?? '')
+  if (span.dim === true) classes.push(css.dim ?? '')
+  if (span.italic === true) classes.push(css.italic ?? '')
+  if (span.underline === true) classes.push(css.underline ?? '')
+
+  const className = classes.filter(Boolean).join(' ')
+
+  if (className === '' && span.fg === undefined && span.bg === undefined) {
+    return span.text
+  }
+
+  return (
+    <span className={className === '' ? undefined : className} key={key} style={style}>
+      {span.text}
+    </span>
+  )
+}
+
+export function AnsiSpans({ line }: { line: AnsiLine }) {
+  if (line.length === 0) return ' '
+
+  return <>{line.map((span, index) => spanNode(span, index))}</>
+}

--- a/ui-web/src/ui/primitives/CodeBlock.tsx
+++ b/ui-web/src/ui/primitives/CodeBlock.tsx
@@ -8,22 +8,29 @@ export interface CodeBlockProps {
   className?: string
   code: string
   language?: string
+  /**
+   * False while the fence is still growing at the tail of a streaming reply.
+   * An unsettled block renders plain text: highlighting is async, so a block
+   * re-highlighted per delta would keep showing the PREVIOUS delta's colored
+   * copy — the reader watches code that lags the stream by one round trip.
+   * The one swap to colored happens when the text is final.
+   */
+  settled?: boolean
 }
 
 /**
  * A fenced code block: sticky banner (language + copy) over the source.
  *
  * Highlighting is progressive by design — the plain text paints immediately
- * and is replaced when the grammar chunk lands. That ordering matters while a
- * reply is streaming: the block is re-rendered on every delta, and waiting for
- * a highlight would leave the reader watching an empty card.
+ * and is replaced when the grammar chunk lands. A block must never fail to
+ * display over a missing grammar.
  */
-export function CodeBlock({ className, code, language }: CodeBlockProps) {
+export function CodeBlock({ className, code, language, settled = true }: CodeBlockProps) {
   const [html, setHtml] = useState<string | null>(null)
   const resolved = normalizeLanguage(language)
 
   useEffect(() => {
-    if (resolved === undefined) {
+    if (resolved === undefined || !settled) {
       setHtml(null)
 
       return
@@ -38,7 +45,7 @@ export function CodeBlock({ className, code, language }: CodeBlockProps) {
     return () => {
       cancelled = true
     }
-  }, [code, resolved])
+  }, [code, resolved, settled])
 
   return (
     <div className={[css.block, className].filter(Boolean).join(' ')}>

--- a/ui-web/src/ui/primitives/DiffBlock.tsx
+++ b/ui-web/src/ui/primitives/DiffBlock.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 
 import { CopyButton } from './CopyButton.tsx'
+import { headTailCap, splitByCap } from './head-tail-cap.ts'
 import css from './DiffBlock.module.css'
 
 export interface DiffBlockProps {
@@ -71,29 +72,34 @@ export function DiffBlock({ className, diff }: DiffBlockProps) {
 
   const added = lines.filter(line => line.kind === 'add').length
   const removed = lines.filter(line => line.kind === 'del').length
-  const overflowing = lines.length > HEAD_LINES && !expanded
-  const shown = overflowing ? lines.slice(0, HEAD_LINES) : lines
+  const cap = headTailCap(lines.length, HEAD_LINES)
+  const folded = cap.hidden > 0 && !expanded
+  const { head, tail } = folded ? splitByCap(lines, cap) : { head: lines, tail: [] }
+
+  const row = (line: DiffLine, key: string) => (
+    <div className={[css.line, css[line.kind]].filter(Boolean).join(' ')} key={key}>
+      {line.text === '' ? ' ' : line.text}
+    </div>
+  )
 
   return (
     <div className={[css.block, className].filter(Boolean).join(' ')}>
       <CopyButton className={css.copyButton} text={diff} />
       <div className={css.body}>
-        {shown.map((line, index) => (
-          <div className={[css.line, css[line.kind]].filter(Boolean).join(' ')} key={index}>
-            {line.text === '' ? ' ' : line.text}
-          </div>
-        ))}
-        {overflowing && (
+        {head.map((line, index) => row(line, `h${index}`))}
+        {cap.hidden > 0 && (
           <button
+            aria-expanded={expanded}
             className={css.expand}
             onClick={() => {
-              setExpanded(true)
+              setExpanded(value => !value)
             }}
             type="button"
           >
-            … show {lines.length - HEAD_LINES} more lines
+            {expanded ? 'collapse' : `… ${cap.hidden} more lines`}
           </button>
         )}
+        {tail.map((line, index) => row(line, `t${index}`))}
       </div>
       <div className={css.footer}>
         └ +{added} −{removed}

--- a/ui-web/src/ui/primitives/IoCard.module.css
+++ b/ui-web/src/ui/primitives/IoCard.module.css
@@ -1,0 +1,74 @@
+/* IN/OUT card: one surface, two labelled scroll windows. */
+.card {
+  display: flex;
+  flex-direction: column;
+  border-radius: 12px;
+  background: var(--cc-alias-markdown-code-block);
+  overflow: hidden;
+}
+
+.section {
+  position: relative;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr);
+  align-items: start;
+  max-height: 150px;
+  padding: 10px 14px;
+  overflow: auto;
+}
+
+/* The gutter label rides its section's scroll, staying put while the text
+   moves — the reader always knows which side of the exchange they are in. */
+.label {
+  position: sticky;
+  top: 0;
+  color: var(--cc-alias-label-caption);
+  font: var(--cc-font-xs-13);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.divider {
+  height: 1px;
+  background: var(--cc-alias-border-l2);
+}
+
+.outWrap {
+  position: relative;
+  display: flex;
+  min-width: 0;
+}
+
+.text {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  color: var(--cc-alias-label-secondary);
+  font-family: var(--cc-font-family-code);
+  font-size: 12px;
+  line-height: 18px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.text[data-error] {
+  color: var(--cc-alias-state-error-primary);
+}
+
+.copyButton {
+  position: sticky;
+  top: 0;
+  align-self: flex-start;
+  flex: none;
+  margin: 0 0 0 8px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--cc-alias-label-secondary);
+  font: var(--cc-font-xs-13);
+  cursor: pointer;
+}
+
+.copyButton:hover {
+  color: var(--cc-alias-label-primary);
+}

--- a/ui-web/src/ui/primitives/IoCard.tsx
+++ b/ui-web/src/ui/primitives/IoCard.tsx
@@ -1,0 +1,47 @@
+import { CopyButton } from './CopyButton.tsx'
+import css from './IoCard.module.css'
+
+export interface IoCardProps {
+  className?: string
+  /** The call's arguments, already formatted for reading. */
+  input?: string
+  /** The call's result text; empty renders as an explicit "(no output)". */
+  output?: string
+  tone?: 'default' | 'error'
+}
+
+/**
+ * The generic tool card: both sides of the exchange, labelled IN and OUT.
+ *
+ * A tool with no dedicated shape (Task, an MCP tool) used to show its output
+ * alone — but for exactly those tools the *arguments* are the only record of
+ * what was asked, and a failed call is unreadable without them. Each side
+ * scrolls in its own window with its label held sticky, so a long prompt
+ * cannot push the result out of reach.
+ */
+export function IoCard({ className, input, output, tone = 'default' }: IoCardProps) {
+  const hasInput = input !== undefined && input !== ''
+
+  return (
+    <div className={[css.card, className].filter(Boolean).join(' ')}>
+      {hasInput && (
+        <div className={css.section}>
+          <span className={css.label}>IN</span>
+          <pre className={css.text}>{input}</pre>
+        </div>
+      )}
+      {hasInput && <span aria-hidden="true" className={css.divider} />}
+      <div className={css.section}>
+        <span className={css.label}>OUT</span>
+        <div className={css.outWrap}>
+          <pre className={css.text} data-error={tone === 'error' ? '' : undefined}>
+            {output === undefined || output === '' ? '(no output)' : output}
+          </pre>
+          {output !== undefined && output !== '' && (
+            <CopyButton className={css.copyButton} text={output} />
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui-web/src/ui/primitives/ReadBlock.tsx
+++ b/ui-web/src/ui/primitives/ReadBlock.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react'
 
 import { CopyButton } from './CopyButton.tsx'
+import { headTailCap, splitByCap } from './head-tail-cap.ts'
 import css from './ReadBlock.module.css'
 
 export interface ReadBlockProps {
@@ -41,9 +42,17 @@ export function ReadBlock({ className, content, label }: ReadBlockProps) {
   const [expanded, setExpanded] = useState(false)
   const lines = useMemo(() => parseLines(content), [content])
 
-  const overflowing = lines.length > HEAD_LINES && !expanded
-  const shown = overflowing ? lines.slice(0, HEAD_LINES) : lines
+  const cap = headTailCap(lines.length, HEAD_LINES)
+  const folded = cap.hidden > 0 && !expanded
+  const { head, tail } = folded ? splitByCap(lines, cap) : { head: lines, tail: [] }
   const plain = useMemo(() => lines.map(line => line.text).join('\n'), [lines])
+
+  const row = (line: ReadLine) => (
+    <div className={css.line} key={line.number}>
+      <span className={css.gutter}>{line.number}</span>
+      <span className={css.content}>{line.text === '' ? ' ' : line.text}</span>
+    </div>
+  )
 
   return (
     <div className={[css.block, className].filter(Boolean).join(' ')}>
@@ -59,23 +68,20 @@ export function ReadBlock({ className, content, label }: ReadBlockProps) {
         </span>
       </div>
       <div className={css.body}>
-        {shown.map(line => (
-          <div className={css.line} key={line.number}>
-            <span className={css.gutter}>{line.number}</span>
-            <span className={css.content}>{line.text === '' ? ' ' : line.text}</span>
-          </div>
-        ))}
-        {overflowing && (
+        {head.map(row)}
+        {cap.hidden > 0 && (
           <button
+            aria-expanded={expanded}
             className={css.expand}
             onClick={() => {
-              setExpanded(true)
+              setExpanded(value => !value)
             }}
             type="button"
           >
-            … show {lines.length - HEAD_LINES} more lines
+            {expanded ? 'collapse' : `… ${cap.hidden} more lines`}
           </button>
         )}
+        {tail.map(row)}
       </div>
     </div>
   )

--- a/ui-web/src/ui/primitives/TerminalBlock.tsx
+++ b/ui-web/src/ui/primitives/TerminalBlock.tsx
@@ -1,7 +1,10 @@
 import { useMemo, useState } from 'react'
 
+import { parseAnsi } from '../ansi.ts'
+import { AnsiSpans } from './AnsiText.tsx'
 import { CopyButton } from './CopyButton.tsx'
 import { StateDot, type RunState } from './StateDot.tsx'
+import { headTailCap, splitByCap } from './head-tail-cap.ts'
 import css from './TerminalBlock.module.css'
 
 export interface TerminalBlockProps {
@@ -12,15 +15,18 @@ export interface TerminalBlockProps {
   state: RunState
 }
 
-/** Lines shown before the "show all" affordance; long output is the norm. */
-const HEAD_LINES = 40
+/** Visible lines when capped; the fold sits mid-card so the tail stays. */
+const MAX_LINES = 40
 
 export function TerminalBlock({ className, command, cwd, output, state }: TerminalBlockProps) {
   const [expanded, setExpanded] = useState(false)
 
-  const lines = useMemo(() => (output ?? '').replace(/\n$/, '').split('\n'), [output])
-  const overflowing = lines.length > HEAD_LINES && !expanded
-  const shown = overflowing ? lines.slice(0, HEAD_LINES) : lines
+  // ANSI is parsed once for the whole output: colors set on one line style the
+  // next, so per-line parsing would drop every multi-line span.
+  const lines = useMemo(() => parseAnsi(output ?? ''), [output])
+  const cap = headTailCap(lines.length, MAX_LINES)
+  const folded = cap.hidden > 0 && !expanded
+  const { head, tail } = folded ? splitByCap(lines, cap) : { head: lines, tail: [] }
   const running = state === 'running'
 
   return (
@@ -45,24 +51,30 @@ export function TerminalBlock({ className, command, cwd, output, state }: Termin
           <div className={css.empty}>(no output)</div>
         ) : (
           <div className={css.output}>
-            {shown.map((line, index) => (
+            {head.map((line, index) => (
               // Output lines have no identity of their own; the index is the
               // only stable key and the list is append-only in practice.
               <div className={css.line} key={index}>
-                {line === '' ? ' ' : line}
+                <AnsiSpans line={line} />
               </div>
             ))}
-            {overflowing && (
+            {cap.hidden > 0 && (
               <button
+                aria-expanded={expanded}
                 className={css.expand}
                 onClick={() => {
-                  setExpanded(true)
+                  setExpanded(value => !value)
                 }}
                 type="button"
               >
-                … show {lines.length - HEAD_LINES} more lines
+                {expanded ? 'collapse' : `… ${cap.hidden} more lines`}
               </button>
             )}
+            {tail.map((line, index) => (
+              <div className={css.line} key={`tail-${index}`}>
+                <AnsiSpans line={line} />
+              </div>
+            ))}
           </div>
         ))}
     </div>

--- a/ui-web/src/ui/primitives/WebBlock.module.css
+++ b/ui-web/src/ui/primitives/WebBlock.module.css
@@ -1,0 +1,92 @@
+/* Web tool card: same 12px surface family as the other tool cards. */
+.block {
+  border-radius: 12px;
+  background: var(--cc-alias-markdown-code-block);
+  color: var(--cc-alias-label-primary);
+  overflow: hidden;
+}
+
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--cc-alias-border-l2);
+  font: var(--cc-font-xs-13);
+}
+
+.label {
+  color: var(--cc-alias-label-secondary);
+}
+
+/* The fetched address: the card's own citation, ellipsized mid-card. */
+.source {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--cc-alias-state-business-primary);
+  font-family: var(--cc-font-family-code);
+  font-size: 12px;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.source:hover {
+  text-decoration: underline;
+}
+
+.copyButton {
+  flex: none;
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--cc-alias-label-secondary);
+  font: inherit;
+  cursor: pointer;
+}
+
+.copyButton:hover {
+  color: var(--cc-alias-label-primary);
+}
+
+.body {
+  max-height: 300px;
+  padding: 10px 14px;
+  overflow: auto;
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.line {
+  min-height: 20px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.line a {
+  color: var(--cc-alias-state-business-primary);
+  text-decoration: none;
+}
+
+.line a:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.expand {
+  display: block;
+  width: 100%;
+  padding: 2px 0;
+  border: none;
+  background: transparent;
+  color: var(--cc-alias-label-tertiary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.expand:hover {
+  color: var(--cc-alias-label-secondary);
+}

--- a/ui-web/src/ui/primitives/WebBlock.tsx
+++ b/ui-web/src/ui/primitives/WebBlock.tsx
@@ -1,0 +1,67 @@
+import { useMemo, useState } from 'react'
+
+import { linkifyText } from '../linkify.tsx'
+import { CopyButton } from './CopyButton.tsx'
+import { headTailCap, splitByCap } from './head-tail-cap.ts'
+import css from './WebBlock.module.css'
+
+export interface WebBlockProps {
+  className?: string
+  /** Search results or extracted page text; URLs inside become links. */
+  text: string
+  /** The fetched address, shown as the card's source line. */
+  url?: string
+}
+
+const MAX_LINES = 40
+
+/**
+ * Card for the web tools. The one thing a search result card owes the reader
+ * that a generic output card does not: its references are FOLLOWABLE — every
+ * URL is an anchor, and a fetch names its source at the top.
+ */
+export function WebBlock({ className, text, url }: WebBlockProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const lines = useMemo(() => text.replace(/\n$/, '').split('\n'), [text])
+  const cap = headTailCap(lines.length, MAX_LINES)
+  const folded = cap.hidden > 0 && !expanded
+  const { head, tail } = folded ? splitByCap(lines, cap) : { head: lines, tail: [] }
+
+  const row = (line: string, key: string) => (
+    <div className={css.line} key={key}>
+      {line === '' ? ' ' : linkifyText(line, key)}
+    </div>
+  )
+
+  return (
+    <div className={[css.block, className].filter(Boolean).join(' ')}>
+      <div className={css.banner}>
+        {url === undefined || url === '' ? (
+          <span className={css.label}>results</span>
+        ) : (
+          <a className={css.source} href={url} rel="noopener noreferrer" target="_blank">
+            {url}
+          </a>
+        )}
+        <CopyButton className={css.copyButton} text={text} />
+      </div>
+      <div className={css.body}>
+        {head.map((line, index) => row(line, `h${index}`))}
+        {cap.hidden > 0 && (
+          <button
+            aria-expanded={expanded}
+            className={css.expand}
+            onClick={() => {
+              setExpanded(value => !value)
+            }}
+            type="button"
+          >
+            {expanded ? 'collapse' : `… ${cap.hidden} more lines`}
+          </button>
+        )}
+        {tail.map((line, index) => row(line, `t${index}`))}
+      </div>
+    </div>
+  )
+}

--- a/ui-web/src/ui/primitives/head-tail-cap.test.ts
+++ b/ui-web/src/ui/primitives/head-tail-cap.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { headTailCap, splitByCap } from './head-tail-cap.ts'
+
+describe('headTailCap', () => {
+  it('shows everything under the cap', () => {
+    expect(headTailCap(10, 40)).toEqual({ head: 10, hidden: 0, tail: 0 })
+  })
+
+  it('does not fold for a saving smaller than the slack', () => {
+    // Hiding 3 lines behind a button costs more than it saves.
+    expect(headTailCap(43, 40)).toEqual({ head: 43, hidden: 0, tail: 0 })
+  })
+
+  it('splits an over-cap count into head, fold, tail', () => {
+    expect(headTailCap(100, 40)).toEqual({ head: 20, hidden: 60, tail: 20 })
+  })
+
+  it('gives the head the odd line', () => {
+    expect(headTailCap(100, 41)).toEqual({ head: 21, hidden: 59, tail: 20 })
+  })
+})
+
+describe('splitByCap', () => {
+  const lines = Array.from({ length: 10 }, (_, index) => index)
+
+  it('returns everything when the cap did not engage', () => {
+    expect(splitByCap(lines, { head: 10, hidden: 0, tail: 0 })).toEqual({ head: lines, tail: [] })
+  })
+
+  it('windows the head and the tail', () => {
+    expect(splitByCap(lines, { head: 2, hidden: 6, tail: 2 })).toEqual({
+      head: [0, 1],
+      tail: [8, 9],
+    })
+  })
+})

--- a/ui-web/src/ui/primitives/head-tail-cap.ts
+++ b/ui-web/src/ui/primitives/head-tail-cap.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared truncation arithmetic for the card primitives (terminal, diff, read).
+ *
+ * A capped card shows the HEAD and the TAIL with the fold in the middle,
+ * because the tail is where a command's verdict lives — the exit error, the
+ * failing test name, the "N files changed" line. Head-only truncation hides
+ * exactly the lines the reader opened the card for.
+ *
+ * The split mirrors the DeepSeek Harness card rule: head = ⌈max/2⌉, tail =
+ * the rest, and a cap that saves less than `SLACK` lines is not applied at
+ * all — a "… 2 more lines" button costs more attention than the lines do.
+ */
+
+export interface HeadTailCap {
+  /** Lines hidden between the two windows; 0 means the cap did not engage. */
+  hidden: number
+  /** Line count of the leading window. */
+  head: number
+  /** Line count of the trailing window. */
+  tail: number
+}
+
+const SLACK = 4
+
+export function headTailCap(total: number, maxLines: number): HeadTailCap {
+  if (total <= maxLines + SLACK) {
+    return { head: total, hidden: 0, tail: 0 }
+  }
+
+  const head = Math.ceil(maxLines / 2)
+  const tail = maxLines - head
+
+  return { head, hidden: total - maxLines, tail }
+}
+
+/** Apply a cap to a line array: `[head, hidden, tail]` windows. */
+export function splitByCap<T>(lines: T[], cap: HeadTailCap): { head: T[]; tail: T[] } {
+  if (cap.hidden === 0) return { head: lines, tail: [] }
+
+  return { head: lines.slice(0, cap.head), tail: lines.slice(lines.length - cap.tail) }
+}


### PR DESCRIPTION
## What

A side-by-side rendering pass of the web client's chat transcript against the DeepSeek Harness reference client, closing every gap in what the reader actually sees. Verified element by element against a fixture session exercising the full vocabulary (all tool families, every markdown construct, ANSI output, errors), plus a live streamed turn on the deepseek provider, in both themes.

## Fixes (things that were wrong)

- **ANSI escapes rendered as glyph salad** in terminal cards. New dependency-free SGR parser (16/256/truecolor, bold/dim/italic/underline, cross-line state, `\r` progress-bar overwrite; other CSI/OSC noise stripped), painted over theme-tuned `--cc-ansi-*` tokens.
- **Display math broke on ordinary TeX**: `$$\int x\,dx$$` printed raw dollars because `\,` lexed as a markdown escape and split the delimiters. Math now lives in the grammar (marked tokenizer extensions for `$…$`, `$$…$$`, `\(…\)`, `\[…\]`, price guards kept) instead of a regex pass over finished tokens.
- **Task lists printed a literal `[x]`** beside the checkbox (marked 18's `checkbox` token fell through to the raw-text arm).
- **`javascript:`/`data:` links rendered as live anchors**; images loaded from any `src`. Links now allowlist http/https/mailto (text kept, anchor dropped otherwise); images must be absolute http(s) and load lazily with no referrer; a backticked URL becomes a followable link.
- **Streaming code blocks lagged the stream**: every delta re-highlighted async, so the block showed the previous delta's colored copy. Unsettled fences render plain and highlight once, at seal.
- **A turn-fatal error painted twice** (interim bubble + Turn-failed notice); the duplicate bubble is dropped.

## Ported from the reference client

- **Incremental streaming markdown**: all but the trailing two blocks are frozen as rendered elements keyed by absolute source offset — a delta re-lexes only the tail, and the seal re-render reconciles instead of remounting.
- **Head/tail truncation** (`headTailCap`) for terminal/diff/read/web cards: head + "… N more lines" + tail, collapsible both ways. The tail is where a command's verdict lives.
- **Rehydration parity**: resumed sessions reconstruct Edit/Write diffs from the stored arguments (`old_string`/`new_string`, MultiEdit `edits`, Write `content`), and recover Search/List counts and "Read N lines" summaries client-side.
- **Todo row summary**: `2/6 done · <in-progress item>` instead of "Todos have been modified successfully."
- **IN/OUT card for unknown tools** (Task, MCP): both sides of the exchange with sticky gutter labels — the arguments are the only record of what was asked, and failures are unreadable without them. Failed Bash keeps its terminal shape.
- **Web cards**: search results and fetches link their URLs; a fetch names its source in the banner.
- **Scroll re-pin on content growth** (ResizeObserver): async highlights, image loads and card expansion no longer leak the flow past the fold while pinned; plus `.item:empty` guard and sealed-reasoning first-line summaries.

## Tests

60 new tests (342 total, all green): ANSI parser, math/task-list/sanitization/streaming-identity markdown suite, head/tail cap, diff synthesis, arg formatting, todo summaries, rehydration counts, linkifier, error dedup. Typecheck and production build pass (CI's gate).

## Out of scope (noted for follow-ups)

Virtualized list, fork/branch actions, hover timestamps, todo dock panel above the composer, per-session scroll restore, transcript paging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)