### PR TITLE
feat(nano): clawcodex --nano — pi-shaped minimal harness profile (PR 1/4)

### DIFF
--- a/src/cli.py
+++ b/src/cli.py
@@ -194,6 +194,19 @@ def main():
     )
     profile_checkpoint("phase3_end_phase4_start")
 
+    if getattr(args, 'nano', False) and not args.print:
+        # Refuse rather than silently launching the maximal TUI: a user who
+        # asked for nano must never be handed the 17K-token surface by
+        # accident. Interactive nano lands in a follow-up PR.
+        from src.cli_core.exit import cli_error
+
+        cli_error(
+            "error: --nano currently requires -p/--print (headless). "
+            "Interactive nano mode is planned; for now run: "
+            "clawcodex --nano -p \"<prompt>\"",
+            2,
+        )
+
     if args.print:
         profile_checkpoint("mode_dispatch_print")
         # ``phase4_dispatch``: launcher has chosen a mode and is about
@@ -526,6 +539,22 @@ Examples:
         help='Emit verbose diagnostics to stderr',
     )
 
+    # ---- Nano mode ----
+    # pi-shaped minimal profile (see src/nano/): six tools (Read, Bash,
+    # Edit, Write, Grep, Glob), a ~600-token system prompt, no per-turn
+    # context injections, /eco on. Top-level because it will eventually
+    # apply to every surface; v1 wires the headless (-p) path only and
+    # errors otherwise rather than silently running maximal.
+    parser.add_argument(
+        '--nano',
+        action='store_true',
+        help=(
+            'Nano mode: minimal pi-style harness profile — six tools, tiny '
+            'system prompt, byte-stable context, eco compression on. '
+            'Currently requires -p/--print (headless).'
+        ),
+    )
+
     # ---- Permissions ----
     # ``--dangerously-skip-permissions`` and ``--allow-dangerously-skip-permissions``
     # apply to all UI modes (REPL, TUI, headless), so they live in a top-level
@@ -696,6 +725,7 @@ def _run_print_mode(args) -> int:
         disallowed_tools=tuple(disallowed),
         include_partial_messages=bool(args.include_partial_messages),
         verbose=bool(args.verbose),
+        nano=bool(getattr(args, 'nano', False)),
     )
     try:
         return run_headless(options)

--- a/src/entrypoints/headless.py
+++ b/src/entrypoints/headless.py
@@ -175,6 +175,10 @@ class HeadlessOptions:
     disallowed_tools: tuple[str, ...] = ()
     include_partial_messages: bool = False
     verbose: bool = False
+    # ``--nano`` — pi-shaped minimal profile: six tools, ~600-token system
+    # prompt, no per-turn injections, eco on. See src/nano/ and
+    # my-docs/clawcodex-nano/nano-design.md. Default off = today's behavior.
+    nano: bool = False
 
     # Mostly for tests: override streams so we can capture output.
     stdin: IO[str] | None = None
@@ -215,6 +219,19 @@ def run_headless(options: HeadlessOptions) -> int:
     # memos are key-less and first-writer pins the content the query
     # path (which passes workspace_root) will read.
     workspace_root = options.workspace_root or Path.cwd()
+
+    if options.nano:
+        # Set the process-wide mode BEFORE any prompt/registry construction
+        # so every chokepoint (build_effective_system_prompt, the reminder
+        # gates in run_query_as_agent_loop) observes it. Eco rides along:
+        # nano is the slim/fast/eco profile, and eco's never-worse guard
+        # makes default-on safe (src/eco/guard.py).
+        from src.eco.state import set_eco_session
+        from src.nano.state import set_nano_mode
+
+        set_nano_mode(True)
+        set_eco_session(True)
+
     from src.deferred_init import start_deferred_prefetches
 
     start_deferred_prefetches(cwd=str(workspace_root))
@@ -304,7 +321,17 @@ def run_headless(options: HeadlessOptions) -> int:
 
     session = Session.create(provider_name, getattr(provider, "model", model or ""))
 
-    tool_registry = build_default_registry(provider=provider)
+    if options.nano:
+        # Nano: exactly six tools, none deferred (src/nano/registry.py) —
+        # no Agent/Task/Skill/ToolSearch/MCP surface at all. The
+        # ``remove_tool`` calls below are harmless no-ops on this registry
+        # (none of the removed tools are registered); they stay
+        # unconditional so the default branch below remains byte-identical.
+        from src.nano.registry import build_nano_registry
+
+        tool_registry = build_nano_registry()
+    else:
+        tool_registry = build_default_registry(provider=provider)
     # AskUserQuestion cannot work here: headless has no terminal, and no
     # surface routes questions back to a client (``ask_user`` below is
     # unconditionally stubbed). Leaving it REGISTERED but stubbed meant the
@@ -697,6 +724,16 @@ def run_headless(options: HeadlessOptions) -> int:
                         effective_system_prompt = (
                             build_effective_system_prompt(
                                 _style_prompt, tool_context, provider=provider,
+                                # Nano: the prompt's tool listing tracks the
+                                # live registry (an allow/deny-filtered tool
+                                # drops off the listing too).
+                                nano_tool_names=(
+                                    tuple(
+                                        t.name
+                                        for t in tool_registry.list_tools()
+                                    )
+                                    if options.nano else None
+                                ),
                             )
                         )
 

--- a/src/nano/__init__.py
+++ b/src/nano/__init__.py
@@ -1,0 +1,23 @@
+"""Nano mode — a pi-shaped minimal profile of clawcodex (``clawcodex --nano``).
+
+Ported from the pi agent harness study (my-docs/clawcodex-nano/): under
+``--nano`` the harness sends a ~600-token system prompt and six tools
+(Read, Bash, Edit, Write, Grep, Glob), injects nothing per turn, and keeps
+the request prefix byte-stable. Without the flag, nothing in this package
+runs and clawcodex behaves exactly as before.
+
+Design doc: my-docs/clawcodex-nano/nano-design.md (gitignored, on-disk).
+"""
+
+from .prompt import build_nano_prompt_blocks
+from .registry import NANO_TOOL_NAMES, build_nano_registry
+from .state import is_nano_mode, reset_nano_mode, set_nano_mode
+
+__all__ = [
+    "NANO_TOOL_NAMES",
+    "build_nano_prompt_blocks",
+    "build_nano_registry",
+    "is_nano_mode",
+    "reset_nano_mode",
+    "set_nano_mode",
+]

