### PR TITLE
feat(nano): pi's edit ladder — multi-edit + fuzzy match (PR 2/4)

### DIFF
--- a/src/nano/edit_ladder.py
+++ b/src/nano/edit_ladder.py
@@ -1,0 +1,365 @@
+"""pi's edit pipeline, ported: multi-edit + exact→fuzzy match ladder.
+
+Faithful Python port of pi's ``edit-diff.ts``
+(reference_projects/pi/packages/coding-agent/src/core/tools/edit-diff.ts),
+with clawcodex field names (``old_string``/``new_string``). Pure string
+functions — no filesystem, no tool_system imports — so the algorithm is
+testable in isolation and reusable.
+
+The ladder, per edit:
+
+1. exact ``str.find`` on the LF-normalized file;
+2. on miss, fuzzy match in normalized space — NFKC, per-line trailing
+   whitespace stripped, smart quotes → ASCII, Unicode dashes → ``-``,
+   exotic spaces → `` `` — which absorbs the common LLM mismatch causes
+   (invisible Unicode, trailing whitespace) with no semantic risk;
+3. every edit is matched against the SAME original content (not applied
+   incrementally), uniqueness is enforced with occurrence counts, overlaps
+   are rejected with a merge hint, and replacements apply in reverse offset
+   order;
+4. when any edit needed fuzzy matching, changed lines are rewritten from
+   normalized space while unchanged lines keep their original bytes
+   (``apply_replacements_preserving_unchanged_lines``).
+
+Errors are :class:`EditLadderError` with pi's actionable wording — each
+message tells the model what to do next, because a failed edit costs a
+full model round-trip.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+
+__all__ = [
+    "Edit",
+    "EditLadderError",
+    "apply_edits_to_normalized_content",
+    "detect_line_ending",
+    "fuzzy_find_text",
+    "normalize_for_fuzzy_match",
+    "normalize_to_lf",
+    "restore_line_endings",
+    "strip_bom",
+]
+
+
+class EditLadderError(ValueError):
+    """A ladder failure with a model-actionable message."""
+
+
+@dataclass(frozen=True)
+class Edit:
+    old_string: str
+    new_string: str
+
+
+# --------------------------------------------------------------------------
+# Line endings / BOM
+# --------------------------------------------------------------------------
+
+def detect_line_ending(content: str) -> str:
+    """``"\\r\\n"`` when the first newline in the file is CRLF, else ``"\\n"``."""
+    crlf = content.find("\r\n")
+    lf = content.find("\n")
+    if lf == -1:
+        return "\n"
+    if crlf == -1:
+        return "\n"
+    return "\r\n" if crlf < lf else "\n"
+
+
+def normalize_to_lf(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def restore_line_endings(text: str, ending: str) -> str:
+    return text.replace("\n", "\r\n") if ending == "\r\n" else text
+
+
+def strip_bom(content: str) -> tuple[str, str]:
+    """Return ``(bom, text)`` — the model never includes an invisible BOM
+    in old_string, so matching must run against the BOM-less text."""
+    if content.startswith("\ufeff"):
+        return "\ufeff", content[1:]
+    return "", content
+
+
+# --------------------------------------------------------------------------
+# Fuzzy normalization
+# --------------------------------------------------------------------------
+
+_SMART_SINGLE = re.compile("[\u2018\u2019\u201A\u201B]")
+_SMART_DOUBLE = re.compile("[\u201C\u201D\u201E\u201F]")
+# U+2010 hyphen … U+2015 horizontal bar, U+2212 minus
+_UNICODE_DASHES = re.compile("[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]")
+# NBSP, en/em/etc. spaces, narrow NBSP, medium math space, ideographic space
+_UNICODE_SPACES = re.compile("[\u00A0\u2002-\u200A\u202F\u205F\u3000]")
+
+
+def normalize_for_fuzzy_match(text: str) -> str:
+    """NFKC + strip trailing whitespace per line + ASCII-fold quotes,
+    dashes, and exotic spaces (pi's ``normalizeForFuzzyMatch``)."""
+    text = unicodedata.normalize("NFKC", text)
+    text = "\n".join(line.rstrip() for line in text.split("\n"))
+    text = _SMART_SINGLE.sub("'", text)
+    text = _SMART_DOUBLE.sub('"', text)
+    text = _UNICODE_DASHES.sub("-", text)
+    text = _UNICODE_SPACES.sub(" ", text)
+    return text
+
+
+@dataclass(frozen=True)
+class FuzzyMatch:
+    found: bool
+    index: int
+    match_length: int
+    used_fuzzy: bool
+    content_for_replacement: str
+
+
+def fuzzy_find_text(content: str, old_string: str) -> FuzzyMatch:
+    """Exact ``find`` first; on miss, search entirely in normalized space."""
+    exact = content.find(old_string)
+    if exact != -1:
+        return FuzzyMatch(True, exact, len(old_string), False, content)
+
+    fuzzy_content = normalize_for_fuzzy_match(content)
+    fuzzy_old = normalize_for_fuzzy_match(old_string)
+    idx = fuzzy_content.find(fuzzy_old)
+    if idx == -1:
+        return FuzzyMatch(False, -1, 0, False, content)
+    return FuzzyMatch(True, idx, len(fuzzy_old), True, fuzzy_content)
+
+
+def _count_occurrences(content: str, old_string: str) -> int:
+    fuzzy_content = normalize_for_fuzzy_match(content)
+    fuzzy_old = normalize_for_fuzzy_match(old_string)
+    if not fuzzy_old:
+        return 0
+    return fuzzy_content.count(fuzzy_old)
+
+
+# --------------------------------------------------------------------------
+# Byte-preserving overlay (fuzzy path)
+# --------------------------------------------------------------------------
+
+def _split_lines_with_endings(content: str) -> list[str]:
+    return re.findall(r"[^\n]*\n|[^\n]+", content)
+
+
+@dataclass(frozen=True)
+class _Replacement:
+    match_index: int
+    match_length: int
+    new_string: str
+
+
+def _line_spans(content: str) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    offset = 0
+    for line in _split_lines_with_endings(content):
+        spans.append((offset, offset + len(line)))
+        offset += len(line)
+    return spans
+
+
+def _replacement_line_range(
+    spans: list[tuple[int, int]], repl: _Replacement
+) -> tuple[int, int]:
+    start_off = repl.match_index
+    end_off = repl.match_index + repl.match_length
+    start_line = -1
+    for i, (s, e) in enumerate(spans):
+        if s <= start_off < e:
+            start_line = i
+            break
+    if start_line == -1:
+        raise EditLadderError("Replacement range is outside the base content.")
+    end_line = start_line
+    while end_line < len(spans) and spans[end_line][1] < end_off:
+        end_line += 1
+    if end_line >= len(spans):
+        raise EditLadderError("Replacement range is outside the base content.")
+    return start_line, end_line + 1
+
+
+def _apply_replacements(
+    content: str, replacements: list[_Replacement], offset: int = 0
+) -> str:
+    result = content
+    for repl in reversed(replacements):
+        idx = repl.match_index - offset
+        result = result[:idx] + repl.new_string + result[idx + repl.match_length:]
+    return result
+
+
+def apply_replacements_preserving_unchanged_lines(
+    original_content: str,
+    base_content: str,
+    replacements: list[_Replacement],
+) -> str:
+    """Rewrite only the lines a replacement touches from normalized space;
+    copy every other line back from the original bytes (pi's
+    ``applyReplacementsPreservingUnchangedLines``)."""
+    original_lines = _split_lines_with_endings(original_content)
+    base_spans = _line_spans(base_content)
+    if len(original_lines) != len(base_spans):
+        raise EditLadderError(
+            "Cannot preserve unchanged lines because the base content has a "
+            "different line count."
+        )
+
+    groups: list[dict] = []
+    for repl in sorted(replacements, key=lambda r: r.match_index):
+        start_line, end_line = _replacement_line_range(base_spans, repl)
+        if groups and start_line < groups[-1]["end"]:
+            groups[-1]["end"] = max(groups[-1]["end"], end_line)
+            groups[-1]["replacements"].append(repl)
+        else:
+            groups.append(
+                {"start": start_line, "end": end_line, "replacements": [repl]}
+            )
+
+    out: list[str] = []
+    line_idx = 0
+    for group in groups:
+        out.extend(original_lines[line_idx:group["start"]])
+        g_start = base_spans[group["start"]][0]
+        g_end = base_spans[group["end"] - 1][1]
+        out.append(
+            _apply_replacements(
+                base_content[g_start:g_end], group["replacements"], g_start
+            )
+        )
+        line_idx = group["end"]
+    out.extend(original_lines[line_idx:])
+    return "".join(out)
+
+
+# --------------------------------------------------------------------------
+# Errors — pi's wording, clawcodex field names
+# --------------------------------------------------------------------------
+
+def _not_found_error(path: str, i: int, total: int) -> EditLadderError:
+    if total == 1:
+        return EditLadderError(
+            f"Could not find the exact text in {path}. The old_string must "
+            "match exactly including all whitespace and newlines."
+        )
+    return EditLadderError(
+        f"Could not find edits[{i}] in {path}. The old_string must match "
+        "exactly including all whitespace and newlines."
+    )
+
+
+def _duplicate_error(path: str, i: int, total: int, count: int) -> EditLadderError:
+    if total == 1:
+        return EditLadderError(
+            f"Found {count} occurrences of the text in {path}. The text must "
+            "be unique. Please provide more context to make it unique, or "
+            "set replace_all=true to change every occurrence."
+        )
+    return EditLadderError(
+        f"Found {count} occurrences of edits[{i}] in {path}. Each old_string "
+        "must be unique. Please provide more context to make it unique."
+    )
+
+
+def _empty_old_error(path: str, i: int, total: int) -> EditLadderError:
+    if total == 1:
+        return EditLadderError(f"old_string must not be empty in {path}.")
+    return EditLadderError(f"edits[{i}].old_string must not be empty in {path}.")
+
+
+def _no_change_error(path: str, total: int) -> EditLadderError:
+    if total == 1:
+        return EditLadderError(
+            f"No changes made to {path}. The replacement produced identical "
+            "content. This might indicate an issue with special characters "
+            "or the text not existing as expected."
+        )
+    return EditLadderError(
+        f"No changes made to {path}. The replacements produced identical "
+        "content."
+    )
+
+
+# --------------------------------------------------------------------------
+# The ladder
+# --------------------------------------------------------------------------
+
+def apply_edits_to_normalized_content(
+    normalized_content: str,
+    edits: list[Edit],
+    path: str,
+    *,
+    replace_all: bool = False,
+) -> tuple[str, str]:
+    """Apply one or more replacements to LF-normalized content.
+
+    Returns ``(base_content, new_content)``. ``replace_all`` is honored only
+    for a single edit (clawcodex's escape hatch; pi has none) and uses exact
+    matching — a fuzzy replace-all would be too eager.
+    """
+    normalized_edits = [
+        Edit(normalize_to_lf(e.old_string), normalize_to_lf(e.new_string))
+        for e in edits
+    ]
+
+    for i, e in enumerate(normalized_edits):
+        if not e.old_string:
+            raise _empty_old_error(path, i, len(normalized_edits))
+
+    if replace_all and len(normalized_edits) == 1:
+        e = normalized_edits[0]
+        if e.old_string not in normalized_content:
+            raise _not_found_error(path, 0, 1)
+        new_content = normalized_content.replace(e.old_string, e.new_string)
+        if new_content == normalized_content:
+            raise _no_change_error(path, 1)
+        return normalized_content, new_content
+
+    initial = [
+        fuzzy_find_text(normalized_content, e.old_string)
+        for e in normalized_edits
+    ]
+    used_fuzzy = any(m.used_fuzzy for m in initial)
+    base = (
+        normalize_for_fuzzy_match(normalized_content)
+        if used_fuzzy else normalized_content
+    )
+
+    matched: list[_Replacement] = []
+    for i, e in enumerate(normalized_edits):
+        m = fuzzy_find_text(base, e.old_string)
+        if not m.found:
+            raise _not_found_error(path, i, len(normalized_edits))
+        count = _count_occurrences(base, e.old_string)
+        if count > 1:
+            raise _duplicate_error(path, i, len(normalized_edits), count)
+        matched.append(_Replacement(m.index, m.match_length, e.new_string))
+
+    ordered = sorted(
+        range(len(matched)), key=lambda i: matched[i].match_index
+    )
+    for prev_i, cur_i in zip(ordered, ordered[1:]):
+        prev, cur = matched[prev_i], matched[cur_i]
+        if prev.match_index + prev.match_length > cur.match_index:
+            raise EditLadderError(
+                f"edits[{prev_i}] and edits[{cur_i}] overlap in {path}. "
+                "Merge them into one edit or target disjoint regions."
+            )
+
+    sorted_matched = [matched[i] for i in ordered]
+    if used_fuzzy:
+        new_content = apply_replacements_preserving_unchanged_lines(
+            normalized_content, base, sorted_matched
+        )
+    else:
+        new_content = _apply_replacements(base, sorted_matched)
+
+    if new_content == normalized_content:
+        raise _no_change_error(path, len(normalized_edits))
+    return normalized_content, new_content

--- a/src/nano/edit_tool.py
+++ b/src/nano/edit_tool.py
@@ -1,0 +1,317 @@
+"""Nano Edit — the stock Edit tool with pi's ladder underneath.
+
+A registry-local variant built with ``dataclasses.replace`` on the stock
+``EditTool`` — ``src/tool_system/tools/edit.py`` is not modified, so the
+non-nano surface stays byte-identical. What changes under nano:
+
+* ``edits[]`` — one call, many disjoint replacements, all matched against
+  the ORIGINAL file (pi's multi-edit contract). The legacy single
+  ``old_string``/``new_string`` form still works.
+* the exact→fuzzy match ladder with byte-preserving overlay, BOM and
+  CRLF hygiene (:mod:`src.nano.edit_ladder`).
+* argument repair for observed model quirks (pi ``edit.ts:105-129``):
+  ``edits`` sent as a JSON string is parsed; pi-trained models'
+  ``oldText``/``newText`` keys are accepted.
+
+What is deliberately kept from clawcodex (advantages pi lacks):
+
+* the read-first-and-unchanged staleness gate;
+* ``replace_all`` as a single-edit escape hatch (exact matching only);
+* create-if-absent via legacy ``old_string=""`` (delegated to the stock
+  implementation, byte-for-byte);
+* the similar-file hint, .ipynb rejection, size guard, trailing-whitespace
+  hygiene on ``new_string``, and the structured-patch result shape every
+  renderer/persistence path already understands.
+"""
+
+from __future__ import annotations
+
+import difflib
+import json
+from dataclasses import replace
+from typing import Any
+
+from src.tool_system.build_tool import Tool
+from src.tool_system.context import ToolContext
+from src.tool_system.diff_utils import (
+    convert_leading_tabs_to_spaces,
+    record_patch_line_totals,
+    unified_diff_hunks,
+)
+from src.tool_system.errors import ToolInputError
+from src.tool_system.protocol import ToolResult
+from src.tool_system.tools.edit import (
+    _MAX_FILE_SIZE,
+    _edit_call,
+    _find_similar_file,
+    _strip_trailing_whitespace,
+    EditTool,
+)
+
+from .edit_ladder import (
+    Edit,
+    EditLadderError,
+    apply_edits_to_normalized_content,
+    detect_line_ending,
+    normalize_to_lf,
+    restore_line_endings,
+    strip_bom,
+)
+
+NANO_EDIT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    # Deliberately open: quirk repair happens in the call, and a strict
+    # schema reject is a worse error message than the ladder's own.
+    "additionalProperties": True,
+    "properties": {
+        "file_path": {
+            "type": "string",
+            "description": "The absolute path to the file to modify",
+        },
+        "edits": {
+            # anyOf so the observed some-models-send-a-JSON-string quirk
+            # survives schema validation and reaches the call's repair step
+            # instead of dying on an InputValidationError round-trip.
+            "anyOf": [
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": True,
+                        "properties": {
+                            "old_string": {
+                                "type": "string",
+                                "description": (
+                                    "Exact text to replace. Must be unique "
+                                    "in the file; keep it as small as "
+                                    "possible while still unique."
+                                ),
+                            },
+                            "new_string": {
+                                "type": "string",
+                                "description": "Replacement text for this edit.",
+                            },
+                        },
+                    },
+                },
+                {"type": "string"},
+            ],
+            "description": (
+                "One or more targeted replacements. Each old_string is "
+                "matched against the original file, not incrementally — "
+                "do not overlap edits; merge nearby changes into one edit."
+            ),
+        },
+        "old_string": {
+            "type": "string",
+            "description": "Single-edit form: the text to replace",
+        },
+        "new_string": {
+            "type": "string",
+            "description": "Single-edit form: the replacement text",
+        },
+        "replace_all": {
+            "type": "boolean",
+            "description": (
+                "Single-edit form only: replace every occurrence of "
+                "old_string (default false)"
+            ),
+        },
+    },
+    "required": ["file_path"],
+}
+
+NANO_EDIT_DOC = (
+    "Edits a file by exact text replacement. You must Read the file first "
+    "(and it must be unchanged since). Pass one or more replacements in "
+    "edits[] — each {old_string, new_string} is matched against the "
+    "original file and must be unique and non-overlapping; merge nearby "
+    "changes into one edit. Whitespace/Unicode near-misses are matched "
+    "leniently, but prefer exact copies. The single old_string/new_string "
+    "form (with optional replace_all) also works."
+)
+
+
+def _prepare_edits(tool_input: dict[str, Any]) -> list[Edit] | None:
+    """Normalize the accepted input shapes to a list of edits.
+
+    Returns None for the pure-legacy form that must delegate to the stock
+    implementation (create-if-absent via ``old_string == ""``).
+    Repairs, in order: ``edits`` as a JSON string (observed from Opus 4.6 /
+    GLM-5.1 — pi ``edit.ts:113``), ``oldText``/``newText`` item keys
+    (pi-trained models), then merges a legacy top-level pair as one more
+    edit (pi ``edit.ts:120-128``).
+    """
+    raw_edits = tool_input.get("edits")
+    if isinstance(raw_edits, str):
+        try:
+            parsed = json.loads(raw_edits)
+            if isinstance(parsed, list):
+                raw_edits = parsed
+        except (ValueError, TypeError):
+            pass
+
+    edits: list[Edit] = []
+    if isinstance(raw_edits, list):
+        for i, item in enumerate(raw_edits):
+            if not isinstance(item, dict):
+                raise ToolInputError(
+                    f"edits[{i}] must be an object with old_string and "
+                    "new_string"
+                )
+            old = item.get("old_string", item.get("oldText"))
+            new = item.get("new_string", item.get("newText"))
+            if not isinstance(old, str) or not isinstance(new, str):
+                raise ToolInputError(
+                    f"edits[{i}] must carry string old_string and new_string"
+                )
+            edits.append(Edit(old, new))
+
+    legacy_old = tool_input.get("old_string")
+    legacy_new = tool_input.get("new_string")
+    if isinstance(legacy_old, str) and isinstance(legacy_new, str):
+        if legacy_old == "" and not edits:
+            # Create-if-absent contract — stock behavior, stock code path.
+            return None
+        edits.append(Edit(legacy_old, legacy_new))
+
+    if not edits:
+        raise ToolInputError(
+            "Edit needs either edits[] (list of {old_string, new_string}) "
+            "or old_string + new_string"
+        )
+    return edits
+
+
+def _nano_edit_call(tool_input: dict[str, Any], context: ToolContext) -> ToolResult:
+    file_path = tool_input.get("file_path")
+    if not isinstance(file_path, str) or not file_path:
+        raise ToolInputError("file_path must be a non-empty string")
+
+    edits = _prepare_edits(tool_input)
+    if edits is None:
+        # Legacy empty-old_string create: byte-identical stock behavior.
+        return _edit_call(tool_input, context)
+
+    replace_all = bool(tool_input.get("replace_all", False))
+    if replace_all and len(edits) > 1:
+        raise ToolInputError(
+            "replace_all only applies to the single old_string/new_string "
+            "form — with edits[], make each old_string unique instead"
+        )
+
+    for i, e in enumerate(edits):
+        if e.old_string == e.new_string:
+            raise ToolInputError(
+                f"edits[{i}]: old_string and new_string must differ"
+                if len(edits) > 1
+                else "old_string and new_string must differ"
+            )
+
+    path = context.ensure_allowed_path(file_path)
+    if path.suffix.lower() == ".ipynb":
+        raise ToolInputError(
+            "Cannot edit .ipynb files with Edit tool. Use the NotebookEdit "
+            "tool instead."
+        )
+    if not path.exists():
+        hint = _find_similar_file(file_path, context.cwd)
+        msg = f"file does not exist: {path}"
+        if hint:
+            msg += f'. Did you mean "{hint}"?'
+        raise ToolInputError(msg)
+    if not path.is_file():
+        raise ToolInputError(f"path is not a file: {path}")
+    try:
+        size = path.stat().st_size
+    except OSError:
+        size = 0
+    if size > _MAX_FILE_SIZE:
+        raise ToolInputError(
+            f"file is too large ({size} bytes, max {_MAX_FILE_SIZE})"
+        )
+    if not context.was_file_read_and_unchanged(path):
+        raise ToolInputError(
+            "file must be read first and be unchanged since last read"
+        )
+
+    # Bytes, not read_text: Python text mode does universal-newline
+    # translation, which would silently erase CRLF before
+    # detect_line_ending ever sees it (pi reads a Buffer for the same
+    # reason). The stock Edit tool LF-ifies CRLF files this way; nano
+    # preserves the file's own endings.
+    raw = path.read_bytes().decode("utf-8", errors="replace")
+    bom, content = strip_bom(raw)
+    ending = detect_line_ending(content)
+    normalized = normalize_to_lf(content)
+
+    # Stock hygiene: strip trailing whitespace on replacements outside
+    # markdown (edit.py:290).
+    is_markdown = path.suffix.lower() in (".md", ".mdx")
+    if not is_markdown:
+        edits = [
+            Edit(e.old_string, _strip_trailing_whitespace(e.new_string))
+            if e.new_string else e
+            for e in edits
+        ]
+
+    try:
+        base, updated = apply_edits_to_normalized_content(
+            normalized, edits, str(path), replace_all=replace_all
+        )
+    except EditLadderError as err:
+        raise ToolInputError(str(err)) from err
+
+    final = bom + restore_line_endings(updated, ending)
+    # write_bytes for the same reason as the bytes read above: write_text
+    # with newline=None would re-translate "\n" per-platform.
+    path.write_bytes(final.encode("utf-8"))
+    context.mark_file_read(path)
+
+    before_lines = convert_leading_tabs_to_spaces(base).splitlines(keepends=True)
+    after_lines = convert_leading_tabs_to_spaces(updated).splitlines(keepends=True)
+    diff_lines = list(
+        difflib.unified_diff(
+            before_lines,
+            after_lines,
+            fromfile=str(path),
+            tofile=str(path),
+            n=3,
+            lineterm="",
+        )
+    )
+    hunks = unified_diff_hunks(diff_lines)
+    record_patch_line_totals(hunks)
+
+    return ToolResult(
+        name="Edit",
+        output={
+            "type": "update",
+            "filePath": str(path),
+            "content": updated,
+            "structuredPatch": hunks,
+            "editsApplied": len(edits),
+        },
+    )
+
+
+def _nano_classifier_input(input_data: dict) -> str:
+    data = input_data or {}
+    fp = data.get("file_path", "")
+    edits = data.get("edits")
+    if isinstance(edits, list) and edits:
+        first = edits[0] if isinstance(edits[0], dict) else {}
+        return (
+            f"{fp}: {len(edits)} edit(s), first "
+            f"{first.get('old_string', '')!r} -> {first.get('new_string', '')!r}"
+        )
+    return f"{fp}: {data.get('old_string', '')!r} -> {data.get('new_string', '')!r}"
+
+
+NanoEditTool: Tool = replace(
+    EditTool,
+    input_schema=NANO_EDIT_SCHEMA,
+    call=_nano_edit_call,
+    prompt=lambda: NANO_EDIT_DOC,
+    to_auto_classifier_input=_nano_classifier_input,
+)

