### PR TITLE
fix(web): the To-dos panel keeps the composer's width, and folds when done

### DIFF
--- a/ui-web/src/conversation/TodoPanel.module.css
+++ b/ui-web/src/conversation/TodoPanel.module.css
@@ -1,10 +1,16 @@
 /* The checklist card docked above the composer. Same 12px card family as the
-   tool cards, on the platform surface so it reads as chrome, not content. */
+   tool cards, on the platform surface so it reads as chrome, not content.
+
+   Sized on the ONE width axis every dock card shares (see QueueDock): the
+   composer card's width minus the dock inset, centred. `width: 100%` alone
+   made it a full-bleed band on wide monitors while everything around it
+   stayed centred. */
 .panel {
   display: flex;
   flex-direction: column;
-  width: 100%;
-  margin-bottom: 8px;
+  width: calc(100% - 2 * var(--cc-composer-side-clearance) - 4 * var(--cc-composer-dock-inset));
+  max-width: calc(var(--cc-composer-card-max-width) - 4 * var(--cc-composer-dock-inset));
+  margin: 0 auto 8px;
   padding: 4px 0 6px;
   border-radius: 12px;
   background: var(--cc-alias-bg-module-platform);

--- a/ui-web/src/conversation/TodoPanel.test.tsx
+++ b/ui-web/src/conversation/TodoPanel.test.tsx
@@ -58,4 +58,32 @@ describe('TodoPanel', () => {
 
     expect(queryByText('Collect findings')).toBeTruthy()
   })
+
+  it('folds itself once every item is completed', () => {
+    const allDone = TODOS.map(todo => ({ ...todo, status: 'completed' as const }))
+    const { getByRole, getByText, queryByText } = render(<TodoPanel todos={allDone} />)
+
+    // A finished checklist is a receipt: header only, until asked.
+    expect(getByText('5 completed')).toBeTruthy()
+    expect(queryByText('Collect findings')).toBeNull()
+
+    fireEvent.click(getByRole('button', { expanded: false }))
+
+    expect(queryByText('Collect findings')).toBeTruthy()
+  })
+
+  it('stays open mid-run even after items complete', () => {
+    const { queryByText, rerender } = render(<TodoPanel todos={TODOS} />)
+
+    rerender(
+      <TodoPanel
+        todos={TODOS.map((todo, index) =>
+          index < 4 ? { ...todo, status: 'completed' as const } : todo,
+        )}
+      />,
+    )
+
+    // One item still pending: the list keeps showing.
+    expect(queryByText('Synthesize report')).toBeTruthy()
+  })
 })

--- a/ui-web/src/conversation/TodoPanel.tsx
+++ b/ui-web/src/conversation/TodoPanel.tsx
@@ -64,9 +64,15 @@ export interface TodoPanelProps {
  * a checklist exists and collapses to its header line on demand.
  */
 function TodoPanelImpl({ todos }: TodoPanelProps) {
-  const [collapsed, setCollapsed] = useState(false)
+  // null = the reader has not chosen; the panel then decides for itself:
+  // open while work is in flight, folded to its header once every item is
+  // done — a finished checklist is a receipt, not something to keep reading.
+  const [choice, setChoice] = useState<boolean | null>(null)
 
   if (todos.length === 0) return null
+
+  const allDone = todos.every(todo => todo.status === 'completed')
+  const collapsed = choice ?? allDone
 
   return (
     <section aria-label="To-dos" className={css.panel}>
@@ -74,7 +80,7 @@ function TodoPanelImpl({ todos }: TodoPanelProps) {
         aria-expanded={!collapsed}
         className={css.header}
         onClick={() => {
-          setCollapsed(value => !value)
+          setChoice(!collapsed)
         }}
         type="button"
       >


### PR DESCRIPTION
Two follow-ups to #866 that a wide monitor exposed (screenshot in the session):

- **Width**: the panel was `width: 100%` of the composer seat — a full-bleed band on ultrawide windows while the transcript and composer stayed centred. It now uses the same width rule as the other dock cards (QueueDock's composer-card axis, centred).
- **Auto-fold**: once every item is completed the panel collapses to its header line (`To-dos · 6 completed`) — a finished checklist is a receipt. Any non-completed item keeps it open, and an explicit reader toggle always wins over the automatic choice.

Verified at 2000×700 in dark mode against a real all-completed session (folds to one line, centred) and an in-flight one (stays open, centred). 2 new tests; 378 total green; typecheck + build pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)