### PR TITLE
fix(web): a session that is still starting emptied the model picker

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -159,6 +159,21 @@ class DesktopSession:
 
     # ── lifecycle ────────────────────────────────────────────────────────────
 
+    @property
+    def ready(self) -> bool:
+        """Whether this session has an agent to talk to.
+
+        A session is published into ``state.sessions`` BEFORE :meth:`start`
+        spawns its agent — building the provider, tool registry and context
+        takes seconds — so there is a wide window where the session exists and
+        ``agent`` is still None. Every caller that reaches for a session has to
+        ask this first; the alternative is what actually shipped:
+        ``AttributeError: 'NoneType' object has no attribute 'send_to_agent'``
+        out of ``model.options``/``commands.catalog``, which the browser
+        swallows into an empty model picker.
+        """
+        return self.agent is not None
+
     async def start(self, cwd: str, spawn: Any = None) -> None:
         # spawn's third arg is a permission-mode override, NOT a resume id;
         # resuming a stored session is a post-init `resume` control request.
@@ -380,12 +395,18 @@ class DesktopSession:
         return title
 
     async def submit_prompt(self, text: str) -> None:
+        if not self.ready:
+            raise ValueError(f"session {self.session_id} is still starting")
         await self._broadcast("message.start", {})
         await self.agent.send_to_agent(
             {"type": "user", "message": {"role": "user", "content": text}}
         )
 
     async def interrupt(self) -> None:
