### PR TITLE
fix(web): a new session no longer inherits the previous session's model

### DIFF
--- a/ui-web/src/conversation/ConversationRoot.tsx
+++ b/ui-web/src/conversation/ConversationRoot.tsx
@@ -25,6 +25,7 @@ import {
   $effort,
   $models,
   $pendingApprovalMode,
+  $pendingModel,
   $queue,
   $sessionId,
   $sessionLoading,
@@ -75,6 +76,7 @@ export function ConversationRoot() {
   const commands = useStore($commands)
   const detailsWidth = useStore($detailsWidth)
   const pendingApproval = useStore($pendingApprovalMode)
+  const pendingModel = useStore($pendingModel)
   const loading = useStore($sessionLoading)
   const tab = useStore($conversationTab)
   const trajectory = useStore($trajectory)
@@ -222,8 +224,12 @@ export function ConversationRoot() {
       }}
       onSubmit={onSubmit}
       running={transcript.running}
-      sessionModel={transcript.info.model}
-      sessionProvider={transcript.info.provider}
+      // The session's model when there is one, else a welcome-screen pick
+      // held for the session that does not exist yet — same shape as the
+      // approval mode above. With neither, the chip falls back to the
+      // catalog, which sessionless reports the config default.
+      sessionModel={transcript.info.model ?? pendingModel?.model}
+      sessionProvider={transcript.info.provider ?? pendingModel?.provider}
       usage={usage}
       vision={transcript.info.vision}
     />

--- a/ui-web/src/state/actions.test.ts
+++ b/ui-web/src/state/actions.test.ts
@@ -20,7 +20,16 @@ import {
   start,
   submitPrompt,
 } from './actions.ts'
-import { $notice, $providers, $queue, $sessionId, $sessionLoading, $transcript } from './store.ts'
+import {
+  $models,
+  $notice,
+  $pendingModel,
+  $providers,
+  $queue,
+  $sessionId,
+  $sessionLoading,
+  $transcript,
+} from './store.ts'
 import { emptyTranscript, type AssistantNode } from './transcript.ts'
 
 /** Answers every RPC from a canned table and lets tests push events. */
@@ -132,6 +141,8 @@ beforeEach(() => {
   $transcript.set(emptyTranscript())
   $sessionId.set(null)
   $providers.set({})
+  $pendingModel.set(null)
+  $models.set({})
   $queue.set([])
 })
 
@@ -406,5 +417,49 @@ describe('setDefaultProvider', () => {
     await settle()
 
     expect($notice.get()).toMatchObject({ text: 'New sessions start on deepseek.' })
+  })
+})
+
+describe('a new session and the previous one', () => {
+  it('does not inherit the previous session model on New session', async () => {
+    // The reported screen: a session running openai:gpt-5.6-luna, config
+    // default deepseek, "New session" → the create carried the OLD session's
+    // model explicitly (from $models, which mirrors whatever session the
+    // picker last asked about) and overrode the default. A model is session
+    // state; a create that names none lets the backend read the global
+    // default into the new session's own config.
+    const gateway = await connect()
+
+    // The picker state after a turn on an openai session.
+    $models.set({ model: 'gpt-5.6-luna', provider: 'openai', providers: [] })
+    $sessionId.set('OLD')
+
+    gateway.results['session.create'] = { session_id: 'S2' }
+    await createSession()
+    await settle()
+
+    const create = gateway.sent.find(frame => frame.method === 'session.create')
+    expect(create).toBeDefined()
+    expect(create?.params).not.toHaveProperty('model')
+    expect(create?.params).not.toHaveProperty('provider')
+  })
+
+  it('consumes a welcome-screen pick with the session it was for', async () => {
+    // The pick rides exactly one create; the NEXT new session is back on the
+    // global default rather than silently inheriting it forever.
+    const gateway = await connect()
+
+    await setModel('deepseek-v4-flash', 'deepseek')
+    await createSession()
+    await settle()
+
+    gateway.results['session.create'] = { session_id: 'S2' }
+    await createSession()
+    await settle()
+
+    const creates = gateway.sent.filter(frame => frame.method === 'session.create')
+    expect(creates).toHaveLength(2)
+    expect(creates[0]?.params).toMatchObject({ model: 'deepseek-v4-flash', provider: 'deepseek' })
+    expect(creates[1]?.params).not.toHaveProperty('model')
   })
 })