--- a/src/nano/prompt.py
+++ b/src/nano/prompt.py
@@ -1,0 +1,267 @@
+"""Nano system prompt — pi's shape, clawcodex's plumbing.
+
+Builds the entire nano system prompt as a block list compatible with
+``query()``'s cache machinery (same ``_cache_scope`` / ``cache_control``
+conventions as ``build_full_system_prompt_blocks`` and the coordinator
+branch of ``build_effective_system_prompt``).
+
+Structure, mirroring pi (`packages/coding-agent/src/core/system-prompt.ts`,
+162 lines for the whole builder):
+
+  identity line
+  Available tools:   (one line per tool)
+  Guidelines:        (a handful of bullets)
+  [non-interactive note]
+  [project context — CLAWCODEX.md, falling back to AGENTS.md / CLAUDE.md]
+  [skills listing — name/description/location; the Read tool is the loader]
+  Current working directory + OS + date
+
+Deliberately absent (the point of nano — see
+my-docs/clawcodex-nano/pi-vs-clawcodex.md §3): the ~3,000-token base
+sections, the ~3,300-token auto-memory doctrine, MCP sections, the git
+status snapshot, and every per-turn reminder. Everything here is
+session-stable, so the whole prompt sits in one cached prefix.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+_IDENTITY = (
+    "You are an expert software engineering agent operating inside "
+    "clawcodex (nano mode). You help the user by reading files, executing "
+    "commands, editing code, and writing new files."
+)
+
+# One line per tool, pi-style. Keyed by tool name so the listing tracks the
+# registry: a tool filtered out via --disallowed-tools drops off the prompt.
+NANO_TOOL_SNIPPETS: dict[str, str] = {
+    "Read": (
+        "read file contents (text, images, PDFs, notebooks); "
+        "offset/limit page through large files"
+    ),
+    "Bash": "execute shell commands in the working directory",
+    "Edit": "make precise file edits by exact text replacement",
+    "Write": "create new files or fully overwrite existing ones",
+    "Grep": "search file contents with regex (respects .gitignore)",
+    "Glob": "find files by glob pattern",
+}
+
+_GUIDELINES = (
+    "- Use Read to examine files instead of cat/sed/head, and Grep/Glob "
+    "instead of shell grep/find",
+    "- Read a file before editing it; make old_string match the file "
+    "exactly, including whitespace",
+    "- Be concise in your responses",
+    "- Show file paths clearly when working with files",
+)
+
+_NON_INTERACTIVE_NOTE = (
+    "You are running non-interactively: no user is available to answer "
+    "questions mid-task. Complete the task fully, verify your work with "
+    "the narrowest sufficient check, then stop."
+)
+
+# Fallback context files when no CLAWCODEX.md exists, in pi's precedence
+# order (resource-loader.ts:71). Root-level only — nano keeps discovery
+# cheap; the CLAWCODEX.md path keeps its existing 3-level walk.
+_FALLBACK_CONTEXT_FILES = ("AGENTS.override.md", "AGENTS.md", "CLAUDE.md")
+_FALLBACK_CONTEXT_MAX_CHARS = 40_000
+
+
+def _xml_escape(text: str) -> str:
+    return (
+        text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    )
+
+
+def _skills_section(cwd: str) -> str:
+    """pi's progressive-disclosure skills listing (skills.ts:335-361).
+
+    Name/description/location triples only; the Read tool is the loader.
+    Best-effort: any failure yields no section, never a broken prompt.
+    """
+    try:
+        from src.command_system import get_skill_tool_commands
+
+        skills = get_skill_tool_commands(cwd)
+    except Exception:
+        return ""
+    if not skills:
+        return ""
+
+    # pi's contract: a listed skill must carry a location the Read tool can
+    # load — nano has no Skill tool, so a skill without a file path would be
+    # advertised but unusable (and would only bloat the prompt). Drop them.
+    entries: list[tuple[str, str, str]] = []
+    for skill in skills:
+        paths = getattr(skill, "paths", None) or []
+        if not paths:
+            continue
+        entries.append((
+            _xml_escape(str(getattr(skill, "name", ""))),
+            _xml_escape(str(getattr(skill, "description", "") or "")),
+            _xml_escape(str(paths[0])),
+        ))
+    if not entries:
+        return ""
+
+    lines = [
+        "The following skills provide specialized instructions for "
+        "specific tasks.",
+        "Use the Read tool to load a skill's file when the task matches "
+        "its description.",
+        "",
+        "<available_skills>",
+    ]
+    for name, desc, location in entries:
+        lines.append("  <skill>")
+        lines.append(f"    <name>{name}</name>")
+        lines.append(f"    <description>{desc}</description>")
+        lines.append(f"    <location>{location}</location>")
+        lines.append("  </skill>")
+    lines.append("</available_skills>")
+    return "\n".join(lines)
+
+
+def _load_fallback_context(workspace_root: str | Path) -> str:
+    """AGENTS.md / CLAUDE.md fallback when no CLAWCODEX.md content exists.
+
+    pi reads AGENTS.override.md > AGENTS.md > CLAUDE.md per directory;
+    clawcodex reads only CLAWCODEX.md (clawcodex_md.py:14). Terminal-bench
+    tasks and most external repos carry AGENTS.md/CLAUDE.md, so nano honors
+    them — first match at the workspace root wins.
+    """
+    root = Path(workspace_root)
+    for name in _FALLBACK_CONTEXT_FILES:
+        candidate = root / name
+        try:
+            if not candidate.is_file():
+                continue
+            text = candidate.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        text = text.strip()
+        if not text:
+            continue
+        if len(text) > _FALLBACK_CONTEXT_MAX_CHARS:
+            text = (
+                text[:_FALLBACK_CONTEXT_MAX_CHARS]
+                + "\n... [truncated: file exceeds nano context budget]"
+            )
+        return (
+            f'<project_instructions path="{candidate}">\n{text}\n'
+            "</project_instructions>"
+        )
+    return ""
+
+
+def _nano_env_info(cwd: str) -> str:
+    """Three cache-stable lines: cwd, OS, date-only stamp."""
+    import platform
+
+    from src.context_system.prompt_assembly import _get_session_start_date_iso
+
+    return "\n".join((
+        f"Current working directory: {cwd}",
+        f"OS: {platform.system()} {platform.release()}",
+        f"Date: {_get_session_start_date_iso()}",
+    ))
+
+
+def build_nano_prompt_text(
+    *,
+    cwd: str,
+    tool_names: tuple[str, ...] | list[str] | None = None,
+    non_interactive: bool = False,
+    style_prompt: str = "",
+) -> str:
+    """The nano base prompt as a single string (no context files)."""
+    names = list(tool_names) if tool_names else list(NANO_TOOL_SNIPPETS)
+    tool_lines = [
+        f"- {name}: {NANO_TOOL_SNIPPETS[name]}"
+        for name in names
+        if name in NANO_TOOL_SNIPPETS
+    ]
+
+    parts = [
+        _IDENTITY,
+        "",
+        "Available tools:",
+        *tool_lines,
+        "",
+        "Guidelines:",
+        *_GUIDELINES,
+    ]
+    if non_interactive:
+        parts += ["", _NON_INTERACTIVE_NOTE]
+    if style_prompt.strip():
+        parts += ["", style_prompt.strip()]
+
+    skills = _skills_section(cwd)
+    if skills:
+        parts += ["", skills]
+
+    # pi-lean env block: cwd + OS + memoized date-only stamp (cache-stable —
+    # same `_get_session_start_date_iso` the default prompt uses). No
+    # data-dir line, no shell/user lines: nano's surface has no
+    # session-resume affordance and every line here is paid on every turn.
+    parts += ["", _nano_env_info(cwd)]
+    return "\n".join(parts)
+
+
+def build_nano_prompt_blocks(
+    *,
+    cwd: str,
+    workspace_root: str | Path | None = None,
+    tool_names: tuple[str, ...] | list[str] | None = None,
+    non_interactive: bool = False,
+    style_prompt: str = "",
+    query_source: str = "main",
+) -> list[dict[str, Any]]:
+    """Full nano system prompt as cache-scoped blocks.
+
+    Block 1: the base prompt (SESSION scope). Block 2 (when present):
+    project instructions — CLAWCODEX.md via the existing extractor, or the
+    AGENTS.md/CLAUDE.md fallback (SESSION scope). The cache marker rides
+    the last block so the entire prompt is one cached prefix; there is no
+    REQUEST-scope (volatile) block at all — nano sends no git snapshot.
+    """
+    from src.context_system.system_prompt_cache import CacheScope
+    from src.state.cache_state import should_1h_cache_ttl
+
+    root = workspace_root or cwd
+
+    blocks: list[dict[str, Any]] = [{
+        "type": "text",
+        "text": build_nano_prompt_text(
+            cwd=cwd,
+            tool_names=tool_names,
+            non_interactive=non_interactive,
+            style_prompt=style_prompt,
+        ),
+        "_cache_scope": CacheScope.SESSION.value,
+    }]
+
+    instructions = ""
+    try:
+        from src.context_system import build_context_prompt_parts
+
+        _snapshot, instructions = build_context_prompt_parts(root, cwd=cwd)
+    except Exception:
+        instructions = ""
+    if not instructions.strip():
+        instructions = _load_fallback_context(root)
+    if instructions.strip():
+        blocks.append({
+            "type": "text",
+            "text": instructions.strip(),
+            "_cache_scope": CacheScope.SESSION.value,
+        })
+
+    blocks[-1]["cache_control"] = {
+        "type": "ephemeral",
+        "ttl": "1h" if should_1h_cache_ttl(query_source) else "5m",
+    }
+    return blocks

--- a/src/nano/registry.py
+++ b/src/nano/registry.py
@@ -1,0 +1,56 @@
+"""Nano tool registry — pi's surface: six tools, nothing deferred.
+
+pi ships four default tools (read, bash, edit, write) plus grep/find/ls on
+request; nano keeps clawcodex's closest six (Grep/Glob replace pi's
+grep/find — same roles, existing implementations). Registering the raw
+static instances (no :func:`_apply_initial_loading_policy`) keeps every
+``should_defer`` False, so ``query()``'s ``<available-deferred-tools>``
+first-user-message block — which busts the message-history cache prefix
+whenever its contents change — is never emitted (it gates on a non-empty
+deferred list, ``src/query/query.py:1024``).
+
+Deliberately absent, per the study (my-docs/clawcodex-nano/pi-vs-clawcodex.md
+§5): Agent/Workflow (orchestration), TaskV2 (pi: "todos confuse models"),
+Skill (skills load via Read — progressive disclosure), ToolSearch (nothing
+to defer at six tools), MCP/user tools (pi has neither in core), and every
+interactive-only tool.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from src.tool_system.registry import ToolRegistry
+from src.tool_system.tools import (
+    BashTool,
+    EditTool,
+    GlobTool,
+    GrepTool,
+    ReadTool,
+    WriteTool,
+)
+
+from .tool_docs import NANO_TOOL_DOCS
+
+# Order mirrors pi's system-prompt tool list (read/bash/edit/write first).
+NANO_TOOLS = (ReadTool, BashTool, EditTool, WriteTool, GrepTool, GlobTool)
+NANO_TOOL_NAMES: tuple[str, ...] = tuple(t.name for t in NANO_TOOLS)
+
+
+def build_nano_registry() -> ToolRegistry:
+    """Registry holding exactly the six nano tools, none deferred.
+
+    Each tool is a registry-local copy carrying its pi-length doc
+    (``NANO_TOOL_DOCS``) as ``prompt`` — ``query()`` sends ``tool.prompt()``
+    as the API description (query.py:1049), so this alone cuts the tool
+    payload from ~2K to ~250 tokens without touching the default registry's
+    instances. Schemas are kept in full: parameter shapes are behavioral,
+    docs are advisory.
+    """
+    registry = ToolRegistry()
+    for tool in NANO_TOOLS:
+        doc = NANO_TOOL_DOCS.get(tool.name)
+        if doc is not None:
+            tool = replace(tool, prompt=lambda _doc=doc: _doc)
+        registry.register(tool)
+    return registry

