### PR TITLE
docs: clarify first Web UI launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Then configure a provider and start coding:
 ```bash
 clawcodex login   # interactive provider + API key setup → ~/.clawcodex/config.json
 clawcodex         # start it in any project — Full Access by default, /permissions to change
-clawcodex web     # start the Web UI at http://127.0.0.1:8081
+clawcodex web --build  # first run: build and start the Web UI at http://127.0.0.1:8081
 ```
 
 Both installers ship the same `clawcodex` lifecycle helpers — `doctor` (diagnose your

--- a/install.sh
+++ b/install.sh
@@ -683,6 +683,7 @@ run_post_install_setup() {
         echo -e "    ${C_BOLD}clawcodex login${C_RESET}        # interactive provider + key setup"
         echo -e "    ${C_BOLD}clawcodex${C_RESET}              # start the REPL in any project"
         echo -e "    ${C_BOLD}clawcodex tui${C_RESET}          # the Ink TUI (Claude-Code-style)"
+        echo -e "    ${C_BOLD}clawcodex web --build${C_RESET}  # first run: build and start the Web UI"
     else
         log_warn "clawcodex not on PATH yet — run 'source ~/.bashrc' (or ~/.zshrc) first."
     fi


### PR DESCRIPTION
## Summary

- use `clawcodex web --build` in Quick Install for the initial Web UI launch
- add the first-run Web UI command to the POSIX installer completion message

## Validation

- `bash -n install.sh`
- `git diff --check`