### PR TITLE
fix(web): group non-Git sessions by workspace

### DIFF
--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -1034,7 +1034,7 @@ class GatewayConnection:
         return await _asyncio.to_thread(self._build_projects_tree, preview_limit)
 
     def _build_projects_tree(self, preview_limit: int) -> dict[str, Any]:
-        from src.server.desktop_projects import build_project_tree
+        from src.server.desktop_projects import build_project_tree, canonical_workspace_path
         from src.server.desktop_sessions import list_session_rows
         from src.utils.git import get_repo_root, list_worktrees
 
@@ -1062,6 +1062,7 @@ class GatewayConnection:
         # in the same repo, so probe each distinct path once.
         repo_cache: dict[str, str | None] = {}
         wt_cache: dict[str, list[str]] = {}
+        workspace_cache: dict[str, str | None] = {}
 
         def worktrees_of(repo_root: str) -> list[str]:
             # ``git worktree list`` is repo-global and main-first from ANY
@@ -1086,10 +1087,16 @@ class GatewayConnection:
                     repo_cache[cwd] = None
             return repo_cache[cwd]
 
+        def workspace_path_of(cwd: str) -> str | None:
+            if cwd not in workspace_cache:
+                workspace_cache[cwd] = canonical_workspace_path(cwd)
+            return workspace_cache[cwd]
+
         return build_project_tree(
             rows,
             repo_root_of=repo_root_of,
             worktrees_of=worktrees_of,
+            workspace_path_of=workspace_path_of,
             active_cwd=active_cwd,
             preview_limit=preview_limit,
         )

--- a/src/server/desktop_projects.py
+++ b/src/server/desktop_projects.py
@@ -4,8 +4,10 @@ Groups saved + live sessions into the ``SidebarProjectTree[]`` shape the
 desktop renderer expects (``ui-desktop/src/app/chat/sidebar/projects/
 workspace-groups.ts``): one *project* per git repo root, each holding one
 *repo* node whose *lanes* are the repo's checkouts (the main "home" lane plus
