### PR TITLE
feat(nano): interactive TUI support — clawcodex --nano launches the Ink TUI (PR 5)

### DIFF
--- a/docs/nano.md
+++ b/docs/nano.md
@@ -8,11 +8,16 @@ changes: nano is a default-off process flag consulted at a handful of
 chokepoints.
 
 ```bash
-clawcodex --nano -p "fix the failing test in src/parser.py"
+clawcodex --nano -p "fix the failing test in src/parser.py"   # headless
+clawcodex --nano                                              # interactive TUI
+clawcodex tui --nano                                          # explicit form
 ```
 
-Nano currently requires `-p`/`--print` (headless). Running `--nano`
-without `-p` errors rather than silently launching the maximal TUI.
+In the interactive TUI, the flag is forwarded to the spawned agent-server
+backend, which builds the nano registry and prompt before the first turn.
+Permission prompts, Shift+Tab mode cycling, and slash commands work as
+usual — nano changes what the *model* sees, not the UI. A mid-session
+`/model` or provider switch keeps the nano surface.
 
 ## What nano sends
 
@@ -61,10 +66,13 @@ The Harbor adapter forwards nano with `--ak nano=1`; see
 
 ## Current limits
 
-- Headless (`-p`) only; interactive TUI nano is planned.
 - No MCP servers, plugin/user tools, subagents, or task tools on the
   nano surface — that is the point; use default mode when you need them.
 - `--allowed-tools`/`--disallowed-tools` still filter the six.
+- Nano is process-global (the /eco contract): on the TUI's `--stdio`
+  transport that is exactly one session; on a multi-session
+  `agent-server --http` process, `--nano` applies to every session it
+  hosts.
 
 Design rationale and the pi study behind it: the harness comparison in
 `my-docs/clawcodex-nano/` (kept out of git) — headline: pi matched or

--- a/src/cli.py
+++ b/src/cli.py
@@ -194,19 +194,6 @@ def main():
     )
     profile_checkpoint("phase3_end_phase4_start")
 
-    if getattr(args, 'nano', False) and not args.print:
-        # Refuse rather than silently launching the maximal TUI: a user who
-        # asked for nano must never be handed the 17K-token surface by
-        # accident. Interactive nano lands in a follow-up PR.
-        from src.cli_core.exit import cli_error
-
-        cli_error(
-            "error: --nano currently requires -p/--print (headless). "
-            "Interactive nano mode is planned; for now run: "
-            "clawcodex --nano -p \"<prompt>\"",
-            2,
-        )
-
     if args.print:
         profile_checkpoint("mode_dispatch_print")
         # ``phase4_dispatch``: launcher has chosen a mode and is about
@@ -257,6 +244,9 @@ def main():
         bypass_selectable=args._resolved_bypass_selectable,
         workspace=(worktree_session.worktree_path if worktree_session else None),
         worktree=worktree_session,
+        # Nano rides the agent-server command (tui_launcher._agent_server_cmd)
+        # so the backend builds the nano registry + prompt before any turn.
+        nano=bool(getattr(args, 'nano', False)),
     )
 
 
@@ -540,18 +530,17 @@ Examples:
     )
 
     # ---- Nano mode ----
-    # pi-shaped minimal profile (see src/nano/): six tools (Read, Bash,
-    # Edit, Write, Grep, Glob), a ~600-token system prompt, no per-turn
-    # context injections, /eco on. Top-level because it will eventually
-    # apply to every surface; v1 wires the headless (-p) path only and
-    # errors otherwise rather than silently running maximal.
+    # pi-shaped minimal profile (see src/nano/, docs/nano.md): six tools
+    # (Read, Bash, Edit, Write, Grep, Glob), a ~300-token system prompt, no
+    # per-turn context injections, /eco on. Applies to headless (-p) and the
+    # interactive TUI (forwarded to the agent-server child via --nano).
     parser.add_argument(
         '--nano',
         action='store_true',
         help=(
             'Nano mode: minimal pi-style harness profile — six tools, tiny '
-            'system prompt, byte-stable context, eco compression on. '
-            'Currently requires -p/--print (headless).'
+            'system prompt, byte-stable context, eco compression on. Works '
+            'headless (-p) and in the interactive TUI.'
         ),
     )
 

--- a/src/entrypoints/agent_server_cli.py
+++ b/src/entrypoints/agent_server_cli.py
@@ -181,6 +181,12 @@ def run_agent_server_subcommand(argv: list[str]) -> int:
              "idle-time-out). stdout is reserved for JSON frames; diagnostics go "
              "to stderr; stdin EOF ends the session.",
     )
