### PR TITLE
fix(web): the model chip contradicted the default it just announced

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -1360,7 +1360,7 @@ class GatewayConnection:
             return {"ok": False, "error": "provider slug required"}
 
         def _write() -> dict[str, Any]:
-            from src.config import load_config, set_default_provider
+            from src.config import get_provider_config, load_config, set_default_provider
             from src.providers import PROVIDER_INFO, canonical_provider_name
 
             pid = canonical_provider_name(slug)
@@ -1373,7 +1373,14 @@ class GatewayConnection:
             if not known:
                 return {"ok": False, "error": f"unknown provider: {slug}"}
             set_default_provider(pid)
-            return {"ok": True, "default": pid}
+            # The model a session spawned on this provider would land on, so a
+            # client can move an unused session onto the new default rather
+            # than leave it advertising the provider just replaced.
+            try:
+                model = str((get_provider_config(pid) or {}).get("default_model") or "")
+            except Exception:  # noqa: BLE001 — the write already succeeded
+                model = ""
+            return {"ok": True, "default": pid, "model": model}
 
         return await asyncio.to_thread(_write)
 
@@ -1587,7 +1594,18 @@ class GatewayConnection:
         }
 
     async def model_options(self, params: dict[str, Any]) -> dict[str, Any]:
-        session = self._first_session(params)
+        # Only a NAMED session answers here. ``provider.list`` is a
+        # process-wide catalog any session can report, but this drives ONE
+        # window's model chip — so a client with no session of its own is
+        # asking what the NEXT session will run on, and the config branch
+        # below already answers exactly that.
+        #
+        # Borrowing an unrelated window's session made the composer advertise
+        # a model this window would never use: with a session still live on
+        # openai, a fresh welcome screen showed "New sessions start on
+        # deepseek." beside an `openai:gpt-5.6-luna` chip — the notice and the
+        # chip describing different sessions.
+        session = self._first_session(params) if _clean(params.get("session_id")) else None
         if session is not None:
             result = await session.control_query("list_model_providers", {})
             if isinstance(result, dict) and result.get("providers"):

--- a/tests/server/test_desktop_gateway.py
+++ b/tests/server/test_desktop_gateway.py
@@ -96,6 +96,20 @@ class FakeAgent:
             elif subtype == "set_permission_mode":
                 self.permission_mode = request.get("mode") or self.permission_mode
                 reply = {"ok": True, "mode": self.permission_mode, "persisted": True}
+            elif subtype == "list_model_providers":
+                reply = {
+                    "ok": True,
+                    "model": self.model,
+                    "provider": self.provider,
+                    "providers": [{
+                        "authenticated": True,
+                        "auth_type": "api_key",
+                        "is_current": True,
+                        "models": [self.model],
+                        "name": "Fake",
+                        "slug": self.provider,
+                    }],
+                }
             elif subtype == "set_recap":
                 value = request.get("value")
                 if value in ("on", "off"):
@@ -494,6 +508,50 @@ def test_default_provider_set_and_listed(tmp_path: Path, monkeypatch) -> None:
             result = _drain_for_response(ws, 4, events)["result"]
             assert result["ok"] is False and "bogus" in result["error"]
             assert json.loads(config_path.read_text())["default_provider"] == "moonshot"