--- a/src/nano/state.py
+++ b/src/nano/state.py
@@ -1,0 +1,37 @@
+"""Process-global nano-mode toggle.
+
+Same shape as :mod:`src.eco.state` (the ``/eco`` session switch): one
+process, one switch, set once at startup from ``--nano`` and consulted at
+the few chokepoints that differ in nano mode (registry construction, system
+prompt assembly, per-turn reminder injection). Subagents run in the same
+process and inherit the mode — intended: a nano session should not spawn
+maximal subagents (it has no Agent tool to do so anyway).
+
+Default off, so a process that never calls :func:`set_nano_mode` follows
+the standard clawcodex paths untouched.
+"""
+
+from __future__ import annotations
+
+import threading
+
+_lock = threading.Lock()
+_nano_on = False
+
+
+def set_nano_mode(on: bool) -> None:
+    """Turn nano mode on/off for this process (startup wiring only)."""
+    global _nano_on
+    with _lock:
+        _nano_on = bool(on)
+
+
+def is_nano_mode() -> bool:
+    """Whether nano mode is active."""
+    with _lock:
+        return _nano_on
+
+
+def reset_nano_mode() -> None:
+    """Clear the toggle (test/teardown helper)."""
+    set_nano_mode(False)

--- a/src/nano/tool_docs.py
+++ b/src/nano/tool_docs.py
@@ -1,0 +1,48 @@
+"""pi-length tool documentation for nano mode.
+
+The default ``tool.prompt()`` docs for the six nano tools total ~8K chars
+(~2K tokens) — Bash alone carries ~3.3K chars of styling and commit
+etiquette. pi's descriptions are 1–3 sentences and the Databricks result
+says that is enough for frontier models. These replacements keep every
+**enforced** contract (read-before-write/edit staleness gates, working-dir
+persistence, uniqueness rule, output truncation) and drop the etiquette.
+
+Applied registry-locally via ``dataclasses.replace`` in
+:func:`src.nano.registry.build_nano_registry` — the default registry's
+instances and docs are untouched.
+"""
+
+from __future__ import annotations
+
+NANO_TOOL_DOCS: dict[str, str] = {
+    "Read": (
+        "Reads a file. Returns text with line numbers (cat -n style); "
+        "images/PDFs/notebooks are returned in a form you can view. Long "
+        "files are truncated — use offset/limit to page through them."
+    ),
+    "Bash": (
+        "Executes a bash command and returns stdout+stderr. The working "
+        "directory persists between commands; shell state does not. Long "
+        "output is truncated. Quote paths containing spaces."
+    ),
+    "Edit": (
+        "Edits a file by exact string replacement. You must Read the file "
+        "first (and it must be unchanged since). old_string must match the "
+        "file exactly — including whitespace — and be unique unless "
+        "replace_all is true; on ambiguity, add surrounding context."
+    ),
+    "Write": (
+        "Writes a file, overwriting any existing content. To overwrite an "
+        "existing file you must Read it first. Prefer Edit for modifying "
+        "existing files."
+    ),
+    "Grep": (
+        "Searches file contents with a regex (ripgrep). Filter with path/"
+        "glob/type; -A/-B/-C add context lines; output_mode selects "
+        "matching lines, file lists, or counts. Results are capped."
+    ),
+    "Glob": (
+        "Finds files by glob pattern (e.g. '**/*.py'), sorted by "
+        "modification time. Use for locating files by name or path shape."
+    ),
+}

