### PR TITLE
fix: one session's model switch rewrote every later session's spawn config

### DIFF
--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -64,7 +64,7 @@ import threading
 import time
 import uuid as _uuid
 from collections.abc import AsyncIterator, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace as _dc_replace
 from pathlib import Path
 from typing import Any
 
@@ -5291,7 +5291,14 @@ def make_spawn_agent(config: AgentServerConfig | None = None):
         sess = _AgentSession(
             session_id=session_id,
             cwd=cwd,
-            config=cfg,
+            # Each session owns a COPY. A model/provider switch writes
+            # self.config (_install_provider: cfg.provider_name/cfg.model),
+            # and with the one shared object that rewrote the spawn template
+            # for the whole process — every later bare session.create
+            # inherited the switched provider, overriding the user's
+            # default_provider until restart. A model is session state; the
+            # template it was born from is not its to edit.
+            config=_dc_replace(cfg),
             loop=loop,
             out_queue=out_queue,
         )

--- a/tests/server/test_spawn_config_isolation.py
+++ b/tests/server/test_spawn_config_isolation.py
@@ -1,0 +1,77 @@
+"""Each spawned session owns its AgentServerConfig.
+
+The bug this pins: ``make_spawn_agent`` handed the SAME config object to
+every session it spawned, and a cross-provider model switch writes that
+object (``_install_provider``: ``cfg.provider_name = name; cfg.model =
+model``). Switch any session's provider and the process-wide spawn template
+was rewritten — every later bare ``session.create`` resolved
+``cfg.provider_name or get_default_provider()`` to the SWITCHED provider,
+silently overriding the user's ``default_provider`` until the server was
+restarted. Observed live: with ``default_provider: deepseek`` on disk, a
+bare create returned deepseek before a picker switch to openai and
+openai:gpt-5.6-luna forever after it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from src.server import agent_server as mod
+from src.server.agent_server import AgentServerConfig, make_spawn_agent
+
+pytestmark = pytest.mark.integration
+
+
+class _FakeSession:
+    """Stands in for _AgentSession: records the config it was handed."""
+
+    captured: list[AgentServerConfig] = []
+
+    def __init__(self, **kwargs) -> None:
+        _FakeSession.captured.append(kwargs["config"])
+        self.config = kwargs["config"]
+        # The attributes spawn() touches after construction.
+        self.tool_context = None
+        self.init_error = None
+
+    def start(self) -> None:
+        pass
+
+    def emit_init(self) -> None:
+        pass
+
+    async def send_to_agent(self, msg) -> None:
+        pass
+
+    async def shutdown(self) -> None:
+        pass
+
+
+def test_each_spawn_owns_its_config(monkeypatch) -> None:
+    _FakeSession.captured = []
+    monkeypatch.setattr(mod, "_AgentSession", _FakeSession)
+    monkeypatch.setattr(mod, "_build_runtime", lambda sess, perm: None)
+
+    base = AgentServerConfig()
+    spawn = make_spawn_agent(base)
+
+    async def two() -> None:
+        await spawn("a", "/tmp/w", None)
+        await spawn("b", "/tmp/w", None)
+
+    asyncio.run(two())
+
+    cfg_a, cfg_b = _FakeSession.captured
+    assert cfg_a is not base and cfg_b is not base and cfg_a is not cfg_b
+    # Values still come from the template.
+    assert cfg_a == base and cfg_b == base
+
+    # What _install_provider does on a cross-provider switch: session A's
+    # write must reach neither the template nor a sibling session.
+    cfg_a.provider_name = "openai"
+    cfg_a.model = "gpt-5.6-luna"
+
+    assert base.provider_name is None and base.model is None
+    assert cfg_b.provider_name is None and cfg_b.model is None


### PR DESCRIPTION
The process-resident poison behind the recurring "new session ignores the default provider" reports (#873, #874, #875 were each real but downstream of this).

## Found by interrogating the live server, not a sandbox

On the reporting deployment, with `default_provider: deepseek` on disk:

- bare `session.create` → `deepseek:deepseek-v4-pro` ✓
- **one** picker switch of an unrelated session to openai
- every bare `session.create` thereafter → `openai:gpt-5.6-luna`, until restart

The client was by then provably innocent — a WebSocket hook captured its create carrying **no model at all** — yet the server resolved it to openai.

## Root cause

`make_spawn_agent` hands the **same `AgentServerConfig` object** to every session it spawns:

```python
cfg = config or AgentServerConfig()
async def spawn(...):
    sess = _AgentSession(..., config=cfg, ...)   # shared, by reference
```

and a cross-provider switch **writes** that object (`_install_provider`):

```python
cfg.provider_name = name
cfg.model = model
```

Session-scoped state written into the process-wide spawn template. From then on `_build_runtime`'s `cfg.provider_name or get_default_provider()` never reached the default again — exactly the architecture violation the owner called out: a model is session config; `default_provider` is the global; a new session must read the global default into its own config.

## Fix

Each spawn hands the session `dataclasses.replace(cfg)` — its own copy. The switch path keeps its config mirror, now scoped to the session it describes. This also un-drifts `model_options`' no-session fallback, documented as "what the FIRST session will actually run on" but silently following the last switch.

## Verified

- Regression test spawns two sessions from one template, applies exactly `_install_provider`'s writes to one, asserts neither the template nor the sibling sees them — fails against the shared object, passes with the copy.
- Full `tests/server/` suite: 720 passed.
- Real-interaction verification on the reporting deployment follows the merge (server-side change: requires one server restart to load).

Merging without CI wait per the author's standing request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)