### PR TITLE
feat(web): a stable default port (8081) you can type from memory

### DIFF
--- a/src/entrypoints/web_cli.py
+++ b/src/entrypoints/web_cli.py
@@ -27,11 +27,18 @@ from __future__ import annotations
 import argparse
 import ipaddress
 import os
+import socket
 import subprocess
 import sys
 import threading
 import webbrowser
 from pathlib import Path
+
+# A STABLE default, so the address is typeable from memory and bookmarkable —
+# GET / inlines the current session token, so http://127.0.0.1:8081 with no
+# ?token works. The old default (0, OS-assigned) never collided but handed out
+# a different port every launch.
+DEFAULT_WEB_PORT = 8081
 
 # Hosts that only accept connections originating on this machine.
 _LOOPBACK_NAMES = frozenset({"localhost", "127.0.0.1", "::1", ""})
@@ -80,8 +87,9 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--host", default="127.0.0.1",
                         help="Bind address (default: 127.0.0.1 — this machine only).")
-    parser.add_argument("--port", type=int, default=0,
-                        help="Port (default: 0 — OS-assigned; the URL is printed).")
+    parser.add_argument("--port", type=int, default=None,
+                        help=f"Port (default: {DEFAULT_WEB_PORT}, scanning upward when "
+                             "taken; 0 = OS-assigned).")
     parser.add_argument("--token", default=None, help="Session token (default: generated).")
     parser.add_argument("--workspace", default=None,
                         help="Default workspace for new sessions (default: cwd).")
@@ -153,6 +161,52 @@ def _open_browser_soon(url: str) -> None:
     threading.Timer(0.25, lambda: webbrowser.open(url)).start()
 
 
+def _port_is_free(host: str, port: int) -> bool:
+    """Whether ``host:port`` can be bound right now.
+
+    A best-effort probe — the real bind happens moments later in uvicorn, so a
+    race is possible but a clean refusal here beats uvicorn's traceback in the
+    common case (a second server, a leftover instance).
+    """
+    family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    try:
+        with socket.socket(family, socket.SOCK_STREAM) as sock:
+            sock.bind((host, port))
+    except OSError:
+        return False
+    return True
+
+
+def _resolve_port(host: str, requested: int | None) -> int | None:
+    """The port to serve on, or None (already reported) when nothing binds.
+
+    An explicit ``--port`` means that port: taken → a clear refusal, never a
+    silent neighbour. No flag → the stable default, scanning a few ports up so
+    a second server coexists instead of dying on "address already in use".
+    ``--port 0`` keeps its old meaning (OS-assigned).
+    """
+    if requested is not None:
+        if requested != 0 and not _port_is_free(host, requested):
+            print(
+                f"web: port {requested} is already in use — pass a different "
+                f"--port, or drop the flag for the default "
+                f"({DEFAULT_WEB_PORT}, scanning upward).",
+                file=sys.stderr,
+            )
+            return None
+        return requested
+    for port in range(DEFAULT_WEB_PORT, DEFAULT_WEB_PORT + 20):
+        if _port_is_free(host, port):
+            if port != DEFAULT_WEB_PORT:
+                print(f"web: port {DEFAULT_WEB_PORT} is in use; using {port}.", flush=True)
+            return port
+    print(
+        f"web: no free port in {DEFAULT_WEB_PORT}-{DEFAULT_WEB_PORT + 19} — pass --port.",
+        file=sys.stderr,
+    )
+    return None
+
+
 def _serve_argv(args: argparse.Namespace) -> list[str]:
     """Translate the web flags into the ``clawcodex serve`` argv it delegates to."""
     argv = ["--host", args.host, "--port", str(args.port)]
@@ -185,6 +239,11 @@ def run_web_subcommand(argv: list[str]) -> int:
             file=sys.stderr,
         )
         return 2
+
+    port = _resolve_port(args.host, args.port)
+    if port is None:
+        return 2
+    args.port = port
 
     app_dir = web_app_dir()
     if args.build:

--- a/tests/entrypoints/test_web_cli.py
+++ b/tests/entrypoints/test_web_cli.py
@@ -79,7 +79,9 @@ def _args(**overrides: object) -> argparse.Namespace:
 
 
 def test_serve_argv_is_minimal_by_default() -> None:
-    assert web_cli._serve_argv(_args()) == ["--host", "127.0.0.1", "--port", "0"]
+    # _serve_argv always receives a RESOLVED port (run_web_subcommand resolves
+    # before delegating), so the translation itself has no default to apply.
+    assert web_cli._serve_argv(_args(port=8081)) == ["--host", "127.0.0.1", "--port", "8081"]
 
 
 def test_serve_argv_forwards_every_agent_flag() -> None:
@@ -111,6 +113,7 @@ def test_web_delegates_to_serve_with_a_ready_hook(monkeypatch: pytest.MonkeyPatc
         return 0
 
     monkeypatch.setattr("src.entrypoints.serve_cli.run_serve_subcommand", fake_serve)
+    monkeypatch.setattr(web_cli, "_port_is_free", lambda host, port: True)
 
     assert web_cli.run_web_subcommand(["--no-open", "--port", "4321"]) == 0
     assert seen["argv"] == ["--host", "127.0.0.1", "--port", "4321"]
@@ -139,3 +142,58 @@ def test_cli_routes_web_to_the_subcommand(monkeypatch: pytest.MonkeyPatch) -> No
 
     assert cli.main() == 0
     assert calls == [["--no-open"]]
+
+
+# ── port resolution ──────────────────────────────────────────────────────────
+
+
+def test_no_flag_lands_on_the_stable_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A default you can type from memory: `clawcodex web` always tries 8081
+    first, instead of the OS-assigned port that changed every launch."""
+    monkeypatch.setattr(web_cli, "_port_is_free", lambda host, port: True)
+
+    assert web_cli._resolve_port("127.0.0.1", None) == web_cli.DEFAULT_WEB_PORT
+
+
+def test_a_busy_default_scans_upward(monkeypatch: pytest.MonkeyPatch,
+                                     capsys: pytest.CaptureFixture[str]) -> None:
+    """A second server coexists on the next port instead of dying on
+    "address already in use"."""
+    monkeypatch.setattr(web_cli, "_port_is_free",
+                        lambda host, port: port != web_cli.DEFAULT_WEB_PORT)
+
+    assert web_cli._resolve_port("127.0.0.1", None) == web_cli.DEFAULT_WEB_PORT + 1
+    assert f"using {web_cli.DEFAULT_WEB_PORT + 1}" in capsys.readouterr().out
+
+
+def test_an_explicit_busy_port_is_refused_not_substituted(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Naming a port means it — serving a neighbour would hand the user a URL
+    that does not match what they asked for."""
+    monkeypatch.setattr(web_cli, "_port_is_free", lambda host, port: False)
+
+    assert web_cli._resolve_port("127.0.0.1", 9013) is None
+    assert "9013 is already in use" in capsys.readouterr().err
+
+
+def test_port_zero_stays_os_assigned(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(web_cli, "_port_is_free", lambda host, port: False)
+
+    assert web_cli._resolve_port("127.0.0.1", 0) == 0
+
+
+def test_no_flag_delegates_the_default_to_serve(monkeypatch: pytest.MonkeyPatch,
+                                                capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setattr("src.server.web_assets.web_dist_dir", lambda: Path("/tmp/dist"))
+    monkeypatch.setattr(web_cli, "_port_is_free", lambda host, port: True)
+    seen: dict[str, object] = {}
+
+    def fake_serve(argv, *, on_ready=None):
+        seen["argv"] = argv
+        return 0
+
+    monkeypatch.setattr("src.entrypoints.serve_cli.run_serve_subcommand", fake_serve)
+
+    assert web_cli.run_web_subcommand(["--no-open"]) == 0
+    assert seen["argv"] == ["--host", "127.0.0.1", "--port", str(web_cli.DEFAULT_WEB_PORT)]


### PR DESCRIPTION
`clawcodex web` bound an OS-assigned port (`--port 0` default), so every launch lived at a different address — nothing to bookmark or type from memory, and the browser's per-origin state (stored token, theme, layout) reset with every new port. `GET /` already inlines the current session token, so with a stable port a bare `http://127.0.0.1:8081` is all anyone needs.

- **No flag → 8081**, scanning a few ports upward when taken, so a second server coexists instead of dying on "address already in use" (previously a raw uvicorn traceback).
- **An explicit `--port` means that port**: taken → a clear refusal, never a silently substituted neighbour.
- **`--port 0`** keeps its old OS-assigned meaning.
- `clawcodex serve` (the desktop's transport) keeps its own defaults.

Tests cover the resolver (default lands on 8081, busy default scans up with a printed note, explicit busy port refused, 0 passes through) and the delegation (`run_web_subcommand` hands serve the resolved port). 72 entrypoint tests, 720 server tests green.

Merging without CI wait per the author's standing request; live demonstration follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)