### PR TITLE
fix(web): the composer defaults to Full access before the session reports a mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The web composer's approval-mode picker now defaults to Full access,
+  matching the mode a session actually starts in (the backend's implicit
+  interactive default, same as the TUI). Before `session.info` arrived it
+  displayed "Ask every time" and then silently flipped once the session
+  spawned in Full Access.
 - The stdio agent-server pins `\n` framing on Windows (text-mode stdout
   would otherwise emit `\r\n` NDJSON), and the startup profiler no longer
   crashes on import when the environment lacks a resolvable home

--- a/ui-web/src/conversation/InputBar.test.tsx
+++ b/ui-web/src/conversation/InputBar.test.tsx
@@ -1,0 +1,46 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { InputBar } from './InputBar.tsx'
+
+afterEach(cleanup)
+
+function renderBar(approvalMode?: 'manual' | 'off' | 'smart') {
+  return render(
+    <InputBar
+      approvalMode={approvalMode}
+      draft=""
+      effort={{ supported: false }}
+      models={{}}
+      onApprovalModeChange={vi.fn()}
+      onDraftChange={vi.fn()}
+      onEffortChange={vi.fn()}
+      onModelChange={vi.fn()}
+      onStop={vi.fn()}
+      onSubmit={vi.fn()}
+      running={false}
+      usage={null}
+    />,
+  )
+}
+
+describe('InputBar approval mode', () => {
+  it('defaults to Full access before session.info reports a mode', () => {
+    // Sessions spawn in Full Access (the backend's implicit interactive
+    // default, same as the TUI), so the pre-session picker must not display
+    // a stricter mode than the session will actually start in.
+    renderBar()
+
+    expect(
+      screen.getByRole('button', { name: 'Approval mode: Full access' }),
+    ).toBeTruthy()
+  })
+
+  it('shows the session-reported mode once known', () => {
+    renderBar('manual')
+
+    expect(
+      screen.getByRole('button', { name: 'Approval mode: Ask every time' }),
+    ).toBeTruthy()
+  })
+})

--- a/ui-web/src/conversation/InputBar.tsx
+++ b/ui-web/src/conversation/InputBar.tsx
@@ -516,8 +516,11 @@ export function InputBar({
               </>
             )}
             <PermissionSelect
+              // Passed through undefined until session.info reports a mode:
+              // PermissionSelect displays the Full Access default but still
+              // treats every pick as a real change while the mode is unknown.
               onChange={onApprovalModeChange}
-              value={approvalMode ?? 'manual'}
+              value={approvalMode}
             />
             <ModelSelect
               models={models}

