### PR TITLE
feat(web): choose the default provider from Settings → Providers

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -800,6 +800,19 @@ def _catalog_from_config() -> dict[str, Any]:
     }
 
 
+def _config_default_provider() -> str:
+    """The config-declared default provider, "" when unreadable.
+
+    Sync (config access); call via ``to_thread``.
+    """
+    try:
+        from src.config import get_default_provider
+
+        return get_default_provider() or ""
+    except Exception:  # noqa: BLE001 — a settings page beats a dead RPC
+        return ""
+
+
 def _clean(value: Any) -> str | None:
     """A non-empty trimmed string, or None (empty selections → base config)."""
     if isinstance(value, str) and value.strip():
@@ -852,6 +865,7 @@ class GatewayConnection:
             "provider.list": self.provider_list,
             "provider.save_key": self.provider_save_key,
             "provider.disconnect": self.provider_disconnect,
+            "provider.set_default": self.provider_set_default,
             "settings.general": self.settings_general,
             "settings.set_output_style": self.settings_set_output_style,
             "settings.set_language": self.settings_set_language,
@@ -1269,18 +1283,55 @@ class GatewayConnection:
         environment variable a key could come from, never the key itself.
         """
         session = self._first_session(params)
+        reply: dict[str, Any] | None = None
         if session is not None:
             result = await session.control_query("list_model_providers", {})
             if isinstance(result, dict) and result.get("providers"):
-                return {
+                reply = {
                     "current": result.get("provider") or "",
                     "providers": result["providers"],
                 }
-        catalog = await asyncio.to_thread(_catalog_from_config)
-        return {
-            "current": catalog.get("provider") or "",
-            "providers": catalog.get("providers") or [],
-        }
+        if reply is None:
+            catalog = await asyncio.to_thread(_catalog_from_config)
+            reply = {
+                "current": catalog.get("provider") or "",
+                "providers": catalog.get("providers") or [],
+            }
+        # `current` is what THIS session runs on; `default` is what config
+        # says the NEXT one starts on. Settings needs both — they differ the
+        # moment a session switches provider or the default is changed.
+        reply["default"] = await asyncio.to_thread(_config_default_provider)
+        return reply
+
+    async def provider_set_default(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Persist ``default_provider`` in the global config.
+
+        A plain config write, so no session is required — changing the default
+        is exactly what someone does when their current default cannot even
+        start a session. A LIVE session keeps the provider it is running on;
+        the default governs sessions created after this.
+        """
+        slug = _clean(params.get("slug"))
+        if slug is None:
+            return {"ok": False, "error": "provider slug required"}
+
+        def _write() -> dict[str, Any]:
+            from src.config import load_config, set_default_provider
+            from src.providers import PROVIDER_INFO, canonical_provider_name
+
+            pid = canonical_provider_name(slug)
+            # The registry, or a config-defined block (custom endpoints) —
+            # anything else would make every later session fail to spawn.
+            configured = load_config().get("providers")
+            known = pid in PROVIDER_INFO or (
+                isinstance(configured, dict) and pid in configured
+            )
+            if not known:
+                return {"ok": False, "error": f"unknown provider: {slug}"}
+            set_default_provider(pid)
+            return {"ok": True, "default": pid}
+
+        return await asyncio.to_thread(_write)
 
     async def provider_save_key(self, params: dict[str, Any]) -> dict[str, Any]:
         """Store an API key for a provider, where `clawcodex login` stores it.

--- a/tests/server/test_desktop_gateway.py
+++ b/tests/server/test_desktop_gateway.py
@@ -384,6 +384,48 @@ def test_approvals_mode_get_and_set(tmp_path: Path) -> None:
         assert _drain_for_response(ws, 5, events)["result"]["ok"] is False
 
 
+def test_default_provider_set_and_listed(tmp_path: Path, monkeypatch) -> None:
+    """Settings → Providers writes `default_provider` to config.json and
+    `provider.list` reports it — without needing any session, because changing
+    the default is exactly what someone does when the current default cannot
+    even start one. New sessions follow it: _build_runtime resolves
+    `cfg.provider_name or get_default_provider()` at spawn time."""
+    import src.config as config_mod
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text("{}")
+    monkeypatch.setattr("src.config.get_global_config_path", lambda: config_path)
+    config_mod._get_default_manager().invalidate()
+    try:
+        state, _ = _fake_state(tmp_path)
+        with TestClient(build_app(state)) as client, _connect(client) as ws:
+            ws.receive_json()
+            events: list[dict] = []
+
+            _rpc(ws, 1, "provider.set_default", {"slug": "deepseek"})
+            result = _drain_for_response(ws, 1, events)["result"]
+            assert result["ok"] is True and result["default"] == "deepseek"
+            saved = json.loads(config_path.read_text())
+            assert saved["default_provider"] == "deepseek"
+
+            # The reader of the same key: the settings page's list reply.
+            _rpc(ws, 2, "provider.list", {})
+            assert _drain_for_response(ws, 2, events)["result"]["default"] == "deepseek"
+
+            # An alias lands as its canonical id, matching the catalog's slugs.
+            _rpc(ws, 3, "provider.set_default", {"slug": "kimi"})
+            assert _drain_for_response(ws, 3, events)["result"]["default"] == "moonshot"
+
+            # An unknown provider is refused — every later session would fail
+            # to spawn on it.
+            _rpc(ws, 4, "provider.set_default", {"slug": "bogus"})
+            result = _drain_for_response(ws, 4, events)["result"]
+            assert result["ok"] is False and "bogus" in result["error"]
+            assert json.loads(config_path.read_text())["default_provider"] == "moonshot"
+    finally:
+        config_mod._get_default_manager().invalidate()
+
+
 def test_recap_get_and_set(tmp_path: Path) -> None:
     """The settings page round-trips the recap toggle: `settings.general`
     reports the flag only when the agent did (so "off" and "unknown" stay

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -235,7 +235,10 @@ export interface GeneralSettingsResult {
 
 /** `provider.list` — every provider, configured or not. Carries no secrets. */
 export interface ProviderListResult {
+  /** The provider the session runs on now. */
   current?: string
+  /** The config default the NEXT session starts on (`default_provider`). */
+  default?: string
   providers?: ModelOption[]
 }
 

--- a/ui-web/src/settings/ProvidersSection.test.tsx
+++ b/ui-web/src/settings/ProvidersSection.test.tsx
@@ -62,7 +62,11 @@ describe('credentialState', () => {
 })
 
 describe('ProvidersSection', () => {
-  const props = { onDisconnect: vi.fn(), onSave: vi.fn().mockResolvedValue(true) }
+  const props = {
+    onDisconnect: vi.fn(),
+    onMakeDefault: vi.fn(),
+    onSave: vi.fn().mockResolvedValue(true),
+  }
 
   it('marks the provider the session is running on', () => {
     render(<ProvidersSection {...props} providers={[DEEPSEEK]} />)
@@ -101,7 +105,7 @@ describe('ProvidersSection', () => {
 
   it('sends the slug and the typed key', async () => {
     const onSave = vi.fn().mockResolvedValue(true)
-    render(<ProvidersSection onDisconnect={vi.fn()} onSave={onSave} providers={[GROQ]} />)
+    render(<ProvidersSection onDisconnect={vi.fn()} onMakeDefault={vi.fn()} onSave={onSave} providers={[GROQ]} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Add key' }))
     fireEvent.change(screen.getByLabelText('API key for Groq'), { target: { value: ' sk-abc ' } })
@@ -112,7 +116,7 @@ describe('ProvidersSection', () => {
 
   it('will not save an empty key', () => {
     const onSave = vi.fn()
-    render(<ProvidersSection onDisconnect={vi.fn()} onSave={onSave} providers={[GROQ]} />)
+    render(<ProvidersSection onDisconnect={vi.fn()} onMakeDefault={vi.fn()} onSave={onSave} providers={[GROQ]} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Add key' }))
     fireEvent.change(screen.getByLabelText('API key for Groq'), { target: { value: '   ' } })
@@ -123,7 +127,7 @@ describe('ProvidersSection', () => {
 
   it('clears the field after a save, so a secret is not left on screen', async () => {
     const onSave = vi.fn().mockResolvedValue(false)
-    render(<ProvidersSection onDisconnect={vi.fn()} onSave={onSave} providers={[GROQ]} />)
+    render(<ProvidersSection onDisconnect={vi.fn()} onMakeDefault={vi.fn()} onSave={onSave} providers={[GROQ]} />)
 
     fireEvent.click(screen.getByRole('button', { name: 'Add key' }))
     const field = screen.getByLabelText('API key for Groq')
@@ -138,7 +142,9 @@ describe('ProvidersSection', () => {
 
   it('reports the provider to disconnect by slug', () => {
     const onDisconnect = vi.fn()
-    render(<ProvidersSection onDisconnect={onDisconnect} onSave={vi.fn()} providers={[DEEPSEEK]} />)
+    render(
+      <ProvidersSection onDisconnect={onDisconnect} onMakeDefault={vi.fn()} onSave={vi.fn()} providers={[DEEPSEEK]} />,
+    )
 
     fireEvent.click(screen.getByRole('button', { name: 'Disconnect' }))
 
@@ -149,6 +155,44 @@ describe('ProvidersSection', () => {
     render(<ProvidersSection {...props} providers={[]} />)
 
     expect(screen.getByText('No providers to show.')).toBeTruthy()
+  })
+
+  it('badges the default provider and offers Make default on the others', () => {
+    render(<ProvidersSection {...props} defaultSlug="deepseek" providers={[DEEPSEEK, GROQ]} />)
+
+    expect(screen.getByText('Default')).toBeTruthy()
+    // One button, on the row that is NOT the default.
+    expect(screen.getAllByRole('button', { name: 'Make default' })).toHaveLength(1)
+  })
+
+  it('reports the provider to make default by slug', () => {
+    const onMakeDefault = vi.fn()
+    render(
+      <ProvidersSection
+        {...props}
+        defaultSlug="deepseek"
+        onMakeDefault={onMakeDefault}
+        providers={[DEEPSEEK, GROQ]}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Make default' }))
+
+    expect(onMakeDefault).toHaveBeenCalledWith('groq')
+  })
+
+  it('badges no row and stays offered everywhere while the default is unknown', () => {
+    // "" means the backend could not say — claiming a default would be a guess.
+    render(<ProvidersSection {...props} providers={[DEEPSEEK, GROQ]} />)
+
+    expect(screen.queryByText('Default')).toBeNull()
+    expect(screen.getAllByRole('button', { name: 'Make default' })).toHaveLength(2)
+  })
+
+  it('orders the default right after the running provider', () => {
+    const order = orderProviders([GROQ, OPENAI, DEEPSEEK], 'groq').map(p => p.slug)
+
+    expect(order).toEqual(['deepseek', 'groq', 'openai'])
   })
 })
 
@@ -174,14 +218,14 @@ describe('providers that take no key', () => {
   })
 
   it('offers neither Add, Replace nor Disconnect', () => {
-    render(<ProvidersSection onDisconnect={vi.fn()} onSave={vi.fn()} providers={[OLLAMA]} />)
+    render(<ProvidersSection onDisconnect={vi.fn()} onMakeDefault={vi.fn()} onSave={vi.fn()} providers={[OLLAMA]} />)
 
     expect(screen.queryByRole('button', { name: /key/i })).toBeNull()
     expect(screen.queryByRole('button', { name: 'Disconnect' })).toBeNull()
   })
 
   it('does not name an environment variable that is not used', () => {
-    render(<ProvidersSection onDisconnect={vi.fn()} onSave={vi.fn()} providers={[OLLAMA]} />)
+    render(<ProvidersSection onDisconnect={vi.fn()} onMakeDefault={vi.fn()} onSave={vi.fn()} providers={[OLLAMA]} />)
 
     expect(screen.queryByText('OLLAMA_API_KEY')).toBeNull()
   })

--- a/ui-web/src/settings/ProvidersSection.tsx
+++ b/ui-web/src/settings/ProvidersSection.tsx
@@ -7,12 +7,16 @@ import css from './Settings.module.css'
 
 /**
  * Order providers by how much the reader cares: the one running now, then the
- * ones with credentials, then the rest alphabetically. The catalog knows ~30
- * providers and a user has configured two of them.
+ * default new sessions start on, then the ones with credentials, then the
+ * rest alphabetically. The catalog knows ~30 providers and a user has
+ * configured two of them.
  */
-export function orderProviders(providers: ModelOption[]): ModelOption[] {
+export function orderProviders(providers: ModelOption[], defaultSlug = ''): ModelOption[] {
+  const isDefault = (p: ModelOption) => defaultSlug !== '' && (p.slug ?? p.name) === defaultSlug
+
   return [...providers].sort((a, b) => {
     if ((a.is_current === true) !== (b.is_current === true)) return a.is_current === true ? -1 : 1
+    if (isDefault(a) !== isDefault(b)) return isDefault(a) ? -1 : 1
     if ((a.authenticated === true) !== (b.authenticated === true)) {
       return a.authenticated === true ? -1 : 1
     }
@@ -42,12 +46,15 @@ export function credentialState(provider: ModelOption): string {
 }
 
 interface ProviderRowProps {
+  /** Whether this provider is the config default new sessions start on. */
+  isDefault: boolean
   onDisconnect: (slug: string) => void
+  onMakeDefault: (slug: string) => void
   onSave: (slug: string, apiKey: string) => Promise<boolean>
   provider: ModelOption
 }
 
-function ProviderRow({ onDisconnect, onSave, provider }: ProviderRowProps) {
+function ProviderRow({ isDefault, onDisconnect, onMakeDefault, onSave, provider }: ProviderRowProps) {
   const [editing, setEditing] = useState(false)
   const [key, setKey] = useState('')
   const [busy, setBusy] = useState(false)
@@ -76,11 +83,23 @@ function ProviderRow({ onDisconnect, onSave, provider }: ProviderRowProps) {
       <div className={css.rowHead}>
         <span className={css.rowName}>{provider.name}</span>
         {provider.is_current === true && <span className={css.badge}>Running</span>}
+        {isDefault && <span className={css.badge}>Default</span>}
         <span className={[css.state, configured ? css.stateOn : ''].filter(Boolean).join(' ')}>
           {configured && <CheckIcon size={11} />}
           {credentialState(provider)}
         </span>
         <span className={css.rowSpacer} />
+        {!editing && !isDefault && (
+          <Button
+            onClick={() => {
+              onMakeDefault(slug)
+            }}
+            size="sm"
+            variant="ghost"
+          >
+            Make default
+          </Button>
+        )}
         {!editing && keyed && (
           <Button
             onClick={() => {
@@ -161,20 +180,30 @@ function ProviderRow({ onDisconnect, onSave, provider }: ProviderRowProps) {
 }
 
 export interface ProvidersSectionProps {
+  /** Slug of the config default new sessions start on ("" when unknown). */
+  defaultSlug?: string
   onDisconnect: (slug: string) => void
+  onMakeDefault: (slug: string) => void
   onSave: (slug: string, apiKey: string) => Promise<boolean>
   providers: ModelOption[]
 }
 
 /**
- * Providers and their credentials.
+ * Providers, their credentials, and the default new sessions start on.
  *
  * The one thing that could not be done from the web at all: a broken or
  * missing key meant hand-editing `~/.clawcodex/config.json`. Keys are written
  * where `clawcodex login` writes them, so a key set here survives a restart
- * and the two paths agree.
+ * and the two paths agree. The default provider is `default_provider` in the
+ * same file — a live session keeps the provider it is running on.
  */
-export function ProvidersSection({ onDisconnect, onSave, providers }: ProvidersSectionProps) {
+export function ProvidersSection({
+  defaultSlug = '',
+  onDisconnect,
+  onMakeDefault,
+  onSave,
+  providers,
+}: ProvidersSectionProps) {
   if (providers.length === 0) {
     return <div className={css.empty}>No providers to show.</div>
   }
@@ -183,12 +212,15 @@ export function ProvidersSection({ onDisconnect, onSave, providers }: ProvidersS
     <div className={css.section}>
       <p className={css.blurb}>
         Keys are stored where <code>clawcodex login</code> stores them, so they survive a
-        restart. A key exported in your shell cannot be removed from here.
+        restart. A key exported in your shell cannot be removed from here. New sessions start
+        on the default provider; the session you are in keeps its own.
       </p>
-      {orderProviders(providers).map(provider => (
+      {orderProviders(providers, defaultSlug).map(provider => (
         <ProviderRow
+          isDefault={defaultSlug !== '' && (provider.slug ?? provider.name) === defaultSlug}
           key={provider.slug ?? provider.name}
           onDisconnect={onDisconnect}
+          onMakeDefault={onMakeDefault}
           onSave={onSave}
           provider={provider}
         />

--- a/ui-web/src/settings/SettingsOverlay.tsx
+++ b/ui-web/src/settings/SettingsOverlay.tsx
@@ -8,6 +8,7 @@ import {
   refreshProviders,
   saveProviderKey,
   setApprovalMode,
+  setDefaultProvider,
   setOutputStyle,
   setRecap,
   setResponseLanguage,
@@ -155,8 +156,12 @@ export function SettingsOverlay() {
               />
             ) : (
               <ProvidersSection
+                defaultSlug={providers.default ?? ''}
                 onDisconnect={slug => {
                   void disconnectProvider(slug)
+                }}
+                onMakeDefault={slug => {
+                  void setDefaultProvider(slug)
                 }}
                 onSave={saveProviderKey}
                 providers={providers.providers ?? []}

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -892,6 +892,40 @@ export async function saveProviderKey(slug: string, apiKey: string): Promise<boo
 }
 
 /**
+ * Persist `default_provider` — what new sessions start on.
+ *
+ * No session required: changing the default is exactly what someone does when
+ * the current default cannot even start one. A live session keeps its
+ * provider; the refreshes below re-seat the settings badge and, when no
+ * session exists, the composer's picker — which is what makes the NEXT
+ * `session.create` actually ride the new default instead of the stale
+ * pre-seeded selection.
+ */
+export async function setDefaultProvider(slug: string): Promise<void> {
+  try {
+    const result = await gateway().request<{ default?: string; error?: string; ok?: boolean }>(
+      'provider.set_default',
+      { slug },
+    )
+
+    if (result.ok === false) {
+      notice(result.error === undefined || result.error === '' ? 'Could not set the default provider' : result.error, 'error')
+
+      return
+    }
+
+    notice(`New sessions start on ${result.default ?? slug}.`)
+  } catch (error) {
+    notice(errorText(error), 'error')
+
+    return
+  }
+
+  await refreshProviders()
+  await refreshModels()
+}
+
+/**
  * Clear a provider's stored credentials.
  *
  * The agent refuses the provider this session is running on, and says so when


### PR DESCRIPTION
Settings → Providers can now set the default provider. The choice persists to `$CONFIG_DIR/config.json` as `default_provider`, and new sessions follow it.

## What changed

- **Each provider row grows a "Make default" action**; the config default wears a **Default** badge and sorts right after the running provider. The blurb states the semantics: new sessions start on the default; the session you are in keeps its own.
- **`provider.set_default`** (new gateway method): canonicalizes the slug (`kimi` → `moonshot`) and refuses providers neither the registry nor config knows — every later session would fail to spawn on one. Plain config write via the existing `set_default_provider()`, so **no session is required**: changing the default is exactly what someone does when the current default cannot even start one.
- **`provider.list` now reports `default` beside `current`** — they differ the moment a session switches provider or the default changes.

## Why new sessions actually follow it

- Server side was already right: `_build_runtime` resolves `cfg.provider_name or get_default_provider()` **at spawn time**, and the write goes through the shared config manager (cache coherence from #870), so the very next spawn sees it.
- Client side needed one deliberate step: after a successful write, the actions refresh both the provider list (badge) and the model catalog. With no session, `model.options` re-reads the config default, re-seating the composer's pre-seeded selection — otherwise the next `session.create` would carry the OLD provider explicitly and override the new default.
- `$CONFIG_DIR` override honored: the write lands wherever `CLAWCODEX_CONFIG_DIR` points, via `get_global_config_path()`.

## Verified

- Gateway test: set → config.json write, alias canonicalization, unknown-slug refusal, `provider.list` reporting `default` (18 gateway tests green).
- UI tests: Default badge placement, one Make-default button per non-default row, slug reporting, unknown-default posture, ordering (402 ui-web tests green, typecheck clean).
- Live in the browser: **Make default on DeepSeek** wrote `default_provider: deepseek`; the badge moved; the composer chip re-seated to `deepseek-v4-pro` with no picker interaction; sending a prompt spawned a session that completed a real turn on deepseek. Restoring Anthropic afterwards left the running session on deepseek — exactly the stated semantics — and returned the config to its original value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)