### PR TITLE
feat(nano): structural advisor gate + fair-benchmark runbook (PR 7)

### DIFF
--- a/docs/nano.md
+++ b/docs/nano.md
@@ -70,6 +70,11 @@ The Harbor adapter forwards nano with `--ak nano=1`; see
 
 - No MCP servers, plugin/user tools, subagents, or task tools on the
   nano surface — that is the point; use default mode when you need them.
+- **No advisor, structurally**: even with `advisor_enabled` in settings
+  (host config or a seeded container), a nano session never activates the
+  reviewer model — its schema + instructions would break the fixed-payload
+  and byte-stability contracts, and a two-model loop is not what a nano
+  benchmark measures.
 - `--allowed-tools`/`--disallowed-tools` still filter the six.
 - Nano is process-global (the /eco contract): on the TUI's `--stdio`
   transport that is exactly one session; on a multi-session

--- a/eval/harbor/RUN_NANO_TB21.md
+++ b/eval/harbor/RUN_NANO_TB21.md
@@ -72,3 +72,18 @@ Comparability notes mirror `RUN_PI_TB21.md`: nano has no
 vision_analyze/websearch, so image- and web-dependent TB tasks will lose
 capability relative to default clawcodex — that difference is part of
 what the A/B measures. Don't describe the runs as "same tools".
