### PR TITLE
feat(web): a To-dos panel docked above the composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of the thought — the last few lines, wrapped, arriving at reading pace —
   that collapses to the quiet one-line "Thought" row when the model moves on.
 
+  And the reference client's task-progress card, ported: a **To-dos panel
+  docked above the composer** — "2 completed · 1 in progress · 3 pending",
+  drawn status glyphs (ring-check, spinning arc, dashed ring), collapsible —
+  folded purely from the transcript so TodoWrite lists and the task
+  registry's incremental creates/updates/snapshots produce one running
+  total, identical live and after a resume.
+
 - **Native Windows support for the CLI.** ClawCodex now runs first-class on
   Windows 10/11 — PowerShell, cmd, and Windows Terminal — with no WSL
   required. The port follows the playbook of a reference Windows-supporting

--- a/ui-web/src/conversation/ConversationRoot.tsx
+++ b/ui-web/src/conversation/ConversationRoot.tsx
@@ -33,6 +33,7 @@ import {
   $transcript,
   $workspace,
 } from '../state/store.ts'
+import { currentTodos } from '../state/todo-progress.ts'
 import { trajectoryStats } from '../state/trajectory.ts'
 import { RunStatsBar } from '../trajectory/RunStatsBar.tsx'
 import { WorkspaceChip } from '../workspace/WorkspaceChip.tsx'
@@ -46,6 +47,7 @@ import { InputBar } from './InputBar.tsx'
 import { PlanReviewPanel } from './PlanReviewPanel.tsx'
 import { QuestionComposer } from './QuestionComposer.tsx'
 import { QueueDock } from './QueueDock.tsx'
+import { TodoPanel } from './TodoPanel.tsx'
 import css from './ConversationRoot.module.css'
 
 /** Distance from the bottom, in px, still counted as "at the bottom". */
@@ -77,6 +79,7 @@ export function ConversationRoot() {
   const tab = useStore($conversationTab)
   const trajectory = useStore($trajectory)
   const stats = useMemo(() => trajectoryStats(trajectory), [trajectory])
+  const todos = useMemo(() => currentTodos(transcript.nodes), [transcript.nodes])
 
   const [draft, setDraft] = useState('')
   // null while in flight, so the panel can say "loading" rather than "no plan".
@@ -413,6 +416,7 @@ export function ConversationRoot() {
               </div>
             )}
             <div className={css.composerSeat} ref={seat}>
+              <TodoPanel todos={todos} />
               <QueueDock items={queue} onRemove={dequeue} />
               {seatPanel}
               <RunStatsBar