--- a/src/query/agent_loop_compat.py
+++ b/src/query/agent_loop_compat.py
@@ -180,6 +180,7 @@ def build_effective_system_prompt(
     provider: Any | None = None,
     mcp_servers: list[Any] | None = None,
     query_source: str = "main",
+    nano_tool_names: tuple[str, ...] | None = None,
 ) -> list[dict[str, Any]]:
     """Assemble the cold-start system prompt for the headless+TUI cutover.
 
@@ -238,6 +239,33 @@ def build_effective_system_prompt(
     from ..coordinator.mode import is_coordinator_mode
 
     cwd = str(tool_context.cwd or tool_context.workspace_root)
+
+    # Nano mode REPLACES the entire base block set with the pi-shaped
+    # minimal prompt (same replace-not-extend pattern as the coordinator
+    # branch below; nano+coordinator is unsupported and nano wins). The
+    # nano builder owns context files (CLAWCODEX.md with AGENTS.md/CLAUDE.md
+    # fallback) and deliberately emits NO git/workspace snapshot, so the
+    # whole prompt is one session-stable cached prefix — return early
+    # rather than falling through to the trailing context blocks.
+    from src.nano.state import is_nano_mode
+
+    if is_nano_mode():
+        from src.nano.prompt import build_nano_prompt_blocks
+
+        return build_nano_prompt_blocks(
+            cwd=cwd,
+            workspace_root=tool_context.workspace_root,
+            tool_names=nano_tool_names,
+            non_interactive=bool(
+                getattr(
+                    getattr(tool_context, "options", None),
+                    "is_non_interactive_session",
+                    False,
+                )
+            ),
+            style_prompt=style_prompt,
+            query_source=query_source,
+        )
 
     coordinator = is_coordinator_mode()
     if coordinator:
@@ -577,12 +605,21 @@ async def run_query_as_agent_loop(
     # failure. Ephemeral: appended to the query's working set only, never
     # persisted to the conversation (matches TS attachments).
     messages_for_query = list(initial_messages)
+
+    # Nano mode sends a byte-stable history: none of the per-turn
+    # reminder/recall injections below fire (pi-vs-clawcodex study §3.4 —
+    # maximal cache hits, no reminder noise competing with the task). The
+    # same gate covers all four injection sites so the invariant is
+    # structural rather than per-feature.
+    from src.nano.state import is_nano_mode
+
+    _inject_reminders = memory_recall_enabled and not is_nano_mode()
     try:
         recall_msg = (
             await _maybe_recall_memories(
                 messages_for_query, provider, tool_context, memory_surfaced,
             )
-            if memory_recall_enabled else None
+            if _inject_reminders else None
         )
         if recall_msg is not None:
             messages_for_query.append(recall_msg)
@@ -595,7 +632,7 @@ async def run_query_as_agent_loop(
     # the last, append a <system-reminder> with today's date at the tail (the
     # cached prefix keeps the memoized start date, so this doesn't bust it).
     # Reuses the "real user turn" gate (memory_recall_enabled == not internal).
-    if memory_recall_enabled:
+    if _inject_reminders:
         try:
             from src.context_system.date_change import get_date_change_reminder
             from src.types.messages import create_user_message
@@ -617,7 +654,7 @@ async def run_query_as_agent_loop(
     # attachments are PERSISTED via on_attachment — TS keeps them in the
     # transcript, and both the throttle scan and the model's context across
     # turns 2..5 depend on them surviving into later turns' initial_messages.
-    if memory_recall_enabled:
+    if _inject_reminders:
         try:
             from src.context_system.plan_mode import (
                 build_plan_mode_attachments,
@@ -672,7 +709,7 @@ async def run_query_as_agent_loop(
     # the same PERSISTED delivery as the plan block above — the throttle scans
     # the transcript for the previous reminder, so it must survive into later
     # turns' initial_messages.
-    if memory_recall_enabled:
+    if _inject_reminders:
         try:
             from src.context_system.plan_mode import wrap_in_system_reminder
             from src.context_system.task_reminder import (

--- a/tests/nano/conftest.py
+++ b/tests/nano/conftest.py
@@ -1,0 +1,42 @@
+"""Shared fixtures for nano-mode tests.
+
+Nano and eco are process-global toggles; every test must leave them off so
+the default-path test suite keeps seeing stock behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.eco.state import reset_eco
+from src.nano.state import reset_nano_mode
+
+
+@pytest.fixture(autouse=True)
+def _reset_nano_state():
+    reset_nano_mode()
+    reset_eco()
+    yield
+    reset_nano_mode()
+    reset_eco()
+
+
+@pytest.fixture
+def no_skills(monkeypatch):
+    """Hermetic prompt tests: no developer-machine skills leak in."""
+    import src.command_system as command_system
+
+    monkeypatch.setattr(
+        command_system, "get_skill_tool_commands", lambda cwd=None: ()
+    )
+
+
+@pytest.fixture
+def no_project_context(monkeypatch):
+    """Hermetic prompt tests: no ~/.clawcodex/CLAWCODEX.md leak."""
+    import src.context_system as context_system
+
+    monkeypatch.setattr(
+        context_system, "build_context_prompt_parts",
+        lambda root, cwd=None: ("", ""),
+    )