-one per linked worktree a session sits in). Sessions with no cwd, or a cwd
-that is not inside a git repo, fall into the synthetic "Home" bucket.
+one per linked worktree a session sits in). A resolvable non-git cwd becomes a
+workspace project keyed by its canonical directory path and labeled by its
+basename. Only sessions with no resolvable cwd fall into the synthetic "Home"
+bucket.
 
 This is the data behind the sidebar's worktree display. The renderer layers
 its live ``git worktree list`` probe on top (injecting EMPTY lanes for
@@ -32,6 +34,21 @@ import os
 from typing import Any, Callable
 
 NO_PROJECT_ID = "__no_project__"
+
+
+def canonical_workspace_path(path: str) -> str | None:
+    """Return the real path for an existing directory, else ``None``.
+
+    DeepSeek Harness uses ``fs.realpath`` as workspace identity so aliases,
+    ``..`` segments, and trailing separators cannot split one directory into
+    multiple sidebar groups. Keep the filesystem lookup outside the pure tree
+    builder by injecting this resolver from the gateway.
+    """
+    try:
+        resolved = os.path.realpath(path)
+    except (OSError, ValueError):
+        return None
+    return resolved if os.path.isdir(resolved) else None
 
 
 def _segments(path: str) -> list[str]:
@@ -97,18 +114,22 @@ def build_project_tree(
     *,
     repo_root_of: Callable[[str], str | None],
     worktrees_of: Callable[[str], list[str]],
+    workspace_path_of: Callable[[str], str | None],
     active_cwd: str | None = None,
     preview_limit: int = 3,
 ) -> dict[str, Any]:
     """Group ``rows`` (SessionInfo dicts) into the sidebar project tree.
 
     ``repo_root_of(cwd)`` → the repo root for a cwd, or None. ``worktrees_of(
-    repo_root)`` → the list of worktree paths for a repo (main first). Both are
-    injected so this stays pure/testable; the gateway wraps them with the
-    git-backed, per-cwd-memoized resolvers.
+    repo_root)`` → the list of worktree paths for a repo (main first).
+    ``workspace_path_of(cwd)`` → the canonical existing directory for a
+    non-git cwd, or None. All are injected so this stays pure/testable; the
+    gateway wraps them with per-path memoized resolvers.
     """
     # repo_root → { "path", "lanes": {lane_key → lane dict} }
     projects: dict[str, dict[str, Any]] = {}
+    # canonical non-git workspace path → sessions
+    workspaces: dict[str, list[dict[str, Any]]] = {}
     home_sessions: list[dict[str, Any]] = []
 
     def _lane_for(repo_root: str, cwd: str) -> tuple[str, str, bool, str]:
@@ -135,7 +156,11 @@ def build_project_tree(
         cwd = (row.get("cwd") or "").strip()
         repo_root = repo_root_of(cwd) if cwd else None
         if not repo_root:
-            home_sessions.append(row)
+            workspace_path = workspace_path_of(cwd) if cwd else None
+            if workspace_path:
+                workspaces.setdefault(workspace_path, []).append(row)
+            else:
+                home_sessions.append(row)
             continue
         proj = projects.setdefault(repo_root, {"path": repo_root, "lanes": {}})
         lane_key, label, is_main, lane_path = _lane_for(repo_root, cwd)
@@ -146,7 +171,10 @@ def build_project_tree(
         )
         lane["sessions"].append(row)
 
-    active_repo = repo_root_of(active_cwd.strip()) if active_cwd and active_cwd.strip() else None
+    active_path = active_cwd.strip() if active_cwd and active_cwd.strip() else None
+    active_project = None
+    if active_path:
+        active_project = repo_root_of(active_path) or workspace_path_of(active_path)
 
     project_nodes: list[dict[str, Any]] = []
     for repo_root, proj in projects.items():
@@ -167,6 +195,36 @@ def build_project_tree(
             }],
             "sessionCount": len(all_sessions),
             "lastActive": max((_recency(s) for s in all_sessions), default=0.0),
+            "previewSessions": preview,
+        })
+
+    for workspace_path, sessions in workspaces.items():
+        label = _basename(workspace_path)
+        preview = sorted(sessions, key=_recency, reverse=True)[:preview_limit]
+        # Keep the same nested wire shape as repo projects. The Web UI hides a
+        # single lane; the stable main-style id also lets the Desktop live-row
+        # overlay upsert into this lane instead of duplicating the session.
+        lane_id = f"{workspace_path}::branch::main"
+        project_nodes.append({
+            "id": workspace_path,
+            "label": label,
+            "path": workspace_path,
+            "isAuto": True,
+            "repos": [{
+                "id": workspace_path,
+                "label": label,
+                "path": workspace_path,
+                "groups": [{
+                    "id": lane_id,
+                    "label": label,
+                    "path": workspace_path,
+                    "isMain": True,
+                    "sessions": sessions,
+                }],
+                "sessionCount": len(sessions),
+            }],
+            "sessionCount": len(sessions),
+            "lastActive": max((_recency(s) for s in sessions), default=0.0),
             "previewSessions": preview,
         })
 
@@ -199,9 +257,9 @@ def build_project_tree(
 
     return {
         "projects": project_nodes,
-        "active_id": active_repo,
+        "active_id": active_project,
         "scoped_session_ids": [str(r.get("id")) for r in rows if r.get("id")],
     }
 
 
-__all__ = ["build_project_tree", "NO_PROJECT_ID"]
+__all__ = ["build_project_tree", "canonical_workspace_path", "NO_PROJECT_ID"]

--- a/tests/server/test_desktop_projects.py
+++ b/tests/server/test_desktop_projects.py
@@ -2,11 +2,19 @@
 
 from __future__ import annotations
 
-from src.server.desktop_projects import NO_PROJECT_ID, build_project_tree
+from src.server.desktop_projects import (
+    NO_PROJECT_ID,
+    build_project_tree,
+    canonical_workspace_path,
+)
 
 
 def _row(sid: str, cwd: str | None, last: float = 0.0) -> dict:
     return {"id": sid, "cwd": cwd, "last_active": last, "title": sid}
+
+
+def _workspace_path(cwd: str) -> str:
+    return cwd
 
 
 def test_groups_sessions_by_repo_root_into_auto_projects():
@@ -15,6 +23,7 @@ def test_groups_sessions_by_repo_root_into_auto_projects():
         rows,
         repo_root_of=lambda cwd: "/repo" if cwd.startswith("/repo") else None,
         worktrees_of=lambda root: ["/repo"],
+        workspace_path_of=_workspace_path,
     )
     assert len(tree["projects"]) == 1
     proj = tree["projects"][0]
