### PR TITLE
feat(nano): deterministic guards — truncation guard + compaction ledger (PR 3/4)

### DIFF
--- a/src/nano/compact_ledger.py
+++ b/src/nano/compact_ledger.py
@@ -1,0 +1,161 @@
+"""pi's file-operation ledger for compaction summaries (nano mode).
+
+pi appends ``<read-files>`` / ``<modified-files>`` path lists to every
+compaction summary and seeds them from the previous compaction, so after
+any number of compactions the model still knows what it has seen and
+touched (compaction/utils.ts ``extractFileOpsFromMessage`` /
+``formatFileOperations``; cumulative seeding in compaction.ts:42-70).
+Paths are cheap insurance against the post-compaction re-exploration
+spiral — a few dozen tokens instead of clawcodex's full-content
+post-compact re-injection.
+
+Clawcodex has no compaction-entry metadata store, so cumulativity works
+by parsing the previous summary's own ledger block out of the message
+stream (the previous summary is a user message that is itself part of
+the span being re-summarized).
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Tool → which ledger its file_path lands in. NotebookEdit is modify;
+# Write and Edit both count as modified (pi: edited ∪ written).
+_READ_TOOLS = {"Read"}
+_MODIFY_TOOLS = {"Edit", "Write", "NotebookEdit"}
+
+# Keep the ledger bounded: a very long session must not grow the summary
+# without limit. Newest-first retention when over the cap.
+MAX_PATHS_PER_LIST = 100
+
+_READ_BLOCK_RE = re.compile(r"<read-files>\n(.*?)</read-files>", re.DOTALL)
+_MODIFIED_BLOCK_RE = re.compile(
+    r"<modified-files>\n(.*?)</modified-files>", re.DOTALL
+)
+
+
+def _block_path(block: Any) -> tuple[str, str] | None:
+    """(tool_name, file_path) for a tool_use block, else None."""
+    if isinstance(block, dict):
+        if block.get("type") != "tool_use":
+            return None
+        name = str(block.get("name", ""))
+        tool_input = block.get("input") or {}
+    else:
+        if getattr(block, "type", None) != "tool_use":
+            return None
+        name = str(getattr(block, "name", ""))
+        tool_input = getattr(block, "input", None) or {}
+    if not isinstance(tool_input, dict):
+        return None
+    path = tool_input.get("file_path") or tool_input.get("notebook_path")
+    if not isinstance(path, str) or not path:
+        return None
+    return name, path
+
+
+def extract_file_ops(messages: list[Any]) -> tuple[list[str], list[str]]:
+    """(read_paths, modified_paths) from assistant tool_use blocks,
+    in first-seen order. A path both read and modified counts as
+    modified only (pi's computeFileLists)."""
+    read: dict[str, None] = {}
+    modified: dict[str, None] = {}
+    for msg in messages:
+        if getattr(msg, "role", None) != "assistant":
+            continue
+        content = getattr(msg, "content", None)
+        if not isinstance(content, list):
+            continue
+        for block in content:
+            hit = _block_path(block)
+            if hit is None:
+                continue
+            name, path = hit
+            if name in _MODIFY_TOOLS:
+                modified.setdefault(path, None)
+            elif name in _READ_TOOLS:
+                read.setdefault(path, None)
+    read_only = [p for p in read if p not in modified]
+    return read_only, list(modified)
+
+
+def _message_text(msg: Any) -> str:
+    content = getattr(msg, "content", None)
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict):
+                parts.append(str(block.get("text", "") or ""))
+            else:
+                parts.append(str(getattr(block, "text", "") or ""))
+        return "\n".join(parts)
+    return ""
+
+
+def parse_previous_ledger(messages: list[Any]) -> tuple[list[str], list[str]]:
+    """Paths from the most recent summary's ledger block, if any."""
+    for msg in reversed(messages):
+        text = _message_text(msg)
+        if "<read-files>" not in text and "<modified-files>" not in text:
+            continue
+        read_m = _READ_BLOCK_RE.search(text)
+        mod_m = _MODIFIED_BLOCK_RE.search(text)
+        read = (
+            [ln.strip() for ln in read_m.group(1).splitlines() if ln.strip()]
+            if read_m else []
+        )
+        modified = (
+            [ln.strip() for ln in mod_m.group(1).splitlines() if ln.strip()]
+            if mod_m else []
+        )
+        return read, modified
+    return [], []
+
+
+def _merge_capped(older: list[str], newer: list[str]) -> list[str]:
+    """Older-first order, de-duped; newest entries win the cap."""
+    merged: dict[str, None] = {}
+    for p in older:
+        merged.setdefault(p, None)
+    for p in newer:
+        merged.setdefault(p, None)
+    paths = list(merged)
+    if len(paths) > MAX_PATHS_PER_LIST:
+        paths = paths[-MAX_PATHS_PER_LIST:]
+    return paths
+
+
+def format_file_operations(read: list[str], modified: list[str]) -> str:
+    """pi's formatFileOperations: tagged path lists, empty sections omitted."""
+    parts: list[str] = []
+    if read:
+        parts.append("<read-files>\n" + "\n".join(read) + "\n</read-files>")
+    if modified:
+        parts.append(
+            "<modified-files>\n" + "\n".join(modified) + "\n</modified-files>"
+        )
+    if not parts:
+        return ""
+    return "\n\n" + "\n\n".join(parts)
+
+
+def append_file_ops_ledger(
+    summary_text: str,
+    all_messages: list[Any],
+    compacted_messages: list[Any],
+) -> str:
+    """Summary + cumulative ledger (previous ledger ∪ this span's ops)."""
+    prev_read, prev_modified = parse_previous_ledger(all_messages)
+    new_read, new_modified = extract_file_ops(compacted_messages)
+    modified = _merge_capped(prev_modified, new_modified)
+    modified_set = set(modified)
+    read = [
+        p for p in _merge_capped(prev_read, new_read) if p not in modified_set
+    ]
+    ledger = format_file_operations(read, modified)
+    if not ledger:
+        return summary_text
+    return summary_text + ledger

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -19,6 +19,7 @@ from ..types.messages import (
     SystemMessage,
     UserMessage,
     create_assistant_api_error_message,
+    create_user_message,
 )
 from ..types.content_blocks import TextBlock, ToolResultBlock, ToolUseBlock
 from ..tool_system.build_tool import Tool, Tools
