### PR TITLE
feat(web): a resumed session's Trajectory shows the run, timings included

### DIFF
--- a/src/server/desktop_sessions.py
+++ b/src/server/desktop_sessions.py
@@ -146,6 +146,15 @@ def load_session_messages(sessions_dir: Path, session_id: str) -> dict[str, Any]
         kind = _display_kind(role, content)
         if kind:
             message["display_kind"] = kind
+        # The wall-clock stamp and stop reason ride along when the file has
+        # them: they are what lets a resumed session's Trajectory tab show the
+        # run's real timings instead of "nothing recorded".
+        timestamp = entry.get("timestamp")
+        if isinstance(timestamp, str) and timestamp:
+            message["timestamp"] = timestamp
+        stop_reason = entry.get("stop_reason")
+        if isinstance(stop_reason, str) and stop_reason:
+            message["stop_reason"] = stop_reason
         messages.append(message)
     # The stored name, so a resumed session keeps the title it was given —
     # the sidebar reads it from this same file, and a header that disagreed

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -923,6 +923,37 @@ def test_a_session_with_no_usable_name_reports_no_title(tmp_path, extra: dict[st
     assert load_session_messages(tmp_path, session_id)["title"] == ""
 
 
+def test_stored_timestamps_and_stop_reasons_survive_the_resume(tmp_path) -> None:
+    # The client's Trajectory tab rebuilds a resumed run's timings from these;
+    # stripping them left the tab claiming nothing was recorded.
+    from src.server.desktop_sessions import load_session_messages
+
+    session_id = _saved(
+        tmp_path,
+        conversation={
+            "messages": [
+                {"role": "user", "content": "hi", "timestamp": "2026-08-14T23:25:53.251669"},
+                {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "hello"}],
+                    "timestamp": "2026-08-14T23:25:58.539747",
+                    "stop_reason": "end_turn",
+                },
+                # Absent or malformed stamps stay absent — never invented.
+                {"role": "user", "content": "next", "timestamp": 12345},
+            ]
+        },
+    )
+
+    messages = load_session_messages(tmp_path, session_id)["messages"]
+
+    assert messages[0]["timestamp"] == "2026-08-14T23:25:53.251669"
+    assert "stop_reason" not in messages[0]
+    assert messages[1]["timestamp"] == "2026-08-14T23:25:58.539747"
+    assert messages[1]["stop_reason"] == "end_turn"
+    assert "timestamp" not in messages[2]
+
+
 # ── general settings (settings.general + setters) ─────────────────────────────
 
 

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -53,6 +53,7 @@ import {
 import {
   applyTrajectoryEvent,
   emptyTrajectory,
+  hydrateStoredTrajectory,
   recordPrompt,
 } from './trajectory.ts'
 import { updatesFor } from '../conversation/PlanReviewPanel.tsx'
@@ -255,8 +256,8 @@ export async function createSession(options: SessionSpawnOptions = {}): Promise<
 
 export async function resumeSession(storedId: string, cwd?: string): Promise<void> {
   $transcript.set(emptyTranscript())
-  // A replayed transcript carries no timings, so the ledger starts empty and
-  // records only what this window observes from here on.
+  // Cleared while the replay is in flight; the stored messages rebuild it
+  // below, timestamps included.
   $trajectory.set(emptyTrajectory())
   $detailsNodeId.set(null)
   $sessionLoading.set(true)
@@ -280,6 +281,10 @@ export async function resumeSession(storedId: string, cwd?: string): Promise<voi
         ...$transcript.get(),
         nodes: hydrateStoredMessages(result.messages),
       })
