### PR TITLE
fix: a switched model now survives stop, quit and resume

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -1580,6 +1580,13 @@ class _AgentSession:
         # persists (model, model_provider) to user settings — /model survives
         # restarts.
         _dispatch_app_state(self, main_loop_model=model)
+        # Persist the choice to the session file NOW, not at the next turn
+        # end: a user who switches and then quits without another turn would
+        # otherwise resume onto the model they switched away from. Guarded on
+        # an existing conversation so an untouched session does not mint a
+        # sidebar row just because its model chip was poked.
+        if getattr(getattr(self, "session", None), "conversation", None) is not None and self.session.conversation.messages:
+            self._save_session()
         # Echo the provider alongside the model. This path cannot CHANGE the
         # provider (a cross-provider id is refused above), but the client
         # displays provider and model as one line and only ever learns the
@@ -2102,6 +2109,10 @@ class _AgentSession:
         cfg.provider_name = name
         cfg.model = model
         self.tool_registry = registry
+        # Same rule as the plain-model switch: the pairing must survive a
+        # quit that happens before the next turn-end save.
+        if getattr(getattr(self, "session", None), "conversation", None) is not None and self.session.conversation.messages:
+            self._save_session()
         # ch03 round-4 GAP A: keep the persisted (model, model_provider)
         # pair coherent across a provider switch — the supplier reads
         # self.provider_name, updated above, so on_change persists the

--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -899,9 +899,23 @@ class GatewayConnection:
         # broken (expired subscription, missing key). Empty values → the base
         # config's default provider.
         params = params or {}
+        provider = _clean(params.get("provider"))
+        model = _clean(params.get("model"))
+        if resume and not (provider or model):
+            # A resumed session comes back on the model it was USING, not the
+            # server's launch default. Without this the runtime either reverts
+            # outright (the in-runtime restore is gated on the provider
+            # matching, which the default rarely does) or restores while the
+            # init-frame info still names the default — so every client shows
+            # the wrong model until the next completed turn.
+            from src.server.desktop_sessions import load_session_meta
+
+            stored = load_session_meta(self.state.saved_sessions_dir(), resume)
+            provider = stored["provider"]
+            model = stored["model"]
         spawn = self.state.spawn_for(
-            _clean(params.get("provider")),
-            _clean(params.get("model")),
+            provider,
+            model,
             _clean(params.get("reasoning_effort") or params.get("effort")),
         )
         try:
@@ -1023,6 +1037,20 @@ class GatewayConnection:
     async def session_resume(self, params: dict[str, Any]) -> dict[str, Any]:
         wanted = str(params.get("session_id") or "") or None
         session = await self._create(params.get("cwd"), wanted, params)