--- a/tests/nano/test_nano_headless.py
+++ b/tests/nano/test_nano_headless.py
@@ -1,0 +1,245 @@
+"""End-to-end nano headless run against a scripted fake provider.
+
+Reuses the fake-wiring pattern of tests/entrypoints/test_headless_goal.py,
+but keeps the REAL registry construction path — the point is to observe
+exactly what a nano session sends on the wire: six tools, the nano system
+prompt, and a first message that is the user's prompt (no
+<available-deferred-tools> block).
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from src.entrypoints import HeadlessOptions, run_headless
+from src.entrypoints import headless as headless_mod
+from src.providers.base import ChatResponse
+
+
+class _FakeProvider:
+    def __init__(self, api_key: str, base_url=None, model=None, *, responses=None):
+        self.api_key = api_key
+        self.base_url = base_url
+        self.model = model or "fake-model"
+        self._responses = list(responses or [])
+        self.calls: list[dict] = []
+
+    def chat(self, messages, tools=None, **kwargs):
+        self.calls.append(
+            {"messages": messages, "tools": tools, "kwargs": kwargs}
+        )
+        if not self._responses:
+            raise AssertionError("FakeProvider ran out of scripted responses")
+        return self._responses.pop(0)
+
+    def chat_stream(self, messages, tools=None, **kwargs):
+        raise NotImplementedError
+
+
+class _Wiring:
+    def __init__(self) -> None:
+        self.script: list[ChatResponse] = []
+        self.created: list[_FakeProvider] = []
+
+    def extend(self, items) -> None:
+        self.script.extend(items)
+
+
+@pytest.fixture
+def fake_wiring(monkeypatch):
+    wiring = _Wiring()
+
+    def _fake_provider_class(provider_name):
+        def _ctor(api_key, base_url=None, model=None):
+            p = _FakeProvider(
+                api_key, base_url, model, responses=list(wiring.script)
+            )
+            wiring.created.append(p)
+            return p
+
+        return _ctor
+
+    monkeypatch.setattr(headless_mod, "get_provider_class", _fake_provider_class)
+    monkeypatch.setattr(
+        headless_mod,
+        "get_provider_config",
+        lambda name: {"api_key": "test-key", "default_model": "fake-model"},
+    )
+    monkeypatch.setattr(headless_mod, "get_default_provider", lambda: "anthropic")
+    monkeypatch.setattr(
+        "src.entrypoints.provider_validation.get_provider_validation_error",
+        lambda name: None,
+    )
+
+    import src.settings.settings as settings_mod
+    from src.settings.types import SettingsSchema
+
+    monkeypatch.setattr(
+        "src.services.startup_gates.check_trust_accepted", lambda root: True
+    )
+    monkeypatch.setattr(
+        settings_mod, "load_settings", lambda *a, **k: SettingsSchema()
+    )
+    monkeypatch.setattr(settings_mod, "_settings_cache", None)
+    yield wiring
+    settings_mod._settings_cache = None
+
+
+def _text(text: str) -> ChatResponse:
+    return ChatResponse(
+        content=text,
+        model="fake-model",
+        usage={"input_tokens": 5, "output_tokens": 3},
+        finish_reason="end_turn",
+        tool_uses=None,
+    )
+
+
+def _tool_use(name: str, tool_input: dict, tool_id: str = "toolu_1") -> ChatResponse:
+    return ChatResponse(
+        content="",
+        model="fake-model",
+        usage={"input_tokens": 5, "output_tokens": 3},
+        finish_reason="tool_use",
+        tool_uses=[{"id": tool_id, "name": name, "input": tool_input}],
+    )
+
+
+def _run(prompt: str, tmp_path, **opt_kwargs):
+    stdout, stderr = io.StringIO(), io.StringIO()
+    code = run_headless(HeadlessOptions(
+        prompt=prompt,
+        output_format="text",
+        stdout=stdout,
+        stderr=stderr,
+        workspace_root=tmp_path,
+        **opt_kwargs,
+    ))
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+def _role(msg) -> str:
+    return str(msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", ""))
+
+
+def _system_text(call: dict) -> str:
+    # Anthropic wire: kwargs["system"] (str or block list). Every other
+    # provider: a leading {"role": "system"} message (query.py:1189).
+    system = call["kwargs"].get("system", "")
+    if isinstance(system, list):
+        return "\n".join(
+            b.get("text", "") for b in system if isinstance(b, dict)
+        )
+    if system:
+        return str(system)
+    msgs = call["messages"]
+    if msgs and _role(msgs[0]) == "system":
+        return _message_text(msgs[0])
+    return ""
+
+
+def _non_system_messages(call: dict) -> list:
+    return [m for m in call["messages"] if _role(m) != "system"]
+
+
+def _content_text(content) -> str:
+    """Recursively flatten message/block content to text.
+
+    Handles the nesting that matters here: a ``tool_result`` block carries
+    its payload under its own ``content`` key (str or block list), not
+    under ``text``.
+    """
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "\n".join(_content_text(b) for b in content)
+    if isinstance(content, dict):
+        if "text" in content:
+            return str(content.get("text") or "")
+        if "content" in content:
+            return _content_text(content.get("content"))
+        return ""
+    return str(content)
+
+
+def _message_text(msg) -> str:
+    content = msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", "")
+    return _content_text(content)
+
+
+def test_nano_sends_six_tools_and_nano_prompt(fake_wiring, tmp_path):
+    fake_wiring.extend([_text("done")])
+    code, out, err = _run("hello", tmp_path, nano=True)
+    assert code == 0, err
+    assert "done" in out
+
+    provider = fake_wiring.created[-1]
+    call = provider.calls[0]
+
+    tool_names = [t["name"] for t in (call["tools"] or call["kwargs"].get("tools") or [])]
+    assert tool_names == ["Read", "Bash", "Edit", "Write", "Grep", "Glob"]
+
+    system_text = _system_text(call)
+    assert "nano mode" in system_text
+    assert "# Doing tasks" not in system_text
+    assert "# auto memory" not in system_text
+
+    # Byte-stability invariant: no <available-deferred-tools> preamble —
+    # the first conversation message is the user's prompt itself.
+    convo = _non_system_messages(call)
+    assert convo, "no conversation messages reached the provider"
+    assert "<available-deferred-tools>" not in _message_text(convo[0])
+    assert "hello" in "".join(_message_text(m) for m in convo)
+
+
+def test_nano_turns_eco_on(fake_wiring, tmp_path):
+    from src.eco.state import is_eco_session
+
+    fake_wiring.extend([_text("done")])
+    code, _, err = _run("hello", tmp_path, nano=True)
+    assert code == 0, err
+    assert is_eco_session()
+
+
+def test_default_run_is_unchanged(fake_wiring, tmp_path):
+    from src.eco.state import is_eco_session
+    from src.nano.state import is_nano_mode
+
+    fake_wiring.extend([_text("done")])
+    code, _, err = _run("hello", tmp_path)
+    assert code == 0, err
+    assert not is_nano_mode()
+    assert not is_eco_session()
+
+    provider = fake_wiring.created[-1]
+    call = provider.calls[0]
+    tool_names = {t["name"] for t in (call["tools"] or call["kwargs"].get("tools") or [])}
+    # The maximal surface: orchestration present, far more than nano's six.
+    # (The exact set is environment-dependent — is_enabled()/settings gates —
+    # so assert shape, not membership roll-call.)
+    assert "Agent" in tool_names
+    assert len(tool_names) > 15
+    assert "# Doing tasks" in _system_text(call)
+
+
+def test_nano_bash_round_trip(fake_wiring, tmp_path):
+    fake_wiring.extend([
+        _tool_use("Bash", {"command": "echo nano-ok"}),
+        _text("finished"),
+    ])
+    code, out, err = _run(
+        "run it", tmp_path, nano=True, skip_permissions=True,
+        permission_mode="bypassPermissions",
+        is_bypass_permissions_mode_available=True,
+    )
+    assert code == 0, err
+    assert "finished" in out
+
+    provider = fake_wiring.created[-1]
+    assert len(provider.calls) == 2
+    followup = "".join(_message_text(m) for m in provider.calls[1]["messages"])
+    assert "nano-ok" in followup

--- a/tests/nano/test_nano_payload.py
+++ b/tests/nano/test_nano_payload.py
@@ -1,0 +1,42 @@
+"""The number nano exists for: fixed per-request payload ≤ ~2K tokens.
+
+The pi-vs-clawcodex study measured pi at ~1,050 tokens and default
+clawcodex at ~17,000. Nano's budget is 2,500 estimated tokens (chars/4,
+conservative) for prompt blocks + tool docs + tool schemas — comfortably
+an order of magnitude under the default, with headroom so an innocuous
+doc tweak doesn't flap the suite. If this test fails, something resident
+crept back into the first request; shrink it rather than raising the bound.
+"""
+
+from __future__ import annotations
+
+import json
+
+from src.nano.prompt import build_nano_prompt_blocks
+from src.nano.registry import build_nano_registry
+
+PAYLOAD_BUDGET_EST_TOKENS = 2_500
+
+
+def _est_tokens(chars: int) -> int:
+    return chars // 4
+
+
+def test_fixed_payload_within_budget(no_skills, no_project_context, tmp_path):
+    blocks = build_nano_prompt_blocks(
+        cwd=str(tmp_path), workspace_root=str(tmp_path),
+        non_interactive=True, query_source="sdk",
+    )
+    prompt_chars = sum(len(b["text"]) for b in blocks)
+
+    tools_chars = 0
+    for tool in build_nano_registry().list_tools():
+        tools_chars += len(tool.prompt())
+        tools_chars += len(json.dumps(dict(tool.input_schema)))
+
+    total = _est_tokens(prompt_chars + tools_chars)
+    assert total <= PAYLOAD_BUDGET_EST_TOKENS, (
+        f"nano fixed payload grew to ~{total} est. tokens "
+        f"(prompt {prompt_chars} ch + tools {tools_chars} ch); "
+        f"budget is {PAYLOAD_BUDGET_EST_TOKENS}"
+    )

--- a/tests/nano/test_nano_prompt.py
+++ b/tests/nano/test_nano_prompt.py
@@ -1,0 +1,122 @@
+"""Nano system prompt: pi's shape, and none of the maximal sections."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from src.nano.prompt import (
+    build_nano_prompt_blocks,
+    build_nano_prompt_text,
+)
+from src.nano.state import set_nano_mode
+from src.query.agent_loop_compat import build_effective_system_prompt
+
+# Section markers of the maximal prompt that must never appear in nano.
+_MAXIMAL_MARKERS = (
+    "# auto memory",
+    "# Doing tasks",
+    "# Persistent Memory",
+    "# Available Tools",
+    "# Tone and style",
+    "# Communicating with the user",
+    "TaskCreate",
+    "<available-deferred-tools>",
+)
+
+
+def test_base_prompt_is_small_and_clean(no_skills, tmp_path):
+    text = build_nano_prompt_text(cwd=str(tmp_path), non_interactive=True)
+    assert "nano mode" in text
+    assert "Available tools:" in text
+    for name in ("Read", "Bash", "Edit", "Write", "Grep", "Glob"):
+        assert f"- {name}: " in text
+    assert "running non-interactively" in text
+    for marker in _MAXIMAL_MARKERS:
+        assert marker not in text
+    # pi territory: a few hundred tokens, not a few thousand.
+    assert len(text) // 4 < 1000
+
+
+def test_tool_listing_tracks_registry_filter(no_skills, tmp_path):
+    text = build_nano_prompt_text(
+        cwd=str(tmp_path), tool_names=("Read", "Bash", "Edit", "Write"),
+    )
+    assert "- Grep: " not in text and "- Glob: " not in text
+    assert "- Read: " in text
+
+
+def test_blocks_all_session_scope_with_one_trailing_cache_marker(
+    no_skills, no_project_context, tmp_path
+):
+    blocks = build_nano_prompt_blocks(
+        cwd=str(tmp_path), workspace_root=str(tmp_path), query_source="sdk",
+    )
+    assert all(b["_cache_scope"] == "session" for b in blocks)
+    assert "cache_control" in blocks[-1]
+    assert all("cache_control" not in b for b in blocks[:-1])
+
+
+def test_agents_md_fallback_when_no_clawcodex_md(
+    no_skills, no_project_context, tmp_path
+):
+    (tmp_path / "AGENTS.md").write_text("Always run ./test.sh before done.")
+    blocks = build_nano_prompt_blocks(
+        cwd=str(tmp_path), workspace_root=str(tmp_path),
+    )
+    joined = "\n".join(b["text"] for b in blocks)
+    assert "<project_instructions" in joined
+    assert "Always run ./test.sh before done." in joined
+
+
+def test_clawcodex_md_wins_over_fallback(no_skills, tmp_path, monkeypatch):
+    import src.context_system as context_system
+
+    monkeypatch.setattr(
+        context_system, "build_context_prompt_parts",
+        lambda root, cwd=None: ("SNAPSHOT", "## Project Instructions\nfrom-clawcodex-md"),
+    )
+    (tmp_path / "AGENTS.md").write_text("fallback-should-not-appear")
+    blocks = build_nano_prompt_blocks(
+        cwd=str(tmp_path), workspace_root=str(tmp_path),
+    )
+    joined = "\n".join(b["text"] for b in blocks)
+    assert "from-clawcodex-md" in joined
+    assert "fallback-should-not-appear" not in joined
+    # The volatile git/workspace snapshot half is deliberately dropped.
+    assert "SNAPSHOT" not in joined
+
+
+def test_build_effective_system_prompt_nano_branch(
+    no_skills, no_project_context, tmp_path
+):
+    set_nano_mode(True)
+    tool_context = SimpleNamespace(
+        cwd=str(tmp_path),
+        workspace_root=str(tmp_path),
+        options=SimpleNamespace(is_non_interactive_session=True),
+    )
+    blocks = build_effective_system_prompt(
+        "STYLE-LINE", tool_context, provider=None, query_source="sdk",
+        nano_tool_names=("Read", "Bash", "Edit", "Write", "Grep", "Glob"),
+    )
+    joined = "\n".join(b["text"] for b in blocks)
+    assert "nano mode" in joined
+    assert "STYLE-LINE" in joined
+    assert "running non-interactively" in joined
+    for marker in _MAXIMAL_MARKERS:
+        assert marker not in joined
+
+
+def test_default_path_unchanged_when_nano_off(no_skills, tmp_path):
+    tool_context = SimpleNamespace(
+        cwd=str(tmp_path),
+        workspace_root=str(tmp_path),
+        options=SimpleNamespace(is_non_interactive_session=True),
+    )
+    blocks = build_effective_system_prompt(
+        "", tool_context, provider=None, query_source="sdk",
+    )
+    joined = "\n".join(b["text"] for b in blocks)
+    # The maximal prompt keeps its signature sections.
+    assert "# Doing tasks" in joined
+    assert "nano mode" not in joined