+      // The same stored messages carry wall-clock timestamps, which is enough
+      // for the Trajectory tab to show the run's shape and its tool timings
+      // instead of "nothing recorded".
+      $trajectory.set(hydrateStoredTrajectory(result.messages))
     }
   } catch (error) {
     notice(`Could not resume that session: ${errorText(error)}`, 'error')

--- a/ui-web/src/state/trajectory.test.ts
+++ b/ui-web/src/state/trajectory.test.ts
@@ -5,6 +5,7 @@ import {
   applyTrajectoryEvent,
   emptyTrajectory,
   formatMs,
+  hydrateStoredTrajectory,
   recordPrompt,
   stepMetrics,
   stepTtft,
@@ -325,5 +326,123 @@ describe('formatting', () => {
     expect(toolSummary('read_file', { file_path: '/a/b.ts' })).toBe('/a/b.ts')
     expect(toolSummary('search_files', { pattern: 'TODO' })).toBe('TODO')
     expect(toolSummary('mystery', {})).toBe('mystery')
+  })
+})
+
+describe('hydrateStoredTrajectory', () => {
+  const T0 = '2026-08-14T23:25:50.000Z'
+  const T1 = '2026-08-14T23:25:53.000Z' // assistant reply, opens a tool
+  const T2 = '2026-08-14T23:25:58.500Z' // tool result: 5.5s tool call
+  const T3 = '2026-08-14T23:26:02.000Z' // final reply: 3.5s step
+
+  const MESSAGES = [
+    { content: 'run the sweep', role: 'user', timestamp: T0 },
+    {
+      content: [
+        { text: 'Listing first.', type: 'text' },
+        { id: 'tu1', input: { command: 'ls src/' }, name: 'Bash', type: 'tool_use' },
+      ],
+      role: 'assistant',
+      stop_reason: 'tool_use',
+      timestamp: T1,
+    },
+    {
+      content: [{ content: 'a.ts\nb.ts', tool_use_id: 'tu1', type: 'tool_result' }],
+      role: 'user',
+      timestamp: T2,
+    },
+    {
+      content: [{ text: 'Two files there.', type: 'text' }],
+      role: 'assistant',
+      stop_reason: 'end_turn',
+      timestamp: T3,
+    },
+  ]
+
+  it('rebuilds turns, steps and tool calls in order', () => {
+    const state = hydrateStoredTrajectory(MESSAGES)
+
+    expect(state.records.map(r => r.kind)).toEqual(['user', 'assistant', 'tool', 'assistant'])
+    expect(state.turn).toBe(1)
+    expect(state.records.map(r => r.step)).toEqual([0, 1, 1, 2])
+    expect(state.openTools).toEqual({})
+  })
+
+  it('derives real durations from the stored timestamps', () => {
+    const state = hydrateStoredTrajectory(MESSAGES)
+    const [, step1, tool, step2] = state.records
+
+    // Step 1 spans the prompt to its reply; the tool spans its envelope to
+    // its result; step 2 spans the last result to the final reply.
+    expect(step1?.durationMs).toBe(3000)
+    expect(tool?.durationMs).toBe(5500)
+    expect(step2?.durationMs).toBe(3500)
+    expect(tool?.toolName).toBe('terminal')
+    expect(tool?.result).toEqual({ output: 'a.ts\nb.ts' })
+  })
+
+  it('reports what the file does not carry as absent, never zero', () => {
+    const state = hydrateStoredTrajectory(MESSAGES)
+    const step = state.records[1]
+
+    expect(step?.metrics?.firstTokenAt).toBeNull()
+    expect(step?.metrics?.usage).toBeUndefined()
+    expect(step?.metrics?.stopReason).toBe('tool_use')
+
+    const stats = trajectoryStats(state)
+
+    expect(stats.turns).toBe(1)
+    expect(stats.steps).toBe(2)
+    expect(stats.inputTokens).toBe(0)
+    expect(stats.ttftMs).toBeNull()
+    expect(stats.llmMs).toBe(6500)
+    expect(stats.toolMs).toBe(5500)
+  })
+
+  it('marks a tool with no stored result as unrecorded, not running', () => {
+    const state = hydrateStoredTrajectory([
+      MESSAGES[0]!,
+      MESSAGES[1]!,
+      // The session ended before tu1's result was written.
+    ])
+    const tool = state.records.find(r => r.kind === 'tool')
+
+    expect(tool?.isError).toBe(true)
+    expect(tool?.error).toBe('No result recorded')
+    expect(state.openTools).toEqual({})
+  })
+
+  it('labels a prose-free step the way the live reducer does', () => {
+    const state = hydrateStoredTrajectory([
+      MESSAGES[0]!,
+      {
+        content: [{ id: 'tu9', input: { command: 'pwd' }, name: 'Bash', type: 'tool_use' }],
+        role: 'assistant',
+        timestamp: T1,
+      },
+    ])
+
+    expect(state.records[1]?.text).toBe('(tool calls only)')
+  })
+
+  it('survives messages with no timestamps', () => {
+    const state = hydrateStoredTrajectory([
+      { content: 'hi', role: 'user' },
+      { content: [{ text: 'hello', type: 'text' }], role: 'assistant' },
+    ])
+
+    expect(state.records).toHaveLength(2)
+    expect(state.records[1]?.durationMs).toBeNull()
+    expect(state.records[1]?.metrics?.startedAt).toBeNull()
+  })
+
+  it('skips hidden messages', () => {
+    const state = hydrateStoredTrajectory([
+      { content: 'internal', display_kind: 'hidden', role: 'user', timestamp: T0 },
+      ...MESSAGES,
+    ])
+
+    expect(state.turn).toBe(1)
+    expect(state.records[0]?.text).toBe('run the sweep')
   })
 })