@@ -2600,7 +2601,23 @@ async def query(
             set_terminal(holder, natural_termination, Terminal(reason="completed"))
             return
 
-        for block in tool_use_blocks:
+        # pi's truncation guard, nano-gated (pi agent-loop.ts:381-406): a
+        # "max_tokens" response was cut mid-generation, so every tool call
+        # it carries may have silently truncated arguments — streamed JSON
+        # is salvage-parsed, so a truncated Write/Edit can look valid while
+        # its content is incomplete. Fail them all without executing; the
+        # error text tells the model to re-issue. Non-nano keeps the
+        # documented run-the-survivors behavior (see the max_tokens
+        # tagging rationale above at _call_model_sync).
+        from src.nano.state import is_nano_mode as _is_nano_mode
+
+        _nano_fail_truncated = _is_nano_mode() and any(
+            getattr(m, "stop_reason", None) == "max_tokens"
+            for m in assistant_messages
+        )
+        _blocks_to_run = [] if _nano_fail_truncated else tool_use_blocks
+
+        for block in _blocks_to_run:
             yield SystemMessage(
                 content=f"Running tool: {block.name}",
                 subtype="tool_use_progress",
@@ -2651,8 +2668,29 @@ async def query(
         can_use_tool = build_can_use_tool(tool_use_context)
         tool_results: list[UserMessage] = []
         hook_stopped = False
+        if _nano_fail_truncated:
+            # Synthesize one error result per un-executed call so tool_use/
+            # tool_result pairing stays intact and the model can re-issue.
+            for block in tool_use_blocks:
+                _guard_text = (
+                    f'<tool_use_error>Tool call "{block.name}" was not '
+                    "executed: the response hit the output token limit, so "
+                    "its arguments may be truncated. Re-issue the tool call "
+                    "with complete arguments.</tool_use_error>"
+                )
+                _guard_msg = create_user_message(
+                    content=[{
+                        "type": "tool_result",
+                        "content": _guard_text,
+                        "is_error": True,
+                        "tool_use_id": block.id,
+                    }],
+                    toolUseResult=_guard_text,
+                )
+                yield _guard_msg
+                tool_results.append(_guard_msg)
         async for update in run_tools(
-            tool_use_blocks,
+            _blocks_to_run,
             assistant_messages,
             can_use_tool,
             tool_use_context,

--- a/src/services/compact/compact.py
+++ b/src/services/compact/compact.py
@@ -455,6 +455,22 @@ async def compact_conversation(
 
     summary_text = format_compact_summary(summary_text)
 
+    # Nano: append pi's cumulative <read-files>/<modified-files> ledger so
+    # the model keeps its working set across any number of compactions
+    # (src/nano/compact_ledger.py). Path lists, not contents — a few dozen
+    # tokens of insurance. No-op (and no import) outside nano mode.
+    from src.nano.state import is_nano_mode
+
+    if is_nano_mode():
+        try:
+            from src.nano.compact_ledger import append_file_ops_ledger
+
+            summary_text = append_file_ops_ledger(
+                summary_text, messages, messages_to_compact
+            )
+        except Exception:
+            logger.debug("nano file-op ledger failed", exc_info=True)
+
     # Create boundary marker
     last_msg_uuid = None
     if messages_to_compact:

--- a/src/services/compact/prompt.py
+++ b/src/services/compact/prompt.py
@@ -284,6 +284,21 @@ Please provide your summary following this structure, ensuring precision and tho
 """
 
 
+# pi's iterative-update contract (compaction.ts UPDATE_SUMMARIZATION_PROMPT),
+# adapted to clawcodex's single-call design: the previous summary is itself
+# part of the span being re-summarized, so preservation is an instruction,
+# not a separate call. Appended only in nano mode.
+NANO_ITERATIVE_ADDENDUM = (
+    "\n\nIf the conversation contains a previous context checkpoint "
+    "summary, treat it as the baseline: PRESERVE all of its information, "
+    "ADD new progress, decisions, and context from the newer messages, "
+    "move items that were completed from in-progress to done, and update "
+    "the next steps. Keep exact file paths, function names, and error "
+    "messages. Do not drop information that is still relevant merely "
+    "because it came from the previous summary."
+)
+
+
 def get_compact_prompt(
     custom_instructions: str | None = None,
     *,
@@ -291,6 +306,10 @@ def get_compact_prompt(
 ) -> str:
     """Return the full compact prompt, optionally appending user instructions."""
     prompt = NO_TOOLS_PREAMBLE + BASE_COMPACT_PROMPT
+    from src.nano.state import is_nano_mode
+
+    if is_nano_mode():
+        prompt += NANO_ITERATIVE_ADDENDUM
     if custom_instructions:
         prompt += f"\n\nAdditional Instructions:\n{custom_instructions}"
     prompt += NO_TOOLS_TRAILER

--- a/tests/nano/test_nano_guards.py
+++ b/tests/nano/test_nano_guards.py
@@ -1,0 +1,189 @@
+"""PR3 deterministic guards: truncation guard + compaction ledger.
+
+The truncation guard is pi's agent-loop.ts:381-406 semantic — a
+max_tokens-cut response's tool calls are failed, never executed — proven
+end-to-end through run_headless with a scripted fake provider, in both
+directions (nano fails them; default still runs them).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.nano.compact_ledger import (
+    append_file_ops_ledger,
+    extract_file_ops,
+    format_file_operations,
+    parse_previous_ledger,
+)
+from src.nano.state import set_nano_mode
+
+from .test_nano_headless import (  # reuse the fake-provider wiring
+    ChatResponse,
+    _message_text,
+    _non_system_messages,
+    _run,
+    _text,
+    _tool_use,
+    fake_wiring,  # noqa: F401  (pytest fixture)
+)
+
+# ---------------------------------------------------------------------------
+# Truncation guard
+# ---------------------------------------------------------------------------
+
+
+def _truncated_tool_use(name: str, tool_input: dict) -> ChatResponse:
+    return ChatResponse(
+        content="",
+        model="fake-model",
+        usage={"input_tokens": 5, "output_tokens": 3},
+        finish_reason="max_tokens",
+        tool_uses=[{"id": "toolu_cut", "name": name, "input": tool_input}],
+    )
+
+
+MARKER = "guard-should-prevent-this"
+
+
+def test_nano_fails_tool_calls_from_truncated_response(
+    fake_wiring, tmp_path
+):
+    target = tmp_path / "victim.txt"
+    fake_wiring.extend([
+        _truncated_tool_use(
+            "Write", {"file_path": str(target), "content": MARKER}
+        ),
+        _text("re-issued nothing, done"),
+    ])
+    code, _out, err = _run(
+        "write it", tmp_path, nano=True, skip_permissions=True,
+        permission_mode="bypassPermissions",
+        is_bypass_permissions_mode_available=True,
+    )
+    assert code == 0, err
+    # The Write must NOT have executed…
+    assert not target.exists()
+    # …and the model must have been told to re-issue.
+    provider = fake_wiring.created[-1]
+    followup = "".join(
+        _message_text(m) for m in _non_system_messages(provider.calls[1])
+    )
+    assert "was not executed" in followup
+    assert "Re-issue the tool call" in followup
+
+
+def test_default_still_runs_truncated_survivors(fake_wiring, tmp_path):
+    # Non-nano keeps the documented run-the-survivors behavior
+    # (query.py max_tokens tagging rationale) — the guard must not leak.
+    target = tmp_path / "victim.txt"
+    fake_wiring.extend([
+        _truncated_tool_use(
+            "Write", {"file_path": str(target), "content": MARKER}
+        ),
+        _text("done"),
+    ])
+    code, _out, err = _run(
+        "write it", tmp_path, skip_permissions=True,
+        permission_mode="bypassPermissions",
+        is_bypass_permissions_mode_available=True,
+    )
+    assert code == 0, err
+    assert target.exists()
+    assert target.read_text() == MARKER
+
+
+def test_nano_normal_stop_still_runs_tools(fake_wiring, tmp_path):
+    # The guard keys on stop_reason, not on nano alone.
+    fake_wiring.extend([
+        _tool_use("Bash", {"command": "echo guard-clear"}),
+        _text("finished"),
+    ])
+    code, _out, err = _run(
+        "run it", tmp_path, nano=True, skip_permissions=True,
+        permission_mode="bypassPermissions",
+        is_bypass_permissions_mode_available=True,
+    )
+    assert code == 0, err
+    provider = fake_wiring.created[-1]
+    followup = "".join(
+        _message_text(m) for m in _non_system_messages(provider.calls[1])
+    )
+    assert "guard-clear" in followup
+    assert "was not executed" not in followup
+
+
+# ---------------------------------------------------------------------------
+# Compaction file-op ledger
+# ---------------------------------------------------------------------------
+
+
+class _Msg:
+    def __init__(self, role, content):
+        self.role = role
+        self.content = content
+
+
+def _assistant_with_tools(*calls):
+    return _Msg(
+        "assistant",
+        [
+            {"type": "tool_use", "name": name, "input": {"file_path": path}}
+            for name, path in calls
+        ],
+    )
+
+
+def test_extract_file_ops_read_vs_modified():
+    msgs = [
+        _assistant_with_tools(("Read", "/a.py"), ("Read", "/b.py")),
+        _assistant_with_tools(("Edit", "/b.py"), ("Write", "/c.py")),
+        _Msg("user", "irrelevant"),
+    ]
+    read, modified = extract_file_ops(msgs)
+    # /b.py was read AND modified → modified only (pi's computeFileLists).
+    assert read == ["/a.py"]
+    assert modified == ["/b.py", "/c.py"]
+
+
+def test_ledger_is_cumulative_across_compactions():
+    prev_summary = _Msg(
+        "user",
+        "Earlier summary…\n\n<read-files>\n/old_read.py\n</read-files>\n\n"
+        "<modified-files>\n/old_mod.py\n</modified-files>",
+    )
+    span = [prev_summary, _assistant_with_tools(("Edit", "/new.py"))]
+    out = append_file_ops_ledger("SUMMARY", span, span)
+    assert "<read-files>\n/old_read.py\n</read-files>" in out
+    assert "/old_mod.py" in out and "/new.py" in out
+    assert out.startswith("SUMMARY")
+
+
+def test_parse_previous_ledger_takes_most_recent():
+    msgs = [
+        _Msg("user", "<modified-files>\n/first.py\n</modified-files>"),
+        _Msg("user", "<modified-files>\n/second.py\n</modified-files>"),
+    ]
+    _read, modified = parse_previous_ledger(msgs)
+    assert modified == ["/second.py"]
+
+
+def test_format_file_operations_omits_empty_sections():
+    assert format_file_operations([], []) == ""
+    only_mod = format_file_operations([], ["/m.py"])
+    assert "<read-files>" not in only_mod
+    assert "<modified-files>\n/m.py\n</modified-files>" in only_mod
+
+
+def test_compact_prompt_addendum_is_nano_gated():
+    from src.services.compact.prompt import (
+        NANO_ITERATIVE_ADDENDUM,
+        get_compact_prompt,
+    )
+
+    assert NANO_ITERATIVE_ADDENDUM not in get_compact_prompt()
+    set_nano_mode(True)
+    try:
+        assert NANO_ITERATIVE_ADDENDUM in get_compact_prompt()
+    finally:
+        set_nano_mode(False)


### PR DESCRIPTION
## What

PR 3 of the pi-port series (#879, #880). Two pi accuracy mechanisms, nano-gated; non-nano behavior unchanged.

**Truncation guard** — a \`max_tokens\`-cut response's tool calls may carry salvage-parsed, silently-truncated arguments (a cut-off Write can destroy a file). Under nano, all of them are failed with *"Re-issue the tool call with complete arguments"* instead of executed, with tool_use/tool_result pairing kept intact. Implemented as a \`_blocks_to_run\` swap at the dispatch seam in \`query.py\` — non-nano keeps the documented run-the-survivors behavior.

**Compaction working-set preservation** — pi's cumulative \`<read-files>/<modified-files>\` ledger appended to every summary (paths only, capped, read∩modified→modified), seeded by parsing the previous summary's ledger; plus pi's iterative-update contract as a nano-gated compact-prompt addendum (preserve baseline, add new, move completed).

## Tests

8 new — both guard directions proven end-to-end through \`run_headless\` (nano refuses; default executes; normal stop under nano still runs tools), ledger unit coverage, prompt gating. \`tests/nano\` 49 passed; query + compact regression suites 118 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)