### PR TITLE
feat(web): settings stage 2 — appearance, language, output style

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -709,6 +709,10 @@ class _AgentSession:
                 "logo_color": _current_logo_color(),
                 # /recap — end-of-turn recap + composer suggestion toggle.
                 "recap": _recap_setting_enabled(),
+                # The preferred response language (set_language). Without this
+                # the setting is write-only: a client can change it but never
+                # show what it currently is.
+                "language": self._language or "",
             })
             return
         if subtype == "set_recap":

--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -852,6 +852,9 @@ class GatewayConnection:
             "provider.list": self.provider_list,
             "provider.save_key": self.provider_save_key,
             "provider.disconnect": self.provider_disconnect,
+            "settings.general": self.settings_general,
+            "settings.set_output_style": self.settings_set_output_style,
+            "settings.set_language": self.settings_set_language,
             "slash.exec": self.slash_exec,
             "command.dispatch": self.command_dispatch,
             "setup.status": self.setup_status,
@@ -1145,6 +1148,55 @@ class GatewayConnection:
     async def permission_cycle(self, params: dict[str, Any]) -> dict[str, Any]:
         result = await self._session(params).control_query("cycle_permission_mode", {})
         return result or {}
+
+    async def settings_general(self, params: dict[str, Any]) -> dict[str, Any]:
+        """The session-side general settings: output style and response language.
+
+        Theme is deliberately absent — it is a property of this browser
+        (localStorage), not of the session, and putting it here would imply a
+        change in one window restyles every other.
+        """
+        session = self._first_session(params)
+        if session is None:
+            return {"available_output_styles": [], "language": "", "output_style": ""}
+        result = await session.control_query("get_settings", {})
+        if not isinstance(result, dict):
+            return {"available_output_styles": [], "language": "", "output_style": ""}
+        styles = result.get("available_output_styles")
+        return {
+            "available_output_styles": styles if isinstance(styles, list) else [],
+            "language": str(result.get("language") or ""),
+            "output_style": str(result.get("output_style") or ""),
+        }
+
+    async def settings_set_output_style(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Switch the output style. The agent refuses mid-turn (it rebuilds the
+        system prompt) and validates the name against the loader's truth; both
+        refusals pass through verbatim."""
+        session = self._first_session(params)
+        if session is None:
+            return {"ok": False, "error": "start a session before changing settings"}
+        result = await session.control_query(
+            "set_output_style", {"style": _clean(params.get("style"))}
+        )
+        if not isinstance(result, dict):
+            return {"ok": False, "error": "no response from the session"}
+        return {"error": str(result.get("error") or ""), "ok": result.get("ok") is not False}
+
+    async def settings_set_language(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Set the preferred response language; empty clears it."""
+        session = self._first_session(params)
+        if session is None:
+            return {"ok": False, "error": "start a session before changing settings"}
+        result = await session.control_query(
+            "set_language", {"language": str(params.get("language") or "")}
+        )
+        if not isinstance(result, dict):
+            return {"ok": False, "error": "no response from the session"}
+        return {
+            "language": str(result.get("language") or ""),
+            "ok": result.get("ok") is not False,
+        }
 
     async def provider_list(self, params: dict[str, Any]) -> dict[str, Any]:
         """Every provider ClawCodex knows, configured or not.

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -921,3 +921,103 @@ def test_a_session_with_no_usable_name_reports_no_title(tmp_path, extra: dict[st
     session_id = _saved(tmp_path, **extra)
 
     assert load_session_messages(tmp_path, session_id)["title"] == ""
+
+
+# ── general settings (settings.general + setters) ─────────────────────────────
+
+
+def _general(reply: Any, *, live: bool = True) -> dict[str, Any]:
+    from src.server.desktop_gateway_methods import GatewayConnection
+
+    connection = GatewayConnection.__new__(GatewayConnection)
+    session = _Queryable(reply) if live else None
+    connection._first_session = lambda p: session  # type: ignore[method-assign]
+    return asyncio.run(GatewayConnection.settings_general(connection, {}))
+
+
+def test_general_settings_report_style_and_language() -> None:
+    result = _general(
+        {
+            "ok": True,
+            "output_style": "explanatory",
+            "available_output_styles": ["default", "explanatory"],
+            "language": "Español",
+        }
+    )
+
+    assert result == {
+        "available_output_styles": ["default", "explanatory"],
+        "language": "Español",
+        "output_style": "explanatory",
+    }
+
+
+def test_general_settings_degrade_to_empty_without_a_session() -> None:
+    # The section renders its needs-a-session state from exactly this shape.
+    assert _general(None, live=False) == {
+        "available_output_styles": [],
+        "language": "",
+        "output_style": "",
+    }
+
+
+def test_set_output_style_passes_the_agents_refusal_through() -> None:
+    # "cannot change output style during an active turn" is the useful part.
+    from src.server.desktop_gateway_methods import GatewayConnection
+
+    connection = GatewayConnection.__new__(GatewayConnection)
+    session = _Queryable({"ok": False, "error": "cannot change output style during an active turn"})
+    connection._first_session = lambda p: session  # type: ignore[method-assign]
+
+    result = asyncio.run(
+        GatewayConnection.settings_set_output_style(connection, {"style": "explanatory"})
+    )
+
+    assert result["ok"] is False
+    assert "active turn" in result["error"]
+    assert session.asked == ("set_output_style", {"style": "explanatory"})
+
+
+def test_set_language_forwards_empty_as_the_clear() -> None:
+    from src.server.desktop_gateway_methods import GatewayConnection
+
+    connection = GatewayConnection.__new__(GatewayConnection)
+    session = _Queryable({"ok": True, "language": ""})
+    connection._first_session = lambda p: session  # type: ignore[method-assign]
+
+    result = asyncio.run(GatewayConnection.settings_set_language(connection, {"language": ""}))
+
+    assert result == {"language": "", "ok": True}
+    assert session.asked == ("set_language", {"language": ""})
+
+
+def test_set_language_composes_the_block_into_the_system_prompt() -> None:
+    # The end of the chain the settings page drives. The block's own wording
+    # matters: "unless the user writes in another language" means an English
+    # prompt legitimately gets an English reply — the setting is a default,
+    # not a hard override.
+    from src.server.agent_server import _AgentSession
+
+    class _Bare:
+        cwd = "/tmp"
+        _language = None
+        _base_system_prompt = None
+        system_prompt = None
+
+        def _reply(self, rid: object, payload: object) -> None:
+            self.last = payload
+
+    bare = _Bare()
+    bare._compose_with_plan = _AgentSession._compose_with_plan.__get__(bare)
+    bare._base_system_prompt = [{"type": "text", "text": "You are ClawCodex."}]
+
+    _AgentSession._do_set_language(bare, "rid", "Spanish")
+
+    assert bare.last == {"ok": True, "language": "Spanish"}
+    assert "Respond in Spanish" in bare.system_prompt[-1]["text"]
+
+    # Empty clears: the block goes, the base stays.
+    _AgentSession._do_set_language(bare, "rid", "")
+
+    assert bare.last == {"ok": True, "language": ""}
+    assert len(bare.system_prompt) == 1

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -224,6 +224,13 @@ export interface ModelOption {
   slug?: string
 }
 
+/** `settings.general` — the session-side general settings. */
+export interface GeneralSettingsResult {
+  available_output_styles?: string[]
+  language?: string
+  output_style?: string
+}
+
 /** `provider.list` — every provider, configured or not. Carries no secrets. */
 export interface ProviderListResult {
   current?: string

--- a/ui-web/src/settings/GeneralSection.test.tsx
+++ b/ui-web/src/settings/GeneralSection.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { GeneralSection, styleLabel } from './GeneralSection.tsx'
+
+afterEach(cleanup)
+
+const SETTINGS = {
+  available_output_styles: ['default', 'explanatory'],
+  language: '',
+  output_style: 'default',
+}
+
+function mount(overrides: Partial<Parameters<typeof GeneralSection>[0]> = {}) {
+  const props = {
+    onLanguage: vi.fn(),
+    onStyle: vi.fn(),
+    onTheme: vi.fn(),
+    sessionLive: true,
+    settings: SETTINGS,
+    theme: 'system' as const,
+    ...overrides,
+  }
+
+  render(<GeneralSection {...props} />)
+
+  return props
+}
+
+describe('styleLabel', () => {
+  it('title-cases the style name for its chip', () => {
+    expect(styleLabel('default')).toBe('Default')
+    expect(styleLabel('explanatory')).toBe('Explanatory')
+  })
+})
+
+describe('GeneralSection', () => {
+  it('marks the active theme and reports a switch', () => {
+    const props = mount({ theme: 'dark' })
+
+    expect(screen.getByRole('button', { name: 'Dark' }).getAttribute('aria-pressed')).toBe('true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Light' }))
+    expect(props.onTheme).toHaveBeenCalledWith('light')
+  })
+
+  it('keeps the theme row working with no session', () => {
+    // Appearance belongs to this browser, not to a session.
+    const props = mount({ sessionLive: false })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dark' }))
+    expect(props.onTheme).toHaveBeenCalledWith('dark')
+  })
+
+  it('disables the session rows until there is a session', () => {
+    mount({ sessionLive: false })
+
+    expect((screen.getByLabelText('Response language') as HTMLInputElement).disabled).toBe(true)
+    expect((screen.getByRole('button', { name: 'Explanatory' }) as HTMLButtonElement).disabled).toBe(
+      true,
+    )
+    expect(screen.getAllByText('Start a session to change this.')).toHaveLength(2)
+  })
+
+  it('saves a typed language, trimmed', () => {
+    const props = mount()
+
+    fireEvent.change(screen.getByLabelText('Response language'), { target: { value: ' Español ' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(props.onLanguage).toHaveBeenCalledWith('Español')
+  })
+
+  it('offers Clear only when a language is set, and clears with an empty string', () => {
+    // Empty is the wire contract for "follow my prompts".
+    const props = mount({ settings: { ...SETTINGS, language: 'Español' } })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }))
+    expect(props.onLanguage).toHaveBeenCalledWith('')
+
+    cleanup()
+    mount()
+    expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull()
+  })
+
+  it('does not offer Save when nothing changed', () => {
+    mount({ settings: { ...SETTINGS, language: 'English' } })
+
+    expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('marks the active output style and reports a switch', () => {
+    const props = mount()
+
+    expect(
+      screen.getByRole('button', { name: 'Default' }).getAttribute('aria-pressed'),
+    ).toBe('true')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Explanatory' }))
+    expect(props.onStyle).toHaveBeenCalledWith('explanatory')
+  })
+
+  it('re-clicking the active style is a no-op', () => {
+    const props = mount()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Default' }))
+    expect(props.onStyle).not.toHaveBeenCalled()
+  })
+})

--- a/ui-web/src/settings/GeneralSection.tsx
+++ b/ui-web/src/settings/GeneralSection.tsx
@@ -1,0 +1,177 @@
+import { useEffect, useState } from 'react'
+
+import type { GeneralSettingsResult } from '../gateway/protocol.ts'
+import { Button } from '../ui/primitives/Button.tsx'
+import { type ThemePreference } from '../state/theme.ts'
+import css from './Settings.module.css'
+
+const THEMES: { id: ThemePreference; label: string }[] = [
+  { id: 'system', label: 'System' },
+  { id: 'light', label: 'Light' },
+  { id: 'dark', label: 'Dark' },
+]
+
+/** Title-case an output style name for its chip ("default" → "Default"). */
+export function styleLabel(style: string): string {
+  if (style === '') return style
+
+  return style.charAt(0).toUpperCase() + style.slice(1)
+}
+
+export interface GeneralSectionProps {
+  onLanguage: (language: string) => void
+  onStyle: (style: string) => void
+  onTheme: (preference: ThemePreference) => void
+  /** False before the first session: the session-side rows need one to talk to. */
+  sessionLive: boolean
+  settings: GeneralSettingsResult
+  theme: ThemePreference
+}
+
+/**
+ * The general section: appearance, response language, output style.
+ *
+ * Appearance is a property of THIS BROWSER (localStorage), and the other two
+ * are properties of the session — the layout says so by disabling the session
+ * rows until a session exists, while the theme row always works.
+ */
+export function GeneralSection({
+  onLanguage,
+  onStyle,
+  onTheme,
+  sessionLive,
+  settings,
+  theme,
+}: GeneralSectionProps) {
+  const [draft, setDraft] = useState(settings.language ?? '')
+
+  // The stored language arrives async; a draft the user has not touched
+  // follows it, one they have does not get overwritten mid-edit.
+  const [touched, setTouched] = useState(false)
+
+  useEffect(() => {
+    if (!touched) setDraft(settings.language ?? '')
+  }, [settings.language, touched])
+
+  const styles = settings.available_output_styles ?? []
+
+  return (
+    <div className={css.section}>
+      <div className={css.row}>
+        <div className={css.rowHead}>
+          <span className={css.rowName}>Appearance</span>
+        </div>
+        <div className={css.rowMeta}>
+          <span>How this browser draws the app. Other windows keep their own choice.</span>
+        </div>
+        <div className={css.choiceRow}>
+          {THEMES.map(entry => (
+            <button
+              aria-pressed={theme === entry.id}
+              className={[css.choice, theme === entry.id ? css.choiceOn : '']
+                .filter(Boolean)
+                .join(' ')}
+              key={entry.id}
+              onClick={() => {
+                onTheme(entry.id)
+              }}
+              type="button"
+            >
+              {entry.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className={css.row}>
+        <div className={css.rowHead}>
+          <span className={css.rowName}>Response language</span>
+        </div>
+        <div className={css.rowMeta}>
+          <span>
+            {sessionLive
+              ? 'The language the agent answers in. Leave empty to follow your prompts.'
+              : 'Start a session to change this.'}
+          </span>
+        </div>
+        <div className={css.keyRow}>
+          <input
+            aria-label="Response language"
+            className={css.keyInput}
+            disabled={!sessionLive}
+            onChange={event => {
+              setTouched(true)
+              setDraft(event.target.value)
+            }}
+            onKeyDown={event => {
+              if (event.key === 'Enter') {
+                setTouched(false)
+                onLanguage(draft.trim())
+              }
+            }}
+            placeholder="e.g. English, 中文, Español"
+            value={draft}
+          />
+          <Button
+            disabled={!sessionLive || draft.trim() === (settings.language ?? '')}
+            onClick={() => {
+              setTouched(false)
+              onLanguage(draft.trim())
+            }}
+            size="sm"
+            variant="primary"
+          >
+            Save
+          </Button>
+          {(settings.language ?? '') !== '' && (
+            <Button
+              disabled={!sessionLive}
+              onClick={() => {
+                setTouched(false)
+                setDraft('')
+                onLanguage('')
+              }}
+              size="sm"
+              variant="ghost"
+            >
+              Clear
+            </Button>
+          )}
+        </div>
+      </div>
+
+      <div className={css.row}>
+        <div className={css.rowHead}>
+          <span className={css.rowName}>Output style</span>
+        </div>
+        <div className={css.rowMeta}>
+          <span>
+            {sessionLive
+              ? 'How the agent writes: default keeps it terse, explanatory teaches as it goes.'
+              : 'Start a session to change this.'}
+          </span>
+        </div>
+        {styles.length > 0 && (
+          <div className={css.choiceRow}>
+            {styles.map(style => (
+              <button
+                aria-pressed={settings.output_style === style}
+                className={[css.choice, settings.output_style === style ? css.choiceOn : '']
+                  .filter(Boolean)
+                  .join(' ')}
+                disabled={!sessionLive}
+                key={style}
+                onClick={() => {
+                  if (style !== settings.output_style) onStyle(style)
+                }}
+                type="button"
+              >
+                {styleLabel(style)}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/ui-web/src/settings/Settings.module.css
+++ b/ui-web/src/settings/Settings.module.css
@@ -228,3 +228,38 @@
 .cancel:hover {
   background: var(--cc-alias-interactive-bg-hover);
 }
+
+/* ── choice chips (theme, output style) ──────────────────────────────────── */
+
+.choiceRow {
+  display: flex;
+  gap: 6px;
+  margin-top: 2px;
+}
+
+.choice {
+  padding: 6px 14px;
+  border: 1px solid var(--cc-alias-border-l2);
+  border-radius: 999px;
+  background: transparent;
+  color: var(--cc-alias-label-secondary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+}
+
+.choice:hover:not(:disabled) {
+  background: var(--cc-alias-interactive-bg-hover);
+}
+
+.choice:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.choiceOn,
+.choiceOn:hover:not(:disabled) {
+  border-color: var(--cc-alias-label-primary);
+  background: var(--cc-alias-interactive-bg-active);
+  color: var(--cc-alias-label-primary);
+}

--- a/ui-web/src/settings/SettingsOverlay.tsx
+++ b/ui-web/src/settings/SettingsOverlay.tsx
@@ -1,13 +1,25 @@
 import { useStore } from '@nanostores/react'
 import { useEffect } from 'react'
 
-import { disconnectProvider, refreshProviders, saveProviderKey } from '../state/actions.ts'
-import { $providers, $settingsTab } from '../state/store.ts'
+import {
+  disconnectProvider,
+  refreshGeneralSettings,
+  refreshProviders,
+  saveProviderKey,
+  setOutputStyle,
+  setResponseLanguage,
+} from '../state/actions.ts'
+import { $themePreference, setThemePreference } from '../state/theme.ts'
+import { GeneralSection } from './GeneralSection.tsx'
+import { $generalSettings, $providers, $sessionId, $settingsTab } from '../state/store.ts'
 import { XIcon } from '../ui/icons.tsx'
 import { ProvidersSection } from './ProvidersSection.tsx'
 import css from './Settings.module.css'
 
-const TABS = [{ id: 'providers', label: 'Providers' }] as const
+const TABS = [
+  { id: 'general', label: 'General' },
+  { id: 'providers', label: 'Providers' },
+] as const
 
 /**
  * Settings, as a full-screen takeover.
@@ -19,13 +31,19 @@ const TABS = [{ id: 'providers', label: 'Providers' }] as const
 export function SettingsOverlay() {
   const tab = useStore($settingsTab)
   const providers = useStore($providers)
+  const general = useStore($generalSettings)
+  const theme = useStore($themePreference)
+  const sessionId = useStore($sessionId)
 
   const open = tab !== null
 
   // Re-read on every open: a key may have been set from the CLI, or another
   // window, since this was last looked at.
   useEffect(() => {
-    if (open) void refreshProviders()
+    if (!open) return
+
+    void refreshProviders()
+    void refreshGeneralSettings()
   }, [open])
 
   useEffect(() => {
@@ -93,13 +111,28 @@ export function SettingsOverlay() {
           </nav>
 
           <div className={css.content}>
-            <ProvidersSection
-              onDisconnect={slug => {
-                void disconnectProvider(slug)
-              }}
-              onSave={saveProviderKey}
-              providers={providers.providers ?? []}
-            />
+            {tab === 'general' ? (
+              <GeneralSection
+                onLanguage={language => {
+                  void setResponseLanguage(language)
+                }}
+                onStyle={style => {
+                  void setOutputStyle(style)
+                }}
+                onTheme={setThemePreference}
+                sessionLive={sessionId !== null}
+                settings={general}
+                theme={theme}
+              />
+            ) : (
+              <ProvidersSection
+                onDisconnect={slug => {
+                  void disconnectProvider(slug)
+                }}
+                onSave={saveProviderKey}
+                providers={providers.providers ?? []}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/ui-web/src/sidebar/Sidebar.tsx
+++ b/ui-web/src/sidebar/Sidebar.tsx
@@ -270,7 +270,7 @@ export function Sidebar({ collapsed }: SidebarProps) {
           aria-label="Settings"
           className={css.iconButton}
           onClick={() => {
-            $settingsTab.set('providers')
+            $settingsTab.set('general')
           }}
           title="Settings"
           type="button"

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -18,6 +18,7 @@ import type {
   GatewayEvent,
   EffortOptionsResult,
   FileSearchResult,
+  GeneralSettingsResult,
   ModelOptionsResult,
   ProviderListResult,
   ProviderMutationResult,
@@ -32,6 +33,7 @@ import {
   $connection,
   $contextUsage,
   $effort,
+  $generalSettings,
   $detailsNodeId,
   $models,
   $notice,
@@ -724,6 +726,71 @@ async function blobToBase64(blob: Blob): Promise<string> {
     }
     reader.readAsDataURL(blob)
   })
+}
+
+/* ── general settings ────────────────────────────────────────────────────── */
+
+export async function refreshGeneralSettings(): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) {
+    $generalSettings.set({})
+
+    return
+  }
+
+  try {
+    $generalSettings.set(
+      await gateway().request<GeneralSettingsResult>('settings.general', {
+        session_id: sessionId,
+      }),
+    )
+  } catch {
+    // The section renders its needs-a-session state; nothing to shout about.
+    $generalSettings.set({})
+  }
+}
+
+export async function setOutputStyle(style: string): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) return
+
+  try {
+    const result = await gateway().request<{ error?: string; ok?: boolean }>(
+      'settings.set_output_style',
+      { session_id: sessionId, style },
+    )
+
+    // The agent refuses mid-turn and rejects unknown names; its wording is
+    // the useful part, so it is shown rather than summarized.
+    if (result.ok === false) notice(result.error === undefined || result.error === '' ? 'Could not change the output style' : result.error, 'error')
+    else notice(`Output style: ${style}`)
+  } catch (error) {
+    notice(errorText(error), 'error')
+  }
+
+  await refreshGeneralSettings()
+}
+
+export async function setResponseLanguage(language: string): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) return
+
+  try {
+    const result = await gateway().request<{ language?: string; ok?: boolean }>(
+      'settings.set_language',
+      { language, session_id: sessionId },
+    )
+
+    if (result.ok === false) notice('Could not set the language', 'error')
+    else notice(language.trim() === '' ? 'Response language cleared.' : `Responses in ${language}.`)
+  } catch (error) {
+    notice(errorText(error), 'error')
+  }
+
+  await refreshGeneralSettings()
 }
 
 /* ── providers (settings) ────────────────────────────────────────────────── */

--- a/ui-web/src/state/store.ts
+++ b/ui-web/src/state/store.ts
@@ -13,6 +13,7 @@ import type {
   CommandEntry,
   ContextUsageResult,
   EffortOptionsResult,
+  GeneralSettingsResult,
   ModelOptionsResult,
   ProviderListResult,
   ProjectNode,
@@ -68,6 +69,7 @@ export const $effort = atom<EffortOptionsResult>({ supported: false })
 /** Settings overlay: null when closed, else the section on show. */
 export const $settingsTab = atom<'general' | 'providers' | null>(null)
 export const $providers = atom<ProviderListResult>({})
+export const $generalSettings = atom<GeneralSettingsResult>({})
 export const $commands = atom<CommandEntry[]>([])
 export const $contextUsage = atom<ContextUsageResult | null>(null)
 


### PR DESCRIPTION
Stage 2 of the config page: the **General** tab — the session-side knobs that existed only as slash commands nobody discovers, plus the browser's own theme.

## What's on it

- **Appearance** — System / Light / Dark. This is a property of *this browser* (localStorage), and the layout says so: the theme row works with no session while the two session rows sit disabled with *"Start a session to change this"*. Theme is deliberately absent from the `settings.general` RPC — putting it there would imply a change in one window restyles every other.
- **Response language** — drives the agent's existing `set_language` control; empty clears. `get_settings` now reports `language`, because without it the setting was **write-only**: a client could change it but never show what it currently is.
- **Output style** — the loader's real list (`default`, `explanatory`) with the active one pressed. The agent's mid-turn refusal and unknown-style rejection pass through verbatim.

## The language semantics, pinned by test

A composition test covers the end of the chain: setting Spanish appends the exact block

```
# Response Language
Respond in Spanish unless the user writes in another language.
```

to the system prompt, and clearing removes it. The wording matters: *"unless the user writes in another language"* means an English prompt legitimately gets an English reply — the setting is a **default**, not a hard override. (I initially read an English reply as the feature failing; it was the instruction working as written.)

## Testing

9 new component specs, 5 new backend specs (RPC passthroughs + the composition test). Full suites green: 707 server, 291 web. `tsc` clean, bundle builds.

Verified live: theme flips instantly with no session and the session rows are disabled; with a session, saving `Spanish` round-trips (the field re-reads Spanish from `get_settings`, Clear appears) and Explanatory ends pressed after its own refetch.

## A genuine bug that fell out, tracked separately

Replaying a stored conversation containing thinking blocks 400s on Anthropic-shaped endpoints — `messages.N.content.0.thinking.signature: Field required` — killing the first turn after some resumes. Pre-existing (conversation replay, not settings); it reproduced twice during verification and deserves its own fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