--- a/ui-web/src/state/trajectory.ts
+++ b/ui-web/src/state/trajectory.ts
@@ -35,6 +35,7 @@ import type {
   ToolCompletePayload,
   ToolStartPayload,
 } from '../gateway/protocol.ts'
+import { renderToolName, renderToolResult } from '../gateway/tool-vocabulary.ts'
 
 export type TrajectoryKind = 'assistant' | 'notice' | 'tool' | 'user'
 
@@ -406,6 +407,199 @@ export function applyTrajectoryEvent(
     default:
       return state
   }
+}
+
+/* ── rehydration ─────────────────────────────────────────────────────────── */
+
+interface StoredTrajectoryBlock {
+  content?: unknown
+  id?: string
+  input?: Record<string, unknown>
+  is_error?: boolean
+  name?: string
+  text?: string
+  thinking?: string
+  tool_use_id?: string
+  type?: string
+}
+
+interface StoredTrajectoryMessage {
+  content?: unknown
+  display_kind?: string
+  role?: string
+  stop_reason?: string
+  timestamp?: string
+}
+
+function storedBlocks(content: unknown): StoredTrajectoryBlock[] {
+  return Array.isArray(content) ? (content as StoredTrajectoryBlock[]) : []
+}
+
+function storedText(content: unknown): string {
+  if (typeof content === 'string') return content
+
+  return storedBlocks(content)
+    .map(block => (block.type === 'text' && typeof block.text === 'string' ? block.text : ''))
+    .join('')
+}
+
+function storedAt(message: StoredTrajectoryMessage): number | null {
+  const parsed = Date.parse(message.timestamp ?? '')
+
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+/**
+ * Stored transcript → a best-effort ledger, so the Trajectory tab of a
+ * resumed session shows the run instead of "nothing recorded".
+ *
+ * The saved file stamps every message with a wall-clock `timestamp`, which is
+ * enough for the shape of the run and for two honest duration families: a
+ * tool call spans its `tool_use` envelope to its `tool_result`, and a model
+ * request spans the previous message to its own reply. What the file does
+ * NOT carry — first-token times, per-step usage, the model id — stays null,
+ * and the readouts render the absence ("First token unavailable") exactly as
+ * they do for a live step that missed a reading. Never a zero standing in
+ * for "unknown".
+ */
+export function hydrateStoredTrajectory(
+  messages: readonly StoredTrajectoryMessage[],
+): TrajectoryState {
+  let state = emptyTrajectory()
+  // When the next model request began: the prompt, or the last tool result.
+  let pendingStart: number | null = null
+  const openByToolId = new Map<string, number>()
+  const rawNames = new Map<string, string>()
+
+  for (const message of messages) {
+    if (message.display_kind === 'hidden') continue
+
+    const at = storedAt(message)
+    const role = message.role ?? 'user'
+    const blocks = storedBlocks(message.content)
+
+    if (role === 'user') {
+      const results = blocks.filter(block => block.type === 'tool_result')
+
+      if (results.length > 0) {
+        for (const block of results) {
+          const toolId = String(block.tool_use_id ?? '')
+          const index = openByToolId.get(toolId)
+
+          if (index === undefined) continue
+
+          const record = recordAt(state, index)
+          const started = record?.startedAt ?? null
+          const text = storedText(block.content)
+          const raw = rawNames.get(toolId) ?? ''
+
+          state = patchRecord(state, index, {
+            durationMs: started !== null && at !== null ? Math.max(0, at - started) : null,
+            endedAt: at,
+            ...(block.is_error === true
+              ? { error: text, isError: true }
+              : { result: renderToolResult(raw, text) }),
+          })
+          openByToolId.delete(toolId)
+        }
+
+        if (openByToolId.size === 0) pendingStart = at
+
+        continue
+      }
+
+      const text = storedText(message.content)
+
+      if (text.trim() === '') continue
+
+      const turn = state.turn + 1
+
+      state = pushRecord(
+        { ...state, stepsThisTurn: 0, turn },
+        {
+          detail: text,
+          durationMs: null,
+          endedAt: at,
+          id: `user-${turn}`,
+          kind: 'user',
+          startedAt: at,
+          step: 0,
+          text: firstLine(text),
+          turn,
+        },
+      )
+      pendingStart = at
+      continue
+    }
+
+    if (role !== 'assistant') continue
+
+    const prose = storedText(message.content)
+    const thinking = blocks
+      .map(block => (block.type === 'thinking' && typeof block.thinking === 'string' ? block.thinking : ''))
+      .join('')
+    const step = state.stepsThisTurn + 1
+    const metrics: StepMetrics = {
+      completedAt: at,
+      firstTokenAt: null,
+      startedAt: pendingStart,
+      ...(typeof message.stop_reason === 'string' && message.stop_reason !== ''
+        ? { stopReason: message.stop_reason }
+        : {}),
+    }
+
+    state = pushRecord(state, {
+      detail: prose,
+      durationMs: pendingStart !== null && at !== null ? Math.max(0, at - pendingStart) : null,
+      endedAt: at,
+      id: `step-${state.turn}-${step}`,
+      kind: 'assistant',
+      metrics,
+      startedAt: pendingStart,
+      step,
+      // Same label the live reducer gives a step that only called tools.
+      text: prose === '' ? '(tool calls only)' : firstLine(prose),
+      ...(thinking === '' ? {} : { thinking }),
+      turn: state.turn,
+    })
+    state = { ...state, stepsThisTurn: step }
+
+    const toolUses = blocks.filter(block => block.type === 'tool_use')
+
+    for (const block of toolUses) {
+      const toolId = String(block.id ?? '')
+      const raw = String(block.name ?? 'tool')
+      const args = block.input ?? {}
+      const name = renderToolName(raw)
+
+      rawNames.set(toolId, raw)
+      state = pushRecord(state, {
+        args,
+        callId: toolId,
+        durationMs: null,
+        endedAt: null,
+        id: `tool-${toolId}`,
+        kind: 'tool',
+        // Tool calls ride the assistant envelope, so its clock is theirs.
+        startedAt: at,
+        step,
+        text: toolSummary(name, args),
+        toolName: name,
+        turn: state.turn,
+      })
+      openByToolId.set(toolId, state.records.length)
+    }
+
+    pendingStart = toolUses.length === 0 ? at : null
+  }
+
+  // A tool whose result never made it into the file (the session ended
+  // mid-call) resolves as the chat hydrator resolves it, not as still-running.
+  for (const index of openByToolId.values()) {
+    state = patchRecord(state, index, { error: 'No result recorded', isError: true })
+  }
+
+  return { ...state, openAssistant: null, openTools: {}, pendingStepStartedAt: null }
 }
 
 /* ── aggregates ──────────────────────────────────────────────────────────── */

--- a/ui-web/src/trajectory/RunStatsBar.tsx
+++ b/ui-web/src/trajectory/RunStatsBar.tsx
@@ -85,7 +85,9 @@ export function RunStatsBar({ model, provider, stats }: RunStatsBarProps) {
         </span>
       )}
 