+    parser.add_argument(
+        "--nano", action="store_true",
+        help="Nano mode (docs/nano.md): six tools, pi-style minimal prompt, "
+             "byte-stable context, /eco on, no MCP. Process-global — on a "
+             "multi-session transport every session in this process is nano.",
+    )
     args = parser.parse_args(argv)
 
     # The agent server is the backend for an interactive TUI/direct-connect
@@ -273,6 +279,7 @@ def run_agent_server_subcommand(argv: list[str]) -> int:
         is_bypass_available=is_bypass_available,
         bypass_selectable=bypass_selectable,
         max_turns=args.max_turns,
+        nano=bool(args.nano),
     )
 
     if args.stdio:

--- a/src/entrypoints/tui_launcher.py
+++ b/src/entrypoints/tui_launcher.py
@@ -87,6 +87,11 @@ def run_tui_launcher(argv: list[str]) -> int:
                         help="Path to the ui-tui client (default: auto-detect).")
     parser.add_argument("--print-connect", action="store_true",
                         help="Run the agent-server directly, print cc:// URL + token, and wait (no TUI).")
+    parser.add_argument(
+        "--nano", action="store_true",
+        help="Nano mode: six tools, pi-style minimal prompt, byte-stable "
+             "context, /eco on, no MCP (docs/nano.md).",
+    )
     args = parser.parse_args(argv)
 
     # ch08 round-4 WI-3 — 'bubble' is a runtime-only sub-agent-escalation
@@ -184,6 +189,7 @@ def launch_ink_tui(
     workspace: str | None = None,
     tui_dir: str | None = None,
     worktree=None,
+    nano: bool = False,
 ) -> int:
     """Launch the Ink TUI as the interactive UI (it spawns + owns the agent-server).
 
@@ -216,6 +222,7 @@ def launch_ink_tui(
         tui_dir=tui_dir,
         print_connect=False,
         worktree_session=worktree,
+        nano=nano,
     )
     try:
         return asyncio.run(_launch(args))
@@ -287,6 +294,10 @@ def _agent_server_cmd(args) -> list[str]:
         cmd += ["--model", args.model]
     if getattr(args, "effort", None):
         cmd += ["--effort", args.effort]
+    if getattr(args, "nano", False):
+        # Nano mode (docs/nano.md) — the backend owns registry + prompt, so
+        # the flag rides the agent-server command, not the Ink client's env.
+        cmd += ["--nano"]
     return cmd
 
 
@@ -347,6 +358,7 @@ def _print_connect(args) -> int:
         *(["--provider", args.provider] if args.provider else []),
         *(["--model", args.model] if args.model else []),
         *(["--effort", args.effort] if getattr(args, "effort", None) else []),
+        *(["--nano"] if getattr(args, "nano", False) else []),
         "--workspace", workspace,
     ])
 

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -135,6 +135,12 @@ class AgentServerConfig:
     # --allow-select-bypass; never derived from settings here (see the
     # multi-tenant --http note in _build_runtime).
     bypass_selectable: bool = False
+    # ``--nano`` — pi-shaped minimal profile (src/nano/, docs/nano.md): six
+    # tools, ~300-token prompt, byte-stable context, /eco on, no MCP.
+    # Process-global once set (the /eco one-process-one-switch contract), so
+    # on a multi-session transport every session in the process is nano; on
+    # the Ink TUI's --stdio transport that is exactly one session.
+    nano: bool = False
     max_turns: int = DEFAULT_MAX_TURNS
     allowed_tools: tuple[str, ...] = ()
     disallowed_tools: tuple[str, ...] = ()
@@ -2078,9 +2084,17 @@ class _AgentSession:
         (``settings.get_persisted_model``) resolves that name back to the
         fusion record.
         """
+        from src.nano.state import is_nano_mode
         from src.tool_system.defaults import build_default_registry
 
-        registry = build_default_registry(provider=provider)
+        if is_nano_mode():
+            # A mid-session provider switch must not resurrect the maximal
+            # surface in a nano session.
+            from src.nano.registry import build_nano_registry
+
+            registry = build_nano_registry()
+        else:
+            registry = build_default_registry(provider=provider)
         cfg = self.config
         # Canonicalize up front so alias-form flags (e.g. KillShell ->
         # TaskStop) resolve while the tool is still registered.
@@ -5747,7 +5761,21 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         # the store's initial state doesn't misreport the mode — see the
         # block after setup_permissions.)
 