+        # Nothing has started yet, so there is nothing to abort — and saying
+        # so would be reporting a failure for an already-satisfied request.
+        if not self.ready:
+            return
         await self.agent.send_to_agent(
             {
                 "type": "control_request",
@@ -396,6 +417,12 @@ class DesktopSession:
 
     async def control_query(self, subtype: str, params: dict[str, Any],
                             timeout: float = CONTROL_TIMEOUT_S) -> Any:
+        # No agent to ask yet: answer the way a timeout does. Every caller
+        # already handles "no reply" (`if not isinstance(result, dict)`) by
+        # degrading to its own fallback, which is the honest outcome — the
+        # alternative was an AttributeError that failed the whole RPC.
+        if not self.ready:
+            return None
         rid = f"srv-{uuid.uuid4().hex[:12]}"
         fut: asyncio.Future = asyncio.get_running_loop().create_future()
         self._pending_control[rid] = fut
@@ -515,6 +542,8 @@ class DesktopSession:
         """Fire-and-forget control request (no reply awaited)."""
         import uuid as _uuid
 
+        if not self.ready:
+            raise ValueError(f"session {self.session_id} is still starting")
         await self.agent.send_to_agent(
             {"type": "control_request", "request_id": f"srv-{_uuid.uuid4().hex[:12]}",
              "request": {"subtype": subtype, **params}}
@@ -890,10 +919,19 @@ class GatewayConnection:
     # ── helpers ──────────────────────────────────────────────────────────────
 
     def _session(self, params: dict[str, Any]) -> DesktopSession:
+        """The named session, which must exist AND be able to act.
+
+        Unlike :meth:`_first_session` there is no fallback for these callers —
+        a prompt or an approval belongs to one session — so a session still
+        spawning its agent is an error with a name, not an AttributeError from
+        somewhere deeper.
+        """
         session_id = str(params.get("session_id") or "")
         session = self.state.sessions.get(session_id)
         if session is None:
             raise ValueError(f"unknown session: {session_id or '<missing>'}")
+        if not session.ready:
+            raise ValueError(f"session {session_id} is still starting")
         return session
 
     async def _create(self, cwd: str | None, resume: str | None,
@@ -935,7 +973,13 @@ class GatewayConnection:
         )
         try:
             await session.start(workspace, spawn=spawn)
-        except Exception:
+        except BaseException:
+            # BaseException, not Exception: a browser that navigates away mid-
+            # spawn cancels this task, and CancelledError does not inherit
+            # Exception. Leaving the half-built session in the registry poisons
+            # the whole process — it never gets an agent, and every later
+            # sessionless call (model.options, commands.catalog …) from any
+            # window picks it up. Re-raised untouched; this only cleans up.
             self.state.sessions.pop(session_id, None)
             raise
         try:
@@ -1574,11 +1618,25 @@ class GatewayConnection:
         return catalog
 
     def _first_session(self, params: dict[str, Any]) -> DesktopSession | None:
+        """A session that can answer a control request, or None.
+
+        ``None`` is a supported answer here — every caller degrades to reading
+        config directly, which is what the welcome screen does before any
+        session exists. So a session that is still starting reports as no
+        session rather than as a broken one.
+
+        A NAMED session that isn't ready gives None rather than falling
+        through to another: the caller asked about that session, and answering
+        with a different session's settings would be worse than answering with
+        the config defaults.
+        """
         session_id = str(params.get("session_id") or "")
-        if session_id and session_id in self.state.sessions:
-            return self.state.sessions[session_id]
+        if session_id:
+            session = self.state.sessions.get(session_id)
+            return session if session is not None and session.ready else None
         for session in self.state.sessions.values():
-            return session
+            if session.ready:
+                return session
         return None
 
     async def config_get(self, params: dict[str, Any]) -> dict[str, Any]:

--- a/tests/server/test_desktop_gateway.py
+++ b/tests/server/test_desktop_gateway.py
@@ -384,6 +384,78 @@ def test_approvals_mode_get_and_set(tmp_path: Path) -> None:
         assert _drain_for_response(ws, 5, events)["result"]["ok"] is False
 
 
+def test_a_starting_session_does_not_break_the_catalog_calls(tmp_path: Path) -> None:
+    """A session is registered BEFORE its agent is spawned, and spawning takes
+    seconds. Any call that reaches for "some session" in that window used to
+    crash on ``'NoneType' object has no attribute 'send_to_agent'`` — the
+    browser swallowed the error and the model picker sat empty ("No configured
+    providers yet") with a nameless model chip.
+
+    Dispatch is serial per socket, so this is reached from a SECOND window
+    while the first one starts a session — reproduced here by registering the
+    half-built session directly, which is exactly the state the traceback
+    proved exists.
+    """
+    from src.server.desktop_gateway_methods import DesktopSession
+
+    state, _ = _fake_state(tmp_path)
+    starting = DesktopSession("starting-1", state)
+    assert starting.agent is None and starting.ready is False
+    state.sessions["starting-1"] = starting
+
+    with TestClient(build_app(state)) as client, _connect(client) as ws:
+        ws.receive_json()
+        events: list[dict] = []
+
+        # Each answers from config rather than failing the whole call.
+        _rpc(ws, 1, "model.options", {})
+        assert "error" not in _drain_for_response(ws, 1, events)
+
+        _rpc(ws, 2, "provider.list", {})
+        assert "error" not in _drain_for_response(ws, 2, events)
+
+        _rpc(ws, 3, "commands.catalog", {})
+        assert "error" not in _drain_for_response(ws, 3, events)
+
+        # Naming it explicitly is answered the same way — with the no-session
+        # fallback, never with another session's settings.
+        _rpc(ws, 4, "settings.general", {"session_id": "starting-1"})
+        assert _drain_for_response(ws, 4, events)["result"]["output_style"] == ""
+
+        # But a call that can only mean THAT session says so by name instead of
+        # dying somewhere deeper.
+        _rpc(ws, 5, "prompt.submit", {"session_id": "starting-1", "text": "hi"})
+        assert "still starting" in _drain_for_response(ws, 5, events)["error"]["message"]
+
+        # A ready session is still preferred over the one that is starting.
+        _rpc(ws, 6, "session.create", {})
+        sid = _drain_for_response(ws, 6, events)["result"]["session_id"]
+        _rpc(ws, 7, "settings.general", {})
+        assert _drain_for_response(ws, 7, events)["result"]["available_output_styles"] == []
+        assert state.sessions[sid].ready is True
+
+
+def test_a_cancelled_create_leaves_no_half_built_session(tmp_path: Path) -> None:
+    """A browser navigating away mid-spawn cancels the create. CancelledError
+    is not an Exception, so the cleanup used to be skipped and the agent-less
+    session stayed in the registry for the life of the process — poisoning
+    every later sessionless call from every window."""
+    from src.server.desktop_gateway_methods import GatewayConnection
+
+    state, _ = _fake_state(tmp_path)
+
+    async def cancelled_spawn(session_id, cwd, resume):
+        raise asyncio.CancelledError
+
+    state.spawn_agent = cancelled_spawn
+    conn = GatewayConnection(object(), state)  # type: ignore[arg-type]
+
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(conn._create(str(tmp_path), None, {}))
+
+    assert state.sessions == {}
+
+
 def test_default_provider_set_and_listed(tmp_path: Path, monkeypatch) -> None:
     """Settings → Providers writes `default_provider` to config.json and
     `provider.list` reports it — without needing any session, because changing

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -305,6 +305,12 @@ function adoptSession(result: SessionResumeResult): void {
 
   void refreshProjects()
   void refreshUsage()
+  // The catalog belongs to the session that just started, not to whatever was
+  // read before it: a cross-provider fallback can land somewhere else
+  // entirely. It is also the picker's only repair point — a `model.options`
+  // that failed at boot would otherwise leave "No configured providers yet"
+  // on screen for the life of the page.
+  void refreshModels()
   // The effort ladder is a property of the model this session ended up on,
   // which is only known now — before a session there is nothing to ask.
   void refreshEffort()


### PR DESCRIPTION
Reported after #871: *"after I set the default provider via the settings/providers page, and create a new session, the model is None"* — a blank model chip and a picker reading **"No configured providers yet"**, which then stayed that way.

## Root cause

The server was raising, on every affected call:

```
AttributeError: 'NoneType' object has no attribute 'send_to_agent'
  desktop_gateway_methods.py: model_options → session.control_query("list_model_providers")
```

`_create()` publishes the session into `state.sessions` **before** `start()` spawns its agent:

```python
self.state.sessions[session_id] = session   # visible now; agent is None
await session.start(workspace, spawn=spawn) # builds provider + tool registry + permissions
```

`_first_session()` handed out *any* session in that window, so every sessionless call (`model.options`, `commands.catalog`, `provider.list`, `settings.general` — exactly what boot and an open Settings overlay fire) reached for an agent that was still `None`. Dispatch is serial per socket, so this is reached from a **second window, or a reload**, while the first one starts a session. The browser's `catch` swallows the failed RPC, which is why the symptom was a silently empty picker rather than an error.

The window is milliseconds on a warm process and **seconds on a cold start** — which is why this showed up in real use and not in my earlier testing.

## The fix

- A session now says whether it can be talked to (`ready`), and both lookups respect it. `_first_session` skips one that is still starting — `None` is already a supported answer, and every caller degrades to reading config, which is exactly what the welcome screen does. A **named** session that isn't ready also yields `None` rather than falling through to a *different* session's settings. `_session()`, which has no fallback, raises `session <id> is still starting` instead of dying deeper.
- `control_query` returns `None` when there is no agent — the same contract as its timeout, which every caller already handles. `submit_prompt`/`send_control` raise by name; `interrupt` is a no-op (nothing started, nothing to abort).
- **`_create` now cleans up on `BaseException`, not `Exception`.** A browser navigating away mid-spawn cancels the task, and `CancelledError` is not an `Exception` — so the half-built session stayed in the registry for the life of the process and poisoned every later sessionless call from every window. That's the variant that made this stick rather than pass.
- Client: `adoptSession` refreshes the model catalog. It belongs to the session that just started (a cross-provider fallback can land elsewhere), and it's the picker's only repair point — a `model.options` that failed at boot otherwise left the empty state on screen for the life of the page.

## Verified

- Two regression tests, both confirmed **failing without the fix** (reverted the source, watched them fail, restored).
- End-to-end reproduction by widening the spawn to 3s (what a cold start really costs), driving two sockets:
  - **pre-fix:** `model.options`, `provider.list`, `commands.catalog` all → `'NoneType' object has no attribute 'send_to_agent'` — the reported traceback exactly.
  - **with fix:** all three answer from config during the window (`model=deepseek-v4-pro provider=deepseek providers=6`) and from the live session after it (30 providers, 40 commands).
- Browser against that same slow server: chip reads `deepseek:deepseek-v4-pro` throughout, the picker lists 76 models with no empty state, and a prompt completes a real turn on deepseek.
- Suites: 718 server tests, 402 ui-web tests, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)