--- a/ui-web/src/state/actions.test.ts
+++ b/ui-web/src/state/actions.test.ts
@@ -363,15 +363,37 @@ describe('setDefaultProvider', () => {
     expect(switchFrame(gateway)).toBeUndefined()
   })
 
-  it('leaves a session that was deliberately put on another provider', async () => {
-    // Its provider is not the outgoing default, so it never inherited it.
+  it('switches even when the client cannot tell what the session inherited', async () => {
+    // The state that shipped broken: an earlier version required
+    // `info.provider` to equal the outgoing default, and those two facts
+    // arrive on different round-trips — in the field the match silently
+    // failed and the chip kept naming the replaced provider. An unused
+    // session has nothing to preserve either way.
     const gateway = await connect(REPLIES)
-    seatUntouchedSession('moonshot')
+    $sessionId.set('S1')
+    $transcript.set(emptyTranscript())
+    $providers.set({})
 
     await setDefaultProvider('deepseek')
     await settle()
 
-    expect(switchFrame(gateway)).toBeUndefined()
+    expect(switchFrame(gateway)?.params.value).toBe('deepseek-v4-pro --provider deepseek')
+  })
+
+  it('does not claim the new default when the switch was refused', async () => {
+    // The refusal has to stay on screen: this session is still on the old
+    // provider, and announcing the new one over it would hide that.
+    const gateway = await connect({
+      ...REPLIES,
+      'config.set': { error: 'deepseek is not configured', ok: false },
+    })
+    seatUntouchedSession()
+
+    await setDefaultProvider('deepseek')
+    await settle()
+
+    expect(switchFrame(gateway)).toBeDefined()
+    expect($notice.get()).toMatchObject({ text: 'deepseek is not configured', tone: 'error' })
   })
 
   it('says which provider new sessions start on, after any switch', async () => {

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -38,6 +38,7 @@ import {
   $models,
   $notice,
   $pendingApprovalMode,
+  $pendingModel,
   $providers,
   $projects,
   $projectsLoading,
@@ -223,15 +224,17 @@ export async function createSession(options: SessionSpawnOptions = {}): Promise<
 
   const params: Record<string, unknown> = { capabilities: CAPABILITIES }
 
-  // A model chosen before there was a session lives in $models, because
-  // `setModel` has nowhere else to put it. Reading it here is what makes that
-  // choice ride the create — without this the picker on the welcome screen
-  // changed the chip and nothing else, and the session spawned on the config
-  // default provider instead. Explicit options still win: a caller naming a
-  // model means it.
-  const selected = $models.get()
-  const provider = options.provider ?? selected.provider
-  const model = options.model ?? selected.model
+  // A model is SESSION state. Only two things may name one on a create: an
+  // explicit option (a caller naming a model means it) and a pick made on the
+  // welcome screen for this very session ($pendingModel). Never $models —
+  // that mirrors whatever session the picker last asked about, and seeding
+  // from it made "New session" inherit the previous session's model. With
+  // neither, the create names no model and the backend reads the global
+  // default (default_provider + its default_model) into the session's own
+  // config, which is what "New sessions start on X." promises.
+  const pending = $pendingModel.get()
+  const provider = options.provider ?? pending?.provider
+  const model = options.model ?? pending?.model
 
   if (options.cwd !== undefined && options.cwd !== '') params.cwd = options.cwd
   if (provider !== undefined && provider !== '') params.provider = provider
@@ -296,6 +299,10 @@ export async function resumeSession(storedId: string, cwd?: string): Promise<voi
 function adoptSession(result: SessionResumeResult): void {
   $sessionId.set(result.session_id)
   $storedSessionId.set(result.stored_session_id ?? result.session_id)
+  // The welcome-screen pick was for the session that now exists — created
+  // with it, or superseded by a resume. Left standing, it would ride every
+  // LATER create too, which is the previous-session inheritance again.
+  $pendingModel.set(null)
 
   if (result.info !== undefined) {
     $transcript.set({ ...$transcript.get(), info: { ...$transcript.get().info, ...result.info } })
@@ -1072,8 +1079,10 @@ export async function setModel(model: string, provider?: string): Promise<boolea
   const sessionId = $sessionId.get()
 
   if (sessionId === null) {
-    // No live session yet: the selection rides the next session.create.
-    $models.set({ ...$models.get(), model, provider: provider ?? $models.get().provider })
+    // No live session yet: hold the pick for the session it is FOR. Not in
+    // $models — that is the catalog, and a selection written there outlives
+    // its session and leaks into later creates.
+    $pendingModel.set({ model, ...(provider === undefined ? {} : { provider }) })
 
     return true
   }

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -908,9 +908,6 @@ export async function saveProviderKey(slug: string, apiKey: string): Promise<boo
  * pre-seeded selection.
  */
 export async function setDefaultProvider(slug: string): Promise<void> {
-  // Read before the write: a session that is on the OUTGOING default was
-  // never a deliberate choice, it just inherited it.
-  const previous = $providers.get().default ?? ''
   let applied = slug
   let model = ''
 
@@ -936,27 +933,34 @@ export async function setDefaultProvider(slug: string): Promise<void> {
     return
   }
 
-  // Move a session that is still following the default onto the new one.
-  // "New session" creates its session eagerly, so the welcome screen usually
-  // HAS one — and a live session's own model outranks the catalog on the
-  // composer chip. Without this the chip kept naming the provider just
-  // replaced, directly under a notice announcing the new one, and the next
-  // prompt ran on the old provider. A session with a turn in it, or one
-  // deliberately switched to something else, is left alone.
+  // Move an UNUSED session onto the new default. "New session" creates its
+  // session eagerly, so the welcome screen usually has one already — and a
+  // live session's model outranks the catalog on the composer chip, so
+  // without this the chip keeps naming the provider just replaced, directly
+  // under a notice announcing the new one, and the next prompt runs on the
+  // old provider.
+  //
+  // The test is only "nothing has happened in it yet": no messages, no turn
+  // in flight. An earlier version also required the session to be running the
+  // OUTGOING default, on the theory that anything else was a deliberate pick
+  // worth preserving — but that read state this action cannot rely on
+  // (`$providers.default` and `info.provider` are populated by different
+  // round-trips at different times), so in the field it silently evaluated
+  // false and the chip stayed wrong. A session with nothing in it has nothing
+  // to preserve, and the user just said which provider they want.
   const transcript = $transcript.get()
-  const inherited =
-    $sessionId.get() !== null &&
-    transcript.nodes.length === 0 &&
-    !transcript.running &&
-    previous !== '' &&
-    transcript.info.provider === previous
+  const unused =
+    $sessionId.get() !== null && transcript.nodes.length === 0 && !transcript.running
 
-  if (inherited && model !== '') await setModel(model, applied)
+  const switched = unused && model !== '' ? await setModel(model, applied) : true
 
   await refreshProviders()
   await refreshModels()
-  // Last, so it survives the switch's own notice.
-  notice(`New sessions start on ${applied}.`)
+
+  // Only over a SUCCESSFUL switch: a refusal leaves its own message, and
+  // announcing the new default over it would hide that this session is still
+  // on the old one.
+  if (switched) notice(`New sessions start on ${applied}.`)
 }
 
 /**
@@ -1063,17 +1067,19 @@ export async function setEffort(effort: string): Promise<void> {
   await refreshEffort()
 }
 
-export async function setModel(model: string, provider?: string): Promise<void> {
+/** Switch the session's model; false when the agent refused it. */
+export async function setModel(model: string, provider?: string): Promise<boolean> {
   const sessionId = $sessionId.get()
 
   if (sessionId === null) {
     // No live session yet: the selection rides the next session.create.
     $models.set({ ...$models.get(), model, provider: provider ?? $models.get().provider })
 
-    return
+    return true
   }
 
   const value = provider === undefined ? model : `${model} --provider ${provider}`
+  let ok = true
 
   try {
     const result = await gateway().request<{ error?: string; ok?: boolean; value?: string }>(
@@ -1081,15 +1087,20 @@ export async function setModel(model: string, provider?: string): Promise<void> 
       { session_id: sessionId, key: 'model', value },
     )
 
-    if (result.ok === false) notice(result.error ?? 'Could not switch model', 'error')
-    else notice(`Model: ${result.value ?? model}`)
+    if (result.ok === false) {
+      ok = false
+      notice(result.error ?? 'Could not switch model', 'error')
+    } else notice(`Model: ${result.value ?? model}`)
   } catch (error) {
+    ok = false
     notice(errorText(error), 'error')
   }
 
   await refreshModels()
   // The ladder belongs to the model, so a switch can add, change or remove it.
   await refreshEffort()
+
+  return ok
 }
 
 export async function refreshCommands(): Promise<void> {

--- a/ui-web/src/state/store.ts
+++ b/ui-web/src/state/store.ts
@@ -83,6 +83,19 @@ export const $contextUsage = atom<ContextUsageResult | null>(null)
  */
 export const $pendingApprovalMode = atom<'manual' | 'off' | 'smart' | null>(null)
 
+/**
+ * A model picked on the welcome screen, before the session it is for exists.
+ *
+ * The ONLY client-side carrier of a model into `session.create`. A model is
+ * session-scoped state: `$models` reflects whatever session the picker last
+ * asked about, so seeding a new session from it made "New session" inherit
+ * the previous session's model instead of the config default. A session
+ * consumes this on adoption; with nothing pending, the create names no model
+ * and the backend resolves the global default (`default_provider` + its
+ * `default_model`) into the new session's own config.
+ */
+export const $pendingModel = atom<{ model: string; provider?: string } | null>(null)
+
 /** Prompts typed while a turn was running, submitted in order when it ends. */
 export const $queue = atom<string[]>([])
 


### PR DESCRIPTION
Fourth round on the deepseek-notice/openai-chip screen, and this one is the actual architecture violation, per the owner's statement of intent: **a model (provider:model_id) is session-scoped config; `default_provider` in config.json is the global default; creating a session reads the global default into the session's own config, and the chip renders from there.**

## The backend already did this — verified over the wire

A bare `session.create` (no provider, no model) on the reporting user's live instance landed on `deepseek:deepseek-v4-pro` — global `default_provider` plus its `default_model`, resolved at spawn into the session's own config. Correct.

## The client violated it

`createSession` seeded `provider`/`model` from `$models` — the **picker state**, which after any turn mirrors the *current* session. So "New session" carried the old session's model as an explicit override, and the backend honoured the explicit ask. A window sitting on `openai:gpt-5.6-luna` therefore kept producing openai sessions directly under "New sessions start on deepseek." — every create was explicitly requesting openai. The two prior fixes (#873, #874) were real but upstream; this inheritance leak survived both.

## The fix

- **`$pendingModel`** is now the only client-side carrier of a model into `session.create`: a pick made on the welcome screen, for the session it is about to create. Explicit `createSession` options still win.
- With nothing pending, the create **names no model at all** — the backend reads the global default into the new session's config, which is what the notice promises.
- The pick is **consumed on adoption** (create or resume), so it rides exactly one session.
- The chip prefers session info → pending pick → catalog (which sessionless reports the config default).

## Verified

- New regression tests: "New session" from a live openai session sends a create with **no** model/provider keys; a welcome-screen pick rides exactly one create. 409 ui-web tests, typecheck clean.
- Real-interaction verification on the reporting deployment follows the merge (client-only change; served dist re-read per request, no server restart needed).

Merging without CI wait per the author's standing request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)