--- a/ui-web/src/conversation/PermissionSelect.test.tsx
+++ b/ui-web/src/conversation/PermissionSelect.test.tsx
@@ -92,6 +92,39 @@ describe('PermissionSelect', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
+  it('displays Full access while the session has not reported a mode', () => {
+    // Sessions spawn in Full Access under the backend's implicit interactive
+    // default, so the unknown-mode display must not claim something stricter.
+    render(<PermissionSelect onChange={vi.fn()} />)
+
+    expect(screen.getByRole('button', { name: 'Approval mode: Full access' })).toBeTruthy()
+  })
+
+  it('registers every pick while the mode is unknown, including Full access', () => {
+    // With no session-reported mode the display is a guess, so a pick that
+    // happens to match the guessed label must still reach onChange — a
+    // deliberate pre-session "Full access" click goes through the full
+    // confirmation ceremony rather than being swallowed as a no-op.
+    const onChange = vi.fn()
+    render(<PermissionSelect onChange={onChange} />)
+    open()
+    fireEvent.click(screen.getByRole('menuitem', { name: /Full access/ }))
+
+    expect(screen.getByRole('alertdialog')).toBeTruthy()
+    fireEvent.click(screen.getByRole('checkbox'))
+    fireEvent.click(screen.getByRole('button', { name: 'Enable full access' }))
+    expect(onChange).toHaveBeenCalledWith('off')
+  })
+
+  it('switches to a stricter mode immediately while the mode is unknown', () => {
+    const onChange = vi.fn()
+    render(<PermissionSelect onChange={onChange} />)
+    open()
+    fireEvent.click(screen.getByRole('menuitem', { name: /Ask every time/ }))
+
+    expect(onChange).toHaveBeenCalledWith('manual')
+  })
+
   it('marks full access on the resting chip', () => {
     // The chip is the only persistent reminder that nothing will be asked.
     render(<PermissionSelect onChange={vi.fn()} value="off" />)

--- a/ui-web/src/conversation/PermissionSelect.tsx
+++ b/ui-web/src/conversation/PermissionSelect.tsx
@@ -48,7 +48,14 @@ const ORDER: ApprovalMode[] = ['manual', 'smart', 'off']
 export interface PermissionSelectProps {
   disabled?: boolean
   onChange: (mode: ApprovalMode) => void
-  value: ApprovalMode
+  /**
+   * The session-reported mode; undefined until `session.info` carries one.
+   * While undefined the picker displays 'off' — sessions spawn in Full Access
+   * under the backend's implicit interactive default (same as the TUI), and a
+   * deployment that dials that down corrects the display as soon as the
+   * session reports its real mode.
+   */
+  value?: ApprovalMode
 }
 
 /**
@@ -81,6 +88,10 @@ export function PermissionSelect({ disabled = false, onChange, value }: Permissi
       const mode = id as ApprovalMode
       setOpen(false)
 
+      // Only a KNOWN equal mode is a no-op. While `value` is undefined the
+      // display is a guess, so every pick must reach `onChange` — otherwise a
+      // deliberate pre-session "Full access" click would be swallowed by the
+      // fallback that happens to show the same label.
       if (mode === value) return
 
       if (mode === 'off') {
@@ -95,7 +106,8 @@ export function PermissionSelect({ disabled = false, onChange, value }: Permissi
     [onChange, value],
   )
 
-  const current = MODES[value] ?? MODES.manual
+  const shown: ApprovalMode = value ?? 'off'
+  const current = MODES[shown] ?? MODES.manual
   const items: MenuEntry[] = ORDER.map(mode => ({
     danger: MODES[mode].danger,
     hint: MODES[mode].hint,
@@ -113,7 +125,7 @@ export function PermissionSelect({ disabled = false, onChange, value }: Permissi
             aria-expanded={open}
             aria-haspopup="menu"
             aria-label={`Approval mode: ${current.label}`}
-            className={[css.trigger, value === 'off' ? css.triggerDanger : '']
+            className={[css.trigger, shown === 'off' ? css.triggerDanger : '']
               .filter(Boolean)
               .join(' ')}
             disabled={disabled}
@@ -134,7 +146,7 @@ export function PermissionSelect({ disabled = false, onChange, value }: Permissi
         onClose={close}
         onSelect={choose}
         open={open}
-        selectedId={value}
+        selectedId={shown}
         side="top"
       />
       {confirming && (


### PR DESCRIPTION
## Summary
- The web composer's approval-mode picker now defaults to **Full access**, matching the mode a session actually starts in — `clawcodex web` rides `clawcodex serve`, which resolves permissions through the same interactive resolver as the TUI (implicit `bypassPermissions` floor). Previously the picker fell back to `'manual'`, displayed "Ask every time", and silently flipped to "Full access" once the session spawned.
- The unknown-mode fallback moved from `InputBar` into `PermissionSelect`: it displays `'off'` while `value` is undefined, but treats every pick as a real change. A deliberate pre-session "Full access" click now goes through the confirmation ceremony instead of being swallowed by the `mode === value` no-op guard (adversarial-review finding).
- Deployments that clamp the default (operator lockdown, persisted `permissions.defaultMode`, root outside a sandbox) are corrected by `session.info` as soon as the session reports its real mode, exactly as before.

## Test Coverage
Tests: 30 → 32 files (+5 tests). Both branches of the fallback are covered:
- `InputBar.test.tsx` (new): renders Full access with no reported mode; renders the session-reported mode once known.
- `PermissionSelect.test.tsx`: unknown-mode display is Full access; a pre-session Full-access pick opens the confirmation and fires `onChange('off')` after acknowledgement; a pre-session stricter pick fires immediately.

## Pre-Landing Review
No issues found (both checklist passes; `'off'` is an existing enum member handled by every consumer).

## Adversarial Review (Claude subagent, medium tier)
1 FIXABLE finding — pre-session explicit Full-access click swallowed by the same-mode no-op guard — **fixed in this PR** (with regression tests). Informational notes on pre-existing mechanisms, left for follow-up:
- `config.set approvals.mode` persists `permissions.defaultMode`, so a stricter pick makes future sessions spawn stricter; the pre-session display then shows Full access until `session.info` corrects it.
- A pre-session mode choice can be dropped if `config.set` fails transiently after session create (`$pendingApprovalMode` is cleared before the request).
- `$pendingApprovalMode` is not cleared when resuming a session, so an abandoned welcome-screen pick can apply to a later created session.
- `session.info` without an `approval_mode` field leaves the fallback on display indefinitely.

## Design Review
Frontend change with no visual/CSS surface beyond which label shows by default — design-lite items not applicable.

## TODOS
No TODO items completed in this PR.

## Test plan
- [x] `ui-web` typecheck passes (`tsc --noEmit`)
- [x] All Vitest tests pass (383 tests, 32 files) — fresh run after review fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)