-        registry = build_default_registry(provider=provider)
+        if cfg.nano:
+            # Nano: set the process-global mode BEFORE registry and prompt
+            # construction so every chokepoint (the nano registry, the nano
+            # branch of build_effective_system_prompt, the per-turn reminder
+            # gates in run_query_as_agent_loop) observes it. Eco rides along,
+            # as on the headless path (entrypoints/headless.py).
+            from src.eco.state import set_eco_session
+            from src.nano.registry import build_nano_registry
+            from src.nano.state import set_nano_mode
+
+            set_nano_mode(True)
+            set_eco_session(True)
+            registry = build_nano_registry()
+        else:
+            registry = build_default_registry(provider=provider)
         profile_checkpoint("agent_server_registry_built")
         if cfg.allowed_tools:
             allow = {n.lower() for n in cfg.allowed_tools}
@@ -5763,8 +5791,10 @@ def _build_runtime(sess: _AgentSession, perm_mode: str | None) -> None:
         try:
             from src.server.mcp_runtime import McpRuntime
 
-            mcp_rt = McpRuntime()
-            if mcp_rt.start():
+            # Nano has no MCP surface (pi parity; docs/nano.md) — never
+            # even construct the runtime, so no servers get spawned.
+            mcp_rt = None if cfg.nano else McpRuntime()
+            if mcp_rt is not None and mcp_rt.start():
                 for mtool in mcp_rt.tools:
                     try:
                         registry.register(mtool)