@@ -32,6 +41,7 @@ def test_linked_worktree_session_gets_its_own_lane():
         rows,
         repo_root_of=lambda cwd: "/repo",
         worktrees_of=lambda root: ["/repo", "/repo/.worktrees/feature"],
+        workspace_path_of=_workspace_path,
     )
     lanes = tree["projects"][0]["repos"][0]["groups"]
     main = [g for g in lanes if g["isMain"]]
@@ -41,17 +51,59 @@ def test_linked_worktree_session_gets_its_own_lane():
     assert [s["id"] for s in linked[0]["sessions"]] == ["feat"]
 
 
-def test_non_repo_and_cwdless_sessions_fall_into_home_bucket():
-    rows = [_row("x", None), _row("y", "/tmp/scratch")]
+def test_non_repo_sessions_group_by_workspace_directory():
+    rows = [
+        _row("scratch-old", "/tmp/scratch", 1.0),
+        _row("scratch-new", "/tmp/scratch", 3.0),
+        _row("other", "/var/tmp/other", 2.0),
+    ]
     tree = build_project_tree(
         rows,
         repo_root_of=lambda cwd: None,  # nothing is a repo
         worktrees_of=lambda root: [],
+        workspace_path_of=_workspace_path,
     )
+
+    assert [project["id"] for project in tree["projects"]] == [
+        "/tmp/scratch",
+        "/var/tmp/other",
+    ]
+    scratch = tree["projects"][0]
+    assert scratch["label"] == "scratch"
+    assert scratch["path"] == "/tmp/scratch"
+    assert scratch["isAuto"] is True
+    assert scratch.get("isNoProject") is None
+    assert {row["id"] for row in scratch["repos"][0]["groups"][0]["sessions"]} == {
+        "scratch-old",
+        "scratch-new",
+    }
+
+
+def test_cwdless_sessions_fall_into_home_bucket():
+    rows = [_row("x", None), _row("y", "")]
+    tree = build_project_tree(
+        rows,
+        repo_root_of=lambda cwd: None,
+        worktrees_of=lambda root: [],
+        workspace_path_of=_workspace_path,
+    )
+
     assert len(tree["projects"]) == 1
     home = tree["projects"][0]
     assert home["id"] == NO_PROJECT_ID and home["isNoProject"] is True
     assert home["sessionCount"] == 2
+
+
+def test_active_non_repo_workspace_uses_its_directory_id():
+    tree = build_project_tree(
+        [_row("x", "/tmp/scratch")],
+        repo_root_of=lambda cwd: None,
+        worktrees_of=lambda root: [],
+        workspace_path_of=_workspace_path,
+        active_cwd="/tmp/scratch",
+    )
+
+    assert tree["active_id"] == "/tmp/scratch"
 
 
 def test_windows_paths_group_case_and_separator_insensitively():
@@ -65,6 +117,7 @@ def test_windows_paths_group_case_and_separator_insensitively():
         rows,
         repo_root_of=lambda cwd: "C:/Repo",
         worktrees_of=lambda root: ["C:/Repo"],
+        workspace_path_of=_workspace_path,
     )
     assert len(tree["projects"]) == 1
     lanes = tree["projects"][0]["repos"][0]["groups"]
@@ -78,7 +131,55 @@ def test_active_id_and_scoped_ids():
         rows,
         repo_root_of=lambda cwd: "/repo",
         worktrees_of=lambda root: ["/repo"],
+        workspace_path_of=_workspace_path,
         active_cwd="/repo",
     )
     assert tree["active_id"] == "/repo"
     assert tree["scoped_session_ids"] == ["a"]