--- a/ui-web/src/conversation/TodoPanel.module.css
+++ b/ui-web/src/conversation/TodoPanel.module.css
@@ -1,0 +1,122 @@
+/* The checklist card docked above the composer. Same 12px card family as the
+   tool cards, on the platform surface so it reads as chrome, not content. */
+.panel {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  margin-bottom: 8px;
+  padding: 4px 0 6px;
+  border-radius: 12px;
+  background: var(--cc-alias-bg-module-platform);
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 6px 14px;
+  border: none;
+  border-radius: 8px;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.headerIcon {
+  flex: none;
+  display: inline-flex;
+  color: var(--cc-alias-label-secondary);
+}
+
+.title {
+  flex: none;
+  color: var(--cc-alias-label-primary);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.counts {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--cc-alias-label-tertiary);
+  font-size: 13px;
+  line-height: 20px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.chevron {
+  flex: none;
+  display: inline-flex;
+  color: var(--cc-alias-label-tertiary);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  /* The list may outgrow its dock; it scrolls rather than squeezing the
+     composer below it. */
+  max-height: 208px;
+  margin: 0;
+  padding: 0 6px;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.item {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+  padding: 3px 8px;
+  border-radius: 8px;
+}
+
+.glyph {
+  flex: none;
+  display: inline-flex;
+  margin-top: 3px;
+}
+
+.glyphDone {
+  color: var(--cc-alias-state-success-primary);
+}
+
+.glyphActive {
+  color: var(--cc-alias-state-business-primary);
+  animation: cc-todo-spin 1.2s linear infinite;
+}
+
+.glyphPending {
+  color: var(--cc-alias-label-caption);
+}
+
+@keyframes cc-todo-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glyphActive {
+    animation: none;
+  }
+}
+
+.text {
+  min-width: 0;
+  color: var(--cc-alias-label-secondary);
+  font-size: 14px;
+  line-height: 20px;
+  overflow-wrap: anywhere;
+}
+
+.item[data-status='completed'] .text {
+  color: var(--cc-alias-label-tertiary);
+}

--- a/ui-web/src/conversation/TodoPanel.test.tsx
+++ b/ui-web/src/conversation/TodoPanel.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { TodoProgressItem } from '../state/todo-progress.ts'
+import { TodoPanel } from './TodoPanel.tsx'
+
+afterEach(cleanup)
+
+const TODOS: TodoProgressItem[] = [
+  { content: 'Define research scope', status: 'completed' },
+  { content: 'Run overview searches', status: 'completed' },
+  { content: 'Delegate deep-dive tracks', id: 'a', status: 'in_progress' },
+  { content: 'Collect findings', status: 'pending' },
+  { content: 'Synthesize report', status: 'pending' },
+]
+
+describe('TodoPanel', () => {
+  it('renders nothing without a checklist', () => {
+    const { container } = render(<TodoPanel todos={[]} />)
+
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('summarises the three states in its header', () => {
+    const { getByText } = render(<TodoPanel todos={TODOS} />)
+
+    expect(getByText('To-dos')).toBeTruthy()
+    expect(getByText('2 completed · 1 in progress · 2 pending')).toBeTruthy()
+  })
+
+  it('drops empty states from the header line', () => {
+    const { getByText } = render(
+      <TodoPanel todos={[{ content: 'only one', status: 'completed' }]} />,
+    )
+
+    expect(getByText('1 completed')).toBeTruthy()
+  })
+
+  it('lists every item with a status glyph', () => {
+    const { container, getByText } = render(<TodoPanel todos={TODOS} />)
+
+    expect(getByText('Delegate deep-dive tracks')).toBeTruthy()
+    expect(container.querySelectorAll('li')).toHaveLength(5)
+    expect(container.querySelectorAll('li[data-status="completed"]')).toHaveLength(2)
+    expect(container.querySelectorAll('li[data-status="in_progress"]')).toHaveLength(1)
+    expect(container.querySelectorAll('li[data-status="pending"]')).toHaveLength(2)
+  })
+
+  it('collapses to the header line and back', () => {
+    const { getByRole, queryByText } = render(<TodoPanel todos={TODOS} />)
+    const header = getByRole('button', { expanded: true })
+
+    fireEvent.click(header)
+
+    expect(queryByText('Collect findings')).toBeNull()
+
+    fireEvent.click(getByRole('button', { expanded: false }))
+
+    expect(queryByText('Collect findings')).toBeTruthy()
+  })
+})

--- a/ui-web/src/conversation/TodoPanel.tsx
+++ b/ui-web/src/conversation/TodoPanel.tsx
@@ -1,0 +1,106 @@
+import { memo, useState } from 'react'
+
+import { ChevronDownIcon, ChevronRightIcon, ListIcon } from '../ui/icons.tsx'
+import {
+  countTodos,
+  type TodoProgressItem,
+  type TodoProgressStatus,
+} from '../state/todo-progress.ts'
+import css from './TodoPanel.module.css'
+
+/**
+ * The three checklist glyphs, drawn rather than typed: a ring with a check
+ * (done), an open arc that spins (in flight), a dashed ring (queued). The
+ * reference client's task panel uses exactly this vocabulary, and it reads at
+ * a glance in a way ✓/◐/○ text glyphs do not.
+ */
+function Glyph({ status }: { status: TodoProgressStatus }) {
+  if (status === 'completed') {
+    return (
+      <svg aria-hidden="true" className={css.glyphDone} fill="none" height="14" viewBox="0 0 14 14" width="14">
+        <circle cx="7" cy="7" r="6" stroke="currentColor" strokeWidth="1.4" />
+        <path d="M4.4 7.2l1.8 1.8 3.4-3.9" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.4" />
+      </svg>
+    )
+  }
+
+  if (status === 'in_progress') {
+    return (
+      <svg aria-hidden="true" className={css.glyphActive} fill="none" height="14" viewBox="0 0 14 14" width="14">
+        {/* Circumference ≈ 37.7; the gap makes the arc read as motion. */}
+        <circle cx="7" cy="7" r="6" stroke="currentColor" strokeDasharray="26 11.7" strokeLinecap="round" strokeWidth="1.6" />
+      </svg>
+    )
+  }
+
+  return (
+    <svg aria-hidden="true" className={css.glyphPending} fill="none" height="14" viewBox="0 0 14 14" width="14">
+      <circle cx="7" cy="7" r="6" stroke="currentColor" strokeDasharray="2.2 2.9" strokeWidth="1.4" />
+    </svg>
+  )
+}
+
+function countsLabel(todos: readonly TodoProgressItem[]): string {
+  const counts = countTodos(todos)
+  const parts: string[] = []
+
+  if (counts.completed > 0) parts.push(`${counts.completed} completed`)
+  if (counts.inProgress > 0) parts.push(`${counts.inProgress} in progress`)
+  if (counts.pending > 0) parts.push(`${counts.pending} pending`)
+
+  return parts.join(' · ')
+}
+
+export interface TodoPanelProps {
+  todos: TodoProgressItem[]
+}
+
+/**
+ * Where the work stands NOW: the session's current checklist as a card docked
+ * above the composer, fed by TodoWrite and the task registry alike.
+ *
+ * The transcript's tool rows say what each call did, in order; this panel is
+ * the running total, always in reach without scrolling back. It appears once
+ * a checklist exists and collapses to its header line on demand.
+ */
+function TodoPanelImpl({ todos }: TodoPanelProps) {
+  const [collapsed, setCollapsed] = useState(false)
+
+  if (todos.length === 0) return null
+
+  return (
+    <section aria-label="To-dos" className={css.panel}>
+      <button
+        aria-expanded={!collapsed}
+        className={css.header}
+        onClick={() => {
+          setCollapsed(value => !value)
+        }}
+        type="button"
+      >
+        <span className={css.headerIcon}>
+          <ListIcon size={14} />
+        </span>
+        <span className={css.title}>To-dos</span>
+        <span className={css.counts}>{countsLabel(todos)}</span>
+        <span className={css.chevron}>
+          {collapsed ? <ChevronRightIcon size={14} /> : <ChevronDownIcon size={14} />}
+        </span>
+      </button>
+      {!collapsed && (
+        <ul className={css.list}>
+          {todos.map((todo, index) => (
+            <li className={css.item} data-status={todo.status} key={todo.id ?? `${index}-${todo.content}`}>
+              <span className={css.glyph}>
+                <Glyph status={todo.status} />
+              </span>
+              <span className={css.text}>{todo.content}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+export const TodoPanel = memo(TodoPanelImpl)

--- a/ui-web/src/state/todo-progress.test.ts
+++ b/ui-web/src/state/todo-progress.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+
+import type { ToolNode, TranscriptNode } from './transcript.ts'
+import { countTodos, currentTodos } from './todo-progress.ts'
+
+let counter = 0
+
+function done(name: string, args: Record<string, unknown>, output?: string): ToolNode {
+  counter += 1
+
+  return {
+    args,
+    id: `t${counter}`,
+    kind: 'tool',
+    name,
+    result: output === undefined ? {} : { output },
+    startedAt: 0,
+    state: 'done',
+    toolId: `tool${counter}`,
+  }
+}
+
+describe('currentTodos', () => {
+  it('is empty for a transcript with no checklist tools', () => {
+    const nodes: TranscriptNode[] = [
+      { id: 'u1', at: 0, kind: 'user', text: 'hi' },
+      done('terminal', { command: 'ls' }, 'a b'),
+    ]
+
+    expect(currentTodos(nodes)).toEqual([])
+  })
+
+  it('takes the latest TodoWrite as the whole list', () => {
+    const nodes = [
+      done('todo', { todos: [{ content: 'one', status: 'pending' }] }),
+      done('todo', {
+        todos: [
+          { content: 'one', status: 'completed' },
+          { content: 'two', status: 'in_progress' },
+        ],
+      }),
+    ]
+
+    expect(currentTodos(nodes)).toEqual([
+      { content: 'one', status: 'completed' },
+      { content: 'two', status: 'in_progress' },
+    ])
+  })
+
+  it('folds the task registry into an ordered checklist', () => {
+    const nodes = [
+      done('TaskCreate', { subject: 'Map the lineup' }, '{"task": {"id": "aaa", "subject": "Map the lineup"}}'),
+      done('TaskCreate', { subject: 'Capture pricing' }, '{"task": {"id": "bbb", "subject": "Capture pricing"}}'),
+      done('TaskUpdate', { status: 'completed', taskId: 'aaa' }, '{"success": true}'),
+      done('TaskUpdate', { taskId: 'bbb' }, '{"success": true, "statusChange": {"from": "pending", "to": "in_progress"}}'),
+    ]
+
+    expect(currentTodos(nodes)).toEqual([
+      { content: 'Map the lineup', id: 'aaa', status: 'completed' },
+      { content: 'Capture pricing', id: 'bbb', status: 'in_progress' },
+    ])
+  })
+
+  it('removes a task deleted by an update', () => {
+    const nodes = [
+      done('TaskCreate', { subject: 'Doomed' }, '{"task": {"id": "x"}}'),
+      done('TaskUpdate', { status: 'deleted', taskId: 'x' }, '{"success": true}'),
+    ]
+
+    expect(currentTodos(nodes)).toEqual([])
+  })
+
+  it('ignores a failed update', () => {
+    const nodes = [
+      done('TaskCreate', { subject: 'Stays pending' }, '{"task": {"id": "x"}}'),
+      done('TaskUpdate', { status: 'completed', taskId: 'x' }, '{"success": false}'),
+    ]
+
+    expect(currentTodos(nodes)).toEqual([{ content: 'Stays pending', id: 'x', status: 'pending' }])
+  })
+
+  it('treats a TaskList result as an authoritative snapshot', () => {
+    const nodes = [
+      done('TaskCreate', { subject: 'Old' }, '{"task": {"id": "gone"}}'),
+      done(
+        'TaskList',
+        {},
+        '{"tasks": [{"id": "a", "subject": "First", "status": "completed"}, {"id": "b", "subject": "Second", "status": "pending"}]}',
+      ),
+    ]
+
+    expect(currentTodos(nodes)).toEqual([
+      { content: 'First', id: 'a', status: 'completed' },
+      { content: 'Second', id: 'b', status: 'pending' },
+    ])
+  })
+
+  it('skips running and failed calls', () => {
+    const running: ToolNode = {
+      args: { todos: [{ content: 'not yet', status: 'pending' }] },
+      id: 'r',
+      kind: 'tool',
+      name: 'todo',
+      startedAt: 0,
+      state: 'running',
+      toolId: 'r',
+    }
+    const failed: ToolNode = { ...running, error: 'boom', id: 'f', state: 'error', toolId: 'f' }
+
+    expect(currentTodos([running, failed])).toEqual([])
+  })
+})
+
+describe('countTodos', () => {
+  it('splits the three states', () => {
+    expect(
+      countTodos([
+        { content: 'a', status: 'completed' },
+        { content: 'b', status: 'completed' },
+        { content: 'c', status: 'in_progress' },
+        { content: 'd', status: 'pending' },
+      ]),
+    ).toEqual({ completed: 2, inProgress: 1, pending: 1 })
+  })
+})

--- a/ui-web/src/state/todo-progress.ts
+++ b/ui-web/src/state/todo-progress.ts
@@ -1,0 +1,180 @@
+/**
+ * The session's CURRENT checklist, folded from the transcript.
+ *
+ * Two tool families write it. TodoWrite carries the whole list each call, so
+ * its latest call simply replaces the state. The task registry
+ * (TaskCreate/TaskUpdate/TaskList) edits incrementally: a create adds a
+ * pending item under the id its result minted, an update moves one item's
+ * status, a list result is an authoritative snapshot. Folding both into one
+ * ordered list is exactly what the TUI's task HUD does — the transcript rows
+ * say what each call did; this says where the work stands NOW.
+ *
+ * Pure over the nodes so the live stream and a rehydrated session agree by
+ * construction.
+ */
+
+import type { TranscriptNode } from './transcript.ts'
+
+export type TodoProgressStatus = 'completed' | 'in_progress' | 'pending'
+
+export interface TodoProgressItem {
+  content: string
+  /** Present for task-registry items; TodoWrite items have no ids. */
+  id?: string
+  status: TodoProgressStatus
+}
+
+function asStatus(value: unknown): TodoProgressStatus | undefined {
+  return value === 'completed' || value === 'in_progress' || value === 'pending'
+    ? value
+    : undefined
+}
+
+function parseJson(text: unknown): Record<string, unknown> | undefined {
+  if (typeof text !== 'string') return undefined
+
+  const trimmed = text.trim()
+
+  if (!trimmed.startsWith('{')) return undefined
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown
+
+    return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function todosFromArgs(args: Record<string, unknown>): TodoProgressItem[] {
+  const raw = args.todos
+
+  if (!Array.isArray(raw)) return []
+
+  return raw.flatMap(entry => {
+    if (entry === null || typeof entry !== 'object') return []
+
+    const record = entry as Record<string, unknown>
+    const content = typeof record.content === 'string' ? record.content : ''
+
+    if (content === '') return []
+
+    return [{ content, status: asStatus(record.status) ?? 'pending' }]
+  })
+}
+
+export function currentTodos(nodes: readonly TranscriptNode[]): TodoProgressItem[] {
+  let list: TodoProgressItem[] = []
+
+  for (const node of nodes) {
+    // Only settled calls move the checklist: a running call has not happened
+    // yet and a failed one changed nothing.
+    if (node.kind !== 'tool' || node.state !== 'done') continue
+
+    const result = parseJson(node.result?.output) ?? parseJson(node.result?.context)
+
+    switch (node.name) {
+      case 'todo': {
+        const todos = todosFromArgs(node.args)
+
+        if (todos.length > 0) list = todos
+
+        break
+      }
+
+      case 'TaskCreate': {
+        const task = result?.task
+
+        if (task === null || typeof task !== 'object') break
+
+        const id = String((task as { id?: unknown }).id ?? '')
+        const content =
+          typeof node.args.subject === 'string'
+            ? node.args.subject
+            : String((task as { subject?: unknown }).subject ?? '')
+
+        if (id === '' || content === '') break
+
+        list = [...list.filter(item => item.id !== id), { content, id, status: 'pending' }]
+        break
+      }
+
+      case 'TaskUpdate': {
+        if (result?.success === false) break
+
+        const id = typeof node.args.taskId === 'string' ? node.args.taskId : ''
+
+        if (id === '') break
+
+        if (node.args.status === 'deleted') {
+          list = list.filter(item => item.id !== id)
+          break
+        }
+
+        const change = result?.statusChange as { to?: unknown } | undefined
+        const status = asStatus(node.args.status) ?? asStatus(change?.to)
+        const subject = typeof node.args.subject === 'string' ? node.args.subject : undefined
+
+        list = list.map(item =>
+          item.id === id
+            ? {
+                ...item,
+                ...(subject !== undefined && subject !== '' && { content: subject }),
+                ...(status !== undefined && { status }),
+              }
+            : item,
+        )
+        break
+      }
+
+      case 'TaskList': {
+        const tasks = result?.tasks
+
+        if (!Array.isArray(tasks)) break
+
+        const snapshot = tasks.flatMap(entry => {
+          if (entry === null || typeof entry !== 'object') return []
+
+          const record = entry as Record<string, unknown>
+          const id = String(record.id ?? '')
+          const content = typeof record.subject === 'string' ? record.subject : ''
+          const status = asStatus(record.status)
+
+          if (content === '' || status === undefined) return []
+
+          return [{ content, ...(id !== '' && { id }), status }]
+        })
+
+        if (snapshot.length > 0) list = snapshot
+        break
+      }
+
+      default:
+        break
+    }
+  }
+
+  return list
+}
+
+export interface TodoProgressCounts {
+  completed: number
+  inProgress: number
+  pending: number
+}
+
+export function countTodos(todos: readonly TodoProgressItem[]): TodoProgressCounts {
+  let completed = 0
+  let inProgress = 0
+  let pending = 0
+
+  for (const todo of todos) {
+    if (todo.status === 'completed') completed += 1
+    else if (todo.status === 'in_progress') inProgress += 1
+    else pending += 1
+  }
+
+  return { completed, inProgress, pending }
+}


### PR DESCRIPTION
## What

The task-progress presentation from the reference client's screenshot: a **To-dos card docked above the composer** showing where the work stands now, instead of asking the reader to reconstruct progress from tool rows scattered through the transcript.

- Header: `☰ To-dos · 2 completed · 1 in progress · 3 pending` (zero categories dropped), collapsible to the header line
- Items with the three drawn glyphs: green ring-check (completed), blue spinning arc (in progress, `prefers-reduced-motion` aware), dashed ring (pending)
- Long lists scroll inside the card rather than squeezing the composer

## How it stays correct

`currentTodos(nodes)` is a pure fold of the transcript — live streams and rehydrated sessions agree by construction:

- **TodoWrite**: its latest call carries the whole list and replaces the state
- **TaskCreate**: adds a pending item under the id its result minted
- **TaskUpdate**: moves one item's status (from arguments or the result's `statusChange.to`), renames on `subject`, removes on `deleted`, ignores `success: false`
- **TaskList**: an authoritative snapshot
- Running and failed calls change nothing

The transcript rows keep saying what each call did, in order; the panel is the running total, always in reach.

## Verification

- 13 new tests (376 total green): the fold (replace/add/update/delete/failed-update/snapshot/running-skip), counts, and the panel component (header summary, glyph states, collapse round-trip)
- Browser QA in light and dark against a fixture mixing TodoWrite and the task registry, plus a **live deepseek turn** where the panel updated in real time as TaskUpdate calls landed
- Typecheck and production build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)