--- a/tests/nano/test_nano_tui.py
+++ b/tests/nano/test_nano_tui.py
@@ -1,0 +1,196 @@
+"""Nano mode on the interactive TUI path (agent-server backend).
+
+Covers the whole flag chain — CLI kwarg → launcher command → agent-server
+argparse → AgentServerConfig → ``_build_runtime`` — plus the mid-session
+provider switch, using the same real-``_AgentSession``/keyless-``ollama``
+harness as tests/server/test_bypass_permissions_wiring.py.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.bootstrap.state import reset_state_for_tests
+from src.eco.state import is_eco_session, reset_eco
+from src.nano.state import is_nano_mode, reset_nano_mode
+from src.services.startup_gates import reset_session_trust_for_testing
+
+pytestmark = pytest.mark.integration
+
+NANO_NAMES = ["Read", "Bash", "Edit", "Write", "Grep", "Glob"]
+
+
+# ---------------------------------------------------------------------------
+# Flag plumbing: launcher command + server CLI parse
+# ---------------------------------------------------------------------------
+
+
+def _launcher_args(**over):
+    base = dict(
+        provider=None, model=None, effort=None, permission_mode="default",
+        is_bypass_available=False, bypass_selectable=False,
+        workspace=None, tui_dir=None, print_connect=False,
+        worktree_session=None, nano=False,
+    )
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def test_agent_server_cmd_carries_nano_flag():
+    from src.entrypoints.tui_launcher import _agent_server_cmd
+
+    assert "--nano" in _agent_server_cmd(_launcher_args(nano=True))
+    assert "--nano" not in _agent_server_cmd(_launcher_args())
+
+
+def test_server_cli_parses_nano_into_config(monkeypatch):
+    import src.entrypoints.agent_server_cli as cli_mod
+
+    captured: dict = {}
+
+    async def _fake_serve_stdio(workspace, agent_config):
+        captured["config"] = agent_config
+        return 0
+
+    monkeypatch.setattr(cli_mod, "_serve_stdio", _fake_serve_stdio)
+    assert cli_mod.run_agent_server_subcommand(["--stdio", "--nano"]) == 0
+    assert captured["config"].nano is True
+
+    captured.clear()
+    assert cli_mod.run_agent_server_subcommand(["--stdio"]) == 0
+    assert captured["config"].nano is False
+
+
+# ---------------------------------------------------------------------------
+# _build_runtime behavior (real session harness)
+# ---------------------------------------------------------------------------
+
+
+def _reset_all() -> None:
+    reset_state_for_tests()
+    reset_session_trust_for_testing()
+    reset_nano_mode()
+    reset_eco()
+    from src.state.app_state import set_active_provider_supplier
+
+    set_active_provider_supplier(None)
+
+
+def _flatten_prompt(system_prompt) -> str:
+    if isinstance(system_prompt, str):
+        return system_prompt
+    if isinstance(system_prompt, list):
+        return "\n".join(
+            str(b.get("text", "")) for b in system_prompt if isinstance(b, dict)
+        )
+    return str(system_prompt or "")
+
+
+class _SessionHarness(unittest.TestCase):
+    """Real ``_AgentSession`` runtime against the keyless ``ollama`` provider
+    with global config redirected to a temp dir (the ch03/bypass shape)."""
+
+    def setUp(self) -> None:
+        _reset_all()
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.ws = root / "ws"
+        self.ws.mkdir()
+        self.config_dir = root / "config-home"
+        self.config_dir.mkdir()
+        global_path = self.config_dir / "config.json"
+        global_path.write_text(json.dumps({}), encoding="utf-8")
+        self._patches = [
+            patch("src.config.get_global_config_path", return_value=global_path),
+            patch("src.config.GLOBAL_CONFIG_DIR", str(self.config_dir)),
+        ]
+        for p in self._patches:
+            p.start()
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+
+    def tearDown(self) -> None:
+        for p in self._patches:
+            p.stop()
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+        _reset_all()
+        self._tmp.cleanup()
+
+    def _build(self, **cfg_kwargs):
+        from src.server.agent_server import (
+            AgentServerConfig,
+            _AgentSession,
+            _build_runtime,
+        )
+
+        sess = _AgentSession(
+            session_id="s-nano-tui",
+            cwd=str(self.ws),
+            config=AgentServerConfig(
+                provider_name="ollama",
+                single_session=True,
+                **cfg_kwargs,
+            ),
+            loop=MagicMock(),
+            out_queue=MagicMock(),
+        )
+        _build_runtime(sess, None)
+        self.assertIsNone(sess.init_error, f"runtime build failed: {sess.init_error}")
+        return sess
+
+
+class TestNanoBuildRuntime(_SessionHarness):
+    def test_nano_session_gets_nano_surface(self) -> None:
+        sess = self._build(nano=True)
+
+        self.assertTrue(is_nano_mode())
+        self.assertTrue(is_eco_session())
+        self.assertEqual(
+            [t.name for t in sess.tool_registry.list_tools()], NANO_NAMES
+        )
+        self.assertIsNone(getattr(sess, "_mcp_runtime", None))
+
+        prompt = _flatten_prompt(sess.system_prompt)
+        self.assertIn("nano mode", prompt)
+        self.assertNotIn("# Doing tasks", prompt)
+        self.assertNotIn("# auto memory", prompt)
+        # Interactive session: the headless-only note must NOT appear.
+        self.assertNotIn("running non-interactively", prompt)
+
+    def test_default_session_unchanged(self) -> None:
+        sess = self._build()
+
+        self.assertFalse(is_nano_mode())
+        self.assertFalse(is_eco_session())
+        names = {t.name for t in sess.tool_registry.list_tools()}
+        self.assertIn("Agent", names)
+        self.assertGreater(len(names), 15)
+        prompt = _flatten_prompt(sess.system_prompt)
+        self.assertIn("# Doing tasks", prompt)
+        self.assertNotIn("nano mode", prompt)
+
+    def test_provider_switch_keeps_nano_surface(self) -> None:
+        sess = self._build(nano=True)
+
+        new_provider = MagicMock()
+        new_provider.get_available_models = MagicMock(return_value=[])
+        sess._install_provider(new_provider, "ollama", "some-model")
+
+        self.assertEqual(
+            [t.name for t in sess.tool_registry.list_tools()], NANO_NAMES
+        )
+
+    def test_allowed_tools_filter_still_applies_in_nano(self) -> None:
+        sess = self._build(nano=True, disallowed_tools=("Glob",))
+        names = [t.name for t in sess.tool_registry.list_tools()]
+        self.assertEqual(names, ["Read", "Bash", "Edit", "Write", "Grep"])


### PR DESCRIPTION
## What

Extends the nano-mode series (#879–#882) to the interactive surface. \`clawcodex --nano\` (and \`clawcodex tui --nano\`) now launches the Ink TUI with the nano backend instead of erroring.

**Chain**: \`cli.py\` → \`launch_ink_tui(nano=…)\` → launcher appends \`--nano\` to the spawned agent-server command (stdio + \`--print-connect\`) → \`agent_server_cli --nano\` → \`AgentServerConfig.nano\` → \`_build_runtime\` sets the process-global mode before registry/prompt construction, so the PR-1 chokepoints (nano prompt branch, reminder gates) engage identically to headless.

Interactive specifics: nano registry with allow/deny filters intact; **MCP runtime never constructed**; mid-session \`/model\`/provider switches rebuild through an \`is_nano_mode()\` branch so the maximal surface can't resurrect; the headless-only prompt note drops automatically; permissions/Shift+Tab/slash commands untouched.

## Tests

6 new (\`tests/nano/test_nano_tui.py\`): launcher command flag, server-CLI parse both directions, and a real-\`_AgentSession\` harness proving the nano surface (six tools, nano prompt, no MCP, eco on, provider-switch persistence, default-session-unchanged). 126 regression tests pass (nano + bypass wiring + spawn isolation + launcher + stdio + init).

**Live e2e**: the real stdio agent-server with \`--nano\` advertised exactly the six tools in \`system/init\` and served a real DeepSeek turn (file write + verify, 3,090 fresh input tokens, result success) — the same transport the Ink client drives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)