--- a/tests/nano/test_nano_registry.py
+++ b/tests/nano/test_nano_registry.py
@@ -1,0 +1,60 @@
+"""Nano registry invariants — the surface IS the contract."""
+
+from __future__ import annotations
+
+import json
+
+from src.nano.registry import NANO_TOOL_NAMES, build_nano_registry
+from src.nano.tool_docs import NANO_TOOL_DOCS
+from src.tool_system.defaults import build_default_registry
+from src.tool_system.tools import BashTool
+
+
+def test_exactly_six_tools_in_pi_order():
+    reg = build_nano_registry()
+    assert [t.name for t in reg.list_tools()] == [
+        "Read", "Bash", "Edit", "Write", "Grep", "Glob",
+    ]
+    assert NANO_TOOL_NAMES == ("Read", "Bash", "Edit", "Write", "Grep", "Glob")
+
+
+def test_nothing_deferred_so_no_deferred_tools_message():
+    # query.py:1024 emits the cache-busting <available-deferred-tools>
+    # first-user-message only for deferred-or-disabled registered tools;
+    # nano must never have any.
+    reg = build_nano_registry()
+    assert [t.name for t in reg.list_tools() if t.should_defer] == []
+    for t in reg.list_tools():
+        assert t.is_enabled()
+
+
+def test_no_orchestration_or_task_surface():
+    reg = build_nano_registry()
+    names = {t.name for t in reg.list_tools()}
+    for absent in (
+        "Agent", "Workflow", "TaskCreate", "TaskUpdate", "TaskList",
+        "TaskGet", "TaskOutput", "TaskStop", "ToolSearch", "Skill",
+        "AskUserQuestion", "EnterPlanMode", "ExitPlanMode", "SendMessage",
+        "CronCreate", "WebFetch", "WebSearch", "TodoWrite", "Memory",
+    ):
+        assert absent not in names
+
+
+def test_pi_length_docs_but_full_schemas():
+    reg = build_nano_registry()
+    for t in reg.list_tools():
+        assert t.prompt() == NANO_TOOL_DOCS[t.name]
+        # docs are pi-length: a few sentences, not the multi-KB defaults
+        assert len(t.prompt()) < 400
+        # schemas are untouched (parameter shape is behavioral)
+        assert json.dumps(dict(t.input_schema))
+
+
+def test_default_registry_instances_untouched():
+    # The nano registry carries copies; the shared static instances (and
+    # therefore the default registry) must keep their full docs.
+    build_nano_registry()
+    assert len(BashTool.prompt()) > 1000
+    default = build_default_registry()
+    bash = next(t for t in default.all_tools() if t.name == "Bash")
+    assert len(bash.prompt()) > 1000

