### PR TITLE
fix: include the Web UI URL in the installer completion message

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -683,7 +683,7 @@ run_post_install_setup() {
         echo -e "    ${C_BOLD}clawcodex login${C_RESET}        # interactive provider + key setup"
         echo -e "    ${C_BOLD}clawcodex${C_RESET}              # start the REPL in any project"
         echo -e "    ${C_BOLD}clawcodex tui${C_RESET}          # the Ink TUI (Claude-Code-style)"
-        echo -e "    ${C_BOLD}clawcodex web --build${C_RESET}  # first run: build and start the Web UI"
+        echo -e "    ${C_BOLD}clawcodex web --build${C_RESET}  # first run: build and start the Web UI at http://127.0.0.1:8081"
     else
         log_warn "clawcodex not on PATH yet — run 'source ~/.bashrc' (or ~/.zshrc) first."
     fi


### PR DESCRIPTION
Add the Web UI address to the installer completion hint so users can copy `clawcodex web --build` for their first run and know to open http://127.0.0.1:8081.

Validated with `bash -n install.sh`, `git diff --check`, and an isolated invocation of the completion-message function. The hosted installer copy in `Singula-Inc/clawcodex-website` is being synchronized as well because the public curl URL currently serves an older copy without any Web UI hint.