+
+
+def test_workspace_path_resolver_canonicalizes_and_rejects_invalid_paths(tmp_path):
+    workspace = tmp_path / "parent" / "workspace"
+    workspace.mkdir(parents=True)
+    alias = workspace / ".." / "workspace"
+
+    assert canonical_workspace_path(str(alias)) == str(workspace.resolve())
+    assert canonical_workspace_path(str(tmp_path / "missing")) is None
+
+
+def test_canonical_workspace_aliases_share_one_project(tmp_path):
+    workspace = tmp_path / "parent" / "workspace"
+    workspace.mkdir(parents=True)
+    alias = workspace / ".." / "workspace"
+    rows = [_row("canonical", str(workspace)), _row("alias", str(alias))]
+
+    tree = build_project_tree(
+        rows,
+        repo_root_of=lambda cwd: None,
+        worktrees_of=lambda root: [],
+        workspace_path_of=canonical_workspace_path,
+        active_cwd=str(alias),
+    )
+
+    assert len(tree["projects"]) == 1
+    project = tree["projects"][0]
+    assert project["id"] == str(workspace.resolve())
+    assert project["label"] == "workspace"
+    assert project["path"] == str(workspace.resolve())
+    assert {row["id"] for row in project["repos"][0]["groups"][0]["sessions"]} == {
+        "canonical",
+        "alias",
+    }
+    assert tree["active_id"] == str(workspace.resolve())
+
+
+def test_unresolved_cwd_falls_into_home_bucket(tmp_path):
+    missing = tmp_path / "missing"
+    tree = build_project_tree(
+        [_row("gone", str(missing))],
+        repo_root_of=lambda cwd: None,
+        worktrees_of=lambda root: [],
+        workspace_path_of=canonical_workspace_path,
+    )
+
+    assert [project["id"] for project in tree["projects"]] == [NO_PROJECT_ID]

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -308,8 +308,9 @@ export interface SessionRow {
 /**
  * `projects.tree` shape (`src/server/desktop_projects.py`): one project per
  * git repo root, each holding repos whose *groups* are the repo's checkouts —
- * the main lane plus one per linked worktree that has sessions in it. Sessions
- * with no cwd, or a cwd outside any repo, land in the synthetic "Home" project.
+ * the main lane plus one per linked worktree that has sessions in it. A valid
+ * non-Git cwd is its own basename-labeled workspace project; only sessions
+ * without a resolvable cwd land in the synthetic "Home" project.
  */
 export interface ProjectLane {
   id: string

--- a/ui-web/src/sidebar/Sidebar.tsx
+++ b/ui-web/src/sidebar/Sidebar.tsx
@@ -103,9 +103,9 @@ function SessionList({ activeId, hiddenId, liveId, project }: SessionListProps) 
 /**
  * The session tree.
  *
- * Sessions are grouped by the repository they were started in, with a lane per
- * worktree — the grouping the backend already computes for the desktop app, so
- * both surfaces place a session in the same place. Collapsed, the column
+ * Sessions are grouped by workspace directory. Git repositories retain a lane
+ * per worktree; non-Git directories use their basename as the project label.
+ * The backend computes the shared Web/Desktop grouping. Collapsed, the column
  * becomes a rail of the three controls that still make sense without labels.
  */
 export function Sidebar({ collapsed }: SidebarProps) {


### PR DESCRIPTION
## Summary

- match deepseek-harness workspace identity for non-Git sessions: canonical directory path with a basename display label
- keep only cwd-less or unresolvable sessions in the synthetic Home bucket
- report the canonical non-Git workspace as `active_id`
- update the shared Web/Desktop gateway contract and sidebar documentation

## Root cause

`projects.tree` treated a failed Git-root probe as equivalent to a missing workspace, so every session started in a normal non-Git directory was grouped under Home.

## Validation

- `python -m pytest -q tests/server/test_desktop_projects.py tests/server/test_desktop_sessions.py tests/server/test_desktop_serve.py tests/server/test_desktop_gateway.py` (66 passed)
- `npm run check` in `ui-web` (31 files, 418 tests)
- `npm run build` in `ui-web`
- live `projects.tree` WebSocket check for `/Users/ericlee2/workspace/elon-blog` returned label `elon-blog`, the canonical path, and no `isNoProject` marker
- `git diff --check`