### PR TITLE
fix(tui): erase row tails so stray glyphs stop sticking to the screen

### DIFF
--- a/ui-tui/packages/clawcodex-ink/src/ink/frame.ts
+++ b/ui-tui/packages/clawcodex-ink/src/ink/frame.ts
@@ -87,6 +87,11 @@ export type Patch =
   | { type: 'cursorShow' }
   | { type: 'cursorMove'; x: number; y: number }
   | { type: 'cursorTo'; col: number }
+  // EL(0). Emitted after a row's last painted cell to wipe anything living to
+  // the right of it. The renderer skips empty cells rather than painting
+  // spaces, so without this a character the renderer did not write (and does
+  // not know about) is never overwritten — see log-update's row-tail heal.
+  | { type: 'eraseToLineEnd' }
   | { type: 'carriageReturn' }
   | { type: 'hyperlink'; uri: string }
   // Pre-serialized style transition string from StylePool.transition() —

--- a/ui-tui/packages/clawcodex-ink/src/ink/inline-scrollback-drift.test.ts
+++ b/ui-tui/packages/clawcodex-ink/src/ink/inline-scrollback-drift.test.ts
@@ -40,6 +40,8 @@ const PROMPT = 'deepseek > '
 const PROMPT_W = PROMPT.length // 11, same as the real composer prompt
 const FOOTER_IDLE = '  ? for shortcuts'
 const FOOTER_BUSY = '  esc to interrupt'
+/** A glyph no component renders — stands in for a write ink did not make. */
+const FOREIGN = '\u00a7'
 
 const ESC = ''
 const BEL = ''
@@ -351,6 +353,10 @@ type StepOpts = Partial<HarnessState> & {
   /** Invoke ink.forceRedraw() after rendering this step (the ctrl+L /
    *  /redraw recovery path — ERASE_SCREEN + CURSOR_HOME + full repaint). */
   forceRedraw?: boolean
+  /** Stamp a character straight into the VT after this step's frame, as if
+   *  something other than ink had written to the terminal. y < 0 targets the
+   *  prompt row. */
+  foreign?: { ch: string; x: number; y: number }
   label: string
 }
 
