### PR TITLE
fix: replaying stored thinking blocks killed the turn on both wire shapes

### DIFF
--- a/src/providers/anthropic_provider.py
+++ b/src/providers/anthropic_provider.py
@@ -241,6 +241,39 @@ def _default_max_tokens(model: str | None) -> int:
     return DEFAULT_MAX_OUTPUT_TOKENS_LEGACY
 
 
+def _strip_unsigned_thinking(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop assistant ``thinking`` blocks that carry no signature.
+
+    Signed blocks replay byte-for-byte (the signature is the opaque state the
+    API validates -- see ``ChatResponse.thinking_blocks``). An UNSIGNED block
+    can never satisfy that contract: Anthropic-shaped endpoints reject it
+    outright ("messages.N.content.0.thinking.signature: Field required"),
+    which killed the first turn after resuming a stored conversation and any
+    later turn against compatible endpoints that emit unsigned thinking.
+    History without a thinking block is legal; history with an unsigned one is
+    a guaranteed 400 -- so the block is dropped, not the turn.
+    ``redacted_thinking`` carries ``data`` rather than a signature and passes
+    through untouched.
+    """
+    out: list[dict[str, Any]] = []
+    for msg in messages:
+        content = msg.get("content")
+        if msg.get("role") != "assistant" or not isinstance(content, list):
+            out.append(msg)
+            continue
+        kept = [
+            block
+            for block in content
+            if not (
+                isinstance(block, dict)
+                and block.get("type") == "thinking"
+                and not block.get("signature")
+            )
+        ]
+        out.append({**msg, "content": kept} if len(kept) != len(content) else msg)
+    return out
+
+
 class AnthropicProvider(BaseProvider):
     """Anthropic Claude provider."""
 
@@ -332,7 +365,7 @@ class AnthropicProvider(BaseProvider):
         """
         prepared = super()._prepare_messages(messages)
         from .openai_responses import strip_responses_item_blocks
-        return strip_responses_item_blocks(prepared)
+        return _strip_unsigned_thinking(strip_responses_item_blocks(prepared))
 
     def _effective_base_url(self) -> str | None:
         """The base URL the SDK will actually use.

--- a/src/providers/openai_compatible.py
+++ b/src/providers/openai_compatible.py
@@ -147,6 +147,26 @@ def _translate_anthropic_multimodal_block(block: Any) -> dict[str, Any] | None:
     return _anthropic_document_block_to_openai(block)
 
 
+def _strip_thinking_blocks(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop ``thinking``/``redacted_thinking`` blocks from assistant history."""
+    out: list[dict[str, Any]] = []
+    for msg in messages:
+        content = msg.get("content")
+        if msg.get("role") != "assistant" or not isinstance(content, list):
+            out.append(msg)
+            continue
+        kept = [
+            block
+            for block in content
+            if not (
+                isinstance(block, dict)
+                and block.get("type") in ("thinking", "redacted_thinking")
+            )
+        ]
+        out.append({**msg, "content": kept} if len(kept) != len(content) else msg)
+    return out
+
+
 def _convert_anthropic_messages_to_openai(
     messages: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -173,6 +193,13 @@ def _convert_anthropic_messages_to_openai(
     # unknown block types. See openai_responses.RESPONSES_ITEM_BLOCK_TYPE.
     from .openai_responses import strip_responses_item_blocks
     messages = strip_responses_item_blocks(messages)
+    # Thinking blocks have no Chat Completions representation either. Passing
+    # them through 400s at DeepSeek-style endpoints ("messages[N]: unknown
+    # variant `thinking`, expected `text`"), which killed every turn after
+    # resuming a stored conversation that carried them. The model regenerates
+    # its own reasoning; history without the old blocks is legal, history with
+    # them is a guaranteed rejection.
+    messages = _strip_thinking_blocks(messages)
 
     result: list[dict[str, Any]] = []
 

--- a/tests/test_anthropic_provider_thinking_replay.py
+++ b/tests/test_anthropic_provider_thinking_replay.py
@@ -1,0 +1,101 @@
+"""Unsigned thinking blocks must not reach the wire.
+
+Signed blocks replay byte-for-byte — the signature carries the opaque state
+the API validates. An unsigned block can never satisfy that contract:
+Anthropic-shaped endpoints reject it outright
+("messages.N.content.0.thinking.signature: Field required"), which killed the
+first turn after resuming a stored conversation and later turns against
+compatible endpoints that emit unsigned thinking (DeepSeek).
+"""
+
+from __future__ import annotations
+
+from src.providers.anthropic_provider import _strip_unsigned_thinking
+
+
+def _assistant(*blocks: dict) -> dict:
+    return {"role": "assistant", "content": list(blocks)}
+
+
+def test_drops_an_unsigned_thinking_block() -> None:
+    out = _strip_unsigned_thinking(
+        [_assistant({"type": "thinking", "thinking": "x"}, {"type": "text", "text": "hi"})]
+    )
+
+    assert out[0]["content"] == [{"type": "text", "text": "hi"}]
+
+
+def test_keeps_a_signed_block_byte_for_byte() -> None:
+    signed = {"type": "thinking", "thinking": "x", "signature": "sig=="}
+    out = _strip_unsigned_thinking([_assistant(signed, {"type": "text", "text": "hi"})])
+
+    assert out[0]["content"][0] is signed
+
+
+def test_keeps_redacted_thinking() -> None:
+    # redacted_thinking carries `data`, not a signature; it is valid replay.
+    redacted = {"type": "redacted_thinking", "data": "opaque"}
+    out = _strip_unsigned_thinking([_assistant(redacted)])
+
+    assert out[0]["content"] == [redacted]
+
+
+def test_treats_an_empty_signature_as_unsigned() -> None:
+    out = _strip_unsigned_thinking(
+        [_assistant({"type": "thinking", "thinking": "x", "signature": ""})]
+    )
+
+    assert out[0]["content"] == []
+
+
+def test_leaves_user_messages_and_string_content_alone() -> None:
+    msgs = [
+        {"role": "user", "content": [{"type": "thinking", "thinking": "quoted"}]},
+        {"role": "assistant", "content": "plain string"},
+    ]
+
+    assert _strip_unsigned_thinking(msgs) == msgs
+
+
+def test_does_not_mutate_its_input() -> None:
+    original = _assistant({"type": "thinking", "thinking": "x"}, {"type": "text", "text": "hi"})
+    msgs = [original]
+
+    _strip_unsigned_thinking(msgs)
+
+    assert len(original["content"]) == 2
+
+
+# ── the OpenAI-compatible path ────────────────────────────────────────────────
+#
+# Chat Completions has no thinking representation at all, so there the strip is
+# unconditional: DeepSeek-style endpoints answer "messages[N]: unknown variant
+# `thinking`, expected `text`" to any that leak through.
+
+
+def test_openai_conversion_drops_thinking_blocks() -> None:
+    from src.providers.openai_compatible import _convert_anthropic_messages_to_openai
+
+    out = _convert_anthropic_messages_to_openai(
+        [
+            {"role": "user", "content": "hi"},
+            _assistant(
+                {"type": "thinking", "thinking": "x", "signature": "even-signed"},
+                {"type": "redacted_thinking", "data": "opaque"},
+                {"type": "text", "text": "HOLA"},
+            ),
+        ]
+    )
+
+    assert out[1]["content"] == [{"type": "text", "text": "HOLA"}]
+
+
+def test_openai_conversion_survives_a_thinking_only_message() -> None:
+    from src.providers.openai_compatible import _convert_anthropic_messages_to_openai
+
+    out = _convert_anthropic_messages_to_openai(
+        [_assistant({"type": "thinking", "thinking": "x"})]
+    )
+
+    assert out[0]["role"] == "assistant"
+    assert out[0]["content"] in ([], "", None)


### PR DESCRIPTION
Resuming a stored conversation whose assistant history carries thinking blocks produced a **guaranteed 400**, with a different spelling per wire:

| wire | error |
|---|---|
| Anthropic-shaped | `messages.1.content.0.thinking.signature: Field required` |
| OpenAI-shaped (DeepSeek) | `messages[2]: unknown variant `thinking`, expected `text`` |

Live turns never hit this — the loop replays blocks byte-for-byte **with their signatures**, which is the documented contract (`ChatResponse.thinking_blocks`: *"the signature carries the opaque state the API validates"*). The poison is history that crossed a boundary: transcripts saved by builds that stored thinking without signatures, hand-written fixtures, imported sessions. One unsigned block anywhere in history killed **every turn** of the resumed session.

## The fix — two strips, one per wire

Each sits at the choke point its provider already uses for foreign blocks, directly beside the existing `strip_responses_item_blocks` call, with the same rationale:

- **`AnthropicProvider._prepare_messages`** drops thinking blocks *without* a signature. Signed blocks still replay byte-for-byte — stripping those would break tool-turn replay. An unsigned block can never validate, so dropping it beats the 400. `redacted_thinking` carries `data`, not a signature, and passes through.
- **The OpenAI conversion** drops *all* `thinking`/`redacted_thinking` blocks: Chat Completions has no representation for them at all, and the model regenerates its own reasoning.

## Verification

**A/B against live servers**, same two-message poisoned transcript (`assistant: [unsigned thinking, text]`), same prompt, minutes apart:

| server | result |
|---|---|
| pre-fix | the DeepSeek 400 above |
| fixed | `REPLY: ALIVE` |

**Control**: a three-turn live-thinking session (`thinking=yes` on every turn — reasoning deltas observed) passes on both, confirming the signed-replay path is untouched.

8 unit specs cover: unsigned dropped, signed kept **byte-for-byte** (`is` identity), redacted kept on the Anthropic path, empty-string signature treated as unsigned, user messages and string content untouched, no input mutation, and the OpenAI path dropping even signed blocks. Provider-adjacent suites: 1065 passed.

Found while verifying the settings page (#861) — a resumed fixture died on its first turn, twice, with the two spellings above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