-      {stats.turns > 0 && (
+      {/* A rehydrated ledger has real timings but no usage; zeros here would
+          read as "this run was free", so the group waits for a measurement. */}
+      {stats.turns > 0 && stats.inputTokens + stats.outputTokens > 0 && (
         <span className={css.group}>
           <span>
             Input <span className={css.value}>{formatTokens(stats.inputTokens)}</span> tok


### PR DESCRIPTION
## What

Opening the Trajectory tab on a resumed session showed "No activity recorded yet" — the ledger only folded live gateway events, on the assumption that replayed transcripts carry no timings. The saved file actually stamps every message with a wall-clock `timestamp` (and `stop_reason`), which is enough for the run's shape and two honest duration families.

## The two halves

**Server** — `load_session_messages` rebuilt each stored message as `{role, content}`, stripping `timestamp`/`stop_reason`. Both now pass through when present; malformed stamps stay absent rather than invented.

**Client** — `hydrateStoredTrajectory(messages)` folds the stored transcript into the same ledger the live reducer builds: turns from prompts, numbered steps from assistant envelopes (with `stop_reason`), tool calls spanning their `tool_use` envelope to their `tool_result`. Real figures where the file has them (tool durations, step spans, the timeline lanes); nulls where it doesn't (TTFT, usage, model) — rendered as "First token unavailable"/"Usage unavailable" exactly like a live step that missed a reading. A tool whose result never made the file resolves as "No result recorded", matching the chat hydrator. The stats bar's token group now waits for a real measurement instead of printing `Input 0 tok` over a rehydrated run.

## Verification

- 8 new tests: server passthrough (present/absent/malformed stamps), and the hydration fold (order, turn/step numbering, derived durations, honest absences, unresolved tools, prose-free steps, hidden messages, missing timestamps)
- Browser-verified on a real resumed deep-research session: full ledger + timeline lanes, resolved tool rows with results and the red error row, footer reading `1 turn · 21 steps · LLM 4m 8s · Tools 5m 32s`
- 390 web tests green, typecheck + production build pass; targeted Python tests pass

Note: the server half means `clawcodex web` needs a restart to pick this up (Python loads at process start); the UI half rides the rebuilt bundle as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)