### PR TITLE
fix(web): the default-provider switch never fired in practice

### DIFF
--- a/ui-web/src/state/actions.test.ts
+++ b/ui-web/src/state/actions.test.ts
@@ -363,15 +363,37 @@ describe('setDefaultProvider', () => {
     expect(switchFrame(gateway)).toBeUndefined()
   })
 
-  it('leaves a session that was deliberately put on another provider', async () => {
-    // Its provider is not the outgoing default, so it never inherited it.
+  it('switches even when the client cannot tell what the session inherited', async () => {
+    // The state that shipped broken: an earlier version required
+    // `info.provider` to equal the outgoing default, and those two facts
+    // arrive on different round-trips — in the field the match silently
+    // failed and the chip kept naming the replaced provider. An unused
+    // session has nothing to preserve either way.
     const gateway = await connect(REPLIES)
-    seatUntouchedSession('moonshot')
+    $sessionId.set('S1')
+    $transcript.set(emptyTranscript())
+    $providers.set({})
 
     await setDefaultProvider('deepseek')
     await settle()
 
-    expect(switchFrame(gateway)).toBeUndefined()
+    expect(switchFrame(gateway)?.params.value).toBe('deepseek-v4-pro --provider deepseek')
+  })
+
+  it('does not claim the new default when the switch was refused', async () => {
+    // The refusal has to stay on screen: this session is still on the old
+    // provider, and announcing the new one over it would hide that.
+    const gateway = await connect({
+      ...REPLIES,
+      'config.set': { error: 'deepseek is not configured', ok: false },
+    })
+    seatUntouchedSession()
+
+    await setDefaultProvider('deepseek')
+    await settle()
+
+    expect(switchFrame(gateway)).toBeDefined()
+    expect($notice.get()).toMatchObject({ text: 'deepseek is not configured', tone: 'error' })
   })
 
   it('says which provider new sessions start on, after any switch', async () => {

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -908,9 +908,6 @@ export async function saveProviderKey(slug: string, apiKey: string): Promise<boo
  * pre-seeded selection.
  */
 export async function setDefaultProvider(slug: string): Promise<void> {
-  // Read before the write: a session that is on the OUTGOING default was
-  // never a deliberate choice, it just inherited it.
-  const previous = $providers.get().default ?? ''
   let applied = slug
   let model = ''
 
@@ -936,27 +933,34 @@ export async function setDefaultProvider(slug: string): Promise<void> {
     return
   }
 
-  // Move a session that is still following the default onto the new one.
-  // "New session" creates its session eagerly, so the welcome screen usually
-  // HAS one — and a live session's own model outranks the catalog on the
-  // composer chip. Without this the chip kept naming the provider just
-  // replaced, directly under a notice announcing the new one, and the next
-  // prompt ran on the old provider. A session with a turn in it, or one
-  // deliberately switched to something else, is left alone.
+  // Move an UNUSED session onto the new default. "New session" creates its
+  // session eagerly, so the welcome screen usually has one already — and a
+  // live session's model outranks the catalog on the composer chip, so
+  // without this the chip keeps naming the provider just replaced, directly
+  // under a notice announcing the new one, and the next prompt runs on the
+  // old provider.
+  //
+  // The test is only "nothing has happened in it yet": no messages, no turn
+  // in flight. An earlier version also required the session to be running the
+  // OUTGOING default, on the theory that anything else was a deliberate pick
+  // worth preserving — but that read state this action cannot rely on
+  // (`$providers.default` and `info.provider` are populated by different
+  // round-trips at different times), so in the field it silently evaluated
+  // false and the chip stayed wrong. A session with nothing in it has nothing
+  // to preserve, and the user just said which provider they want.
   const transcript = $transcript.get()
-  const inherited =
-    $sessionId.get() !== null &&
-    transcript.nodes.length === 0 &&
-    !transcript.running &&
-    previous !== '' &&
-    transcript.info.provider === previous
+  const unused =
+    $sessionId.get() !== null && transcript.nodes.length === 0 && !transcript.running
 
-  if (inherited && model !== '') await setModel(model, applied)
+  const switched = unused && model !== '' ? await setModel(model, applied) : true
 
   await refreshProviders()
   await refreshModels()
-  // Last, so it survives the switch's own notice.
-  notice(`New sessions start on ${applied}.`)
+
+  // Only over a SUCCESSFUL switch: a refusal leaves its own message, and
+  // announcing the new default over it would hide that this session is still
+  // on the old one.
+  if (switched) notice(`New sessions start on ${applied}.`)
 }
 
 /**
@@ -1063,17 +1067,19 @@ export async function setEffort(effort: string): Promise<void> {
   await refreshEffort()
 }
 
-export async function setModel(model: string, provider?: string): Promise<void> {
+/** Switch the session's model; false when the agent refused it. */
+export async function setModel(model: string, provider?: string): Promise<boolean> {
   const sessionId = $sessionId.get()
 
   if (sessionId === null) {
     // No live session yet: the selection rides the next session.create.
     $models.set({ ...$models.get(), model, provider: provider ?? $models.get().provider })
 
-    return
+    return true
   }
 
   const value = provider === undefined ? model : `${model} --provider ${provider}`
+  let ok = true
 
   try {
     const result = await gateway().request<{ error?: string; ok?: boolean; value?: string }>(
@@ -1081,15 +1087,20 @@ export async function setModel(model: string, provider?: string): Promise<void> 
       { session_id: sessionId, key: 'model', value },
     )
 
-    if (result.ok === false) notice(result.error ?? 'Could not switch model', 'error')
-    else notice(`Model: ${result.value ?? model}`)
+    if (result.ok === false) {
+      ok = false
+      notice(result.error ?? 'Could not switch model', 'error')
+    } else notice(`Model: ${result.value ?? model}`)
   } catch (error) {
+    ok = false
     notice(errorText(error), 'error')
   }
 
   await refreshModels()
   // The ladder belongs to the model, so a switch can add, change or remove it.
   await refreshEffort()
+
+  return ok
 }
 
 export async function refreshCommands(): Promise<void> {


### PR DESCRIPTION
Third report of the same screen: **"New sessions start on deepseek."** above an **`openai:gpt-5.6-luna`** chip. #873 added the switch that moves an unused session onto the new default, and it *was* deployed — but its guard evaluated false on a real machine, so the switch was never requested.

## Diagnosed against the running instance, not a reproduction

That's what finally settled it, after two rounds of fixes that passed in my sandbox:

- the deployed checkout was current (`bc945b8`, bundle rebuilt after the commit) — not a stale redeploy;
- `model.options` with no session already answered `deepseek:deepseek-v4-pro`, so the #873 server half worked;
- the process held **two live sessions, both on openai**, and the window was attached to one;
- issuing the switch by hand against one of those idle sessions returned `{ok: True}` and it moved to `deepseek:deepseek-v4-pro`.

So the mechanism worked and the client simply never asked.

## Why the guard failed

It required the session to be running the **outgoing** default:

```ts
transcript.info.provider === previous   // previous = $providers.get().default
```

on the theory that anything else was a deliberate pick worth preserving. Those two facts are populated by different round-trips at different times — `$providers.default` by the settings panel's refresh, `info.provider` by create/resume — so the comparison is only dependable in a reproduction that happens to order them favourably. In the field it fell through silently, which is the worst shape a guard can have: no error, no log, just a setting that appears to do nothing.

The test is now only **"nothing has happened in this session yet"**: no messages, no turn in flight. A session with nothing in it has nothing to preserve, and the user has just said which provider they want.

Also stop masking a refusal: `setModel` now reports whether the agent took the switch, and the "New sessions start on X." confirmation is written only over a successful one. Previously a refusal was displayed and then immediately overwritten by a line claiming the change had taken.

## Verified

- Both regression tests fail against the shipped version — including one that pins the exact field state (empty providers snapshot, empty session info) that made the old guard fall through.
- Browser, full flow: boot on openai → New session → Settings → Providers → Make default DeepSeek → chip reads `deepseek:deepseek-v4-pro` under the matching notice.
- 719 server tests, 407 ui-web tests, typecheck clean.

Merging without waiting on CI, per the author's standing request; I'll verify on the reporting deployment itself rather than only in a sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)