### PR TITLE
feat(nano): TB 2.1 validation — 2/2 pass at 4.4× lower cost; adapter + docs (PR 4/4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ ClawCodex keeps your request prefix **byte-stable**, so DeepSeek's prompt cache 
 
 ***
 
+<div align="center">
+
+# 🐜 `--nano` Mode
+
+# The pi-style minimal harness, built in
+
+### Terminal-Bench 2.1 A/B (`fix-git` + `pypi-server`), same model, same wheel, one flag apart: **2/2 solved in both modes** — nano at **$0.0042 vs $0.0186 total (4.4× cheaper)**, up to 5.2× less input, faster on both.
+
+Six tools, a **~2K-token** fixed payload (vs ~16K default), zero per-turn injections, /eco on.
+`clawcodex --nano -p "<task>"` ports the pi harness's edit ladder (multi-edit + fuzzy match),
+truncation guard, and compaction file-ledger — while non-nano behavior stays byte-identical.
+**[docs/nano.md](docs/nano.md)**
+
+</div>
+
+***
+
 ## ⚡ Quick Install
 
 **One line** — installs `uv`, Python 3.10+, and puts `clawcodex` on your PATH.

--- a/docs/nano.md
+++ b/docs/nano.md
@@ -1,0 +1,72 @@
+# Nano mode (`clawcodex --nano`)
+
+A pi-shaped minimal harness profile: **slim, fast, eco**. Under `--nano`,
+clawcodex behaves almost like the [pi coding agent](https://pi.dev) —
+six tools, a few-hundred-token system prompt, a byte-stable request
+prefix, and deterministic output compression. Without the flag, nothing
+changes: nano is a default-off process flag consulted at a handful of
+chokepoints.
+
+```bash
+clawcodex --nano -p "fix the failing test in src/parser.py"
+```
+
+Nano currently requires `-p`/`--print` (headless). Running `--nano`
+without `-p` errors rather than silently launching the maximal TUI.
+
+## What nano sends
+
+| | nano | default |
+|---|---|---|
+| Tools | **6** — Read, Bash, Edit, Write, Grep, Glob | 24+ (Agent, TaskV2, Skill, ToolSearch, MCP, …) |
+| System prompt | ~300 tokens + your CLAWCODEX.md | ~7,000 tokens (incl. auto-memory doctrine) |
+| Tool docs | 1–3 sentences each | full Claude Code-scale docs |
+| Fixed payload | **≈ 2,000 tokens** | ≈ 17,000 tokens |
+| Per-turn injections | none — byte-stable history | deferred-tools block, reminders, attachments |
+| /eco | **on** (never-worse guard) | off |
+
+Measured on terminal-bench 2.1 (`fix-git` + `pypi-server`,
+deepseek-v4-flash, identical wheel, k=1): **both tasks solved in both
+modes (reward 1.0)** — nano at **$0.0042 total vs $0.0186 (4.4×
+cheaper)**, e.g. fix-git: 54.8K vs 282.6K input tokens, $0.00165 vs
+$0.01015, 75 s vs 128 s. Full tables: `eval/harbor/RUN_NANO_TB21.md`.
+
+## What nano does differently
+
+- **Skills are listed, not tooled**: the system prompt carries
+  name/description/location triples and the Read tool is the loader
+  (pi's progressive disclosure). Skills without a file location are
+  omitted.
+- **Context files**: CLAWCODEX.md as usual; when none exists, nano falls
+  back to `AGENTS.override.md` → `AGENTS.md` → `CLAUDE.md` at the
+  workspace root (pi's precedence).
+- **Edit is pi's ladder**: pass several `{old_string, new_string}` pairs
+  in one call via `edits[]`, all matched against the original file;
+  near-miss whitespace/Unicode is rescued by a normalized fuzzy match
+  that still preserves untouched lines byte-for-byte; CRLF and BOM
+  round-trip correctly. The read-first staleness gate stays. The legacy
+  single `old_string`/`new_string` form (and `replace_all`) still works.
+- **Truncation guard**: tool calls carried by a `max_tokens`-cut
+  response are failed with "re-issue with complete arguments" instead of
+  executed with possibly-truncated arguments.
+- **Compaction keeps the working set**: every auto/manual compaction
+  summary ends with cumulative `<read-files>`/`<modified-files>` path
+  ledgers, and the summarizer is instructed to update (not discard) a
+  previous checkpoint.
+
+## Benchmarking
+
+The Harbor adapter forwards nano with `--ak nano=1`; see
+`eval/harbor/RUN_NANO_TB21.md` for terminal-bench 2.1 A/B instructions.
+
+## Current limits
+
+- Headless (`-p`) only; interactive TUI nano is planned.
+- No MCP servers, plugin/user tools, subagents, or task tools on the
+  nano surface — that is the point; use default mode when you need them.
+- `--allowed-tools`/`--disallowed-tools` still filter the six.
+
+Design rationale and the pi study behind it: the harness comparison in
+`my-docs/clawcodex-nano/` (kept out of git) — headline: pi matched or
+beat the maximal harnesses on Databricks' real-PR benchmark while
+sending ~3× less context per turn.

--- a/eval/harbor/RUN_NANO_TB21.md
+++ b/eval/harbor/RUN_NANO_TB21.md
@@ -1,0 +1,74 @@
+# Running clawcodex --nano on terminal-bench 2.1
+
+Nano mode (`docs/nano.md`) is clawcodex's pi-shaped minimal profile. The
+Harbor adapter forwards it with a single agent kwarg, so any run
+documented in `README.md` / `RUN_PI_TB21.md` becomes a nano run by adding
+`--ak nano=1`.
+
+## A/B a task (nano vs default), DeepSeek
+
+```bash
+export DEEPSEEK_API_KEY=sk-...
+
+# nano
+PYTHONPATH=$PWD/eval/harbor harbor run \
+  --dataset terminal-bench/terminal-bench-2-1 \
+  --agent clawcodex_agent:Clawcodex \
+  --model deepseek/deepseek-v4-flash \
+  --jobs-dir eval/harbor/jobs-nano \
+  --n-concurrent 4 \
+  --ak nano=1
+
+# baseline: same command, no --ak nano=1, --jobs-dir eval/harbor/jobs-default
+```
+
+Filter to single tasks with `-i 'terminal-bench/fix-git'` (hub datasets
+namespace task names). To eval unreleased working-tree changes, build a
+wheel and point `source` at it:
+
+```bash
+uv build --wheel
+...  --ak source=$PWD/dist/clawcodex_cli-<version>-py3-none-any.whl --ak nano=1
+```
+
+Then compare with the existing tooling (`compare_results.py`,
+`compare_trajectories.py`) across the two jobs dirs.
+
+## Measured (2026-08-15, deepseek-v4-flash, this adapter, k=1)
+
+Identical wheel, only `--ak nano=1` differing:
+
+**`terminal-bench/fix-git`**
+
+| | nano | default | ratio |
+|---|---|---|---|
+| reward | **1.0** | **1.0** | = |
+| input tokens | 54,847 | 282,601 | **5.2× less** |
+| cache tokens | 48,896 | 233,344 | 4.8× less |
+| output tokens | 2,421 | 9,283 | 3.8× less |
+| cost | **$0.00165** | **$0.01015** | **6.2× cheaper** |
+| job runtime | 75 s | 128 s | 1.7× faster |
+
+**`terminal-bench/pypi-server`**
+
+| | nano | default | ratio |
+|---|---|---|---|
+| reward | **1.0** | **1.0** | = |
+| input tokens | 111,554 | 300,198 | **2.7× less** |
+| output tokens | 4,941 | 7,362 | 1.5× less |
+| cost | **$0.00255** | **$0.00849** | **3.3× cheaper** |
+| job runtime | 100 s | 117 s | 1.2× faster |
+
+Aggregate: **2/2 pass in both modes; nano $0.0042 vs default $0.0186 —
+4.4× cheaper** at equal quality. Nano's fix-git trajectory was 10 focused
+Bash calls, zero tool errors.
+
+Nano sends six tools and a ~2K-token fixed payload (vs ~16K default), no
+per-turn injections, /eco on. A trivial live A/B outside Harbor
+(deepseek-v4-pro, write-and-verify, both solved in 4 turns) showed the
+same shape: 3,439 vs 27,173 fresh input tokens.
+
+Comparability notes mirror `RUN_PI_TB21.md`: nano has no
+vision_analyze/websearch, so image- and web-dependent TB tasks will lose
+capability relative to default clawcodex — that difference is part of
+what the A/B measures. Don't describe the runs as "same tools".

--- a/eval/harbor/clawcodex_agent.py
+++ b/eval/harbor/clawcodex_agent.py
@@ -389,12 +389,23 @@ class Clawcodex(BaseInstalledAgent):
         advisor: str | None = None,
         advisor_effort: str | None = None,
         vision: str | None = None,
+        nano: bool | str = False,
         *args,
         **kwargs,
     ):
         from harbor.utils.env import parse_bool_env_value
 
         self._subscription = parse_bool_env_value(subscription, name="subscription")
+        # ``--ak nano=1`` — run clawcodex in nano mode (pi-shaped minimal
+        # profile: six tools, ~2K-token fixed payload, byte-stable context,
+        # eco on). A constructor kwarg rather than a CLI_FLAGS entry because
+        # CLI_FLAGS emits ``--flag value`` pairs and ``--nano`` is a bare
+        # store_true flag. Harbor parses ``--ak nano=1`` to the int 1, which
+        # parse_bool_env_value rejects — stringify non-bools first.
+        self._nano = (
+            nano if isinstance(nano, bool)
+            else parse_bool_env_value(str(nano).lower(), name="nano")
+        )
         self._source = source
         # A ``source`` that resolves to a real file on the host is a
         # working-tree build to upload rather than a spec for uv to resolve
@@ -896,6 +907,8 @@ class Clawcodex(BaseInstalledAgent):
             parts += ["--model", shlex.quote(self._parsed_model_name)]
         if self._parsed_model_provider:
             parts += ["--provider", shlex.quote(self._parsed_model_provider)]
+        if self._nano:
+            parts.append("--nano")
 
         # NOTE: build_cli_flags() output is NOT shell-quoted by the base
         # class — safe while every CLI_FLAGS entry is int/enum-typed; quote

--- a/scripts/nano_payload_report.py
+++ b/scripts/nano_payload_report.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Fixed-payload report: nano vs default first-request token estimates.
+
+Prints what each mode sends before any conversation exists — system
+prompt blocks + tool docs + tool schemas — using the same chars/4
+estimate the payload budget test enforces (tests/nano/test_nano_payload.py).
+
+Run from the repo root:  uv run python scripts/nano_payload_report.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def _est(chars: int) -> int:
+    return chars // 4
+
+
+def _tools_chars(tools) -> tuple[int, int]:
+    docs = schemas = 0
+    for t in tools:
+        prompt = t.prompt() if callable(t.prompt) else str(t.prompt or "")
+        docs += len(prompt)
+        try:
+            schemas += len(json.dumps(dict(t.input_schema)))
+        except Exception:
+            schemas += len(str(t.input_schema))
+    return docs, schemas
+
+
+def main() -> int:
+    cwd = str(Path.cwd())
+
+    from src.nano.prompt import build_nano_prompt_blocks
+    from src.nano.registry import build_nano_registry
+
+    nano_blocks = build_nano_prompt_blocks(
+        cwd=cwd, workspace_root=cwd, non_interactive=True, query_source="sdk"
+    )
+    nano_prompt = sum(len(b["text"]) for b in nano_blocks)
+    nano_tools = build_nano_registry().list_tools()
+    nano_docs, nano_schemas = _tools_chars(nano_tools)
+
+    from src.context_system.prompt_assembly import (
+        build_full_system_prompt_blocks,
+    )
+    from src.tool_system.defaults import (
+        ESSENTIAL_INITIAL_TOOL_NAMES,
+        build_default_registry,
+    )
+
+    default_blocks = build_full_system_prompt_blocks(
+        cwd=cwd, non_interactive=True, use_cache=False
+    )
+    default_prompt = sum(len(b.get("text", "")) for b in default_blocks)
+    default_tools = [
+        t for t in build_default_registry().all_tools()
+        if t.name in ESSENTIAL_INITIAL_TOOL_NAMES
+    ]
+    default_docs, default_schemas = _tools_chars(default_tools)
+
+    rows = [
+        ("", "nano", "default"),
+        ("tools", str(len(nano_tools)), str(len(default_tools))),
+        (
+            "system prompt",
+            f"~{_est(nano_prompt):,} tok",
+            f"~{_est(default_prompt):,} tok",
+        ),
+        (
+            "tool docs",
+            f"~{_est(nano_docs):,} tok",
+            f"~{_est(default_docs):,} tok",
+        ),
+        (
+            "tool schemas",
+            f"~{_est(nano_schemas):,} tok",
+            f"~{_est(default_schemas):,} tok",
+        ),
+        (
+            "TOTAL fixed",
+            f"~{_est(nano_prompt + nano_docs + nano_schemas):,} tok",
+            f"~{_est(default_prompt + default_docs + default_schemas):,} tok",
+        ),
+    ]
+    width = max(len(r[0]) for r in rows) + 2
+    for label, nano_v, default_v in rows:
+        print(f"{label:<{width}}{nano_v:>14}{default_v:>16}")
+
+    total_nano = nano_prompt + nano_docs + nano_schemas
+    total_default = default_prompt + default_docs + default_schemas
+    if total_nano:
+        print(f"\nratio: {total_default / total_nano:.1f}x")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Final PR of the pi-port series (#879, #880, #881). Validates \`--nano\` on terminal-bench 2.1 example by example and ships the benchmarking machinery + docs.

## Measured (identical wheel, deepseek-v4-flash, harbor, k=1)

| task | reward (nano / default) | cost | input tokens | runtime |
|---|---|---|---|---|
| fix-git | **1.0 / 1.0** | **$0.00165 / $0.01015 (6.2×)** | 54.8K / 282.6K (5.2×) | 75s / 128s |
| pypi-server | **1.0 / 1.0** | **$0.00255 / $0.00849 (3.3×)** | 111.5K / 300.2K (2.7×) | 100s / 117s |
| **aggregate** | **2/2 both** | **$0.0042 / $0.0186 (4.4×)** | | |

Nano's fix-git trajectory: 10 focused Bash calls, zero tool errors. Plus a live non-Harbor A/B on a trivial 4-turn task: 3,439 vs 27,173 fresh input tokens.

## Ships

- harbor adapter \`--ak nano=1\` (int-coercion before \`parse_bool_env_value\`)
- \`eval/harbor/RUN_NANO_TB21.md\` runbook with the measured tables
- \`scripts/nano_payload_report.py\` (~2.3K vs ~16.0K est. fixed tokens, 7.1×)
- \`docs/nano.md\` + README banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)