+        # init_info was captured at SPAWN: before the resume control restored
+        # the stored model on a fresh runtime, and at create time for a
+        # still-live session that has since been switched. Either way the
+        # reply would name a model the session is not on — the chip renders
+        # this, so the user reads a switch that held as a revert. Re-read the
+        # live settings and tell the truth, here where both paths converge.
+        settings = await session.control_query("get_settings", {})
+        if isinstance(settings, dict):
+            live_model = settings.get("fusion") or settings.get("model")
+            if live_model:
+                session.init_info["model"] = str(live_model)
+            if settings.get("provider"):
+                session.init_info["provider"] = str(settings["provider"])
+        session.refresh_session_info()
         response: dict[str, Any] = {
             "session_id": session.session_id,
             "stored_session_id": wanted or session.session_id,

--- a/src/server/desktop_sessions.py
+++ b/src/server/desktop_sessions.py
@@ -101,6 +101,27 @@ def _display_kind(role: str, content: Any) -> str | None:
     return None
 
 
+def load_session_meta(sessions_dir: Path, session_id: str) -> dict[str, Any]:
+    """The stored session's model/provider pairing, for the resume spawn.
+
+    A resumed session should come back on the model it was using — not the
+    server's launch default. Empty strings when the file is absent or predates
+    these fields, which callers read as "no opinion".
+    """
+    safe = _safe_id(session_id)
+    if safe is None:
+        return {"model": "", "provider": ""}
+    data = _read_session_file(sessions_dir / f"{safe}.json")
+    if data is None:
+        return {"model": "", "provider": ""}
+    model = data.get("model")
+    provider = data.get("provider")
+    return {
+        "model": model if isinstance(model, str) else "",
+        "provider": provider if isinstance(provider, str) else "",
+    }
+
+
 def load_session_messages(sessions_dir: Path, session_id: str) -> dict[str, Any] | None:
     """Transcript for one saved session: ``{messages, message_count, title}``.
 

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -1021,3 +1021,158 @@ def test_set_language_composes_the_block_into_the_system_prompt() -> None:
 
     assert bare.last == {"ok": True, "language": ""}
     assert len(bare.system_prompt) == 1
+
+
+# ── model persistence across stop / quit / resume ─────────────────────────────
+
+
+def test_load_session_meta_reads_the_stored_pairing(tmp_path) -> None:
+    import json
+
+    from src.server.desktop_sessions import load_session_meta
+
+    (tmp_path / "s1.json").write_text(
+        json.dumps({"session_id": "s1", "model": "deepseek-v4-flash", "provider": "deepseek"})
+    )
+
+    assert load_session_meta(tmp_path, "s1") == {
+        "model": "deepseek-v4-flash",
+        "provider": "deepseek",
+    }
+
+
+@pytest.mark.parametrize("payload", [{}, {"model": 7, "provider": None}])
+def test_load_session_meta_has_no_opinion_on_junk(tmp_path, payload: dict[str, Any]) -> None:
+    import json
+
+    from src.server.desktop_sessions import load_session_meta
+
+    (tmp_path / "s1.json").write_text(json.dumps({"session_id": "s1", **payload}))
+
+    assert load_session_meta(tmp_path, "s1") == {"model": "", "provider": ""}
+    assert load_session_meta(tmp_path, "missing") == {"model": "", "provider": ""}
+
+
+def test_session_resume_reports_the_live_model_not_the_spawn_default() -> None:
+    # The init frame is captured at spawn, before the resume control restores
+    # the stored model — replying with it makes every client render a revert
+    # that did not happen.
+    from src.server.desktop_gateway_methods import GatewayConnection
+
+    class _Session:
+        session_id = "rt1"
+        init_info = {"model": "launch-default", "provider": "deepseek", "cwd": "/w"}
+        titled = True
+
+        def __init__(self) -> None:
+            self.refreshed = False
+
+        async def control_query(self, subtype: str, params: dict[str, Any]) -> Any:
+            assert subtype == "get_settings"
+            return {"model": "deepseek-v4-flash", "provider": "deepseek", "fusion": ""}
+
+        def refresh_session_info(self) -> None:
+            self.refreshed = True
+
+    session = _Session()
+    connection = GatewayConnection.__new__(GatewayConnection)
+
+    async def _create(cwd: Any, resume: Any, params: Any) -> Any:
+        return session
+
+    connection._create = _create  # type: ignore[method-assign]
+
+    class _State:
+        def saved_sessions_dir(self):  # pragma: no cover - not reached
+            raise AssertionError
+
+    connection.state = _State()  # type: ignore[attr-defined]
+
+    result = asyncio.run(
+        GatewayConnection.session_resume(
+            connection, {"session_id": "stored-1", "omit_messages": True}
+        )
+    )
+
+    assert result["info"]["model"] == "deepseek-v4-flash"
+    # …and the correction is pushed to clients already listening.
+    assert session.refreshed is True
+
+
+def test_set_model_persists_the_session_file_immediately() -> None:
+    # A user who switches and then quits without another turn must not resume
+    # onto the model they switched away from — the turn-end save is too late.
+    from src.server.agent_server import _AgentSession
+
+    class _Conv:
+        messages = [{"role": "user", "content": "hi"}]
+
+    class _Sess:
+        conversation = _Conv()
+
+    class _Provider:
+        model = "deepseek-v4-pro"
+
+    class _Bare:
+        provider = _Provider()
+        provider_name = "deepseek"
+        session = _Sess()
+        saved = False
+
+        def _reply(self, rid: object, payload: object) -> None:
+            self.last = payload
+
+        def _do_set_fusion_model(self, rid: object, model: str) -> bool:
+            return False
+
+        def _available_models(self) -> list[str]:
+            return ["deepseek-v4-pro", "deepseek-v4-flash"]
+
+        def _save_session(self) -> None:
+            self.saved = True
+
+    bare = _Bare()
+    _AgentSession._do_set_model(bare, "rid", "deepseek-v4-flash", None)
+
+    assert bare.last["ok"] is True
+    assert bare.provider.model == "deepseek-v4-flash"
+    assert bare.saved is True
+
+
+def test_set_model_does_not_mint_a_file_for_an_untouched_session() -> None:
+    # Poking the model chip on a session with no conversation must not create
+    # a sidebar row.
+    from src.server.agent_server import _AgentSession
+
+    class _Conv:
+        messages: list = []
+
+    class _Sess:
+        conversation = _Conv()
+
+    class _Provider:
+        model = "deepseek-v4-pro"
+
+    class _Bare:
+        provider = _Provider()
+        provider_name = "deepseek"
+        session = _Sess()
+        saved = False
+
+        def _reply(self, rid: object, payload: object) -> None:
+            self.last = payload
+
+        def _do_set_fusion_model(self, rid: object, model: str) -> bool:
+            return False
+
+        def _available_models(self) -> list[str]:
+            return []
+
+        def _save_session(self) -> None:
+            self.saved = True
+
+    bare = _Bare()
+    _AgentSession._do_set_model(bare, "rid", "deepseek-v4-flash", None)
+
+    assert bare.last["ok"] is True
+    assert bare.saved is False


### PR DESCRIPTION
Report: switch the model, and the choice is gone after stopping the turn or after quitting and resuming. Three defects stacked, each measured over the wire before fixing:

## 1. The resume reply lied

`init_info` is captured at **spawn** — before the resume control restores the stored model on a fresh runtime, and at create time for a still-live session switched since. Either way the reply named a model the session was not on. The chip renders exactly that field, so the user reads a revert that (sometimes) never actually happened:

```
resume info     : deepseek/deepseek-v4-pro    ← what the UI showed
resumed runtime : deepseek/deepseek-v4-flash  ← what was actually running
```

`session_resume` now re-reads `get_settings` where both paths converge, stamps the truth into the reply, and pushes a `session.info` correction to clients already listening.

## 2. The resumed runtime spawned on the launch default

The in-runtime restore is gated (an explicit launch model wins; the stored provider must match the runtime's). A cross-provider session — or any serve launched with `--model` — came back **genuinely** reverted. The gateway now spawns a resumed session with the **stored** provider/model pairing (explicit params still win), so the runtime is born on the right model instead of being patched toward it afterwards.

## 3. A switch only persisted at turn end

Switch, then quit without another turn, and the save never happened — resume restored the model you switched *away* from. `_do_set_model` and `_install_provider` (the cross-provider/fusion funnel) now persist the session file at switch time, guarded on a non-empty conversation so poking the chip on an untouched session does not mint a sidebar row.

## Verification — wire probes, fresh server per phase

| flow | result |
|---|---|
| switch → turn → interrupt | model kept |
| switch **mid-turn** → interrupt | model kept |
| switch → turn → **quit** → relaunch → resume | two sessions on different models each came back on its own — info and runtime both truthful (A/B) |
| switch → **no turn** → quit → relaunch → resume | model kept (save-on-switch) |

6 new regression specs: the meta reader (and its junk shapes), the truthful resume reply + pushed correction, save-on-switch, and the no-file-for-untouched-sessions guard. Full suite: 713 server tests green. No client changes — every surface (web, TUI, desktop) gets this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
