### PR TITLE
fix(harbor): container config seeding wrote to a directory the CLI never reads (PR 14)

### DIFF
--- a/eval/harbor/clawcodex_agent.py
+++ b/eval/harbor/clawcodex_agent.py
@@ -805,9 +805,19 @@ class Clawcodex(BaseInstalledAgent):
 
         clawcodex's ``--effort`` flag governs the MAIN loop only; subagents
         (Agent tool) resolve effort from ``settings.effort``. Seeding the
-        container's global config (home-anchored ``~/.clawcodex/config.json``
-        — the global-config path deliberately does not follow
-        CLAWCODEX_CONFIG_DIR) makes the requested effort session-wide.
+        container's global config makes the requested effort session-wide.
+
+        The seed is written to ``$CLAWCODEX_CONFIG_DIR/config.json``
+        (``_CONTAINER_CONFIG_DIR``) — the SAME directory ``_build_env``
+        points the CLI at. It used to go to home-anchored
+        ``~/.clawcodex/config.json`` under a stale claim that the
+        global-config path "deliberately does not follow
+        CLAWCODEX_CONFIG_DIR": ``src/config.py`` has since unified the
+        config root on ``get_user_config_dir()`` (which honors the env
+        var), so every home-anchored seed — effort, advisor, vision,
+        env-block keys, fusion records — was silently inert in the
+        container. Found when a ``--ak vision=`` run's ``system/init``
+        advertised no vision tool.
 
         Also forwards the host's stored API keys (the global config's ``env``
         block) so tools that need one work inside the container -- WebSearch
@@ -871,12 +881,16 @@ class Clawcodex(BaseInstalledAgent):
         if not config:
             return
         payload = json.dumps(config)
+        # The literal container config dir, NOT "$CLAWCODEX_CONFIG_DIR": this
+        # exec's env carries only CLAWCODEX_SEED_CONFIG, so the variable would
+        # expand empty here. _inject_subscription_credentials writes only
+        # anthropic-oauth.json into the same dir — no clobber.
         await self.exec_as_agent(
             environment,
             command=(
-                'mkdir -p "$HOME/.clawcodex" && '
+                f'mkdir -p {_CONTAINER_CONFIG_DIR} && '
                 'printf \'%s\' "$CLAWCODEX_SEED_CONFIG" > '
-                '"$HOME/.clawcodex/config.json"'
+                f'{_CONTAINER_CONFIG_DIR}/config.json'
             ),
             env={"CLAWCODEX_SEED_CONFIG": payload},
         )


### PR DESCRIPTION
All `--ak` seeded config (advisor, vision, env-block keys, fusion, subagent-tier effort) was silently inert in containers: the seed went to `~/.clawcodex/config.json` while `CLAWCODEX_CONFIG_DIR` pointed the CLI at `/installed-agent/clawcodex-config` — the adapter comment predates config.py's config-root unification. Found when a vision-seeded nano run advertised six tools in `system/init`. Seed now writes to the literal container config dir; no oauth clobber; copy-back privacy unchanged. Main-loop `--effort` rides a CLI flag and was unaffected, so completed benchmark comparisons stand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)