--- a/uv.lock
+++ b/uv.lock
@@ -298,7 +298,7 @@ wheels = [
 
 [[package]]
 name = "clawcodex-cli"
-version = "1.4.0"
+version = "1.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
@@ -314,9 +314,11 @@ dependencies = [
     { name = "pyyaml" },
     { name = "regex" },
     { name = "rich" },
+    { name = "starlette" },
     { name = "textual" },
     { name = "tiktoken" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "uvicorn" },
     { name = "wcwidth" },
     { name = "websockets" },
 ]
@@ -324,6 +326,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "build" },
+    { name = "pyte" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -337,11 +340,12 @@ requires-dist = [
     { name = "httpx-sse", specifier = ">=0.4" },
     { name = "markdownify", specifier = ">=0.11" },
     { name = "mcp", specifier = ">=1.27.0,<2" },
-    { name = "openai", specifier = ">=1.109.1" },
+    { name = "openai", specifier = ">=1.109.1,<3" },
     { name = "pathspec", specifier = ">=0.11" },
     { name = "pillow", specifier = ">=10.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pyte", marker = "extra == 'dev'", specifier = ">=0.8.2" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
@@ -349,10 +353,12 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "regex", specifier = ">=2023.0" },
     { name = "rich", specifier = ">=13.9.4" },
+    { name = "starlette", specifier = ">=0.27" },
     { name = "textual", specifier = ">=0.79" },
     { name = "tiktoken", specifier = ">=0.7.0" },
     { name = "twine", marker = "extra == 'dev'", specifier = ">=5.0.0" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.16.0" },
+    { name = "uvicorn", specifier = ">=0.31.1" },
     { name = "wcwidth", specifier = ">=0.2" },
     { name = "websockets", specifier = ">=14.0" },
 ]
@@ -1356,6 +1362,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
+]
+
+[[package]]
+name = "pyte"
+version = "0.8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/ab/b599762933eba04de7dc5b31ae083112a6c9a9db15b01d3109ad797559d9/pyte-0.8.2.tar.gz", hash = "sha256:5af970e843fa96a97149d64e170c984721f20e52227a2f57f0a54207f08f083f", size = 92301, upload-time = "2023-11-12T09:33:43.217Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/d0/bb522283b90853afbf506cd5b71c650cf708829914efd0003d615cf426cd/pyte-0.8.2-py3-none-any.whl", hash = "sha256:85db42a35798a5aafa96ac4d8da78b090b2c933248819157fc0e6f78876a0135", size = 31627, upload-time = "2023-11-12T09:33:41.096Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

First of four PRs porting the pi agent harness's major features behind a \`--nano\` flag (design: gitignored \`my-docs/clawcodex-nano/nano-design.md\`, from the pi-vs-clawcodex study). **Non-nano behavior is byte-identical** — nano is a default-off process flag consulted at four chokepoints.

Under \`clawcodex --nano -p "<prompt>"\`:

- **Six tools** (Read, Bash, Edit, Write, Grep, Glob), none deferred, with pi-length docs applied registry-locally (\`dataclasses.replace\`; the default registry keeps full docs). No Agent/Task/Skill/ToolSearch/MCP surface.
- **~280-token system prompt** replacing the ~7K-token maximal one: identity, one line per tool, short guidelines, skills as read-to-load \`name/description/location\` triples (pi's progressive disclosure — no Skill tool), CLAWCODEX.md with AGENTS.md/CLAUDE.md fallback, cache-stable env lines. Implemented as a replace-not-extend branch in \`build_effective_system_prompt\`, same pattern as coordinator mode.
- **Byte-stable history**: the \`<available-deferred-tools>\` message-0 block vanishes by construction; date-change / task-reminder / plan attachments / memory recall are structurally gated off.
- **/eco on by default** (never-worse-guarded).
- \`--nano\` without \`-p\` errors clearly (interactive nano is a follow-up).

## Measured

Fixed per-request payload: **~2,023 est. tokens vs ~17,000 default (8.4×)** — enforced by a 2,500-token budget test.

## Tests

17 new tests in \`tests/nano/\` (registry invariants, prompt content/negative markers, payload budget, fake-provider headless integration incl. a Bash round-trip and a default-run-unchanged check). Regression suites pass: \`test_headless_goal\`, \`test_agent_loop_compat*\`, \`test_headless_*\`, \`test_cli_core\` (100 passed, 5 skipped).

## Next PRs

2. pi's edit ladder (multi-edit + fuzzy normalization, nano-gated) · 3. max_tokens tool-call guard + compaction file-op ledger · 4. harbor \`--nano\` forwarding + TB 2.1 A/B validation runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)