--- a/src/nano/prompt.py
+++ b/src/nano/prompt.py
@@ -51,8 +51,11 @@ NANO_TOOL_SNIPPETS: dict[str, str] = {
 _GUIDELINES = (
     "- Use Read to examine files instead of cat/sed/head, and Grep/Glob "
     "instead of shell grep/find",
-    "- Read a file before editing it; make old_string match the file "
+    "- Read a file before editing it; each old_string must match the file "
     "exactly, including whitespace",
+    "- When changing multiple places in one file, use ONE Edit call with "
+    "multiple entries in edits[]; keep each old_string as small as "
+    "possible while still unique, and never overlap edits",
     "- Be concise in your responses",
     "- Show file paths clearly when working with files",
 )

--- a/src/nano/registry.py
+++ b/src/nano/registry.py
@@ -23,17 +23,19 @@ from dataclasses import replace
 from src.tool_system.registry import ToolRegistry
 from src.tool_system.tools import (
     BashTool,
-    EditTool,
     GlobTool,
     GrepTool,
     ReadTool,
     WriteTool,
 )
 
+from .edit_tool import NanoEditTool
 from .tool_docs import NANO_TOOL_DOCS
 
 # Order mirrors pi's system-prompt tool list (read/bash/edit/write first).
-NANO_TOOLS = (ReadTool, BashTool, EditTool, WriteTool, GrepTool, GlobTool)
+# Edit is the nano variant carrying pi's multi-edit + fuzzy ladder
+# (src/nano/edit_tool.py); it brings its own doc and schema.
+NANO_TOOLS = (ReadTool, BashTool, NanoEditTool, WriteTool, GrepTool, GlobTool)
 NANO_TOOL_NAMES: tuple[str, ...] = tuple(t.name for t in NANO_TOOLS)
 
 

--- a/src/nano/tool_docs.py
+++ b/src/nano/tool_docs.py
@@ -25,12 +25,9 @@ NANO_TOOL_DOCS: dict[str, str] = {
         "directory persists between commands; shell state does not. Long "
         "output is truncated. Quote paths containing spaces."
     ),
-    "Edit": (
-        "Edits a file by exact string replacement. You must Read the file "
-        "first (and it must be unchanged since). old_string must match the "
-        "file exactly — including whitespace — and be unique unless "
-        "replace_all is true; on ambiguity, add surrounding context."
-    ),
+    # Edit is intentionally absent: the nano registry swaps in
+    # NanoEditTool (src/nano/edit_tool.py), which carries its own doc for
+    # the multi-edit + fuzzy-ladder contract.
     "Write": (
         "Writes a file, overwriting any existing content. To overwrite an "
         "existing file you must Read it first. Prefer Edit for modifying "

--- a/tests/nano/test_nano_edit.py
+++ b/tests/nano/test_nano_edit.py
@@ -1,0 +1,253 @@
+"""pi edit ladder: algorithm unit tests + nano Edit tool integration.
+
+Mirrors the failure modes pi engineered away (edit-diff.ts): multi-edit
+against the original file, fuzzy Unicode/whitespace rescue with
+byte-preserving overlay, CRLF/BOM hygiene, occurrence-counted errors,
+and model-quirk argument repair.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.nano.edit_ladder import (
+    Edit,
+    EditLadderError,
+    apply_edits_to_normalized_content,
+    detect_line_ending,
+    normalize_for_fuzzy_match,
+)
+from src.nano.edit_tool import NanoEditTool, _prepare_edits
+from src.tool_system.errors import ToolInputError
+
+# ---------------------------------------------------------------------------
+# Ladder unit tests
+# ---------------------------------------------------------------------------
+
+
+def _apply(content, edits, **kw):
+    return apply_edits_to_normalized_content(content, edits, "f.py", **kw)
+
+
+def test_exact_single_edit():
+    base, new = _apply("a\nb\nc\n", [Edit("b", "B")])
+    assert new == "a\nB\nc\n"
+
+
+def test_multi_edit_matched_against_original_any_order():
+    content = "alpha\nbeta\ngamma\n"
+    # Deliberately given in reverse file order — offsets must not shift.
+    base, new = _apply(
+        content, [Edit("gamma", "GAMMA"), Edit("alpha", "ALPHA")]
+    )
+    assert new == "ALPHA\nbeta\nGAMMA\n"
+
+
+def test_overlapping_edits_rejected_with_merge_hint():
+    with pytest.raises(EditLadderError, match="overlap.*Merge them"):
+        _apply("abcdef\n", [Edit("abcd", "x"), Edit("cdef", "y")])
+
+
+def test_duplicate_occurrences_counted():
+    with pytest.raises(EditLadderError, match="Found 3 occurrences"):
+        _apply("x\nx\nx\n", [Edit("x", "y")])
+
+
+def test_not_found_is_actionable():
+    with pytest.raises(EditLadderError, match="must match exactly"):
+        _apply("a\n", [Edit("nope", "y")])
+
+
+def test_empty_old_string_rejected():
+    with pytest.raises(EditLadderError, match="must not be empty"):
+        _apply("a\n", [Edit("", "y")])
+
+
+def test_no_change_rejected():
+    with pytest.raises(EditLadderError, match="No changes made"):
+        # Only in fuzzy space do these "match": replacement equals original.
+        _apply("a\n", [Edit("a ", "a")])  # trailing space fuzzy-matches "a"
+
+
+def test_fuzzy_rescues_trailing_whitespace():
+    content = "def f():   \n    return 1\n"
+    base, new = _apply(content, [Edit("def f():\n    return 1", "def f():\n    return 2")])
+    assert "return 2" in new
+
+
+def test_fuzzy_rescues_smart_quotes_and_dashes():
+    content = "print(“hello”)  # em—dash\n"
+    base, new = _apply(content, [Edit('print("hello")  # em-dash', 'print("bye")')])
+    assert "bye" in new
+
+
+def test_fuzzy_preserves_unchanged_lines_bytes():
+    # Line 1 has trailing spaces the fuzzy normalization strips; an edit on
+    # line 3 must leave line 1's original bytes alone.
+    content = "keep me   \nmiddle\ntarget\n"
+    base, new = _apply(content, [Edit("target", "TARGET")])
+    assert new.startswith("keep me   \n")
+    assert new.endswith("TARGET\n")
+
+
+def test_replace_all_single_edit():
+    base, new = _apply("x = x + x\n", [Edit("x", "y")], replace_all=True)
+    assert new == "y = y + y\n"
+
+
+def test_normalize_for_fuzzy_match_folds_unicode():
+    assert normalize_for_fuzzy_match("‘a’ “b” – c d  ") == "'a' \"b\" - c d"
+
+
+def test_detect_line_ending():
+    assert detect_line_ending("a\r\nb\n") == "\r\n"
+    assert detect_line_ending("a\nb\r\n") == "\n"
+    assert detect_line_ending("abc") == "\n"
+
+
+# ---------------------------------------------------------------------------
+# Argument repair (model quirks)
+# ---------------------------------------------------------------------------
+
+
+def test_edits_as_json_string_repaired():
+    edits = _prepare_edits({
+        "file_path": "f",
+        "edits": '[{"old_string": "a", "new_string": "b"}]',
+    })
+    assert edits == [Edit("a", "b")]
+
+
+def test_pi_style_oldtext_keys_accepted():
+    edits = _prepare_edits({
+        "file_path": "f",
+        "edits": [{"oldText": "a", "newText": "b"}],
+    })
+    assert edits == [Edit("a", "b")]
+
+
+def test_legacy_pair_merges_with_edits():
+    edits = _prepare_edits({
+        "file_path": "f",
+        "edits": [{"old_string": "a", "new_string": "b"}],
+        "old_string": "c",
+        "new_string": "d",
+    })
+    assert edits == [Edit("a", "b"), Edit("c", "d")]
+
+
+def test_legacy_create_form_delegates():
+    assert _prepare_edits({
+        "file_path": "f", "old_string": "", "new_string": "content",
+    }) is None
+
+
+# ---------------------------------------------------------------------------
+# Tool-level integration (real filesystem via ToolContext)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tool_context(tmp_path):
+    from src.tool_system.context import ToolContext
+
+    return ToolContext(cwd=tmp_path, workspace_root=tmp_path)
+
+
+def _write_and_read(tool_context, tmp_path, name, content):
+    p = tmp_path / name
+    p.write_text(content, encoding="utf-8")
+    tool_context.mark_file_read(p)
+    return p
+
+
+def test_tool_multi_edit_end_to_end(tool_context, tmp_path):
+    p = _write_and_read(
+        tool_context, tmp_path, "m.py", "a = 1\nb = 2\nc = 3\n"
+    )
+    result = NanoEditTool.call(
+        {
+            "file_path": str(p),
+            "edits": [
+                {"old_string": "a = 1", "new_string": "a = 10"},
+                {"old_string": "c = 3", "new_string": "c = 30"},
+            ],
+        },
+        tool_context,
+    )
+    assert p.read_text() == "a = 10\nb = 2\nc = 30\n"
+    assert result.output["editsApplied"] == 2
+    assert result.output["structuredPatch"]
+
+
+def test_tool_requires_read_first(tool_context, tmp_path):
+    p = tmp_path / "unread.py"
+    p.write_text("x\n")
+    with pytest.raises(ToolInputError, match="read first"):
+        NanoEditTool.call(
+            {"file_path": str(p), "old_string": "x", "new_string": "y"},
+            tool_context,
+        )
+
+
+def test_tool_crlf_file_edited_with_lf_oldstring(tool_context, tmp_path):
+    p = _write_and_read(
+        tool_context, tmp_path, "w.txt", "line one\r\nline two\r\n"
+    )
+    NanoEditTool.call(
+        {
+            "file_path": str(p),
+            "edits": [{"old_string": "line one\nline two", "new_string": "merged"}],
+        },
+        tool_context,
+    )
+    assert p.read_bytes() == b"merged\r\n"
+
+
+def test_tool_preserves_bom(tool_context, tmp_path):
+    p = tmp_path / "b.txt"
+    p.write_bytes("﻿hello world\n".encode("utf-8"))
+    tool_context.mark_file_read(p)
+    NanoEditTool.call(
+        {"file_path": str(p), "old_string": "hello", "new_string": "goodbye"},
+        tool_context,
+    )
+    assert p.read_bytes().startswith("﻿".encode("utf-8"))
+    assert b"goodbye world" in p.read_bytes()
+
+
+def test_tool_legacy_create_still_works(tool_context, tmp_path):
+    p = tmp_path / "new.txt"
+    result = NanoEditTool.call(
+        {"file_path": str(p), "old_string": "", "new_string": "fresh\n"},
+        tool_context,
+    )
+    assert p.read_text() == "fresh\n"
+    assert result.output["type"] == "create"
+
+
+def test_tool_replace_all_with_edits_rejected(tool_context, tmp_path):
+    p = _write_and_read(tool_context, tmp_path, "r.txt", "x x\n")
+    with pytest.raises(ToolInputError, match="replace_all only applies"):
+        NanoEditTool.call(
+            {
+                "file_path": str(p),
+                "replace_all": True,
+                "edits": [
+                    {"old_string": "a", "new_string": "b"},
+                    {"old_string": "c", "new_string": "d"},
+                ],
+            },
+            tool_context,
+        )
+
+
+def test_stock_edit_tool_unchanged():
+    # The nano variant must be a copy: the registered stock tool keeps its
+    # exact-match call and old schema.
+    from src.tool_system.tools.edit import EditTool
+
+    assert "edits" not in EditTool.input_schema["properties"]
+    assert EditTool.input_schema["required"] == [
+        "file_path", "old_string", "new_string",
+    ]

--- a/tests/nano/test_nano_registry.py
+++ b/tests/nano/test_nano_registry.py
@@ -41,11 +41,17 @@ def test_no_orchestration_or_task_surface():
 
 
 def test_pi_length_docs_but_full_schemas():
+    from src.nano.edit_tool import NANO_EDIT_DOC
+
     reg = build_nano_registry()
     for t in reg.list_tools():
-        assert t.prompt() == NANO_TOOL_DOCS[t.name]
+        if t.name == "Edit":
+            # The nano Edit variant carries its own multi-edit doc.
+            assert t.prompt() == NANO_EDIT_DOC
+        else:
+            assert t.prompt() == NANO_TOOL_DOCS[t.name]
         # docs are pi-length: a few sentences, not the multi-KB defaults
-        assert len(t.prompt()) < 400
+        assert len(t.prompt()) < 500
         # schemas are untouched (parameter shape is behavioral)
         assert json.dumps(dict(t.input_schema))
 


### PR DESCRIPTION
## What

PR 2 of the pi-port series (after #879). Adds pi's edit pipeline as a **registry-local Edit variant** used only by the nano registry — \`src/tool_system/tools/edit.py\` is untouched, so the non-nano surface stays byte-identical.

- \`edits[]\` multi-edit matched against the **original** file, overlap detection with a merge hint, reverse-offset application
- exact → fuzzy match ladder (NFKC, trailing-whitespace, smart quotes/dashes/spaces) with pi's **byte-preserving overlay** — unchanged lines keep their original bytes
- **BOM + CRLF hygiene via byte-level I/O** — found and avoided a real defect: \`read_text\`'s universal-newline translation silently LF-ifies CRLF files in the stock tool (left as-is there for parity; can upstream later)
- occurrence-counted, model-actionable errors (pi's wording)
- argument repair for observed model quirks (JSON-string \`edits\`, pi-style \`oldText\`/\`newText\`), admitted through the schema via \`anyOf\` so repair happens in the call rather than dying as an InputValidationError round-trip
- clawcodex advantages kept: staleness gate, \`replace_all\` escape hatch, create-if-absent legacy form (delegates to stock code), similar-file hints, guards, structured-patch result shape

## Tests

24 new (ladder unit + tool integration: CRLF/BOM round-trips, multi-edit e2e, quirk repair, stock-tool-unchanged). Full \`tests/nano\` 41 passed; \`tests/tools\`, tool-parity and build-tool suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)