### PR TITLE
fix(advisor): default activation to off

### DIFF
--- a/src/utils/advisor.py
+++ b/src/utils/advisor.py
@@ -393,7 +393,7 @@ def decide_advisor_mode(
     *,
     force_client_mode: bool = False,
     advisor_provider: str | None = None,
-    advisor_enabled: bool = True,
+    advisor_enabled: bool = False,
 ) -> str:
     """Pick activation mode for the upcoming turn.
 
@@ -422,9 +422,9 @@ def decide_advisor_mode(
 
     ``advisor_enabled`` is the master switch (settings ``advisor_enabled``,
     default False in production): when False the advisor is INACTIVE regardless
-    of model/provider. The parameter defaults True so direct callers (the
-    activation truth-table tests) keep their behavior; production call sites pass
-    ``get_settings().advisor_enabled``.
+    of model/provider. The parameter deliberately defaults False so callers must
+    explicitly opt in, just like users do through ``advisor_enabled`` in config
+    or the ``/advisor`` command.
     """
     if not advisor_enabled:
         return ADVISOR_MODE_INACTIVE

--- a/tests/test_advisor_client_side.py
+++ b/tests/test_advisor_client_side.py
@@ -68,6 +68,16 @@ class TestDecideAdvisorMode(unittest.TestCase):
             )
             self.assertEqual(mode, ADVISOR_MODE_INACTIVE)
 
+    def test_inactive_by_default_even_when_fully_configured(self) -> None:
+        """The decision helper itself must be opt-in, not only its callers."""
+        mode = decide_advisor_mode(
+            self._first_party_provider(),
+            "claude-opus-4-6",
+            "claude-opus-4-6",
+            advisor_provider="anthropic",
+        )
+        self.assertEqual(mode, ADVISOR_MODE_INACTIVE)
+
     def test_server_side_for_1p_with_valid_models(self) -> None:
         # Server-side now requires advisor_provider == "anthropic" too.
         with patch(
@@ -79,6 +89,7 @@ class TestDecideAdvisorMode(unittest.TestCase):
                 "claude-opus-4-6",
                 "claude-opus-4-6",
                 advisor_provider="anthropic",
+                advisor_enabled=True,
             )
             self.assertEqual(mode, ADVISOR_MODE_SERVER_SIDE)
 
@@ -93,6 +104,7 @@ class TestDecideAdvisorMode(unittest.TestCase):
                 "claude-opus-4-6",
                 force_client_mode=True,
                 advisor_provider="anthropic",
+                advisor_enabled=True,
             )
             self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
 
@@ -108,6 +120,7 @@ class TestDecideAdvisorMode(unittest.TestCase):
                 "claude-opus-4-5",
                 "claude-opus-4-6",
                 advisor_provider="anthropic",
+                advisor_enabled=True,
             )
             self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
 
@@ -123,6 +136,7 @@ class TestDecideAdvisorMode(unittest.TestCase):
                 "gpt-5.4",
                 "claude-opus-4-6",
                 advisor_provider="anthropic",
+                advisor_enabled=True,
             )
             self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
 
@@ -139,6 +153,7 @@ class TestDecideAdvisorMode(unittest.TestCase):
                 "claude-opus-4-6",
                 "gemini-2.5-pro",
                 advisor_provider="gemini",
+                advisor_enabled=True,
             )
             self.assertEqual(mode, ADVISOR_MODE_CLIENT_SIDE)
 


### PR DESCRIPTION
## Summary
- make the central advisor activation decision fail closed by default
- require an explicit enablement from config or /advisor
- cover fully configured default-off behavior

## Validation
- python -m compileall -q src/utils/advisor.py
- pytest -q tests/test_advisor_client_side.py tests/test_advisor_helpers.py tests/test_advisor_command.py tests/server/test_advisor_control.py