+
+## Fair nano-vs-pi setup
+
+For a clean head-to-head against pi, pair **nano** with **stock pi**
+(`--ak tools=off`, its native 4-tool surface): both are then text-only
+with no web access — capability parity of absence on TB's image/web
+tasks. `--ak tools=on` (the default) would grant pi vision_analyze +
+websearch that nano lacks. Keep both harnesses at model defaults: pass
+no `--ak effort=` / `--ak thinking=` and leave `CLAWCODEX_EFFORT` and
+`PI_THINKING` unset. The advisor is structurally off under nano
+(query.py's nano gate — settings cannot enable it), and it is never
+seeded unless `--ak advisor=` is passed; pass no advisor kwargs. Pin
+what runs: nano via a wheel built from the commit under test
+(`--ak source=`), pi via its adapter-pinned npm version
+(`--ak pi_version=` to override).

--- a/src/query/query.py
+++ b/src/query/query.py
@@ -919,27 +919,38 @@ async def _call_model_sync(
     advisor_mode = ADVISOR_MODE_INACTIVE
     advisor_model_normalized: str | None = None
     try:
-        from ..settings.settings import get_settings
-        settings = get_settings()
-        configured = (getattr(settings, "advisor_model", "") or "").strip()
-        configured_provider = (getattr(settings, "advisor_provider", "") or "").strip()
-        force_client = bool(getattr(settings, "advisor_client_mode", False))
-        # Master switch (default False): the advisor stays inactive unless the
-        # user opted in via `advisor_enabled` in ~/.clawcodex/config.json.
-        advisor_enabled = bool(getattr(settings, "advisor_enabled", False))
-        if configured and advisor_enabled:
-            from ..models.model import canonical_model_name
-            candidate = canonical_model_name(configured)
-            advisor_mode = decide_advisor_mode(
-                provider,
-                main_loop_model,
-                candidate,
-                force_client_mode=force_client,
-                advisor_provider=configured_provider,
-                advisor_enabled=advisor_enabled,
-            )
-            if advisor_mode != ADVISOR_MODE_INACTIVE:
-                advisor_model_normalized = candidate
+        # Nano mode never runs an advisor — structural, not settings-driven.
+        # A second reviewer model appends its tool schema and
+        # ADVISOR_TOOL_INSTRUCTIONS to every request, which breaks nano's
+        # fixed-payload and byte-stability contracts (docs/nano.md), and a
+        # two-model loop is not the harness a nano benchmark measures. The
+        # gate sits here, above the settings read, so an advisor_enabled
+        # inherited from the host config or seeded into a container cannot
+        # leak into a nano session.
+        from src.nano.state import is_nano_mode as _advisor_is_nano
+
+        if not _advisor_is_nano():
+            from ..settings.settings import get_settings
+            settings = get_settings()
+            configured = (getattr(settings, "advisor_model", "") or "").strip()
+            configured_provider = (getattr(settings, "advisor_provider", "") or "").strip()
+            force_client = bool(getattr(settings, "advisor_client_mode", False))
+            # Master switch (default False): the advisor stays inactive unless the
+            # user opted in via `advisor_enabled` in ~/.clawcodex/config.json.
+            advisor_enabled = bool(getattr(settings, "advisor_enabled", False))
+            if configured and advisor_enabled:
+                from ..models.model import canonical_model_name
+                candidate = canonical_model_name(configured)
+                advisor_mode = decide_advisor_mode(
+                    provider,
+                    main_loop_model,
+                    candidate,
+                    force_client_mode=force_client,
+                    advisor_provider=configured_provider,
+                    advisor_enabled=advisor_enabled,
+                )
+                if advisor_mode != ADVISOR_MODE_INACTIVE:
+                    advisor_model_normalized = candidate
     except Exception:
         logger.exception(
             "Advisor activation check failed; treating advisor as inactive"

--- a/tests/nano/test_nano_guards.py
+++ b/tests/nano/test_nano_guards.py
@@ -175,6 +175,68 @@ def test_format_file_operations_omits_empty_sections():
     assert "<modified-files>\n/m.py\n</modified-files>" in only_mod
 
 
+# ---------------------------------------------------------------------------
+# Advisor gate — nano never runs a reviewer model, whatever settings say
+# ---------------------------------------------------------------------------
+
+
+def _advisor_settings():
+    from src.settings.types import SettingsSchema
+
+    return SettingsSchema(
+        advisor_enabled=True,
+        advisor_model="deepseek-v4-pro",
+        advisor_provider="deepseek",
+        advisor_client_mode=True,
+    )
+
+
+def _patch_advisor_settings(monkeypatch):
+    import src.settings.settings as settings_mod
+
+    monkeypatch.setattr(
+        settings_mod, "load_settings", lambda *a, **k: _advisor_settings()
+    )
+    monkeypatch.setattr(settings_mod, "_settings_cache", None)
+
+
+def _sent_tool_names(call: dict) -> list[str]:
+    return [t["name"] for t in (call["tools"] or call["kwargs"].get("tools") or [])]
+
+
+def test_nano_never_activates_the_advisor(fake_wiring, tmp_path, monkeypatch):
+    # Even with a fully configured, enabled advisor in settings (as a host
+    # config leak or container seed would produce), a nano session must send
+    # exactly the six tools and no advisor instructions — the gate sits above
+    # the settings read (query.py advisor resolution).
+    _patch_advisor_settings(monkeypatch)
+    fake_wiring.extend([_text("done")])
+    code, _out, err = _run("hello", tmp_path, nano=True)
+    assert code == 0, err
+
+    call = fake_wiring.created[-1].calls[0]
+    assert _sent_tool_names(call) == [
+        "Read", "Bash", "Edit", "Write", "Grep", "Glob",
+    ]
+    all_text = "".join(_message_text(m) for m in call["messages"]) + str(
+        call["kwargs"].get("system", "")
+    )
+    assert "advisor" not in all_text.lower()
+
+
+def test_default_mode_advisor_still_works(fake_wiring, tmp_path, monkeypatch):
+    # The gate must be nano-scoped: the same settings in default mode
+    # resolve CLIENT_SIDE (force_client + registered provider class) and
+    # append the advisor tool schema.
+    _patch_advisor_settings(monkeypatch)
+    fake_wiring.extend([_text("done")])
+    code, _out, err = _run("hello", tmp_path)
+    assert code == 0, err
+
+    call = fake_wiring.created[-1].calls[0]
+    assert "advisor" in _sent_tool_names(call)
+
+
 def test_compact_prompt_addendum_is_nano_gated():
     from src.services.compact.prompt import (
         NANO_ITERATIVE_ADDENDUM,


### PR DESCRIPTION
Nano never runs an advisor, structurally: the resolution gate sits above the settings read in \`query.py\`, so \`advisor_enabled\` from a host config or seeded container cannot leak into a nano session (its schema + instructions would break the fixed-payload/byte-stability contracts). Proven in both directions: nano with a fully configured advisor sends exactly six tools and no advisor text; the same settings in default mode still resolve CLIENT_SIDE. 117 regression tests pass. Adds the \`RUN_NANO_TB21.md\` fair nano-vs-pi setup section (stock \`tools=off\` pi pairing, model-default effort/thinking, no advisor kwargs, version pinning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)