### PR TITLE
feat: raise agent iteration turn budgets (30/20/50 → 100/100/200)

### DIFF
--- a/src/agent/run_agent.py
+++ b/src/agent/run_agent.py
@@ -35,7 +35,9 @@ logger = logging.getLogger(__name__)
 
 # Fallback max turns for subagents when no explicit limit is set.
 # Prevents unbounded loops that appear as hangs to the user.
-SUBAGENT_DEFAULT_MAX_TURNS = 30
+# Raised 30 -> 100: real multi-step subagent work was hitting the cap and
+# truncating before completion.
+SUBAGENT_DEFAULT_MAX_TURNS = 100
 
 
 @dataclass

--- a/src/goals/goals.py
+++ b/src/goals/goals.py
@@ -57,7 +57,9 @@ logger = logging.getLogger(__name__)
 
 #: Turn budget backstop (donor default). CC ships unbounded; the budget
 #: pauses (never clears) so ``/goal resume`` continues with a fresh budget.
-DEFAULT_GOAL_MAX_TURNS = 20
+#: Raised 20 -> 100: goal runs were exhausted at the cap before finishing
+#: multi-step tasks.
+DEFAULT_GOAL_MAX_TURNS = 100
 
 #: Claude Code's documented condition cap (docs/en/goal).
 GOAL_CONDITION_MAX_CHARS = 4000

--- a/src/query/config.py
+++ b/src/query/config.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 class QueryConfig:
     model: str = "claude-sonnet-4-6"
     max_tokens: int = 16384
-    max_turns: int = 50
+    max_turns: int = 200
     effort: str = "high"
     temperature: float | None = None
     stop_sequences: list[str] | None = None
@@ -41,7 +41,7 @@ class QueryConfig:
 class FrozenQueryConfig:
     model: str = "claude-sonnet-4-6"
     max_tokens: int = 16384
-    max_turns: int = 50
+    max_turns: int = 200
     effort: str = "high"
     temperature: float | None = None
     stop_sequences: tuple[str, ...] | None = None

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -97,7 +97,9 @@ DEFAULT_ASK_USER_TIMEOUT_S = 1800.0
 #: Default agent-loop turn ceiling for an interactive session. Shared by the
 #: dataclass default below and the ``--max-turns`` CLI flag (agent_server_cli.py)
 #: so the two can't drift apart from independently hand-edited literals.
-DEFAULT_MAX_TURNS = 50
+#: Raised 50 -> 200: interactive sessions were capped mid-task on long
+#: agentic runs.
+DEFAULT_MAX_TURNS = 200
 
 _SHUTDOWN = object()  # sentinel pushed onto the worker inbox to stop it
 


### PR DESCRIPTION
feat: raise agent iteration turn budgets (30/20/50 → 100/100/200)

## Why

Split out from PR #903 (agentforce314/clawcodex#903) at review request:
these constant bumps are independent of the compaction work and are easier
to review / revert on their own.

Real motivation: in practice, long multi-step agentic runs were hitting the
existing turn ceilings and truncating genuine work before it finished:

- `SUBAGENT_DEFAULT_MAX_TURNS` 30 → 100 — subagents (no explicit limit)
  aborted mid-task on multi-step work.
- `DEFAULT_GOAL_MAX_TURNS` 20 → 100 — `/goal` runs exhausted the budget
  before completing multi-step tasks.
- `QueryConfig.max_turns` (and frozen twin) 50 → 200 — query/agent loops
  capped mid-run on longer sessions.
- `DEFAULT_MAX_TURNS` 50 → 200 — interactive session ceiling (shared with
  `--max-turns` CLI flag), capped mid-task on long runs.

These are 2–4x increases to iteration budgets. They are **not** required
by the cost-aware compaction path (that feature degrades gracefully when
pricing is unavailable and works at any budget); they simply give real
agentic work room to finish.

## Changes

| Constant | Before → After | File |
| --- | --- | --- |
| `SUBAGENT_DEFAULT_MAX_TURNS` | 30 → 100 | `src/agent/run_agent.py` |
| `DEFAULT_GOAL_MAX_TURNS` | 20 → 100 | `src/goals/goals.py` |
| `QueryConfig.max_turns` | 50 → 200 | `src/query/config.py` (line 13) |
| `FrozenQueryConfig.max_turns` | 50 → 200 | `src/query/config.py` (line 44) |
| `DEFAULT_MAX_TURNS` | 50 → 200 | `src/server/agent_server.py` |

## Verification

- All five constants are simple integer literals; no call-site logic changed.
- Syntax-validated the four touched modules (ast.parse).

## Note for reviewers

These are pure constant bumps with no behavioral logic. If the larger
budgets are undesirable (e.g. cost/runaway-loop concerns), they revert
cleanly as a unit. Reverting this PR does not affect the compaction work
in #903.