+    finally:
+        config_mod._get_default_manager().invalidate()
+
+
+def test_model_options_without_a_session_describes_the_next_one(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A window with no session of its own asks what the NEXT session will run
+    on — never what some other window is running.
+
+    Reported as a composer showing "New sessions start on deepseek." beside an
+    `openai:gpt-5.6-luna` chip: the sessionless call borrowed a session that
+    was still live on the old provider, so the notice and the chip described
+    different sessions.
+    """
+    import src.config as config_mod
+
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "default_provider": "deepseek",
+        "providers": {"deepseek": {"api_key": "k", "default_model": "deepseek-v4-pro"}},
+    }))
+    monkeypatch.setattr("src.config.get_global_config_path", lambda: config_path)
+    config_mod._get_default_manager().invalidate()
+    try:
+        state, agents = _fake_state(tmp_path)
+        with TestClient(build_app(state)) as client, _connect(client) as ws:
+            ws.receive_json()
+            events: list[dict] = []
+
+            _rpc(ws, 1, "session.create", {})
+            sid = _drain_for_response(ws, 1, events)["result"]["session_id"]
+            assert agents[0].provider == "fakeprov"
+
+            # No session named: the config default, not the live session's.
+            _rpc(ws, 2, "model.options", {})
+            result = _drain_for_response(ws, 2, events)["result"]
+            assert result["provider"] == "deepseek"
+            assert result["model"] == "deepseek-v4-pro"
+
+            # Naming one still reports what THAT session is really running.
+            _rpc(ws, 3, "model.options", {"session_id": sid})
+            result = _drain_for_response(ws, 3, events)["result"]
+            assert result["provider"] == "fakeprov"
     finally:
         config_mod._get_default_manager().invalidate()
 

--- a/ui-web/src/state/actions.test.ts
+++ b/ui-web/src/state/actions.test.ts
@@ -13,13 +13,14 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 import { GatewayClient } from '../gateway/client.ts'
 import {
   createSession,
+  setDefaultProvider,
   setModel,
   dequeue,
   setGatewayClient,
   start,
   submitPrompt,
 } from './actions.ts'
-import { $queue, $sessionId, $sessionLoading, $transcript } from './store.ts'
+import { $notice, $providers, $queue, $sessionId, $sessionLoading, $transcript } from './store.ts'
 import { emptyTranscript, type AssistantNode } from './transcript.ts'
 
 /** Answers every RPC from a canned table and lets tests push events. */
@@ -130,6 +131,7 @@ beforeEach(() => {
   window.__CLAWCODEX_SESSION_TOKEN__ = 'test-token'
   $transcript.set(emptyTranscript())
   $sessionId.set(null)
+  $providers.set({})
   $queue.set([])
 })
 
@@ -311,5 +313,76 @@ describe('createSession', () => {
     await settle()
 
     expect($sessionLoading.get()).toBe(false)
+  })
+})
+
+describe('setDefaultProvider', () => {
+  const REPLIES = {
+    'provider.set_default': { default: 'deepseek', model: 'deepseek-v4-pro', ok: true },
+    'provider.list': { default: 'deepseek', providers: [] },
+    'config.set': { ok: true, value: 'deepseek-v4-pro' },
+  }
+
+  /** A live session that has not been used, running the outgoing default. */
+  function seatUntouchedSession(provider = 'openai'): void {
+    $sessionId.set('S1')
+    $transcript.set({
+      ...emptyTranscript(),
+      info: { model: 'gpt-5.6-luna', provider },
+    })
+    $providers.set({ default: 'openai', providers: [] })
+  }
+
+  const switchFrame = (gateway: FakeGateway) =>
+    gateway.sent.find(frame => frame.method === 'config.set' && frame.params.key === 'model')
+
+  it('moves an unused session onto the new default', async () => {
+    // "New session" creates its session eagerly, so the welcome screen has
+    // one — and its own model outranks the catalog on the chip. Without the
+    // switch the composer keeps naming the provider just replaced.
+    const gateway = await connect(REPLIES)
+    seatUntouchedSession()
+
+    await setDefaultProvider('deepseek')
+    await settle()
+
+    expect(switchFrame(gateway)?.params.value).toBe('deepseek-v4-pro --provider deepseek')
+  })
+
+  it('leaves a session that has been used alone', async () => {
+    const gateway = await connect(REPLIES)
+    seatUntouchedSession()
+    $transcript.set({
+      ...$transcript.get(),
+      nodes: [{ id: 'n1', kind: 'user', text: 'hello' }] as never,
+    })
+
+    await setDefaultProvider('deepseek')
+    await settle()
+
+    expect(switchFrame(gateway)).toBeUndefined()
+  })
+
+  it('leaves a session that was deliberately put on another provider', async () => {
+    // Its provider is not the outgoing default, so it never inherited it.
+    const gateway = await connect(REPLIES)
+    seatUntouchedSession('moonshot')
+
+    await setDefaultProvider('deepseek')
+    await settle()
+
+    expect(switchFrame(gateway)).toBeUndefined()
+  })
+
+  it('says which provider new sessions start on, after any switch', async () => {
+    // The switch reports its own model change; the durable fact has to win
+    // the line, or the confirmation the user asked for is overwritten.
+    await connect(REPLIES)
+    seatUntouchedSession()
+
+    await setDefaultProvider('deepseek')
+    await settle()
+
+    expect($notice.get()).toMatchObject({ text: 'New sessions start on deepseek.' })
   })
 })

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -908,11 +908,19 @@ export async function saveProviderKey(slug: string, apiKey: string): Promise<boo
  * pre-seeded selection.
  */
 export async function setDefaultProvider(slug: string): Promise<void> {
+  // Read before the write: a session that is on the OUTGOING default was
+  // never a deliberate choice, it just inherited it.
+  const previous = $providers.get().default ?? ''
+  let applied = slug
+  let model = ''
+
   try {
-    const result = await gateway().request<{ default?: string; error?: string; ok?: boolean }>(
-      'provider.set_default',
-      { slug },
-    )
+    const result = await gateway().request<{
+      default?: string
+      error?: string
+      model?: string
+      ok?: boolean
+    }>('provider.set_default', { slug })
 
     if (result.ok === false) {
       notice(result.error === undefined || result.error === '' ? 'Could not set the default provider' : result.error, 'error')
@@ -920,15 +928,35 @@ export async function setDefaultProvider(slug: string): Promise<void> {
       return
     }
 
-    notice(`New sessions start on ${result.default ?? slug}.`)
+    applied = result.default ?? slug
+    model = result.model ?? ''
   } catch (error) {
     notice(errorText(error), 'error')
 
     return
   }
 
+  // Move a session that is still following the default onto the new one.
+  // "New session" creates its session eagerly, so the welcome screen usually
+  // HAS one — and a live session's own model outranks the catalog on the
+  // composer chip. Without this the chip kept naming the provider just
+  // replaced, directly under a notice announcing the new one, and the next
+  // prompt ran on the old provider. A session with a turn in it, or one
+  // deliberately switched to something else, is left alone.
+  const transcript = $transcript.get()
+  const inherited =
+    $sessionId.get() !== null &&
+    transcript.nodes.length === 0 &&
+    !transcript.running &&
+    previous !== '' &&
+    transcript.info.provider === previous
+
+  if (inherited && model !== '') await setModel(model, applied)
+
   await refreshProviders()
   await refreshModels()
+  // Last, so it survives the switch's own notice.
+  notice(`New sessions start on ${applied}.`)
 }
 
 /**


### PR DESCRIPTION
Follow-up to #871/#872. Reported as an inconsistent display: **"New sessions start on deepseek."** sitting directly under an **`openai:gpt-5.6-luna`** chip.

Two independent causes, both a window reading somebody else's session.

## 1. A sessionless call borrowed a stranger's session

`model.options` asked `_first_session`, which returns *any* live session when the caller names none. So a window with no session of its own — the welcome screen — was told what an unrelated window was running.

That call drives **one window's chip**, unlike `provider.list`, which is a process-wide catalog any session can legitimately report. With no session named, the honest answer is what the *next* session will run on — which the config branch already computes. It now only consults a session the caller actually named.

Reproduced over two sockets: with a session live on openai, `provider.set_default deepseek` then a sessionless `model.options` returned `openai:gpt-5.6-luna` before, `deepseek:deepseek-v4-pro` after — while a window naming the session still correctly gets `openai:gpt-5.6-luna`.

## 2. …which still didn't fix the report, because "New session" is eager

`New session` calls `createSession()` immediately, so the welcome screen usually **does** have a session — spawned on the outgoing default. A live session's own model outranks the catalog on the chip (`sessionModel ?? models.model`), so the chip kept naming the provider just replaced, and the next prompt ran on it. The setting appeared to do nothing until you started yet another session.

A session that is still **following** the default now moves with it: `provider.set_default` also reports the new provider's configured `default_model`, and an untouched session switches to it through the picker's existing `config.set model` path — no new session, no stale one left behind.

Deliberately narrow. The switch happens only when the session has no messages, is not mid-turn, and is running the **outgoing default** — so a session you picked a model for yourself is never overridden. The confirmation notice is written last so the switch's own "Model: …" line can't bury it.

## Verified

- Browser, the exact reported flow: boot on openai → New session → Settings → Providers → Make default DeepSeek. Chip reads `deepseek:deepseek-v4-pro` beside the matching notice, and the next prompt completes a real turn on deepseek.
- Both regression tests confirmed **failing without their fix** (reverted each source file, watched it fail, restored):
  - server: a sessionless `model.options` reports the config default, while a named one still reports what that session is really running;
  - client: an untouched session on the outgoing default is switched; one with a turn, or deliberately on another provider, is left alone; and the notice survives the switch.
- Suites: 719 server tests, 406 ui-web tests, typecheck clean.

Merging without waiting on CI at the author's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)