### PR TITLE
fix: refresh OpenAI subscription models and correct Fusion provider grouping

### DIFF
--- a/src/providers/__init__.py
+++ b/src/providers/__init__.py
@@ -89,7 +89,9 @@ PROVIDER_INFO: dict[str, ProviderInfo] = {
         "default_base_url": "https://api.openai.com/v1",
         "default_model": "gpt-5.4",
         "available_models": [
-            # GPT-5.6 — the current frontier generation. Sol / Terra / Luna are
+            # https://developers.openai.com/api/docs/models (2026-09-06)
+            "gpt-6-astra",
+            # GPT-5.6 — Sol / Terra / Luna are
             # durable capability tiers rather than a size ladder: Sol is the
             # flagship, Terra balances capability against cost, Luna is the
             # cheap high-volume tier. ``gpt-5.6`` is OpenAI's alias for Sol.

--- a/src/providers/catalog.py
+++ b/src/providers/catalog.py
@@ -84,6 +84,10 @@ def provider_catalog(
     ``current_ready`` marks the active provider authenticated because the
     session demonstrably constructed it.
 
+    The session's flat model list includes every enabled Fusion model.
+    Group those by their BASE provider here; the vision provider supplies
+    only image understanding and does not own the fused model.
+
     Credential probing deliberately mirrors ``get_provider_config``'s literal
     lookup rather than trying to be cleverer than it, because
     ``_do_set_provider`` resolves the same way: a row reported here as
@@ -109,7 +113,11 @@ def provider_catalog(
         resolve_api_key,
     )
 
+    from .fusion_models import load_fusion_models
+
     current_id = canonical_provider_name(current) if current else None
+    fusion_models = load_fusion_models()
+    fusion_names = {model.name.lower() for model in fusion_models}
 
     rows: list[dict[str, Any]] = []
     for pid, info in PROVIDER_INFO.items():
@@ -131,6 +139,28 @@ def provider_catalog(
         models = [str(m) for m in (info.get("available_models") or [])]
         if is_current and current_models:
             models = [str(m) for m in current_models]
+        elif pid == "openai":
+            # The inactive row must use the same auth-specific catalog as a
+            # live OpenAI session. Construction only checks local credentials;
+            # it neither creates an SDK client nor refreshes OAuth tokens.
+            try:
+                from src.config import get_provider_config
+                from .openai_provider import OpenAIProvider
+
+                models = OpenAIProvider(
+                    api_key=api_key,
+                    base_url=get_provider_config(pid).get("base_url"),
+                ).get_available_models()
+            except Exception:  # noqa: BLE001 — retain the static fallback
+                pass
+
+        own_fusion = [
+            model.name for model in fusion_models
+            if model.enabled and canonical_provider_name(model.base.provider) == pid
+        ]
+        models = list(dict.fromkeys(
+            own_fusion + [m for m in models if m.lower() not in fusion_names]
+        ))
 
         row: dict[str, Any] = {
             "slug": pid,

--- a/src/providers/openai_responses.py
+++ b/src/providers/openai_responses.py
@@ -40,10 +40,14 @@ logger = logging.getLogger(__name__)
 # filter it; Gemini's converter drops unknown block types by construction.
 RESPONSES_ITEM_BLOCK_TYPE = "openai_responses_item"
 
-# Models served by the ChatGPT-subscription backend. Source of truth:
-# OpenCode's ALLOWED_MODELS (plugin/openai/codex.ts:15) — which matches the
-# live list Codex CLI caches from the backend (~/.codex/models_cache.json).
+# Models offered for ChatGPT subscriptions, separate from the API catalog.
+# Current Codex model IDs: https://learn.chatgpt.com/docs/models (2026-09-06).
+# Availability still depends on the user's plan (Spark requires Pro).
 SUBSCRIPTION_MODELS = [
+    "gpt-6-astra",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
     "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
@@ -138,7 +142,7 @@ def supports_reasoning(model: str) -> bool:
         # older and more exercised path — whereas including them wrongly is a
         # hard 400 on every request.
         return False
-    if m.startswith(("gpt-5", "o1", "o3", "o4")):
+    if m.startswith(("gpt-5", "gpt-6", "o1", "o3", "o4")):
         return True
     return "codex" in m
 

--- a/tests/providers/test_openrouter_catalog.py
+++ b/tests/providers/test_openrouter_catalog.py
@@ -99,9 +99,9 @@ class TestOpenAIDirectCatalogue:
         assert provider.get_available_models() == self.DIRECT
         assert provider.get_available_models() is not self.DIRECT
 
-    def test_leads_with_the_5_6_generation(self):
-        assert self.DIRECT[0] == "gpt-5.6"
-        assert {"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} <= set(self.DIRECT)
+    def test_leads_with_astra_and_keeps_the_5_6_generation(self):
+        assert self.DIRECT[0] == "gpt-6-astra"
+        assert {"gpt-5.6", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} <= set(self.DIRECT)
 
     def test_ids_are_bare_not_openrouter_qualified(self):
         """``openai/gpt-5.6-sol`` is OpenRouter's addressing; the direct API

--- a/tests/server/test_model_provider_picker.py
+++ b/tests/server/test_model_provider_picker.py
@@ -161,6 +161,70 @@ class TestProviderCatalog:
         assert active["total_models"] == 1
         assert other["models"] == PROVIDER_INFO["anthropic"]["available_models"]
 
+    @pytest.mark.parametrize("current", ["openai", "deepseek", "anthropic", "glm", "ollama"])
+    def test_fusion_models_are_grouped_by_base_provider(self, current):
+        config_mod.save_config({"fusionModels": [
+            {
+                "name": "deepseek-v4-flash-luna",
+                "base": "deepseek:deepseek-v4-flash",
+                "vision": "openai:gpt-5.6-luna",
+            },
+            {"name": "glm-vision", "base": "glm:GLM-5.1", "vision": "openai:gpt-5.6-luna"},
+            {
+                "name": "disabled-fusion", "base": "deepseek:deepseek-v4-pro",
+                "vision": "openai:gpt-5.6-luna", "enabled": False,
+            },
+        ]})
+        session = _StubSession(provider_name=current)
+        # Exercise the real flat session inventory that caused the screenshot:
+        # it includes Fusion models belonging to other providers.
+        session.provider.get_available_models = lambda: ["native-model"]
+        session._models = _AgentSession._available_models(session)
+        assert "deepseek-v4-flash-luna" in session._models
+        _AgentSession._do_list_model_providers(session, "catalog")
+        assert session.last["ok"] is True
+        rows = {r["slug"]: r for r in session.last["providers"]}
+        for pid, row in rows.items():
+            assert ("deepseek-v4-flash-luna" in row["models"]) is (pid == "deepseek")
+            assert ("glm-vision" in row["models"]) is (pid == "zai")
+            assert "disabled-fusion" not in row["models"]
+            assert row["total_models"] == len(row["models"]) == len(set(row["models"]))
+        assert rows["deepseek"]["models"][0] == "deepseek-v4-flash-luna"
+        assert rows["zai" if current == "glm" else current]["models"][-1] == "native-model"
+
+    @pytest.mark.parametrize("api_key,base_url,subscription", [
+        ("", None, True),
+        ("sk-test", None, False),
+        ("", "https://proxy.example/v1", False),
+    ])
+    def test_inactive_openai_catalog_matches_its_auth_route(
+        self, monkeypatch, api_key, base_url, subscription,
+    ):
+        from src.providers.openai_responses import SUBSCRIPTION_MODELS
+
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        monkeypatch.setattr("src.providers.resolve_api_key", lambda pid: api_key if pid == "openai" else "")
+        monkeypatch.setattr(
+            "src.auth.openai_subscription.load_credentials",
+            lambda: SimpleNamespace(account_id="acct-test"),
+        )
+        def no_network(*args, **kwargs):
+            pytest.fail("Listing providers must not refresh OAuth or create an SDK client")
+
+        monkeypatch.setattr("src.auth.openai_subscription.get_valid_credentials", no_network)
+        monkeypatch.setattr("src.providers.openai_provider.OpenAIProvider._create_client", no_network)
+        if base_url:
+            config_mod.save_config({"providers": {"openai": {"base_url": base_url}}})
+        row = next(r for r in provider_catalog(current="deepseek") if r["slug"] == "openai")
+        expected = SUBSCRIPTION_MODELS if subscription else PROVIDER_INFO["openai"]["available_models"]
+        assert row["models"] == expected
+        assert {"gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} <= set(row["models"])
+        assert ("gpt-4o" in row["models"]) is not subscription
+
+    def test_live_gateway_models_are_not_filtered_by_vendor_name(self):
+        rows = provider_catalog(current="openai", current_models=["deepseek-custom", "gpt-6-astra"])
+        assert rows[0]["models"] == ["deepseek-custom", "gpt-6-astra"]
+
     def test_unreadable_config_still_yields_a_full_catalog(self, monkeypatch):
         """One bad config block must not blank the picker."""
         monkeypatch.setattr(

--- a/tests/test_openai_provider_routing.py
+++ b/tests/test_openai_provider_routing.py
@@ -26,7 +26,8 @@ from src.providers.openai_responses import (
     supports_reasoning,
 )
 
-REASONING = ["gpt-5.6-luna", "gpt-5.5", "gpt-5", "o1-preview", "o3-mini", "o4-mini",
+REASONING = ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+             "gpt-5.5", "gpt-5", "o1-preview", "o3-mini", "o4-mini",
              "gpt-5-codex", "codex-mini-latest"]
 PLAIN = ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-3.5-turbo", "chatgpt-4o-latest",
          # the non-reasoning variants of a reasoning family — the prefix

--- a/tests/test_openai_subscription.py
+++ b/tests/test_openai_subscription.py
@@ -636,7 +636,11 @@ def test_effort_setting_reaches_reasoning_body(monkeypatch) -> None:
 def test_provider_lists_subscription_models(monkeypatch) -> None:
     provider = _subscription_provider(monkeypatch)
     models = provider.get_available_models()
+    assert models[:4] == [
+        "gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+    ]
     assert "gpt-5.5" in models and "gpt-5.3-codex-spark" in models
+    assert "gpt-4o" not in models and "gpt-5.4-pro" not in models
 
 
 def test_api_key_wins_over_subscription(monkeypatch) -> None:


### PR DESCRIPTION
After `clawcodex login` with a ChatGPT subscription, `/model` showed only four older OpenAI models and incorrectly placed every saved Fusion model under the active provider. For example, `deepseek-v4-flash-luna` appeared under OpenAI even though its base model runs on DeepSeek.

Refresh the subscription catalog with GPT-6 Astra and GPT-5.6 Sol, Terra, and Luna; add Astra to the API catalog and Responses routing. Resolve the inactive OpenAI row using the same subscription/API-key/custom-endpoint rules as a live provider. Group enabled Fusion models under their base provider, preserving native and discovered model lists and keeping the flat session inventory available for typed cross-provider selection.

Model IDs verified against [OpenAI's Codex model documentation](https://learn.chatgpt.com/docs/models) and [API model catalog](https://developers.openai.com/api/docs/models) on September 6, 2026. The subscription catalog remains curated; access depends on the account's plan.

Validation:
- 484 backend tests passed across providers, model commands, subscription auth, Responses routing, provider picker, and Fusion controls.
- 27 TUI tests passed for model picker, model switching, and provider display.
- Regression coverage reproduces the screenshot's misplaced Fusion model, checks inactive-provider grouping and aliases, excludes disabled Fusion entries, and checks subscription/API-key/custom-endpoint catalogs without network calls.
- `git diff --check` passed.

CI comparison: the full Linux suite passed 10,438 tests, with only the same two MiniMax `httpx`/`httpx2` SDK failures seen in the [previous merged PR's run](https://github.com/agentforce314/clawcodex/actions/runs/33786542170). Harbor's seven missing-`_websearch` failures also match that baseline exactly. Web and both desktop checks passed. Windows passed 10,414 tests; all six failures (Nano encoding/CRLF, directory permissions, config-home defaults, and the same two MiniMax SDK tests) also occurred in that baseline run. No new test failures were introduced. See the [complete PR CI run](https://github.com/agentforce314/clawcodex/actions/runs/34062868249).