@@ -386,6 +392,10 @@ function runScenario(steps: Array<StepOpts & { assert?: boolean }>, scrollbox: b
       .map(f => `${f.label}: ${JSON.stringify(f.bytes)}`)
       .join('\n')}`
 
+  const assertNoForeignChar = (label: string) => {
+    expect(vt.dump().includes(FOREIGN), `foreign char never cleared\n${ctx(label)}`).toBe(false)
+  }
+
   const assertComposerIntact = (label: string) => {
     const promptRow = vt.findRow('deepseek')
     expect(promptRow, `prompt row missing\n${ctx(label)}`).toBeGreaterThanOrEqual(0)
@@ -413,7 +423,7 @@ function runScenario(steps: Array<StepOpts & { assert?: boolean }>, scrollbox: b
     }
   }
 
-  for (const { assert = true, forceRedraw = false, label, ...patch } of steps) {
+  for (const { assert = true, forceRedraw = false, foreign, label, ...patch } of steps) {
     Object.assign(state, patch)
     const before = stdout.chunks.length
     ink.render(React.createElement(Harness, { ...state, lines: [...state.lines] }))
@@ -427,8 +437,13 @@ function runScenario(steps: Array<StepOpts & { assert?: boolean }>, scrollbox: b
     frames.push({ bytes, label })
     vt.feed(bytes)
 
+    if (foreign) {
+      vt.grid[foreign.y < 0 ? vt.findRow('deepseek') : foreign.y]![foreign.x] = foreign.ch
+    }
+
     if (assert) {
       assertComposerIntact(label)
+      assertNoForeignChar(label)
     }
   }
 
@@ -530,6 +545,66 @@ describe('inline-mode physical screen stays in sync across a full turn', () => {
 
   it('G: full realism — shell offset + ScrollBox + flash + reflow + virt slide', () => {
     runScenario(lifecycleSteps({ flashOnEnd: true, reflowOnEnd: true, virtSlideOnIdle: true }), true, 3)
+  })
+
+  // The renderer skips empty cells instead of painting spaces, so a character
+  // it did not write sits in a cell its model calls empty and no diff can ever
+  // remove it. Before the row-tail erase this survived the whole lifecycle.
+  it('I: a foreign char on a repainted row is cleared by later frames', () => {
+    const steps = lifecycleSteps({ flashOnEnd: false, reflowOnEnd: false, virtSlideOnIdle: true })
+    const at = steps.findIndex(s => s.label === 'virt-slide')
+    steps.splice(at + 1, 0, { assert: false, foreign: { ch: FOREIGN, x: 30, y: -1 }, label: 'foreign-write' })
+
+    runScenario(steps, false, 3)
+  })
+
+  // ctrl+L was the only thing that could clear one. Keep it that way.
+  it('J: ctrl+L clears a foreign char', () => {
+    const steps = lifecycleSteps({ flashOnEnd: false, reflowOnEnd: false, virtSlideOnIdle: true })
+    const at = steps.findIndex(s => s.label === 'virt-slide')
+    steps.splice(at + 1, 0, { assert: false, foreign: { ch: FOREIGN, x: 30, y: -1 }, label: 'foreign-write' })
+    steps.splice(at + 2, 0, { forceRedraw: true, label: 'ctrl-l' })
+
+    runScenario(steps, false, 3)
+  })
+
+  // ---- Known gaps in the row-tail erase. Each asserts that the run throws
+  // FOR THE DOCUMENTED REASON. `it.fails` was the obvious tool and the wrong
+  // one: it passes on ANY throw, so the first version of the interior case
+  // "passed" because its stamp landed inside the word `deepseek` and tripped
+  // `prompt row missing` instead — the tripwire recorded nothing and would
+  // never have flipped when the gap closed. toThrow(/…/) pins the reason and
+  // still flips loudly if a heal makes the run stop throwing.
+  //
+  // Both gaps fall out of the design: the erase anchors at lastPaintedX + 1 and
+  // only runs for rows the diff pass wrote to. Closing them needs a periodic
+  // in-place full-row repaint, not a bigger tail.
+
+  const gapSteps = (foreign: { ch: string; x: number; y: number }) => {
+    const steps = lifecycleSteps({ flashOnEnd: false, reflowOnEnd: false, virtSlideOnIdle: true })
+    const at = steps.findIndex(s => s.label === 'virt-slide')
+    steps.splice(at + 1, 0, { assert: false, foreign, label: 'foreign-write' })
+
+    return steps
+  }
+
+  // Interior: any cell whose model value does not change between frames is
+  // never re-emitted, and the tail anchor starts past it. Stamped on the
+  // composer's top border — a STABLE PAINTED cell, the sharpest form of the
+  // gap, and not one of the harness's own needles.
+  it('GAP: a foreign char INTERIOR to a row is not cleared', () => {
+    expect(() => runScenario(gapSteps({ ch: FOREIGN, x: 20, y: 4 }), false, 3)).toThrow(
+      /foreign char never cleared/
+    )
+  })
+
+  // Settled rows: during a long turn the only rows repainting are the busy line
+  // and the composer. Everything above is untouched, so nothing erases it —
+  // this is the "persists indefinitely" case from the bug report.
+  it('GAP: a foreign char on an UNTOUCHED transcript row is not cleared', () => {
+    expect(() => runScenario(gapSteps({ ch: FOREIGN, x: 35, y: 1 }), false, 3)).toThrow(
+      /foreign char never cleared/
+    )
   })
 
   it('H: ctrl+L mid-session re-anchors and typing stays correct after it', () => {

--- a/ui-tui/packages/clawcodex-ink/src/ink/log-update.test.ts
+++ b/ui-tui/packages/clawcodex-ink/src/ink/log-update.test.ts
@@ -2,7 +2,16 @@ import { describe, expect, it } from 'vitest'
 
 import type { Frame } from './frame.js'
 import { LogUpdate } from './log-update.js'
-import { CellWidth, CharPool, createScreen, HyperlinkPool, type Screen, setCellAt, StylePool } from './screen.js'
+import {
+  CellWidth,
+  CharPool,
+  createScreen,
+  HyperlinkPool,
+  isEmptyCellAt,
+  type Screen,
+  setCellAt,
+  StylePool
+} from './screen.js'
 
 /**
  * Contract tests for LogUpdate.render() — the diff-to-ANSI path that owns
@@ -67,6 +76,32 @@ describe('LogUpdate.render diff contract', () => {
     expect(written).toContain('CHANGE')
     expect(written).not.toContain('HELLO')
     expect(written).not.toContain('STAYSHERE')
+  })
+
+  // The row-tail erase anchors one column past the last non-empty cell, so
+  // "non-empty" has to mean every cell the terminal still shows something in.
+  // If a wide char's spacer ever counted as empty the anchor would land ON it
+  // and EL(0) would slice the character in half.
+  it('a wide char and its spacer both count as painted, so the tail anchor clears them', () => {
+    const screen = mkScreen(10, 1)
+    setCellAt(screen, 0, 0, { char: '世', styleId: stylePool.none, width: CellWidth.Wide, hyperlink: undefined })
+    setCellAt(screen, 1, 0, { char: '', styleId: stylePool.none, width: CellWidth.SpacerTail, hyperlink: undefined })
+
+    expect(isEmptyCellAt(screen, 0, 0), 'wide char cell').toBe(false)
+    expect(isEmptyCellAt(screen, 1, 0), 'its spacer tail').toBe(false)
+    expect(isEmptyCellAt(screen, 2, 0), 'the column after it').toBe(true)
+  })
+
+  // Same anchor, opposite risk: EL honours the current background (BCE), so a
+  // space carrying a background style is a VISIBLE block. It must not be
+  // treated as blank, or the erase would eat a coloured region.
+  it('a styled space counts as painted, so the tail erase cannot eat it', () => {
+    const screen = mkScreen(10, 1)
+    const styled = stylePool.intern([{ type: 'ansi', code: '[41m', endCode: '[49m' }])
+
+    setCellAt(screen, 0, 0, { char: ' ', styleId: styled, width: CellWidth.Narrow, hyperlink: undefined })
+
+    expect(isEmptyCellAt(screen, 0, 0), 'space with a background style').toBe(false)
   })
 
   it('width change emits a clearTerminal patch before repainting', () => {

--- a/ui-tui/packages/clawcodex-ink/src/ink/log-update.ts
+++ b/ui-tui/packages/clawcodex-ink/src/ink/log-update.ts
@@ -4,6 +4,7 @@ import { logForDebugging } from '../utils/debug.js'
 
 import type { Diff, FlickerReason, Frame } from './frame.js'
 import type { Point } from './layout/geometry.js'
+import { logDroppedRow, logSkippedWideCell, renderDebugEnabled } from './render-debug.js'
 import {
   type Cell,
   cellAt,
@@ -375,6 +376,15 @@ export class LogUpdate {
     // First pass: render changes to existing rows (rows < prev.screen.height)
     let needsFullReset = false
     let resetTriggerY = -1
+    // Rows this pass wrote to, and rows it dropped — both collected per ROW
+    // rather than per cell. diffEach walks row-major ascending, so a trailing
+    // compare against the last entry dedupes without a Set (this file is
+    // engineered for zero allocation on the diff path) AND makes the ascending
+    // order the erase loop's cursor walk relies on an explicit property.
+    const touchedRows: number[] = []
+    const droppedRows: number[] = []
+    // Read once per frame, not per cell: process.env lookups are ~190ns.
+    const traceDrops = renderDebugEnabled()
     diffEach(prev.screen, next.screen, (x, y, removed, added) => {
       // Skip new rows - we'll render them directly after
       if (growing && y >= prev.screen.height) {
@@ -408,6 +418,17 @@ export class LogUpdate {
       // physical buffer. Shrink-to-visible cases are handled above.
       if (y < viewportY) {
         if (!altScreen) {
+          // Dropped on purpose — but only sound if the row really has scrolled
+          // away. When it has not, this is where visible corruption is born:
+          // the change is discarded and no later frame repaints it. Recorded
+          // per ROW and emitted after the pass: the condition worth catching is
+          // a BURST (a virtualization slide drops thousands of cells at once),
+          // and a blocking write per cell would stall the very render loop
+          // whose timing is under investigation.
+          if (traceDrops && droppedRows[droppedRows.length - 1] !== y) {
+            droppedRows.push(y)
+          }
+
           return
         }
 
@@ -419,6 +440,10 @@ export class LogUpdate {
 
       moveCursorTo(screen, x, y)
 
+      if (touchedRows[touchedRows.length - 1] !== y) {
+        touchedRows.push(y)
+      }
+
       if (added) {
         const targetHyperlink = added.hyperlink
         currentHyperlink = transitionHyperlink(screen.diff, currentHyperlink, targetHyperlink)
@@ -426,6 +451,11 @@ export class LogUpdate {
 
         if (writeCellWithStyleStr(screen, added, styleStr)) {
           currentStyleId = added.styleId
+        } else if (traceDrops) {
+          // Refused as too wide for the edge. next.screen still calls the cell
+          // painted, so the next frame diffs clean and it is never repainted —
+          // a permanent hole. Traced alongside the scrolled-off drops.
+          logSkippedWideCell({ char: added.char, viewportWidth: screen.viewportWidth, x, y })
         }
       } else if (removed) {
         // Cell was removed - clear it with a space
@@ -447,6 +477,18 @@ export class LogUpdate {
       }
     })
 
+    for (const y of droppedRows) {
+      logDroppedRow({
+        nextLine: readLine(next.screen, y),
+        physCursorRow: this.physCursorRow,
+        prevLine: readLine(prev.screen, y),
+        screenHeight: next.screen.height,
+        viewportHeight: next.viewport.height,
+        viewportY,
+        y
+      })
+    }
+
     if (needsFullReset) {
       return this.fullReset(next, 'offscreen', altScreen, {
         triggerY: resetTriggerY,
@@ -458,6 +500,59 @@ export class LogUpdate {
     // Reset styles before rendering new rows (they'll set their own styles)
     currentStyleId = transitionStyle(screen.diff, stylePool, currentStyleId, stylePool.none)
     currentHyperlink = transitionHyperlink(screen.diff, currentHyperlink, undefined)
+
+    // Erase the tail of every row this pass wrote to. The renderer skips empty
+    // cells instead of painting spaces, so a character it did not write is in a
+    // cell its model calls empty and no diff can ever remove it; EL(0) restores
+    // the guarantee the old trailing-space padding gave us, at 4 bytes.
+    //
+    // PARTIAL BY CONSTRUCTION — this heals a row's TAIL, on rows the diff pass
+    // TOUCHED. It does not reach:
+    //   - interior columns (the anchor starts past the content, and an
+    //     unchanged painted cell is never re-emitted either), or
+    //   - rows no frame rewrote, which during a long turn is everything above
+    //     the busy line and composer.
+    // Both are pinned as it.fails cases in inline-scrollback-drift.test.ts.
+    // Closing them needs a periodic in-place full-row repaint (EL(2) + repaint
+    // per reachable row — NOT fullReset, whose clearTerminal carries
+    // ERASE_SCROLLBACK and would destroy the user's history). Until then a
+    // stray glyph outside the tail still needs ctrl+L.
+    //
+    // Ordering is load-bearing. After the style reset above: EL honours the
+    // current background (BCE), so erasing under an active style would paint a
+    // coloured bar. Before the growth pass below, which walks the cursor
+    // downward from here. Grown rows get no erase of their own: an inline frame
+    // is bottom-anchored so its new rows arrive by scrolling at the bottom
+    // margin (blank by construction), and the shrink path's clear(N) above
+    // already wiped any row the frame is re-growing into. Both of those are
+    // properties of bottom-anchoring, not of LF itself — LF onto a row that is
+    // not at the bottom margin moves onto existing content.
+    //
+    // Two preconditions, both re-checked rather than assumed. Reachability:
+    // the scrolled-off guard above returns before `touchedRows.push`, so an
+    // unreachable row cannot reach this list — but a clamped cursor-up here
+    // would desync physCursorRow and every later relative move (#633, "typing
+    // lands one row below the input box"), too costly to rest on another
+    // loop's control flow. Width: EL(0) erases to the end of the TERMINAL
+    // line, not of the frame, so a narrower frame would wipe columns ink does
+    // not own. Today the screen is built at terminalColumns and they always
+    // match; this keeps that a stated precondition rather than a coincidence.
+    if (next.screen.width >= next.viewport.width) {
+      for (const y of touchedRows) {
+        if (y < viewportY) {
+          continue
+        }
+
+        const tailX = lastPaintedX(next.screen, y) + 1
+
+        if (tailX >= next.screen.width) {
+          continue
+        }
+
+        moveCursorTo(screen, tailX, y)
+        screen.diff.push({ type: 'eraseToLineEnd' })
+      }
+    }
 
     // Handle growth: render new rows directly (they naturally scroll the terminal)
     if (growing) {
@@ -577,6 +672,21 @@ function transitionStyle(diff: Diff, stylePool: StylePool, currentId: number, ta
   return targetId
 }
 
+/**
+ * Rightmost column of row `y` holding content, or -1 for a blank row.
+ * Everything past it is meant to be blank, which makes it the anchor for the
+ * row-tail erase.
+ */
+function lastPaintedX(screen: Screen, y: number): number {
+  for (let x = screen.width - 1; x >= 0; x--) {
+    if (!isEmptyCellAt(screen, x, y)) {
+      return x
+    }
+  }
+
+  return -1
+}
+
 function readLine(screen: Screen, y: number): string {
   let line = ''
 
@@ -607,6 +717,8 @@ function renderFrameSlice(
   // Track the styleId of the last rendered cell on this line (-1 if none).
   // Passed to visibleCellAtIndex to enable fg-only space optimization.
   let lastRenderedStyleId = -1
+  // Once per slice, never per cell — process.env lookups are ~190ns.
+  const traceSkips = renderDebugEnabled()
 
   const { width: screenWidth, cells, charPool, hyperlinkPool } = frame.screen
 
@@ -659,6 +771,11 @@ function renderFrameSlice(
       if (writeCellWithStyleStr(screen, cell, styleStr)) {
         currentStyleId = cell.styleId
         lastRenderedStyleId = cell.styleId
+      } else if (traceSkips) {
+        // The likelier of the two edge-drop sites: this pass walks EVERY cell
+        // of every row, so it meets the right edge on all of them, where the
+        // diff pass only gets there when that cell changed.
+        logSkippedWideCell({ char: cell.char, viewportWidth: screen.viewportWidth, x, y })
       }
     }
 

--- a/ui-tui/packages/clawcodex-ink/src/ink/render-debug.test.ts
+++ b/ui-tui/packages/clawcodex-ink/src/ink/render-debug.test.ts
@@ -1,0 +1,98 @@
+import { mkdtempSync, readFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { logDroppedRow, logSkippedWideCell, renderDebugEnabled } from './render-debug.js'
+
+const SAMPLE = {
+  nextLine: 'after',
+  physCursorRow: 12,
+  prevLine: 'before',
+  screenHeight: 40,
+  viewportHeight: 20,
+  viewportY: 7,
+  y: 3
+}
+
+let dir: string | undefined
+
+const useTempLog = (): string => {
+  dir = mkdtempSync(join(tmpdir(), 'render-debug-'))
+  const file = join(dir, 'trace.log')
+  process.env.CLAWCODEX_RENDER_DEBUG_FILE = file
+
+  return file
+}
+
+afterEach(() => {
+  delete process.env.CLAWCODEX_RENDER_DEBUG
+  delete process.env.CLAWCODEX_RENDER_DEBUG_FILE
+
+  if (dir) {
+    rmSync(dir, { force: true, recursive: true })
+    dir = undefined
+  }
+})
+
+describe('render-debug', () => {
+  it('writes nothing until the flag is set', () => {
+    const file = useTempLog()
+
+    expect(renderDebugEnabled()).toBe(false)
+    logDroppedRow(SAMPLE)
+
+    expect(() => readFileSync(file)).toThrow()
+  })
+
+  it('records the row and the two numbers that explain why it was dropped', () => {
+    const file = useTempLog()
+    process.env.CLAWCODEX_RENDER_DEBUG = '1'
+
+    expect(renderDebugEnabled()).toBe(true)
+    logDroppedRow(SAMPLE)
+
+    const entry = JSON.parse(readFileSync(file, 'utf8').trim())
+    expect(entry).toMatchObject({
+      event: 'dropped-scrolled-off-row',
+      nextLine: 'after',
+      // The suspects: the renderer believed row 3 sat above the visible band.
+      physCursorRow: 12,
+      prevLine: 'before',
+      viewportY: 7,
+      y: 3
+    })
+  })
+
+  // The other silent-drop site: a wide char refused at the viewport edge. The
+  // model still calls that cell painted, so it never repaints — the tracer has
+  // to name this one too or it points at the wrong suspect.
+  it('records a wide char refused at the viewport edge', () => {
+    const file = useTempLog()
+    process.env.CLAWCODEX_RENDER_DEBUG = '1'
+
+    logSkippedWideCell({ char: '世', viewportWidth: 80, x: 79, y: 4 })
+
+    const entry = JSON.parse(readFileSync(file, 'utf8').trim())
+    expect(entry).toMatchObject({ char: '世', event: 'skipped-wide-cell-at-edge', viewportWidth: 80, x: 79, y: 4 })
+  })
+
+  it('treats 0 and false as off, so an inherited env var cannot switch it on', () => {
+    useTempLog()
+
+    for (const v of ['0', 'false', '']) {
+      process.env.CLAWCODEX_RENDER_DEBUG = v
+      expect(renderDebugEnabled(), `value ${JSON.stringify(v)}`).toBe(false)
+    }
+  })
+
+  // A read-only cwd or a full disk is not a rendering problem — diagnostics
+  // must never be the thing that takes the UI down.
+  it('swallows a write failure instead of throwing into the render loop', () => {
+    process.env.CLAWCODEX_RENDER_DEBUG = '1'
+    process.env.CLAWCODEX_RENDER_DEBUG_FILE = join(tmpdir(), 'no-such-dir-here', 'nested', 'trace.log')
+
+    expect(() => logDroppedRow(SAMPLE)).not.toThrow()
+  })
+})

--- a/ui-tui/packages/clawcodex-ink/src/ink/render-debug.ts
+++ b/ui-tui/packages/clawcodex-ink/src/ink/render-debug.ts
@@ -1,0 +1,87 @@
+/**
+ * Opt-in render tracing for the "stray characters on screen" class of bug.
+ *
+ * The renderer owns the screen through an incremental cell diff, so anything
+ * that makes its model disagree with the real terminal shows up as glyphs it
+ * can never clean up. It has TWO places where it knowingly does not paint a
+ * cell, and they fail in opposite directions:
+ *
+ *   1. The scrolled-off guard in log-update's diff pass drops changes to rows
+ *      it believes are already in terminal scrollback. If that belief is ever
+ *      wrong the row keeps its OLD content — a stray glyph.
+ *   2. writeCellWithStyleStr refuses a wide char that would cross the viewport
+ *      edge. That one is worse: the model still records the cell as painted, so
+ *      prev === next on the following frame and nothing ever repaints it —
+ *      permanent divergence at the right edge, showing as a MISSING glyph.
+ *
+ * Set CLAWCODEX_RENDER_DEBUG=1 to record both. Output goes to a FILE, never
+ * stdout — writing a diagnostic to the terminal being diagnosed would be its
+ * own foreign write. Defaults to clawcodex-render-debug.log in the system temp
+ * directory (not the cwd, which would drop it into the user's repo mid-debug);
+ * override with CLAWCODEX_RENDER_DEBUG_FILE.
+ */
+
+import { appendFileSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
+
+const enabled = (): boolean => {
+  const v = process.env.CLAWCODEX_RENDER_DEBUG
+
+  return !!v && v !== '0' && v !== 'false'
+}
+
+const target = (): string => process.env.CLAWCODEX_RENDER_DEBUG_FILE || join(tmpdir(), 'clawcodex-render-debug.log')
+
+/** True when tracing is on. Read ONCE per frame — this is a process.env lookup
+ *  (~190ns), far too slow for the per-cell diff path. */
+export const renderDebugEnabled = enabled
+
+function record(entry: Record<string, number | string>): void {
+  try {
+    appendFileSync(target(), `${JSON.stringify({ ...entry, at: new Date().toISOString() })}\n`)
+  } catch {
+    // Diagnostics must never take the UI down — a read-only cwd or a full disk
+    // is not a rendering problem.
+  }
+}
+
+/**
+ * Record a diff change dropped because its row was judged unreachable.
+ *
+ * Call once per ROW, after the diff pass — never per cell. The condition worth
+ * catching is a burst (a virtualization slide drops thousands of cells in one
+ * frame), and a blocking write per cell would stall the render loop whose
+ * timing is under investigation.
+ *
+ * `viewportY` is where the renderer thinks the visible band starts and
+ * `physCursorRow` is the tracked physical row it derives that from; when a drop
+ * coincides with visible corruption, those two are the suspects.
+ */
+export function logDroppedRow(info: {
+  nextLine: string
+  physCursorRow: number
+  prevLine: string
+  screenHeight: number
+  viewportHeight: number
+  viewportY: number
+  y: number
+}): void {
+  if (!enabled()) {
+    return
+  }
+
+  record({ ...info, event: 'dropped-scrolled-off-row' })
+}
+
+/**
+ * Record a wide char refused at the viewport edge (drop site 2 above). Rare by
+ * construction — at most a couple per frame — so this one is safe per cell.
+ */
+export function logSkippedWideCell(info: { char: string; viewportWidth: number; x: number; y: number }): void {
+  if (!enabled()) {
+    return
+  }
+
+  record({ ...info, event: 'skipped-wide-cell-at-edge' })
+}

--- a/ui-tui/packages/clawcodex-ink/src/ink/terminal.ts
+++ b/ui-tui/packages/clawcodex-ink/src/ink/terminal.ts
@@ -7,7 +7,7 @@ import { gte } from '../utils/semver.js'
 
 import { getClearTerminalSequence } from './clearTerminal.js'
 import type { Diff } from './frame.js'
-import { cursorMove, cursorTo, eraseLines } from './termio/csi.js'
+import { cursorMove, cursorTo, eraseLines, eraseToEndOfLine } from './termio/csi.js'
 import { BSU, ESU, HIDE_CURSOR, SHOW_CURSOR } from './termio/dec.js'
 import { link } from './termio/osc.js'
 
@@ -242,6 +242,11 @@ export function writeDiffToTerminal(
 
       case 'clearTerminal':
         buffer += getClearTerminalSequence()
+
+        break
+
+      case 'eraseToLineEnd':
+        buffer += eraseToEndOfLine()
 
         break
 


### PR DESCRIPTION
## The bug

Lone characters — an `s`, sometimes an `i` or a `1` — appear at arbitrary positions on the TUI screen during long turns and never go away. They accumulate, so a long session collects several.

## Root cause

The renderer owns the screen through an incremental cell diff and, as an optimization, **skips cells it considers empty rather than painting spaces**. So any character on screen that ink did *not* write sits in a cell its model calls empty, and no frame, keystroke, or repaint ever overwrites it. It is permanent.

Proven by stamping a foreign character into the VT emulator mid-lifecycle and running the rest of a full turn: it survived every subsequent frame, keystroke and virtualization slide. Only `ctrl+L` cleared it.

`fullReset` cannot be used to heal routinely — its `clearTerminal` is `ERASE_SCREEN + ERASE_SCROLLBACK` and would destroy the user's scroll history. That is why the existing code drops silently.

`log-update.test.ts` already documented this bug class ("scattered letters after rapid resize") as unfixed, listing two candidate fixes. The row-tail erase is a third they had not considered.

## The fix

Erase the tail of every row the diff pass wrote to — new `eraseToLineEnd` patch (`EL(0)`), anchored one column past the last painted cell. Restores the guarantee the old trailing-space padding gave us, at 4 bytes a row instead of N.

## This is partial, and says so

It heals a row's **tail**, on rows a frame **rewrote**. It does not reach:

- cells whose model value is unchanged between frames (interior-empty is a subset), or
- rows nothing repaints — during a long turn, everything above the busy line and composer.

Both are pinned as `toThrow(/foreign char never cleared/)` tests that fire if someone closes them, and stated in the docblock. **A stray glyph outside a repainted row's tail still needs `ctrl+L`.**

The real fix is a periodic frame-local `EL(2)` + repaint per reachable row. Explicitly **not** auto-firing `forceRedraw`: its `ERASE_SCREEN` blanks the shell output above an inline frame and `CURSOR_HOME` re-anchors it to the top, so the display jumps — worse than the strays.

## Tracing

The byte source is still unidentified (backend stdio, NDJSON leakage and OSC 52 all ruled out), so `CLAWCODEX_RENDER_DEBUG=1` records both places the renderer knowingly skips a cell:

1. the scrolled-off row guard → stale glyph;
2. `writeCellWithStyleStr` refusing a wide char at the viewport edge → records the cell as painted, so `prev === next` forever and it shows as a **missing** glyph.

Output goes to a file, never stdout — a diagnostic printed to the terminal being diagnosed would be its own foreign write.

## Anchor invariants

Pinned in `log-update.test.ts`: a wide char's `SpacerTail` and a background-styled space are both non-empty, so the anchor lands past them rather than slicing a glyph or eating a coloured region (`EL` honours BCE).

## Verification

- Mutation-tested: the regression test fails with the erase disabled, passes with it — re-verified after every rewrite
- Full ui-tui suite: 7 failures, **identical to the clean-tree baseline on this commit** (all pre-existing, none in the renderer)
- `typecheck` and `eslint` clean
- Real-TUI PTY run: no residue, +5.1% output bytes
- Reviewed to APPROVE over three rounds; the review caught a per-cell blocking file write in the tracer, a docblock claiming one drop site when there are two, and a gap test that passed for the wrong reason

## Not included

Follow-ups deliberately left out: the frame-local repaint above, and the `removed`-cell space writes the EL now repeats (where the +5.1% would come back from).

CI is skipped per request (`[skip ci]`); note `ui-tui` has no CI gate regardless — its vitest suite runs locally only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)