### PR TITLE
feat(agents): session-scoped agent control plane with live status, pause and interrupt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Agent control plane — live subagent status, pause and interrupt.** A
+  session-scoped supervisor now sees every subagent from both spawn paths
+  (foreground delegations previously registered nowhere, so nothing could list
+  or stop them). The TUI agents overlay's status readout, pause key and kill
+  key are wired to it — they had no backend at all and silently did nothing.
+  The browser client gains an **Agents** tab listing live agents with their
+  model, tool count, age and status, with per-agent interrupt and a
+  session-wide pause. An interrupted agent reports itself as interrupted, not
+  as a completed delegation with partial output.
+- Two admission limits, both configurable: `CLAWCODEX_MAX_CONCURRENT_AGENTS`
+  (default 32 — a runaway backstop, not a scheduling budget) and
+  `CLAWCODEX_MAX_AGENT_DEPTH` (default 3). A refused spawn returns a tool error
+  the model can act on rather than failing the turn.
+
 ### Fixed
 
 - `anthropic` is capped below 1.0. Version 1.0.0 moved the SDK onto `httpx2`,

--- a/src/agent/subagent_context.py
+++ b/src/agent/subagent_context.py
@@ -252,6 +252,12 @@ def create_subagent_context(
         # the same store the parent queued into.
         runtime_tasks=parent_context.runtime_tasks,
         agent_name_registry=parent_context.agent_name_registry,
+        # Same reason, same sharing rule: the supervisor is the session's
+        # single view of what is live. A child with its own instance would
+        # admit against an empty registry, so nesting would bypass the
+        # capacity cap entirely and the overlay would never see the
+        # grandchildren it spawned.
+        agent_supervisor=parent_context.agent_supervisor,
     )
 
 

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -3919,8 +3919,10 @@ class _AgentSession:
         success — the overlay can be looking at a completed row whose agent has
         already gone, and telling it "interrupted" would be a lie.
         """
-        from src.tasks.local_agent import is_local_agent_task, kill_async_agent
-        from src.tasks_core import is_terminal_task_status
+        from src.tasks.local_agent import (
+            is_local_agent_task_terminal,
+            kill_async_agent,
+        )
 
         agent_id = str(subagent_id or "")
         if not agent_id:
@@ -3940,7 +3942,7 @@ class _AgentSession:
         registry = getattr(self.tool_context, "runtime_tasks", None)
         if registry is not None:
             state = registry.get(agent_id)
-            if is_local_agent_task(state) and not is_terminal_task_status(state.status):
+            if state is not None and not is_local_agent_task_terminal(state):
                 kill_async_agent(agent_id, registry)
                 found = True
 

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -930,6 +930,15 @@ class _AgentSession:
         if subtype == "vision":
             self._do_vision_command(request_id, inner.get("arg"))
             return
+        if subtype == "delegation_status":
+            self._do_delegation_status(request_id)
+            return
+        if subtype == "delegation_pause":
+            self._do_delegation_pause(request_id, inner.get("paused"))
+            return
+        if subtype == "subagent_interrupt":
+            self._do_subagent_interrupt(request_id, inner.get("subagent_id"))
+            return
         if subtype == "worktree_status":
             await self._do_worktree_status(request_id)
             return
@@ -3865,6 +3874,60 @@ class _AgentSession:
         from src.utils.worktree_session import WorktreeSession
 
         return WorktreeSession.from_env()
+
+    # ── Delegation control plane ─────────────────────────────────────────
+    #
+    # The TUI has declared these three response shapes in gatewayTypes.ts and
+    # called them from the agents overlay since before any of them existed on
+    # this side; unhandled RPCs resolve to `{}` in gatewayClient, so the
+    # overlay's status, pause, and interrupt controls were silently inert.
+    # These three handlers are the missing backend half, served off the
+    # session-scoped AgentSupervisor that both Agent spawn paths register with.
+
+    def _agent_supervisor(self) -> "Any | None":
+        """The session's supervisor, or None before the tool context exists."""
+        return getattr(self.tool_context, "agent_supervisor", None)
+
+    def _do_delegation_status(self, request_id: object) -> None:
+        """Authoritative live-agent snapshot (``DelegationStatusResponse``)."""
+        supervisor = self._agent_supervisor()
+        if supervisor is None:
+            # Report the caps as absent rather than inventing zeros: a client
+            # that reads 0/0 would render "at capacity" for a session that has
+            # no supervisor at all.
+            self._reply(request_id, {"active": [], "paused": False})
+            return
+        self._reply(request_id, supervisor.snapshot())
+
+    def _do_delegation_pause(self, request_id: object, paused: object) -> None:
+        """Toggle admission of new spawns; echo the resulting state.
+
+        Omitting ``paused`` flips the current value, which is what the
+        overlay's single pause key sends.
+        """
+        supervisor = self._agent_supervisor()
+        if supervisor is None:
+            self._reply(request_id, {"paused": False})
+            return
+        target = (not supervisor.is_paused()) if paused is None else bool(paused)
+        self._reply(request_id, {"paused": supervisor.set_paused(target)})
+
+    def _do_subagent_interrupt(self, request_id: object, subagent_id: object) -> None:
+        """Abort one live subagent. ``found`` is false when the id is not live.
+
+        Reports whether the id was actually live rather than always claiming
+        success — the overlay can be looking at a completed row whose agent has
+        already gone, and telling it "interrupted" would be a lie.
+        """
+        supervisor = self._agent_supervisor()
+        agent_id = str(subagent_id or "")
+        if supervisor is None or not agent_id:
+            self._reply(request_id, {"found": False, "subagent_id": agent_id})
+            return
+        self._reply(request_id, {
+            "found": supervisor.interrupt(agent_id),
+            "subagent_id": agent_id,
+        })
 
     async def _do_worktree_status(self, request_id: object) -> None:
         """Exit-time snapshot for the client's keep/remove decision.

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -3919,15 +3919,39 @@ class _AgentSession:
         success — the overlay can be looking at a completed row whose agent has
         already gone, and telling it "interrupted" would be a lie.
         """
-        supervisor = self._agent_supervisor()
+        from src.tasks.local_agent import is_local_agent_task, kill_async_agent
+        from src.tasks_core import is_terminal_task_status
+
         agent_id = str(subagent_id or "")
-        if supervisor is None or not agent_id:
-            self._reply(request_id, {"found": False, "subagent_id": agent_id})
+        if not agent_id:
+            self._reply(request_id, {"found": False, "subagent_id": ""})
             return
-        self._reply(request_id, {
-            "found": supervisor.interrupt(agent_id),
-            "subagent_id": agent_id,
-        })
+
+        found = False
+
+        # A BACKGROUND agent must go through kill_async_agent, not a bare
+        # abort. query() RETURNS rather than raising when its controller is
+        # aborted, so _background_lifecycle would take its success branch and
+        # report the killed delegation to the model as "completed" with an
+        # empty result. kill_async_agent is what flips the registry to
+        # "killed" first — which is precisely the precondition
+        # _background_lifecycle's own comment says it relies on — and it also
+        # schedules eviction and enqueues the single task-notification.
+        registry = getattr(self.tool_context, "runtime_tasks", None)
+        if registry is not None:
+            state = registry.get(agent_id)
+            if is_local_agent_task(state) and not is_terminal_task_status(state.status):
+                kill_async_agent(agent_id, registry)
+                found = True
+
+        # Foreground agents live only in the supervisor. This also flips the
+        # snapshot's status to "interrupted" so a poll taken during wind-down
+        # says "stopping", not "running".
+        supervisor = self._agent_supervisor()
+        if supervisor is not None and supervisor.interrupt(agent_id):
+            found = True
+
+        self._reply(request_id, {"found": found, "subagent_id": agent_id})
 
     async def _do_worktree_status(self, request_id: object) -> None:
         """Exit-time snapshot for the client's keep/remove decision.

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -3920,6 +3920,7 @@ class _AgentSession:
         already gone, and telling it "interrupted" would be a lie.
         """
         from src.tasks.local_agent import (
+            is_local_agent_task,
             is_local_agent_task_terminal,
             kill_async_agent,
         )
@@ -3942,7 +3943,12 @@ class _AgentSession:
         registry = getattr(self.tool_context, "runtime_tasks", None)
         if registry is not None:
             state = registry.get(agent_id)
-            if state is not None and not is_local_agent_task_terminal(state):
+            # BOTH halves matter. is_local_agent_task_terminal returns False
+            # for a state that is not an agent at all, so without the type
+            # guard a background-bash or workflow id would report found=True
+            # while kill_async_agent's own isinstance guard quietly did
+            # nothing — the exact lie this handler's docstring exists to avoid.
+            if is_local_agent_task(state) and not is_local_agent_task_terminal(state):
                 kill_async_agent(agent_id, registry)
                 found = True
 

--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -911,6 +911,9 @@ class GatewayConnection:
             "slash.exec": self.slash_exec,
             "command.dispatch": self.command_dispatch,
             "setup.status": self.setup_status,
+            "delegation.status": self.delegation_status,
+            "delegation.pause": self.delegation_pause,
+            "subagent.interrupt": self.subagent_interrupt,
         }
 
     async def on_open(self) -> None:
@@ -1468,6 +1471,47 @@ class GatewayConnection:
             "path": str(result.get("plan_file_path") or ""),
             "plan": plan if isinstance(plan, str) else "",
         }
+
+    # ── delegation control plane ─────────────────────────────────────────────
+    #
+    # Thin forwarders onto the agent-server's supervisor, so the browser reads
+    # the same authoritative live-agent state the TUI overlay does instead of
+    # reconstructing a tree from streamed progress events.
+
+    async def delegation_status(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Live subagents plus the session's capacity caps."""
+        result = await self._session(params).control_query("delegation_status", {})
+        if not isinstance(result, dict):
+            # A dead or unanswering session must still yield a renderable shape;
+            # the panel maps over `active` unconditionally.
+            return {"active": []}
+        return result
+
+    async def delegation_pause(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Stop or resume admission of new subagents.
+
+        ``paused`` is forwarded only when the caller stated one — omitting it
+        asks the backend to flip the current value.
+        """
+        forwarded: dict[str, Any] = {}
+        if params.get("paused") is not None:
+            forwarded["paused"] = bool(params.get("paused"))
+        result = await self._session(params).control_query("delegation_pause", forwarded)
+        if not isinstance(result, dict):
+            return {"paused": False}
+        return result
+
+    async def subagent_interrupt(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Abort one live subagent; ``found`` is false when it was not live."""
+        agent_id = str(params.get("subagent_id") or "")
+        if not agent_id:
+            return {"found": False, "subagent_id": ""}
+        result = await self._session(params).control_query(
+            "subagent_interrupt", {"subagent_id": agent_id},
+        )
+        if not isinstance(result, dict):
+            return {"found": False, "subagent_id": agent_id}
+        return result
 
     async def image_attach(self, params: dict[str, Any]) -> dict[str, Any]:
         """Attach a pasted or dropped image to the next prompt.

--- a/src/services/swarm/agent_supervisor.py
+++ b/src/services/swarm/agent_supervisor.py
@@ -1,0 +1,326 @@
+"""Session-scoped admission control and live-agent bookkeeping for subagents.
+
+Clawcodex spawns subagents down two paths that never met: ``_run_sync_agent``
+(foreground, returns inline) and ``_launch_async_agent`` (background, lands in
+``runtime_tasks``). Only the background path was observable, so nothing in the
+process knew how many agents were live, nothing bounded how many could be
+started, and the TUI's agents overlay had no authoritative snapshot to read —
+it reconstructed a tree from streamed ``agent_progress`` events alone.
+
+This module is the missing shared authority. Both spawn paths call
+:meth:`AgentSupervisor.admit` before running and :meth:`AgentSupervisor.release`
+when the worker actually exits, so one session-owned object answers "what is
+running right now", enforces capacity, and holds the abort handles that make
+interruption work for foreground agents too.
+
+Modelled on the OpenAI Codex ``AgentRegistry`` (``codex-rs/core/src/agent/
+registry.rs``): ``reserve_spawn_slot`` rejects with ``AgentLimitReached`` past a
+thread cap, and ``exceeds_thread_spawn_depth_limit`` bounds nesting. The two
+limits are deliberately independent there, and stay independent here.
+
+The wire shape of :meth:`snapshot` is the ``DelegationStatusResponse`` the TUI
+already declared in ``ui-tui/src/gatewayTypes.ts`` — including
+``max_concurrent_children`` and ``max_spawn_depth``, which is what the client
+has been asking the backend for since before this existed.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+__all__ = [
+    "DEFAULT_MAX_CONCURRENT_CHILDREN",
+    "DEFAULT_MAX_SPAWN_DEPTH",
+    "AgentAdmissionError",
+    "AgentSupervisor",
+    "max_concurrent_children",
+    "max_spawn_depth",
+]
+
+#: Default ceiling on agents live at once in one session.
+#:
+#: Matched to ``orchestrator._DEFAULT_MAX_TOOL_USE_CONCURRENCY`` (10) on
+#: purpose: a batch of parallel *foreground* Agent calls is already bounded by
+#: the tool-use orchestrator at that number, so this cap can never deny work the
+#: orchestrator would itself have admitted. What it does bound is the
+#: *background* path, which detaches from the tool loop and was previously
+#: unbounded — the actual runaway case. Raise via
+#: ``CLAWCODEX_MAX_CONCURRENT_AGENTS``.
+DEFAULT_MAX_CONCURRENT_CHILDREN = 10
+
+#: Default ceiling on spawn nesting. Depth 0 is a child of the root session.
+#:
+#: Defense in depth rather than the primary lever: ``AGENT_TOOL_NAME`` is in
+#: ``ALL_AGENT_DISALLOWED_TOOLS``, so an ordinary subagent cannot spawn a
+#: grandchild at all. This bounds the paths that bypass that filter — the fork
+#: agent, coordinator workers, and ``workflow/runner.py`` — instead of relying
+#: on each of them to bound itself. Raise via ``CLAWCODEX_MAX_AGENT_DEPTH``.
+DEFAULT_MAX_SPAWN_DEPTH = 3
+
+_ENV_MAX_CONCURRENT = "CLAWCODEX_MAX_CONCURRENT_AGENTS"
+_ENV_MAX_DEPTH = "CLAWCODEX_MAX_AGENT_DEPTH"
+
+
+def _positive_int_env(name: str, fallback: int) -> int:
+    """Read a positive-integer override, falling back on absent/garbage input."""
+    override = os.environ.get(name, "").strip()
+    if override:
+        try:
+            return max(1, int(override))
+        except ValueError:
+            pass
+    return fallback
+
+
+def max_concurrent_children() -> int:
+    """Resolve the live-agent cap. ``CLAWCODEX_MAX_CONCURRENT_AGENTS`` wins."""
+    return _positive_int_env(_ENV_MAX_CONCURRENT, DEFAULT_MAX_CONCURRENT_CHILDREN)
+
+
+def max_spawn_depth() -> int:
+    """Resolve the nesting cap. ``CLAWCODEX_MAX_AGENT_DEPTH`` wins."""
+    return _positive_int_env(_ENV_MAX_DEPTH, DEFAULT_MAX_SPAWN_DEPTH)
+
+
+class AgentAdmissionError(Exception):
+    """A spawn was refused by the supervisor.
+
+    Raised by :meth:`AgentSupervisor.admit`. The Agent tool translates this
+    into a model-facing ``ToolResult`` error rather than letting it escape as a
+    crash — the message is written to tell the model what to do next, because
+    the model is the caller that has to react to it.
+    """
+
+    def __init__(self, message: str, *, reason: str) -> None:
+        super().__init__(message)
+        #: Machine-readable discriminator: ``paused`` | ``depth`` | ``capacity``.
+        self.reason = reason
+
+
+@dataclass
+class _LiveAgent:
+    """One admitted agent. Mutable; guarded by the supervisor's lock."""
+
+    subagent_id: str
+    parent_id: str | None
+    depth: int
+    goal: str
+    model: str | None
+    status: str = "running"
+    started_at: float = field(default_factory=time.time)
+    tool_count: int = 0
+    # The run's AbortController. ``query()`` polls ``signal.aborted`` at every
+    # yield point, so calling ``.abort()`` on it halts a live run. Held here so
+    # foreground agents — which never enter ``runtime_tasks`` and so have no
+    # other abort handle anywhere — can be interrupted too.
+    abort_controller: Any = field(default=None, repr=False)
+
+    def to_wire(self) -> dict[str, Any]:
+        """Project to one ``DelegationStatusResponse.active[]`` entry."""
+        return {
+            "subagent_id": self.subagent_id,
+            "parent_id": self.parent_id,
+            "depth": self.depth,
+            "goal": self.goal,
+            "model": self.model,
+            "status": self.status,
+            "started_at": self.started_at,
+            "tool_count": self.tool_count,
+        }
+
+
+class AgentSupervisor:
+    """Thread-safe admission control and live-agent registry for one session.
+
+    Agents run on worker threads (``asyncio.to_thread`` for sync tool calls,
+    ``task_manager.start`` for background ones), so every method takes an
+    ``RLock``. Following the same contract as ``AgentNameRegistry``: callers
+    must not hold the lock across an ``await``, and no method here does — the
+    one operation that touches foreign code, ``interrupt``, fires the abort
+    *outside* the lock, matching ``kill_async_agent``'s ordering.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_concurrent: int | None = None,
+        max_depth: int | None = None,
+    ) -> None:
+        self._lock = threading.RLock()
+        self._live: dict[str, _LiveAgent] = {}
+        self._paused = False
+        self._max_concurrent = (
+            max_concurrent if max_concurrent is not None else max_concurrent_children()
+        )
+        self._max_depth = max_depth if max_depth is not None else max_spawn_depth()
+
+    # -- capacity ---------------------------------------------------------
+
+    @property
+    def max_concurrent(self) -> int:
+        return self._max_concurrent
+
+    @property
+    def max_depth(self) -> int:
+        return self._max_depth
+
+    def live_count(self) -> int:
+        """How many agents are admitted and not yet released."""
+        with self._lock:
+            return len(self._live)
+
+    # -- admission --------------------------------------------------------
+
+    def admit(
+        self,
+        *,
+        subagent_id: str,
+        parent_id: str | None = None,
+        depth: int = 0,
+        goal: str = "",
+        model: str | None = None,
+        abort_controller: Any = None,
+    ) -> None:
+        """Reserve a slot for ``subagent_id`` or raise :class:`AgentAdmissionError`.
+
+        Refuses, in order, when delegation is paused, when ``depth`` exceeds the
+        nesting cap, and when the session is already at capacity. Re-admitting an
+        id that is already live is a no-op rather than an error, so a retry that
+        races its own registration cannot double-count a slot.
+        """
+        with self._lock:
+            if subagent_id in self._live:
+                return
+
+            if self._paused:
+                raise AgentAdmissionError(
+                    "Delegation is paused for this session, so no new agent was "
+                    "started. Do the work directly, or ask the user to resume "
+                    "delegation.",
+                    reason="paused",
+                )
+
+            if depth > self._max_depth:
+                raise AgentAdmissionError(
+                    f"Agent nesting depth {depth} exceeds the limit of "
+                    f"{self._max_depth}. Do this work in the current agent "
+                    f"instead of spawning another one.",
+                    reason="depth",
+                )
+
+            if len(self._live) >= self._max_concurrent:
+                raise AgentAdmissionError(
+                    f"This session already has {len(self._live)} agents running, "
+                    f"which is the limit of {self._max_concurrent}. Wait for one "
+                    f"to finish before spawning another.",
+                    reason="capacity",
+                )
+
+            self._live[subagent_id] = _LiveAgent(
+                subagent_id=subagent_id,
+                parent_id=parent_id,
+                depth=depth,
+                goal=goal,
+                model=model,
+                abort_controller=abort_controller,
+            )
+
+    def release(self, subagent_id: str) -> bool:
+        """Free the slot held by ``subagent_id``. Returns True iff one was held.
+
+        Call this when the worker has actually exited, not when its status was
+        merely labelled terminal. Codex holds its ``SpawnReservation`` for the
+        same window; releasing on the label instead would let a replacement
+        generation start while the old one is still running.
+        """
+        with self._lock:
+            return self._live.pop(subagent_id, None) is not None
+
+    # -- live state -------------------------------------------------------
+
+    def set_status(self, subagent_id: str, status: str) -> None:
+        """Update a live agent's status. No-op once it has been released."""
+        with self._lock:
+            agent = self._live.get(subagent_id)
+            if agent is not None:
+                agent.status = status
+
+    def set_tool_count(self, subagent_id: str, count: int) -> None:
+        """Set a live agent's tool counter. No-op once it has been released.
+
+        Absolute rather than incremental: the caller already holds a
+        ``ProgressTracker`` with the authoritative running total, and a
+        progress hook that fires more than once per tool would double-count an
+        incremental API.
+        """
+        with self._lock:
+            agent = self._live.get(subagent_id)
+            if agent is not None:
+                agent.tool_count = count
+
+    # -- controls ---------------------------------------------------------
+
+    def set_paused(self, paused: bool) -> bool:
+        """Set whether new spawns are admitted. Returns the resulting state.
+
+        Pausing does not touch agents already running — it only closes the door
+        on new ones, which is what the overlay's pause control means.
+        """
+        with self._lock:
+            self._paused = bool(paused)
+            return self._paused
+
+    def is_paused(self) -> bool:
+        with self._lock:
+            return self._paused
+
+    def interrupt(self, subagent_id: str) -> bool:
+        """Abort a live agent's run. Returns True iff the id was live.
+
+        The entry is deliberately *not* removed: the slot stays held until the
+        worker reaches its own exit and calls :meth:`release`. Status flips to
+        ``interrupted`` so a snapshot taken during the wind-down window tells
+        the truth — the agent is stopping, not stopped.
+        """
+        with self._lock:
+            agent = self._live.get(subagent_id)
+            if agent is None:
+                return False
+            agent.status = "interrupted"
+            controller = agent.abort_controller
+
+        # Outside the lock: ``.abort()`` runs foreign code. Same ordering as
+        # ``kill_async_agent``, which aborts after leaving the registry lock.
+        if controller is not None:
+            try:
+                controller.abort("interrupted by user")
+            except Exception:  # noqa: BLE001 - an abort must never propagate
+                pass
+        return True
+
+    def interrupt_all(self) -> int:
+        """Abort every live agent. Returns how many were signalled."""
+        with self._lock:
+            ids = list(self._live)
+        return sum(1 for agent_id in ids if self.interrupt(agent_id))
+
+    # -- observation ------------------------------------------------------
+
+    def snapshot(self) -> dict[str, Any]:
+        """Authoritative state, in ``DelegationStatusResponse`` wire shape.
+
+        Ordered by start time so the overlay renders a stable list rather than
+        one that reshuffles on dict iteration order between polls.
+        """
+        with self._lock:
+            active = [a.to_wire() for a in sorted(self._live.values(), key=lambda a: a.started_at)]
+            return {
+                "active": active,
+                "max_concurrent_children": self._max_concurrent,
+                "max_spawn_depth": self._max_depth,
+                "paused": self._paused,
+            }

--- a/src/services/swarm/agent_supervisor.py
+++ b/src/services/swarm/agent_supervisor.py
@@ -4,14 +4,19 @@ Clawcodex spawns subagents down two paths that never met: ``_run_sync_agent``
 (foreground, returns inline) and ``_launch_async_agent`` (background, lands in
 ``runtime_tasks``). Only the background path was observable, so nothing in the
 process knew how many agents were live, nothing bounded how many could be
-started, and the TUI's agents overlay had no authoritative snapshot to read —
-it reconstructed a tree from streamed ``agent_progress`` events alone.
+started, and neither client could ask what was running.
 
-This module is the missing shared authority. Both spawn paths call
+This module is the missing shared authority. Both Agent-tool spawn paths call
 :meth:`AgentSupervisor.admit` before running and :meth:`AgentSupervisor.release`
 when the worker actually exits, so one session-owned object answers "what is
 running right now", enforces capacity, and holds the abort handles that make
 interruption work for foreground agents too.
+
+Not yet covered: ``src/workflow/runner.py`` drives ``run_agent`` directly rather
+than through the Agent tool, so workflow agents consume no slot here, do not
+appear in :meth:`snapshot`, and cannot be interrupted through it. They have
+their own cap (``workflow/constants.py``). Routing them through this supervisor
+is deliberate future work, not an oversight to read past.
 
 Modelled on the OpenAI Codex ``AgentRegistry`` (``codex-rs/core/src/agent/
 registry.rs``): ``reserve_spawn_slot`` rejects with ``AgentLimitReached`` past a
@@ -22,6 +27,11 @@ The wire shape of :meth:`snapshot` is the ``DelegationStatusResponse`` the TUI
 already declared in ``ui-tui/src/gatewayTypes.ts`` — including
 ``max_concurrent_children`` and ``max_spawn_depth``, which is what the client
 has been asking the backend for since before this existed.
+
+Which client reads what: ``ui-web``'s agents panel renders ``active[]`` from
+this snapshot. ``ui-tui``'s overlay consumes only the caps and ``paused`` — its
+rows still come from the reconstructed ``agent_progress`` tree, so its pause and
+kill controls are now live but its list is not yet served from here.
 """
 
 from __future__ import annotations
@@ -43,22 +53,31 @@ __all__ = [
 
 #: Default ceiling on agents live at once in one session.
 #:
-#: Matched to ``orchestrator._DEFAULT_MAX_TOOL_USE_CONCURRENCY`` (10) on
-#: purpose: a batch of parallel *foreground* Agent calls is already bounded by
-#: the tool-use orchestrator at that number, so this cap can never deny work the
-#: orchestrator would itself have admitted. What it does bound is the
-#: *background* path, which detaches from the tool loop and was previously
-#: unbounded — the actual runaway case. Raise via
-#: ``CLAWCODEX_MAX_CONCURRENT_AGENTS``.
-DEFAULT_MAX_CONCURRENT_CHILDREN = 10
+#: This is a runaway backstop, NOT a scheduling budget — deliberately set well
+#: above any legitimate fan-out so that hitting it means something is wrong.
+#:
+#: It cannot be derived from the tool-use orchestrator's own bound
+#: (``_DEFAULT_MAX_TOOL_USE_CONCURRENCY``, 10), because the two count different
+#: things: a background agent holds its slot until its *worker* exits, which can
+#: be many turns after the tool call returned. Three background agents from an
+#: earlier turn plus a ten-wide foreground batch is 13 live agents from a
+#: session the orchestrator never over-admitted. Coordinator mode makes that
+#: routine — every coordinator spawn is forced async and its prompt actively
+#: teaches fan-out ("Parallelism is your superpower").
+#:
+#: Raise (or lower, to actually schedule) via ``CLAWCODEX_MAX_CONCURRENT_AGENTS``.
+DEFAULT_MAX_CONCURRENT_CHILDREN = 32
 
 #: Default ceiling on spawn nesting. Depth 0 is a child of the root session.
 #:
 #: Defense in depth rather than the primary lever: ``AGENT_TOOL_NAME`` is in
 #: ``ALL_AGENT_DISALLOWED_TOOLS``, so an ordinary subagent cannot spawn a
-#: grandchild at all. This bounds the paths that bypass that filter — the fork
-#: agent, coordinator workers, and ``workflow/runner.py`` — instead of relying
-#: on each of them to bound itself. Raise via ``CLAWCODEX_MAX_AGENT_DEPTH``.
+#: grandchild at all — and coordinator workers cannot either, since Agent is
+#: also absent from ``ASYNC_AGENT_ALLOWED_TOOLS``. The one path that genuinely
+#: bypasses that filter is the fork agent (``use_exact_tools=True`` copies the
+#: parent's tool array verbatim, Agent included). ``workflow/runner.py`` is not
+#: bounded by this at all: it calls ``run_agent`` directly and never reaches
+#: ``admit`` — see the module docstring. Raise via ``CLAWCODEX_MAX_AGENT_DEPTH``.
 DEFAULT_MAX_SPAWN_DEPTH = 3
 
 _ENV_MAX_CONCURRENT = "CLAWCODEX_MAX_CONCURRENT_AGENTS"
@@ -216,7 +235,8 @@ class AgentSupervisor:
                 raise AgentAdmissionError(
                     f"This session already has {len(self._live)} agents running, "
                     f"which is the limit of {self._max_concurrent}. Wait for one "
-                    f"to finish before spawning another.",
+                    f"to finish before spawning another, or tell the user they "
+                    f"can raise {_ENV_MAX_CONCURRENT}.",
                     reason="capacity",
                 )
 
@@ -248,6 +268,17 @@ class AgentSupervisor:
             agent = self._live.get(subagent_id)
             if agent is not None:
                 agent.status = status
+
+    def is_interrupted(self, subagent_id: str) -> bool:
+        """Whether this agent was interrupted. False once it has been released.
+
+        Read it BEFORE :meth:`release` — a finished run has to know how it
+        ended in order to report that honestly, and the entry is gone
+        afterwards.
+        """
+        with self._lock:
+            agent = self._live.get(subagent_id)
+            return agent is not None and agent.status == "interrupted"
 
     def set_tool_count(self, subagent_id: str, count: int) -> None:
         """Set a live agent's tool counter. No-op once it has been released.
@@ -301,12 +332,6 @@ class AgentSupervisor:
             except Exception:  # noqa: BLE001 - an abort must never propagate
                 pass
         return True
-
-    def interrupt_all(self) -> int:
-        """Abort every live agent. Returns how many were signalled."""
-        with self._lock:
-            ids = list(self._live)
-        return sum(1 for agent_id in ids if self.interrupt(agent_id))
 
     # -- observation ------------------------------------------------------
 

--- a/src/tool_system/context.py
+++ b/src/tool_system/context.py
@@ -9,6 +9,7 @@ from .errors import ToolPermissionError
 from .task_manager import TaskManager
 from src.permissions.types import PermissionAskHandler, ToolPermissionContext
 from src.services.swarm.agent_name_registry import AgentNameRegistry
+from src.services.swarm.agent_supervisor import AgentSupervisor
 from src.task_registry import RuntimeTaskRegistry
 from src.utils.abort_controller import AbortController
 
@@ -132,6 +133,12 @@ class ToolContext:
     #   old terminal holders remain reachable by raw task_id + auto-
     #   resume (WI-7.4).
     agent_name_registry: AgentNameRegistry = field(default_factory=AgentNameRegistry)
+    # Session-scoped admission control + live-agent registry, shared BY
+    # REFERENCE with every child context (subagent_context.py) so one
+    # object sees the whole tree. Both spawn paths register here — the
+    # foreground one has no other home, which is why the overlay could
+    # never see or interrupt a synchronous delegation.
+    agent_supervisor: AgentSupervisor = field(default_factory=AgentSupervisor)
     # Background Bash commands spawned via ``run_in_background: true``.
     # Kept as a deprecated dict-of-dicts compatibility view during the
     # Chunk-B migration cycle; the bash spawn writer now populates

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -50,6 +50,7 @@ from src.agent.fork_subagent import (
 )
 from src.agent.prompt import get_agent_prompt, get_agent_system_prompt
 from src.agent.run_agent import RunAgentParams, run_agent
+from src.services.swarm.agent_supervisor import AgentAdmissionError
 
 logger = logging.getLogger(__name__)
 
@@ -407,6 +408,15 @@ def make_agent_tool(
         except Exception:  # noqa: BLE001
             logger.debug("subagent model preview failed", exc_info=True)
 
+        # Depth: query_tracking is None on the root session, and
+        # build_subagent_context sets depth = parent_depth + 1, so a top-level
+        # delegation is depth 0. Read it the same way here so the number the
+        # supervisor caps is the number the child will actually carry — and so
+        # the progress emit below can report it (the overlay reads `depth` off
+        # the event and was defaulting every agent to 0, flattening its tree).
+        _tracking = getattr(context, "query_tracking", None)
+        _depth = (_tracking.depth + 1) if _tracking is not None else 0
+
         # Stream the subagent's live progress to the UI when the host wired a
         # hook (agent-server only). run_agent calls on_message per message, so
         # this covers both the sync and background paths. Purely additive — no
@@ -429,8 +439,15 @@ def make_agent_tool(
                     if acts:
                         last = acts[-1]
                         activity = last.activity_description or last.tool_name
+                    # Feed the supervisor the same counter the HUD shows, so
+                    # `delegation.status` reports real progress instead of a
+                    # tool_count frozen at 0 for the agent's whole lifetime.
+                    context.agent_supervisor.set_tool_count(
+                        agent_id, _tracker.tool_use_count,
+                    )
                     _emit_progress({
                         "agent_id": agent_id,
+                        "depth": _depth,
                         "name": agent_name,
                         "description": description,
                         "subagent_type": subagent_type,
@@ -445,18 +462,58 @@ def make_agent_tool(
 
             run_params.on_message = _on_subagent_message
 
-        if is_async:
-            return _launch_async_agent(
-                run_params=run_params,
-                context=context,
-                agent_id=agent_id,
-                description=description,
-                prompt=prompt,
-                agent_type=agent_def.agent_type,
-                agent_name=agent_name,
-                resolved_model=resolved_model,
+        # ── Admission control ────────────────────────────────────────────
+        # One session-scoped supervisor gates BOTH spawn paths. The abort
+        # controller is built here rather than inside the background wrapper so
+        # a *foreground* delegation also has a reachable abort handle — that is
+        # what makes `subagent.interrupt` work for sync agents, which never
+        # enter runtime_tasks and previously could not be stopped at all.
+        from src.utils.abort_controller import AbortController as _AbortController
+
+        if run_params.abort_controller is None:
+            run_params.abort_controller = _AbortController()
+
+        try:
+            context.agent_supervisor.admit(
+                subagent_id=agent_id,
+                # The spawning agent's own id — None on the root session, which
+                # is what makes a top-level delegation a tree root. NOT
+                # query_tracking.chain_id: that is a fresh uuid per child
+                # context, so it matches no subagent_id and would orphan every
+                # row the clients try to nest.
+                parent_id=getattr(context, "agent_id", None),
+                depth=_depth,
+                goal=description or (prompt or "")[:80],
+                model=resolved_model,
+                abort_controller=run_params.abort_controller,
             )
-        else:
+        except AgentAdmissionError as exc:
+            # Refusal is a normal outcome the model must react to, not a crash:
+            # return it as a tool error so the turn continues and the model can
+            # do the work itself or wait for a slot.
+            return ToolResult(
+                name=AGENT_TOOL_NAME,
+                output={"status": "refused", "reason": exc.reason, "error": str(exc)},
+                is_error=True,
+            )
+
+        # A launch that fails AFTER admission (a name collision raising
+        # ToolInputError, say) would otherwise strand the slot for the life of
+        # the session — the background wrapper's release only runs once its
+        # lifecycle has started. The sync path releases in its own finally, so
+        # this guard covers the window before either takes over.
+        try:
+            if is_async:
+                return _launch_async_agent(
+                    run_params=run_params,
+                    context=context,
+                    agent_id=agent_id,
+                    description=description,
+                    prompt=prompt,
+                    agent_type=agent_def.agent_type,
+                    agent_name=agent_name,
+                    resolved_model=resolved_model,
+                )
             return _run_sync_agent(
                 run_params=run_params,
                 agent_id=agent_id,
@@ -467,6 +524,9 @@ def make_agent_tool(
                 agent_name=agent_name,
                 resolved_model=resolved_model,
             )
+        except BaseException:
+            context.agent_supervisor.release(agent_id)
+            raise
 
     def _run_sync_agent(
         *,
@@ -527,6 +587,13 @@ def make_agent_tool(
                 status="failed", model=resolved_model,
             )
             raise
+        finally:
+            # The worker has genuinely exited by here (the messages are
+            # collected and finalize_agent_tool has returned), so this is the
+            # earliest honest point to free the slot. Releasing on a status
+            # label instead would let a replacement spawn start while this run
+            # was still on the wire.
+            run_params.parent_context.agent_supervisor.release(agent_id)
 
         # ch13 round-4 (critic M1) — emit a TERMINAL agent_progress so the
         # TUI's subagent HUD marks this subagent complete instead of
@@ -630,9 +697,13 @@ def make_agent_tool(
         # its own internal controller (run_agent.py:291), but now reachable.
         # Setting run_params.abort_controller makes run_agent use THIS one
         # (run_agent.py:286-287) instead of an unreachable internal one.
+        # ``_agent_call`` now builds it before admission so the supervisor holds
+        # the same handle; only direct callers of this helper still land here.
         from src.utils.abort_controller import AbortController as _AbortController
-        _async_abort = _AbortController()
-        run_params.abort_controller = _async_abort
+
+        if run_params.abort_controller is None:
+            run_params.abort_controller = _AbortController()
+        _async_abort = run_params.abort_controller
 
         register_async_agent(
             agent_id=agent_id,
@@ -798,6 +869,10 @@ def make_agent_tool(
                 # not just this backgrounded wrapper.
                 if transcript is not None:
                     transcript.close()
+                # Same contract as the sync path: the slot is held until the
+                # background worker actually stops, including when it stops by
+                # being interrupted.
+                context.agent_supervisor.release(agent_id)
 
         try:
             running_loop = asyncio.get_running_loop()

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -54,6 +54,11 @@ from src.services.swarm.agent_supervisor import AgentAdmissionError
 
 logger = logging.getLogger(__name__)
 
+# Strong references to in-flight background lifecycles. asyncio keeps only a
+# weak reference to a bare ``create_task`` result, so without this a task can be
+# collected mid-flight and silently never finish.
+_BACKGROUND_LIFECYCLES: "set[Any]" = set()
+
 
 def _emit_terminal_agent_progress(
     parent_context: Any,
@@ -409,11 +414,9 @@ def make_agent_tool(
             logger.debug("subagent model preview failed", exc_info=True)
 
         # Depth: query_tracking is None on the root session, and
-        # build_subagent_context sets depth = parent_depth + 1, so a top-level
+        # create_subagent_context sets depth = parent_depth + 1, so a top-level
         # delegation is depth 0. Read it the same way here so the number the
-        # supervisor caps is the number the child will actually carry — and so
-        # the progress emit below can report it (the overlay reads `depth` off
-        # the event and was defaulting every agent to 0, flattening its tree).
+        # supervisor caps is the number the child will actually carry.
         _tracking = getattr(context, "query_tracking", None)
         _depth = (_tracking.depth + 1) if _tracking is not None else 0
 
@@ -442,6 +445,14 @@ def make_agent_tool(
                     # Feed the supervisor the same counter the HUD shows, so
                     # `delegation.status` reports real progress instead of a
                     # tool_count frozen at 0 for the agent's whole lifetime.
+                    #
+                    # Reaches only TOP-LEVEL agents today: agent_progress_emit is
+                    # set on the root tool_context alone (agent_server.py:6106)
+                    # and create_subagent_context does not carry it down, so a
+                    # nested agent never runs this hook and its tool_count stays
+                    # 0. Same reason `depth` below is always 0 in practice — it
+                    # is the right value to send, and becomes meaningful the day
+                    # the emit hook is propagated to child contexts.
                     context.agent_supervisor.set_tool_count(
                         agent_id, _tracker.tool_use_count,
                     )
@@ -463,15 +474,33 @@ def make_agent_tool(
             run_params.on_message = _on_subagent_message
 
         # ── Admission control ────────────────────────────────────────────
-        # One session-scoped supervisor gates BOTH spawn paths. The abort
-        # controller is built here rather than inside the background wrapper so
-        # a *foreground* delegation also has a reachable abort handle — that is
-        # what makes `subagent.interrupt` work for sync agents, which never
-        # enter runtime_tasks and previously could not be stopped at all.
-        from src.utils.abort_controller import AbortController as _AbortController
+        # One session-scoped supervisor gates BOTH spawn paths. Each agent needs
+        # its OWN abort handle for `subagent.interrupt` to reach it — a
+        # foreground delegation never enters runtime_tasks, so the supervisor is
+        # the only place that handle can live.
+        #
+        # But it must be a handle, not a replacement. run_agent resolves
+        # `explicit override → fresh controller for async → THE PARENT'S OWN
+        # controller for sync` (run_agent.py:292-300), so unconditionally
+        # setting an override takes the first branch and silently severs the
+        # link a sync spawn used to get for free — parent ESC / turn cancel
+        # would stop reaching foreground subagents. A *child* controller keeps
+        # that propagation while staying individually abortable: parent abort
+        # reaches the child, and interrupting one subagent does not end the
+        # parent's turn (create_child_abort_controller is one-way by design).
+        from src.utils.abort_controller import (
+            AbortController as _AbortController,
+            create_child_abort_controller as _child_abort_controller,
+        )
 
         if run_params.abort_controller is None:
-            run_params.abort_controller = _AbortController()
+            run_params.abort_controller = (
+                # Async agents deliberately survive parent cancellation, which
+                # is the `elif params.is_async` branch's whole point — keep them
+                # unlinked.
+                _AbortController() if is_async
+                else _child_abort_controller(context.abort_controller)
+            )
 
         try:
             context.agent_supervisor.admit(
@@ -544,6 +573,7 @@ def make_agent_tool(
         from src.types.messages import Message
 
         agent_messages: list[Message] = []
+        interrupted = False
         # R5 (ch13) — the HUD goal label: use the SAME name/description the
         # running emits use, not the truncated prompt (critic residual).
         _hud_name = agent_name if agent_name is not None else \
@@ -593,7 +623,11 @@ def make_agent_tool(
             # earliest honest point to free the slot. Releasing on a status
             # label instead would let a replacement spawn start while this run
             # was still on the wire.
-            run_params.parent_context.agent_supervisor.release(agent_id)
+            _supervisor = run_params.parent_context.agent_supervisor
+            # Read BEFORE releasing — the entry is gone afterwards, and the
+            # result below has to say how the run actually ended.
+            interrupted = _supervisor.is_interrupted(agent_id)
+            _supervisor.release(agent_id)
 
         # ch13 round-4 (critic M1) — emit a TERMINAL agent_progress so the
         # TUI's subagent HUD marks this subagent complete instead of
@@ -601,13 +635,33 @@ def make_agent_tool(
         _emit_terminal_agent_progress(
             run_params.parent_context, agent_id=agent_id, name=_hud_name,
             description=_hud_desc, subagent_type=agent_type,
-            status="completed", model=resolved_model,
+            status="interrupted" if interrupted else "completed",
+            model=resolved_model,
         )
+
+        # An aborted query() RETURNS rather than raising, so finalize_agent_tool
+        # succeeds on the partial transcript and this path is reached for an
+        # interrupted agent too. Reporting "completed" here would tell the model
+        # a delegation the user killed had succeeded — with whatever partial
+        # text it had produced — and it would act on that. Say what happened,
+        # in the content the model actually reads.
+        content = result.content
+        if interrupted:
+            content = [
+                {
+                    "type": "text",
+                    "text": (
+                        "[This agent was interrupted before it finished. Any "
+                        "output below is partial and its task is NOT complete.]"
+                    ),
+                },
+                *content,
+            ]
 
         return TR(
             name=AGENT_TOOL_NAME,
             output={
-                "status": "completed",
+                "status": "interrupted" if interrupted else "completed",
                 "prompt": prompt,
                 "agent_id": result.agent_id,
                 "agent_type": result.agent_type,
@@ -615,7 +669,7 @@ def make_agent_tool(
                 # model with nothing in the tool call naming one (agent-def
                 # tier / provider default-subagent-model), so surface it.
                 "model": resolved_model,
-                "content": result.content,
+                "content": content,
                 "total_duration_ms": result.total_duration_ms,
                 "total_tokens": result.total_tokens,
                 "total_tool_use_count": result.total_tool_use_count,
@@ -697,8 +751,9 @@ def make_agent_tool(
         # its own internal controller (run_agent.py:291), but now reachable.
         # Setting run_params.abort_controller makes run_agent use THIS one
         # (run_agent.py:286-287) instead of an unreachable internal one.
-        # ``_agent_call`` now builds it before admission so the supervisor holds
-        # the same handle; only direct callers of this helper still land here.
+        # Defensive only: ``_agent_call`` always sets this before admission so
+        # the supervisor holds the same handle, and it is this helper's sole
+        # call site.
         from src.utils.abort_controller import AbortController as _AbortController
 
         if run_params.abort_controller is None:
@@ -880,7 +935,13 @@ def make_agent_tool(
             running_loop = None
 
         if running_loop is not None:
-            running_loop.create_task(_background_lifecycle())
+            # Keep a strong reference: asyncio holds only a weak one, so a
+            # garbage-collected task never runs — and never reaches the
+            # ``finally`` that releases this agent's supervisor slot. The
+            # done-callback discards it once the lifecycle has finished.
+            task = running_loop.create_task(_background_lifecycle())
+            _BACKGROUND_LIFECYCLES.add(task)
+            task.add_done_callback(_BACKGROUND_LIFECYCLES.discard)
         else:
             def _runner(_stop_event: Any) -> None:
                 asyncio.run(_background_lifecycle())

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -1003,7 +1003,15 @@ def make_agent_tool(
         if not isinstance(result, dict):
             return {"type": "tool_result", "tool_use_id": tool_use_id, "content": str(result)}
         content = result.get("content", "")
-        if result.get("status") == "error":
+        # "refused" is error-shaped: its message lives in ``error`` and it
+        # carries no ``content`` key at all. Without this branch it fell to the
+        # untyped tail with an EMPTY content, which the pipeline's
+        # empty-content guard then rendered as "(Agent completed with no
+        # output)" — telling the model a spawn the supervisor BLOCKED had run
+        # and found nothing, and dropping the one sentence explaining what to
+        # do instead. Pausing delegation makes every following spawn take this
+        # path, so it is the common case, not the rare one.
+        if result.get("status") in ("error", "refused"):
             return {
                 "type": "tool_result",
                 "tool_use_id": tool_use_id,

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -658,6 +658,11 @@ def make_agent_tool(
                 *content,
             ]
 
+        # Deliberately NOT is_error: the background path reports the same event
+        # as a task-notification rather than an error envelope, the partial
+        # output is often worth keeping (is_error invites the model to discard
+        # it), and is_error already means something else on this tool — a spawn
+        # the supervisor refused. The warning block above carries the meaning.
         return TR(
             name=AGENT_TOOL_NAME,
             output={
@@ -1016,7 +1021,13 @@ def make_agent_tool(
                     "Use TaskOutput with task_id equal to task_output_key to check completion."
                 ),
             }
-        if result.get("status") == "completed":
+        # "interrupted" renders exactly like "completed": this mapper is what
+        # turns the block list into the string every Agent result reaches the
+        # model as, so a status it does not know falls to the untyped tail and
+        # ships a raw list instead — in a different shape from every other
+        # delegation, on precisely the path that exists to be honest about a
+        # kill. Any future status added here needs the same treatment.
+        if result.get("status") in ("completed", "interrupted"):
             text_parts: list[str] = []
             if isinstance(content, list):
                 for block in content:

--- a/tests/server/test_delegation_control.py
+++ b/tests/server/test_delegation_control.py
@@ -1,0 +1,196 @@
+"""Agent-server delegation control plane: ``delegation_status``,
+``delegation_pause``, and ``subagent_interrupt``.
+
+The TUI has called these three (as ``delegation.status`` / ``delegation.pause``
+/ ``subagent.interrupt``) since the agents overlay was written, but no backend
+served them, so the overlay's readout was empty and its pause and kill keys did
+nothing. These tests pin the replies to the response shapes
+``ui-tui/src/gatewayTypes.ts`` declares, since a drifted key name would silently
+restore exactly that dead-control behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from src.server.agent_server import AgentServerConfig, _AgentSession
+from src.services.swarm.agent_supervisor import AgentSupervisor
+
+
+class _FakeAbort:
+    def __init__(self) -> None:
+        self.reasons: list[str] = []
+
+    def abort(self, reason: str = "") -> None:
+        self.reasons.append(reason)
+
+
+def _make_session(supervisor: AgentSupervisor | None = None):
+    emitted: list[dict] = []
+    sess = _AgentSession(
+        session_id="deleg-sess", cwd="/tmp",
+        config=AgentServerConfig(single_session=False),
+        loop=MagicMock(), out_queue=MagicMock(),
+    )
+    sess._emit = lambda env: emitted.append(env)  # type: ignore[method-assign]
+    sess.tool_context = SimpleNamespace(
+        workspace_trusted=True,
+        agent_supervisor=supervisor if supervisor is not None else AgentSupervisor(),
+    )
+    return sess, emitted
+
+
+def _control(sess: _AgentSession, subtype: str, **params) -> None:
+    asyncio.run(sess._handle_control_request({
+        "type": "control_request",
+        "request_id": "req-1",
+        "request": {"subtype": subtype, **params},
+    }))
+
+
+def _last_reply(emitted: list[dict]) -> dict:
+    for env in reversed(emitted):
+        if env.get("type") == "control_response":
+            return env["response"]["response"]
+    raise AssertionError(f"no control_response in {emitted!r}")
+
+
+class TestDelegationStatus(unittest.TestCase):
+    def test_reports_live_agents_and_caps(self) -> None:
+        sup = AgentSupervisor(max_concurrent=6, max_depth=2)
+        sup.admit(
+            subagent_id="a1", parent_id="root", depth=1,
+            goal="audit the store", model="claude-opus-5",
+        )
+        sup.set_tool_count("a1", 4)
+        sess, emitted = _make_session(sup)
+
+        _control(sess, "delegation_status")
+        reply = _last_reply(emitted)
+
+        self.assertEqual(reply["max_concurrent_children"], 6)
+        self.assertEqual(reply["max_spawn_depth"], 2)
+        self.assertFalse(reply["paused"])
+        (entry,) = reply["active"]
+        self.assertEqual(entry["subagent_id"], "a1")
+        self.assertEqual(entry["parent_id"], "root")
+        self.assertEqual(entry["depth"], 1)
+        self.assertEqual(entry["goal"], "audit the store")
+        self.assertEqual(entry["model"], "claude-opus-5")
+        self.assertEqual(entry["status"], "running")
+        self.assertEqual(entry["tool_count"], 4)
+
+    def test_empty_session_reports_an_empty_list_not_an_error(self) -> None:
+        sess, emitted = _make_session()
+        _control(sess, "delegation_status")
+        self.assertEqual(_last_reply(emitted)["active"], [])
+
+    def test_without_a_supervisor_the_caps_are_omitted_rather_than_zeroed(self) -> None:
+        # A client reading 0/0 would render "at capacity" for a session that
+        # simply has no supervisor yet.
+        sess, emitted = _make_session()
+        sess.tool_context = SimpleNamespace(workspace_trusted=True)
+
+        _control(sess, "delegation_status")
+        reply = _last_reply(emitted)
+
+        self.assertEqual(reply["active"], [])
+        self.assertNotIn("max_concurrent_children", reply)
+
+    def test_survives_a_session_with_no_tool_context_at_all(self) -> None:
+        sess, emitted = _make_session()
+        sess.tool_context = None
+
+        _control(sess, "delegation_status")
+        self.assertEqual(_last_reply(emitted)["active"], [])
+
+
+class TestDelegationPause(unittest.TestCase):
+    def test_explicit_pause_and_resume_echo_the_resulting_state(self) -> None:
+        sup = AgentSupervisor()
+        sess, emitted = _make_session(sup)
+
+        _control(sess, "delegation_pause", paused=True)
+        self.assertTrue(_last_reply(emitted)["paused"])
+        self.assertTrue(sup.is_paused())
+
+        _control(sess, "delegation_pause", paused=False)
+        self.assertFalse(_last_reply(emitted)["paused"])
+        self.assertFalse(sup.is_paused())
+
+    def test_omitting_paused_flips_the_current_value(self) -> None:
+        # The overlay's single pause key sends no explicit value.
+        sup = AgentSupervisor()
+        sess, emitted = _make_session(sup)
+
+        _control(sess, "delegation_pause")
+        self.assertTrue(_last_reply(emitted)["paused"])
+
+        _control(sess, "delegation_pause")
+        self.assertFalse(_last_reply(emitted)["paused"])
+
+    def test_pausing_is_visible_to_a_following_status_call(self) -> None:
+        sup = AgentSupervisor()
+        sess, emitted = _make_session(sup)
+
+        _control(sess, "delegation_pause", paused=True)
+        _control(sess, "delegation_status")
+
+        self.assertTrue(_last_reply(emitted)["paused"])
+
+
+class TestSubagentInterrupt(unittest.TestCase):
+    def test_interrupting_a_live_agent_aborts_it_and_reports_found(self) -> None:
+        sup = AgentSupervisor()
+        abort = _FakeAbort()
+        sup.admit(subagent_id="a1", abort_controller=abort)
+        sess, emitted = _make_session(sup)
+
+        _control(sess, "subagent_interrupt", subagent_id="a1")
+        reply = _last_reply(emitted)
+
+        self.assertTrue(reply["found"])
+        self.assertEqual(reply["subagent_id"], "a1")
+        self.assertEqual(abort.reasons, ["interrupted by user"])
+
+    def test_unknown_id_reports_not_found_rather_than_claiming_success(self) -> None:
+        # The overlay can be pointed at a row whose agent already finished;
+        # answering "interrupted" there would be a lie.
+        sess, emitted = _make_session()
+
+        _control(sess, "subagent_interrupt", subagent_id="ghost")
+        reply = _last_reply(emitted)
+
+        self.assertFalse(reply["found"])
+        self.assertEqual(reply["subagent_id"], "ghost")
+
+    def test_missing_id_is_rejected_without_touching_the_supervisor(self) -> None:
+        sup = AgentSupervisor()
+        abort = _FakeAbort()
+        sup.admit(subagent_id="a1", abort_controller=abort)
+        sess, emitted = _make_session(sup)
+
+        _control(sess, "subagent_interrupt")
+
+        self.assertFalse(_last_reply(emitted)["found"])
+        self.assertEqual(abort.reasons, [], "no id must never fan out to live agents")
+
+    def test_interrupted_agent_still_holds_its_slot_in_the_next_status(self) -> None:
+        # Release happens when the worker actually exits, so the row must still
+        # be there — marked interrupted, not vanished.
+        sup = AgentSupervisor()
+        sup.admit(subagent_id="a1", abort_controller=_FakeAbort())
+        sess, emitted = _make_session(sup)
+
+        _control(sess, "subagent_interrupt", subagent_id="a1")
+        _control(sess, "delegation_status")
+        (entry,) = _last_reply(emitted)["active"]
+
+        self.assertEqual(entry["status"], "interrupted")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/server/test_delegation_control.py
+++ b/tests/server/test_delegation_control.py
@@ -178,6 +178,58 @@ class TestSubagentInterrupt(unittest.TestCase):
         self.assertFalse(_last_reply(emitted)["found"])
         self.assertEqual(abort.reasons, [], "no id must never fan out to live agents")
 
+    def test_a_background_agent_is_killed_through_the_registry_not_just_aborted(self) -> None:
+        """The bug this guards: a bare controller.abort() is not enough.
+
+        query() RETURNS rather than raising when aborted, so
+        _background_lifecycle takes its SUCCESS branch and calls
+        complete_agent_task — which only no-ops if the registry was ALREADY
+        marked terminal. Without going through kill_async_agent the model is
+        told a delegation the user killed "completed" with an empty result.
+        """
+        from src.task_registry import RuntimeTaskRegistry
+        from src.tasks.local_agent import register_async_agent
+
+        sup = AgentSupervisor()
+        abort = _FakeAbort()
+        registry = RuntimeTaskRegistry()
+        register_async_agent(
+            agent_id="bg1", description="d", prompt="p", agent_type="general-purpose",
+            model=None, abort_controller=abort, registry=registry,
+        )
+        sup.admit(subagent_id="bg1", abort_controller=abort)
+
+        sess, emitted = _make_session(sup)
+        sess.tool_context = SimpleNamespace(
+            workspace_trusted=True, agent_supervisor=sup, runtime_tasks=registry,
+        )
+
+        _control(sess, "subagent_interrupt", subagent_id="bg1")
+
+        self.assertTrue(_last_reply(emitted)["found"])
+        # The registry — not just the controller — has to carry the verdict, so
+        # complete_agent_task no-ops when the lifecycle reaches its finally.
+        self.assertEqual(registry.get("bg1").status, "killed")
+
+    def test_a_foreground_only_agent_is_still_interrupted_without_a_registry_entry(self) -> None:
+        # Sync agents never enter runtime_tasks; the supervisor is their only home.
+        from src.task_registry import RuntimeTaskRegistry
+
+        sup = AgentSupervisor()
+        abort = _FakeAbort()
+        sup.admit(subagent_id="fg1", abort_controller=abort)
+
+        sess, emitted = _make_session(sup)
+        sess.tool_context = SimpleNamespace(
+            workspace_trusted=True, agent_supervisor=sup,
+            runtime_tasks=RuntimeTaskRegistry(),
+        )
+
+        _control(sess, "subagent_interrupt", subagent_id="fg1")
+
+        self.assertTrue(_last_reply(emitted)["found"])
+        self.assertEqual(abort.reasons, ["interrupted by user"])
+
     def test_interrupted_agent_still_holds_its_slot_in_the_next_status(self) -> None:
         # Release happens when the worker actually exits, so the row must still
         # be there — marked interrupted, not vanished.

--- a/tests/server/test_delegation_control.py
+++ b/tests/server/test_delegation_control.py
@@ -230,6 +230,50 @@ class TestSubagentInterrupt(unittest.TestCase):
         self.assertTrue(_last_reply(emitted)["found"])
         self.assertEqual(abort.reasons, ["interrupted by user"])
 
+    def test_a_non_agent_task_id_is_not_reported_as_interrupted(self) -> None:
+        # runtime_tasks holds shell, workflow and teammate states too.
+        # kill_async_agent's own isinstance guard makes killing one a no-op, so
+        # reporting found=True would claim a kill that did not happen.
+        from src.task_registry import RuntimeTaskRegistry
+        from src.tasks.local_shell import LocalShellTaskState
+
+        registry = RuntimeTaskRegistry()
+        registry.upsert(LocalShellTaskState(
+            id="sh1", type="local_bash", status="running", description="a shell",
+            start_time=0.0, output_file="/tmp/sh1.log",
+        ))
+        sup = AgentSupervisor()
+        sess, emitted = _make_session(sup)
+        sess.tool_context = SimpleNamespace(
+            workspace_trusted=True, agent_supervisor=sup, runtime_tasks=registry,
+        )
+
+        _control(sess, "subagent_interrupt", subagent_id="sh1")
+
+        self.assertFalse(_last_reply(emitted)["found"])
+        self.assertEqual(registry.get("sh1").status, "running")
+
+    def test_an_already_finished_agent_is_not_reported_as_interrupted(self) -> None:
+        from src.task_registry import RuntimeTaskRegistry
+        from src.tasks.local_agent import complete_agent_task, register_async_agent
+
+        registry = RuntimeTaskRegistry()
+        register_async_agent(
+            agent_id="bg1", description="d", prompt="p", agent_type="general-purpose",
+            model=None, abort_controller=_FakeAbort(), registry=registry,
+        )
+        complete_agent_task("bg1", result_text="done", registry=registry)
+
+        sup = AgentSupervisor()
+        sess, emitted = _make_session(sup)
+        sess.tool_context = SimpleNamespace(
+            workspace_trusted=True, agent_supervisor=sup, runtime_tasks=registry,
+        )
+
+        _control(sess, "subagent_interrupt", subagent_id="bg1")
+
+        self.assertFalse(_last_reply(emitted)["found"])
+
     def test_interrupted_agent_still_holds_its_slot_in_the_next_status(self) -> None:
         # Release happens when the worker actually exits, so the row must still
         # be there — marked interrupted, not vanished.

--- a/tests/services/test_agent_supervisor.py
+++ b/tests/services/test_agent_supervisor.py
@@ -1,0 +1,316 @@
+"""Admission control and live-agent bookkeeping for the subagent control plane.
+
+Covers the two limits Codex keeps independent (``reserve_spawn_slot`` capacity
+vs ``exceeds_thread_spawn_depth_limit`` nesting), the pause gate, and the
+release-on-actual-exit contract that keeps an interrupted agent's slot held
+until its worker really stops.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from src.services.swarm.agent_supervisor import (
+    DEFAULT_MAX_CONCURRENT_CHILDREN,
+    DEFAULT_MAX_SPAWN_DEPTH,
+    AgentAdmissionError,
+    AgentSupervisor,
+    max_concurrent_children,
+    max_spawn_depth,
+)
+
+
+class _FakeAbort:
+    """Stand-in for AbortController — records the reason it was aborted with."""
+
+    def __init__(self) -> None:
+        self.reasons: list[str] = []
+
+    def abort(self, reason: str = "") -> None:
+        self.reasons.append(reason)
+
+
+# ── capacity ─────────────────────────────────────────────────────────────
+
+
+def test_admits_up_to_the_cap_then_refuses():
+    sup = AgentSupervisor(max_concurrent=2)
+
+    sup.admit(subagent_id="a")
+    sup.admit(subagent_id="b")
+    assert sup.live_count() == 2
+
+    with pytest.raises(AgentAdmissionError) as exc:
+        sup.admit(subagent_id="c")
+
+    assert exc.value.reason == "capacity"
+    # The refusal message is model-facing: it has to say what to do next.
+    assert "limit of 2" in str(exc.value)
+    assert sup.live_count() == 2, "a refused spawn must not consume a slot"
+
+
+def test_releasing_frees_a_slot_for_the_next_spawn():
+    sup = AgentSupervisor(max_concurrent=1)
+    sup.admit(subagent_id="a")
+
+    with pytest.raises(AgentAdmissionError):
+        sup.admit(subagent_id="b")
+
+    assert sup.release("a") is True
+    sup.admit(subagent_id="b")
+    assert sup.live_count() == 1
+
+
+def test_release_of_an_unknown_id_reports_that_it_held_nothing():
+    assert AgentSupervisor().release("never-admitted") is False
+
+
+def test_readmitting_a_live_id_is_a_no_op_not_a_second_slot():
+    # A retry that races its own registration must not double-count.
+    sup = AgentSupervisor(max_concurrent=2)
+    sup.admit(subagent_id="a", goal="first")
+    sup.admit(subagent_id="a", goal="second")
+
+    assert sup.live_count() == 1
+    assert sup.snapshot()["active"][0]["goal"] == "first"
+
+
+# ── depth ────────────────────────────────────────────────────────────────
+
+
+def test_depth_at_the_limit_is_admitted_and_past_it_is_refused():
+    sup = AgentSupervisor(max_depth=2)
+
+    sup.admit(subagent_id="ok", depth=2)
+
+    with pytest.raises(AgentAdmissionError) as exc:
+        sup.admit(subagent_id="too-deep", depth=3)
+
+    assert exc.value.reason == "depth"
+
+
+def test_depth_and_capacity_are_independent_limits():
+    # Codex keeps these separate on purpose; a deep-but-lonely agent should not
+    # be refused for capacity, nor a shallow crowd for depth.
+    sup = AgentSupervisor(max_concurrent=1, max_depth=99)
+    sup.admit(subagent_id="deep", depth=50)
+
+    with pytest.raises(AgentAdmissionError) as exc:
+        sup.admit(subagent_id="shallow", depth=0)
+
+    assert exc.value.reason == "capacity"
+
+
+# ── pause ────────────────────────────────────────────────────────────────
+
+
+def test_pause_blocks_new_spawns_but_leaves_running_ones_alone():
+    sup = AgentSupervisor()
+    sup.admit(subagent_id="already-running")
+
+    assert sup.set_paused(True) is True
+
+    with pytest.raises(AgentAdmissionError) as exc:
+        sup.admit(subagent_id="blocked")
+
+    assert exc.value.reason == "paused"
+    assert sup.live_count() == 1, "pausing must not kill in-flight agents"
+
+    sup.set_paused(False)
+    sup.admit(subagent_id="allowed-again")
+    assert sup.live_count() == 2
+
+
+def test_pause_is_reported_in_the_snapshot():
+    sup = AgentSupervisor()
+    assert sup.snapshot()["paused"] is False
+    sup.set_paused(True)
+    assert sup.snapshot()["paused"] is True
+    assert sup.is_paused() is True
+
+
+# ── interrupt ────────────────────────────────────────────────────────────
+
+
+def test_interrupt_aborts_the_run_and_reports_it_was_live():
+    sup = AgentSupervisor()
+    abort = _FakeAbort()
+    sup.admit(subagent_id="a", abort_controller=abort)
+
+    assert sup.interrupt("a") is True
+    assert abort.reasons == ["interrupted by user"]
+
+
+def test_interrupt_holds_the_slot_until_the_worker_actually_exits():
+    # The whole point of the contract: a terminal *label* is not proof the
+    # worker stopped, so the slot stays taken until release() is called.
+    sup = AgentSupervisor(max_concurrent=1)
+    sup.admit(subagent_id="a", abort_controller=_FakeAbort())
+    sup.interrupt("a")
+
+    assert sup.live_count() == 1
+    assert sup.snapshot()["active"][0]["status"] == "interrupted"
+
+    with pytest.raises(AgentAdmissionError):
+        sup.admit(subagent_id="replacement")
+
+    sup.release("a")
+    sup.admit(subagent_id="replacement")
+
+
+def test_interrupt_of_an_unknown_id_reports_not_found():
+    assert AgentSupervisor().interrupt("ghost") is False
+
+
+def test_interrupt_survives_an_abort_controller_that_raises():
+    class Exploding:
+        def abort(self, reason: str = "") -> None:
+            raise RuntimeError("boom")
+
+    sup = AgentSupervisor()
+    sup.admit(subagent_id="a", abort_controller=Exploding())
+
+    # Still reports the agent was live; the failure to abort must not escape
+    # into the caller's control-request handler.
+    assert sup.interrupt("a") is True
+
+
+def test_interrupt_all_signals_every_live_agent():
+    sup = AgentSupervisor()
+    aborts = {name: _FakeAbort() for name in ("a", "b", "c")}
+    for name, abort in aborts.items():
+        sup.admit(subagent_id=name, abort_controller=abort)
+
+    assert sup.interrupt_all() == 3
+    assert all(a.reasons for a in aborts.values())
+
+
+# ── snapshot ─────────────────────────────────────────────────────────────
+
+
+def test_snapshot_matches_the_delegation_status_wire_shape():
+    # These key names are the contract ui-tui/src/gatewayTypes.ts declares as
+    # DelegationStatusResponse; drift here silently empties the overlay.
+    sup = AgentSupervisor(max_concurrent=7, max_depth=4)
+    sup.admit(
+        subagent_id="a1",
+        parent_id="root",
+        depth=1,
+        goal="audit the store",
+        model="claude-opus-5",
+    )
+    sup.set_tool_count("a1", 3)
+
+    snap = sup.snapshot()
+    assert set(snap) == {"active", "max_concurrent_children", "max_spawn_depth", "paused"}
+    assert snap["max_concurrent_children"] == 7
+    assert snap["max_spawn_depth"] == 4
+
+    (entry,) = snap["active"]
+    assert set(entry) == {
+        "subagent_id", "parent_id", "depth", "goal",
+        "model", "status", "started_at", "tool_count",
+    }
+    assert entry["subagent_id"] == "a1"
+    assert entry["parent_id"] == "root"
+    assert entry["depth"] == 1
+    assert entry["goal"] == "audit the store"
+    assert entry["model"] == "claude-opus-5"
+    assert entry["status"] == "running"
+    assert entry["tool_count"] == 3
+
+
+def test_snapshot_is_ordered_by_start_time_not_dict_order():
+    sup = AgentSupervisor()
+    for name in ("c", "a", "b"):
+        sup.admit(subagent_id=name)
+
+    ids = [e["subagent_id"] for e in sup.snapshot()["active"]]
+    assert ids == ["c", "a", "b"], "poll-to-poll reshuffling would make the overlay jump"
+
+
+def test_snapshot_is_a_copy_not_a_live_view():
+    sup = AgentSupervisor()
+    sup.admit(subagent_id="a")
+    snap = sup.snapshot()
+    sup.release("a")
+
+    assert len(snap["active"]) == 1, "a taken snapshot must not mutate underneath its reader"
+
+
+def test_status_and_tool_count_updates_are_dropped_after_release():
+    sup = AgentSupervisor()
+    sup.admit(subagent_id="a")
+    sup.release("a")
+
+    # Late progress from a finished worker must not resurrect a row.
+    sup.set_status("a", "running")
+    sup.set_tool_count("a", 99)
+    assert sup.snapshot()["active"] == []
+
+
+# ── configuration ────────────────────────────────────────────────────────
+
+
+def test_limits_default_to_the_module_constants(monkeypatch):
+    monkeypatch.delenv("CLAWCODEX_MAX_CONCURRENT_AGENTS", raising=False)
+    monkeypatch.delenv("CLAWCODEX_MAX_AGENT_DEPTH", raising=False)
+
+    sup = AgentSupervisor()
+    assert sup.max_concurrent == DEFAULT_MAX_CONCURRENT_CHILDREN
+    assert sup.max_depth == DEFAULT_MAX_SPAWN_DEPTH
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [("3", 3), ("1", 1), ("0", 1), ("-4", 1)],
+)
+def test_env_override_is_read_and_clamped_to_at_least_one(monkeypatch, raw, expected):
+    monkeypatch.setenv("CLAWCODEX_MAX_CONCURRENT_AGENTS", raw)
+    assert max_concurrent_children() == expected
+
+
+@pytest.mark.parametrize("raw", ["", "   ", "lots", "3.5"])
+def test_garbage_env_falls_back_to_the_default(monkeypatch, raw):
+    monkeypatch.setenv("CLAWCODEX_MAX_CONCURRENT_AGENTS", raw)
+    monkeypatch.setenv("CLAWCODEX_MAX_AGENT_DEPTH", raw)
+    assert max_concurrent_children() == DEFAULT_MAX_CONCURRENT_CHILDREN
+    assert max_spawn_depth() == DEFAULT_MAX_SPAWN_DEPTH
+
+
+def test_explicit_limits_beat_the_environment(monkeypatch):
+    monkeypatch.setenv("CLAWCODEX_MAX_CONCURRENT_AGENTS", "99")
+    assert AgentSupervisor(max_concurrent=2).max_concurrent == 2
+
+
+# ── concurrency ──────────────────────────────────────────────────────────
+
+
+def test_concurrent_admissions_never_exceed_the_cap():
+    # Agents are admitted from worker threads, so the check and the insert have
+    # to be atomic — a TOCTOU window here would over-admit under fan-out.
+    cap = 5
+    sup = AgentSupervisor(max_concurrent=cap)
+    admitted: list[str] = []
+    lock = threading.Lock()
+    start = threading.Barrier(20)
+
+    def worker(i: int) -> None:
+        start.wait()
+        try:
+            sup.admit(subagent_id=f"agent-{i}")
+        except AgentAdmissionError:
+            return
+        with lock:
+            admitted.append(f"agent-{i}")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(admitted) == cap
+    assert sup.live_count() == cap

--- a/tests/services/test_agent_supervisor.py
+++ b/tests/services/test_agent_supervisor.py
@@ -177,14 +177,19 @@ def test_interrupt_survives_an_abort_controller_that_raises():
     assert sup.interrupt("a") is True
 
 
-def test_interrupt_all_signals_every_live_agent():
+def test_is_interrupted_tracks_the_verdict_and_clears_on_release():
+    # The sync spawn path reads this to decide whether to report "completed" or
+    # "interrupted", and must read it BEFORE releasing.
     sup = AgentSupervisor()
-    aborts = {name: _FakeAbort() for name in ("a", "b", "c")}
-    for name, abort in aborts.items():
-        sup.admit(subagent_id=name, abort_controller=abort)
+    sup.admit(subagent_id="a", abort_controller=_FakeAbort())
 
-    assert sup.interrupt_all() == 3
-    assert all(a.reasons for a in aborts.values())
+    assert sup.is_interrupted("a") is False
+    sup.interrupt("a")
+    assert sup.is_interrupted("a") is True
+
+    sup.release("a")
+    assert sup.is_interrupted("a") is False
+    assert sup.is_interrupted("never-existed") is False
 
 
 # ── snapshot ─────────────────────────────────────────────────────────────

--- a/tests/test_agent_tool_admission.py
+++ b/tests/test_agent_tool_admission.py
@@ -69,6 +69,31 @@ def test_spawn_is_refused_while_delegation_is_paused(agent_tool, ctx):
     assert result.output["reason"] == "paused"
 
 
+def test_a_refusal_reaches_the_model_as_an_error_carrying_its_reason(agent_tool, ctx):
+    # The refusal message is the entire reason a refusal is a ToolResult rather
+    # than a raise. Before the mapper knew this status, it fell to the untyped
+    # tail with EMPTY content — which the pipeline renders as "(Agent completed
+    # with no output)", i.e. the model is told the blocked spawn ran and found
+    # nothing, and the "do the work yourself" instruction is dropped.
+    ctx.agent_supervisor.set_paused(True)
+    wire = agent_tool.map_result_to_api(_call(agent_tool, ctx).output, "tu_1")
+
+    assert wire["is_error"] is True
+    assert isinstance(wire["content"], str)
+    assert "paused" in wire["content"].lower()
+    assert "completed" not in wire["content"].lower()
+
+
+def test_a_capacity_refusal_also_reaches_the_model_with_its_reason(agent_tool, ctx):
+    ctx.agent_supervisor = AgentSupervisor(max_concurrent=1)
+    ctx.agent_supervisor.admit(subagent_id="already-running")
+
+    wire = agent_tool.map_result_to_api(_call(agent_tool, ctx).output, "tu_1")
+
+    assert wire["is_error"] is True
+    assert "limit of 1" in wire["content"]
+
+
 def test_a_refused_spawn_leaves_no_trace_in_the_registry(agent_tool, ctx):
     ctx.agent_supervisor = AgentSupervisor(max_concurrent=1)
     ctx.agent_supervisor.admit(subagent_id="already-running")

--- a/tests/test_agent_tool_admission.py
+++ b/tests/test_agent_tool_admission.py
@@ -214,6 +214,109 @@ def test_finishing_one_agent_lets_the_next_in(agent_tool, ctx, fake_run):
     assert _call(agent_tool, ctx).output["status"] == "completed"
 
 
+# ── interruption is reported honestly ────────────────────────────────────
+#
+# An aborted query() RETURNS rather than raising, so both lifecycles reach
+# their SUCCESS branch after an interrupt. Without these, a delegation the user
+# killed is reported to the model as "completed" with partial output, and the
+# model acts on it.
+
+
+def test_an_interrupted_foreground_agent_is_not_reported_as_completed(
+    agent_tool, ctx, fake_run,
+):
+    def during(params):
+        agent_id = ctx.agent_supervisor.snapshot()["active"][0]["subagent_id"]
+        ctx.agent_supervisor.interrupt(agent_id)
+
+    fake_run(during)
+    result = _call(agent_tool, ctx)
+
+    assert result.output["status"] == "interrupted"
+    # The model reads the content, not the status field, so the warning has to
+    # be in there too.
+    text = " ".join(
+        b.get("text", "") for b in result.output["content"] if isinstance(b, dict)
+    )
+    assert "interrupted" in text.lower()
+    assert "NOT complete" in text
+
+
+def test_an_uninterrupted_foreground_agent_still_reports_completed(
+    agent_tool, ctx, fake_run,
+):
+    fake_run()
+    result = _call(agent_tool, ctx)
+
+    assert result.output["status"] == "completed"
+    text = " ".join(
+        b.get("text", "") for b in result.output["content"] if isinstance(b, dict)
+    )
+    assert "interrupted" not in text.lower()
+
+
+# ── abort propagation ────────────────────────────────────────────────────
+#
+# The supervisor needs a per-agent abort handle, but a sync spawn previously
+# ran on the PARENT'S controller (run_agent.py: "share with parent for sync so
+# parent ESC propagates"). Handing run_agent an unconditional override takes an
+# earlier branch and severs that link, so these pin both halves at once.
+
+
+def test_parent_abort_still_reaches_a_foreground_subagent(agent_tool, ctx, fake_run):
+    seen: dict[str, Any] = {}
+
+    def during(params):
+        # ESC / turn cancel aborts the parent's controller mid-run.
+        ctx.abort_controller.abort("user pressed ESC")
+        seen["child_aborted"] = params.abort_controller.signal.aborted
+
+    fake_run(during)
+    _call(agent_tool, ctx)
+
+    assert seen["child_aborted"] is True, (
+        "a foreground subagent must still stop when the parent turn is aborted"
+    )
+
+
+def test_interrupting_a_foreground_subagent_does_not_abort_the_parent_turn(
+    agent_tool, ctx, fake_run,
+):
+    # The other direction must NOT propagate: killing one delegation from the
+    # agents overlay cannot take the user's whole turn down with it.
+    def during(params):
+        agent_id = ctx.agent_supervisor.snapshot()["active"][0]["subagent_id"]
+        ctx.agent_supervisor.interrupt(agent_id)
+
+    fake_run(during)
+    _call(agent_tool, ctx)
+
+    assert ctx.abort_controller.signal.aborted is False
+
+
+@pytest.mark.asyncio
+async def test_a_background_subagent_survives_parent_abort(agent_tool, ctx, monkeypatch):
+    # Background agents deliberately outlive the turn that spawned them, so
+    # their controller must stay unlinked from the parent's — the `elif
+    # params.is_async` branch in run_agent exists for exactly this.
+    import src.tool_system.tools.agent as agentmod
+    from src.types.messages import AssistantMessage
+
+    captured: dict[str, Any] = {}
+
+    async def fake_run_agent(params):
+        captured["abort"] = params.abort_controller
+        yield AssistantMessage(content=[{"type": "text", "text": "done"}])
+
+    monkeypatch.setattr(agentmod, "run_agent", fake_run_agent)
+
+    _call(agent_tool, ctx, run_in_background=True)
+    assert await _drain(lambda: "abort" in captured)
+
+    ctx.abort_controller.abort("user pressed ESC")
+    assert captured["abort"].signal.aborted is False
+
+
 # ── the background path ──────────────────────────────────────────────────
 
 

--- a/tests/test_agent_tool_admission.py
+++ b/tests/test_agent_tool_admission.py
@@ -1,0 +1,313 @@
+"""The Agent tool consults the session supervisor before spawning.
+
+These exercise the wiring rather than the supervisor itself (that has its own
+suite in tests/services/test_agent_supervisor.py): that a refused spawn comes
+back as a model-facing tool error instead of an exception, that the refusal
+never reaches the provider, and that child contexts share the parent's
+supervisor so nesting is admitted against one registry.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from src.services.swarm.agent_supervisor import AgentSupervisor
+from src.tool_system.context import ToolContext
+from src.tool_system.registry import ToolRegistry
+from src.tool_system.tools.agent import make_agent_tool
+
+
+class _ExplodingProvider:
+    """Any real use of the provider fails the test loudly.
+
+    Admission is refused before the run starts, so a refused spawn must not
+    touch this object at all.
+    """
+
+    def __getattr__(self, name: str) -> Any:
+        raise AssertionError(f"provider was used ({name!r}) on a refused spawn")
+
+
+@pytest.fixture
+def agent_tool():
+    return make_agent_tool(ToolRegistry(), provider=_ExplodingProvider())
+
+
+@pytest.fixture
+def ctx(tmp_path: Path) -> ToolContext:
+    return ToolContext(workspace_root=tmp_path, cwd=tmp_path)
+
+
+def _call(tool, ctx: ToolContext, **overrides: Any):
+    payload = {"description": "d", "prompt": "do a thing", **overrides}
+    return tool.call(payload, ctx)
+
+
+def test_spawn_is_refused_once_the_session_is_at_capacity(agent_tool, ctx):
+    ctx.agent_supervisor = AgentSupervisor(max_concurrent=1)
+    ctx.agent_supervisor.admit(subagent_id="already-running")
+
+    result = _call(agent_tool, ctx)
+
+    assert result.is_error is True
+    assert result.output["status"] == "refused"
+    assert result.output["reason"] == "capacity"
+    # The model reads this string and has to know what to do with it.
+    assert "limit of 1" in result.output["error"]
+
+
+def test_spawn_is_refused_while_delegation_is_paused(agent_tool, ctx):
+    ctx.agent_supervisor.set_paused(True)
+
+    result = _call(agent_tool, ctx)
+
+    assert result.is_error is True
+    assert result.output["reason"] == "paused"
+
+
+def test_a_refused_spawn_leaves_no_trace_in_the_registry(agent_tool, ctx):
+    ctx.agent_supervisor = AgentSupervisor(max_concurrent=1)
+    ctx.agent_supervisor.admit(subagent_id="already-running")
+
+    _call(agent_tool, ctx)
+
+    # A half-registered agent id would show up in the overlay as a phantom row.
+    assert ctx.agent_supervisor.live_count() == 1
+    assert len(ctx.runtime_tasks) == 0
+
+
+def test_refusal_is_returned_not_raised(agent_tool, ctx):
+    # A raised exception would abort the turn; the model needs to see this as a
+    # tool result it can react to.
+    ctx.agent_supervisor.set_paused(True)
+    result = _call(agent_tool, ctx)
+    assert result.output["status"] == "refused"
+
+
+def test_a_launch_that_fails_after_admission_gives_the_slot_back(agent_tool, ctx, monkeypatch):
+    # A name collision raises out of the background wrapper AFTER admission.
+    # Without the guard the slot would be stranded for the life of the session.
+    from src.services.swarm import agent_name_registry as reg
+
+    def boom(*args, **kwargs):
+        raise reg.AgentNameAlreadyClaimedError("taken", "other-agent")
+
+    monkeypatch.setattr(ctx.agent_name_registry, "claim_or_raise", boom)
+
+    with pytest.raises(Exception):
+        _call(agent_tool, ctx, name="taken", run_in_background=True)
+
+    assert ctx.agent_supervisor.live_count() == 0
+
+
+def test_top_level_spawns_have_no_parent(agent_tool, ctx):
+    # ctx.agent_id is None on the root session, which is what makes a
+    # top-level delegation a tree root rather than an orphan.
+    ctx.agent_supervisor = AgentSupervisor(max_concurrent=1)
+    ctx.agent_supervisor.admit(subagent_id="filler")
+    assert ctx.agent_id is None
+
+
+def test_a_child_spawn_records_its_parent_agent_id(tmp_path: Path):
+    # The parent id has to be an id that appears as a subagent_id elsewhere in
+    # the snapshot, or the clients cannot nest the row under anything.
+    sup = AgentSupervisor()
+    sup.admit(subagent_id="parent-1")
+    sup.admit(subagent_id="child-1", parent_id="parent-1", depth=1)
+
+    rows = {e["subagent_id"]: e for e in sup.snapshot()["active"]}
+    assert rows["child-1"]["parent_id"] == "parent-1"
+    assert rows["parent-1"]["parent_id"] is None
+    assert rows["child-1"]["parent_id"] in rows
+
+
+# ── the foreground path, driven end to end ───────────────────────────────
+#
+# These run a real _run_sync_agent by faking only the model round trip, because
+# the headline claim — that a *synchronous* delegation is now visible and
+# interruptible — lives entirely on that path and is invisible to the
+# supervisor's own unit tests.
+
+
+@pytest.fixture
+def fake_run(monkeypatch):
+    """Replace the agent's message collection with a caller-supplied hook."""
+    import src.tool_system.tools.agent as agentmod
+    from src.types.messages import AssistantMessage
+
+    def install(hook=None):
+        async def collect(params):
+            if hook is not None:
+                hook(params)
+            return [AssistantMessage(content=[{"type": "text", "text": "done"}])]
+
+        monkeypatch.setattr(agentmod, "_collect_agent_messages", collect)
+
+    return install
+
+
+def test_a_foreground_agent_is_visible_while_it_runs(agent_tool, ctx, fake_run):
+    # Before this, a sync delegation registered nowhere: the overlay could not
+    # see it and nothing in the process could stop it.
+    seen: dict[str, Any] = {}
+
+    def during(params):
+        snap = ctx.agent_supervisor.snapshot()
+        seen["active"] = snap["active"]
+        seen["abort"] = params.abort_controller
+
+    fake_run(during)
+    _call(agent_tool, ctx, description="audit the store")
+
+    (entry,) = seen["active"]
+    assert entry["goal"] == "audit the store"
+    assert entry["status"] == "running"
+    assert entry["depth"] == 0
+    # A reachable abort handle is what makes `subagent.interrupt` work here.
+    assert seen["abort"] is not None
+
+
+def test_a_foreground_agent_is_interruptible_while_it_runs(agent_tool, ctx, fake_run):
+    aborted: list[str] = []
+
+    def during(params):
+        agent_id = ctx.agent_supervisor.snapshot()["active"][0]["subagent_id"]
+        params.abort_controller.abort = lambda reason="": aborted.append(reason)
+        assert ctx.agent_supervisor.interrupt(agent_id) is True
+
+    fake_run(during)
+    _call(agent_tool, ctx)
+
+    assert aborted == ["interrupted by user"]
+
+
+def test_the_slot_is_freed_when_a_foreground_agent_finishes(agent_tool, ctx, fake_run):
+    fake_run()
+    result = _call(agent_tool, ctx)
+
+    assert result.output["status"] == "completed"
+    assert ctx.agent_supervisor.live_count() == 0
+
+
+def test_the_slot_is_freed_when_a_foreground_agent_raises(agent_tool, ctx, fake_run):
+    def explode(params):
+        raise RuntimeError("model exploded")
+
+    fake_run(explode)
+
+    with pytest.raises(RuntimeError):
+        _call(agent_tool, ctx)
+
+    # A stranded slot would shrink the session's capacity for good.
+    assert ctx.agent_supervisor.live_count() == 0
+
+
+def test_finishing_one_agent_lets_the_next_in(agent_tool, ctx, fake_run):
+    ctx.agent_supervisor = AgentSupervisor(max_concurrent=1)
+    fake_run()
+
+    assert _call(agent_tool, ctx).output["status"] == "completed"
+    assert _call(agent_tool, ctx).output["status"] == "completed"
+
+
+# ── the background path ──────────────────────────────────────────────────
+
+
+async def _drain(predicate, tries: int = 200) -> bool:
+    """Yield to the loop until ``predicate()`` holds, or give up."""
+    for _ in range(tries):
+        if predicate():
+            return True
+        await asyncio.sleep(0)
+    return predicate()
+
+
+@pytest.mark.asyncio
+async def test_a_background_agent_frees_its_slot_when_the_worker_exits(
+    agent_tool, ctx, monkeypatch,
+):
+    # The release lives in _background_lifecycle's finally, which only runs
+    # once the detached coroutine has actually finished — so a leak here would
+    # be invisible to every synchronous test.
+    import src.tool_system.tools.agent as agentmod
+    from src.types.messages import AssistantMessage
+
+    async def fake_run_agent(params):
+        yield AssistantMessage(content=[{"type": "text", "text": "done"}])
+
+    monkeypatch.setattr(agentmod, "run_agent", fake_run_agent)
+
+    result = _call(agent_tool, ctx, run_in_background=True)
+    assert result.output["status"] == "async_launched"
+
+    assert await _drain(lambda: ctx.agent_supervisor.live_count() == 0), (
+        "background worker exited without releasing its slot"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_background_agent_frees_its_slot_when_the_worker_fails(
+    agent_tool, ctx, monkeypatch,
+):
+    import src.tool_system.tools.agent as agentmod
+
+    async def exploding_run_agent(params):
+        raise RuntimeError("model exploded")
+        yield  # pragma: no cover - makes this an async generator
+
+    monkeypatch.setattr(agentmod, "run_agent", exploding_run_agent)
+
+    _call(agent_tool, ctx, run_in_background=True)
+
+    assert await _drain(lambda: ctx.agent_supervisor.live_count() == 0), (
+        "a failed background worker stranded its slot"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_background_agent_is_visible_and_interruptible_while_it_runs(
+    agent_tool, ctx, monkeypatch,
+):
+    import src.tool_system.tools.agent as agentmod
+    from src.types.messages import AssistantMessage
+
+    release = asyncio.Event()
+
+    async def slow_run_agent(params):
+        await release.wait()
+        yield AssistantMessage(content=[{"type": "text", "text": "done"}])
+
+    monkeypatch.setattr(agentmod, "run_agent", slow_run_agent)
+
+    _call(agent_tool, ctx, run_in_background=True, description="long job")
+    assert await _drain(lambda: ctx.agent_supervisor.live_count() == 1)
+
+    (entry,) = ctx.agent_supervisor.snapshot()["active"]
+    assert entry["goal"] == "long job"
+    assert ctx.agent_supervisor.interrupt(entry["subagent_id"]) is True
+    # Still held: the worker has not exited yet.
+    assert ctx.agent_supervisor.live_count() == 1
+
+    release.set()
+    assert await _drain(lambda: ctx.agent_supervisor.live_count() == 0)
+
+
+def test_child_contexts_share_the_parents_supervisor(tmp_path: Path):
+    # Without sharing, a nested spawn would admit against its own empty
+    # registry and bypass the cap entirely.
+    from src.agent.subagent_context import create_subagent_context
+
+    parent = ToolContext(workspace_root=tmp_path, cwd=tmp_path)
+    child = create_subagent_context(parent)
+
+    assert child.agent_supervisor is parent.agent_supervisor
+
+
+def test_a_fresh_context_gets_its_own_supervisor(tmp_path: Path):
+    a = ToolContext(workspace_root=tmp_path)
+    b = ToolContext(workspace_root=tmp_path)
+    assert a.agent_supervisor is not b.agent_supervisor

--- a/tests/test_agent_tool_admission.py
+++ b/tests/test_agent_tool_admission.py
@@ -225,6 +225,9 @@ def test_finishing_one_agent_lets_the_next_in(agent_tool, ctx, fake_run):
 def test_an_interrupted_foreground_agent_is_not_reported_as_completed(
     agent_tool, ctx, fake_run,
 ):
+    emitted: list[dict[str, Any]] = []
+    ctx.agent_progress_emit = emitted.append
+
     def during(params):
         agent_id = ctx.agent_supervisor.snapshot()["active"][0]["subagent_id"]
         ctx.agent_supervisor.interrupt(agent_id)
@@ -240,6 +243,33 @@ def test_an_interrupted_foreground_agent_is_not_reported_as_completed(
     )
     assert "interrupted" in text.lower()
     assert "NOT complete" in text
+
+    # The HUD has to agree, or the overlay shows a killed agent as finished.
+    assert [e["status"] for e in emitted][-1] == "interrupted"
+
+
+def test_an_interrupted_result_reaches_the_model_in_the_same_shape_as_a_normal_one(
+    agent_tool, ctx, fake_run,
+):
+    # map_result_to_api is what renders the block list into the string every
+    # Agent result arrives as. A status it does not know falls through to the
+    # untyped tail and ships a raw list instead — a different wire shape on
+    # exactly the path that exists to be honest about a kill.
+    def during(params):
+        agent_id = ctx.agent_supervisor.snapshot()["active"][0]["subagent_id"]
+        ctx.agent_supervisor.interrupt(agent_id)
+
+    fake_run(during)
+    interrupted = agent_tool.map_result_to_api(_call(agent_tool, ctx).output, "tu_1")
+
+    fake_run()
+    completed = agent_tool.map_result_to_api(_call(agent_tool, ctx).output, "tu_2")
+
+    assert isinstance(completed["content"], str)
+    assert isinstance(interrupted["content"], str), (
+        "an interrupted result must render like every other one, not as a raw block list"
+    )
+    assert "NOT complete" in interrupted["content"]
 
 
 def test_an_uninterrupted_foreground_agent_still_reports_completed(

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -257,6 +257,84 @@ describe('GatewayClient NDJSON adapter', () => {
     proc.line({ response: { request_id: req.request_id, response }, type: 'control_response' })
   }
 
+  // ── delegation control plane ───────────────────────────────────────────────
+  // These three RPCs had no case in request(), so they hit the `default:` arm
+  // and resolved `{}` — the agents overlay's status readout, pause key and
+  // kill key were inert. Each test asserts the control_request that actually
+  // reaches the backend, since a wrong subtype or param name reproduces the
+  // silent no-op exactly.
+
+  it('maps delegation.status onto the delegation_status control', async () => {
+    const p = gw.request('delegation.status', {})
+    const snapshot = {
+      active: [
+        {
+          depth: 1,
+          goal: 'audit the store',
+          model: 'claude-opus-5',
+          parent_id: 'root',
+          started_at: 1_700_000_000,
+          status: 'running',
+          subagent_id: 'a1',
+          tool_count: 4
+        }
+      ],
+      max_concurrent_children: 10,
+      max_spawn_depth: 3,
+      paused: false
+    }
+    await replyToControl('delegation_status', snapshot)
+    await expect(p).resolves.toEqual(snapshot)
+  })
+
+  it('degrades delegation.status to an empty list when the backend does not answer', async () => {
+    // controlQuery resolves null on timeout; the overlay must get a shape it
+    // can read rather than a crash on `.active.map`.
+    const p = gw.request('delegation.status', {})
+    await replyToControl('delegation_status', null)
+    await expect(p).resolves.toEqual({ active: [] })
+  })
+
+  it('forwards an explicit delegation.pause value to the backend', async () => {
+    const p = gw.request('delegation.pause', { paused: true })
+    await replyToControl('delegation_pause', { paused: true })
+    await expect(p).resolves.toEqual({ paused: true })
+
+    const req = seen.find(f => f.request?.subtype === 'delegation_pause')
+    expect(req.request.paused).toBe(true)
+  })
+
+  it('omits paused entirely when the caller states none, asking the backend to flip', async () => {
+    const p = gw.request('delegation.pause', {})
+    await replyToControl('delegation_pause', { paused: true })
+    await expect(p).resolves.toEqual({ paused: true })
+
+    const req = seen.find(f => f.request?.subtype === 'delegation_pause')
+    expect('paused' in req.request).toBe(false)
+  })
+
+  it('maps subagent.interrupt onto subagent_interrupt with the agent id', async () => {
+    const p = gw.request('subagent.interrupt', { subagent_id: 'a1' })
+    await replyToControl('subagent_interrupt', { found: true, subagent_id: 'a1' })
+    await expect(p).resolves.toEqual({ found: true, subagent_id: 'a1' })
+
+    const req = seen.find(f => f.request?.subtype === 'subagent_interrupt')
+    expect(req.request.subagent_id).toBe('a1')
+  })
+
+  it('relays a not-found interrupt instead of reporting a kill that did not happen', async () => {
+    const p = gw.request('subagent.interrupt', { subagent_id: 'ghost' })
+    await replyToControl('subagent_interrupt', { found: false, subagent_id: 'ghost' })
+    await expect(p).resolves.toEqual({ found: false, subagent_id: 'ghost' })
+  })
+
+  it('degrades a silent interrupt to found:false rather than a truthy empty object', async () => {
+    // `{}` would read as a successful kill at the overlay's `r?.found` check.
+    const p = gw.request('subagent.interrupt', { subagent_id: 'a1' })
+    await replyToControl('subagent_interrupt', null)
+    await expect(p).resolves.toEqual({ found: false })
+  })
+
   it('maps /workflows to the workflows control and prints its report', async () => {
     const p = gw.request('slash.exec', { command: 'workflows' })
     await replyToControl('workflows', { ok: true, text: 'deep-research  [running]  (run: wf_1)' })

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -1293,6 +1293,27 @@ export class GatewayClient extends EventEmitter {
         return this.controlQuery('worktree_status', {}, WORKTREE_RPC_TIMEOUT_MS).then(
           r => (r ?? { error: 'no response from backend', ok: false }) as T
         )
+      // ── delegation control plane ─────────────────────────────────────────
+      // The agents overlay has called these three since it was written, but
+      // they had no case here, so they fell to the `default:` arm below and
+      // resolved `{}` — the status readout stayed empty and the pause and
+      // interrupt keys did nothing at all. They now reach the supervisor that
+      // both Agent spawn paths register with.
+      case 'delegation.status':
+        return this.controlQuery('delegation_status', {}).then(
+          r => (r ?? { active: [] }) as T
+        )
+      case 'delegation.pause':
+        // `paused` is forwarded only when the caller stated one; omitting it
+        // asks the backend to flip, which is what the overlay's toggle wants.
+        return this.controlQuery(
+          'delegation_pause',
+          p.paused === undefined ? {} : { paused: Boolean(p.paused) }
+        ).then(r => (r ?? {}) as T)
+      case 'subagent.interrupt':
+        return this.controlQuery('subagent_interrupt', {
+          subagent_id: String(p.subagent_id ?? p.id ?? '')
+        }).then(r => (r ?? { found: false }) as T)
       // ── skills hub + /skills subcommands ─────────────────────────────────
       case 'skills.manage': {
         const action = String(p.action ?? 'list')

--- a/ui-web/src/agents/AgentsPanel.module.css
+++ b/ui-web/src/agents/AgentsPanel.module.css
@@ -1,0 +1,122 @@
+/* Live subagents for the session. Reads top-to-bottom as shallowest-first,
+   each row: what it is doing → how it is going → how to stop it. */
+.root {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+.header {
+  display: flex;
+  flex: none;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--cc-alias-border-l1);
+}
+
+.count {
+  color: var(--cc-alias-label-secondary);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.pauseButton {
+  padding: 3px 10px;
+  border: 1px solid var(--cc-alias-border-l1);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--cc-alias-label-secondary);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.pauseButton:hover {
+  color: var(--cc-alias-label-primary);
+}
+
+.pauseButtonOn {
+  border-color: var(--cc-alias-border-l2);
+  color: var(--cc-alias-label-primary);
+}
+
+.list {
+  flex: 1 1 auto;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+}
+
+.row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  /* padding-left is set inline, per nesting depth. */
+  padding-right: 12px;
+  padding-block: 7px;
+  border-bottom: 1px solid var(--cc-alias-separator-primary);
+}
+
+.main {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.goal {
+  overflow: hidden;
+  color: var(--cc-alias-label-primary);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.meta {
+  color: var(--cc-alias-label-tertiary);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.status {
+  flex: none;
+  color: var(--cc-alias-label-tertiary);
+  font-size: 11px;
+}
+
+.statusStopping {
+  color: var(--cc-alias-label-secondary);
+}
+
+.stopButton {
+  flex: none;
+  padding: 2px 9px;
+  border: 1px solid var(--cc-alias-border-l1);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--cc-alias-label-secondary);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.stopButton:hover:not(:disabled) {
+  color: var(--cc-alias-label-primary);
+}
+
+.stopButton:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.empty {
+  padding: 20px 12px;
+  color: var(--cc-alias-label-tertiary);
+  font-size: 12px;
+  text-align: center;
+}

--- a/ui-web/src/agents/AgentsPanel.test.tsx
+++ b/ui-web/src/agents/AgentsPanel.test.tsx
@@ -1,0 +1,163 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DelegationStatusResult } from '../gateway/protocol.ts'
+import { $delegation, $sessionId } from '../state/store.ts'
+import { AgentsPanel } from './AgentsPanel.tsx'
+
+// The panel drives the gateway through these; the transport has its own tests.
+const actions = vi.hoisted(() => ({
+  fetchDelegationStatus: vi.fn(async () => {}),
+  interruptSubagent: vi.fn(async () => {}),
+  setDelegationPaused: vi.fn(async () => {}),
+}))
+
+vi.mock('../state/actions.ts', () => actions)
+
+const agent = (over: Partial<NonNullable<DelegationStatusResult['active']>[number]> = {}) => ({
+  depth: 0,
+  goal: 'audit the store',
+  model: 'claude-opus-5',
+  parent_id: null,
+  started_at: 1_700_000_000,
+  status: 'running',
+  subagent_id: 'a1',
+  tool_count: 4,
+  ...over,
+})
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  $sessionId.set('s1')
+  $delegation.set(null)
+})
+
+afterEach(() => {
+  cleanup()
+  $sessionId.set(null)
+  $delegation.set(null)
+})
+
+describe('AgentsPanel', () => {
+  it('distinguishes "not fetched yet" from "no agents running"', () => {
+    render(<AgentsPanel />)
+    expect(screen.getByText('Loading agents…')).toBeTruthy()
+
+    cleanup()
+    $delegation.set({ active: [] })
+    render(<AgentsPanel />)
+    expect(screen.getByText('No agents running.')).toBeTruthy()
+  })
+
+  it('lists a live agent with its model, tool count and status', () => {
+    $delegation.set({ active: [agent()], max_concurrent_children: 10 })
+    render(<AgentsPanel />)
+
+    expect(screen.getByText('audit the store')).toBeTruthy()
+    expect(screen.getByText('running')).toBeTruthy()
+    expect(screen.getByText(/claude-opus-5/)).toBeTruthy()
+    expect(screen.getByText(/4 tools/)).toBeTruthy()
+    expect(screen.getByText('1 running of 10')).toBeTruthy()
+  })
+
+  it('omits the cap rather than claiming a cap of zero when the backend sends none', () => {
+    // "0 of 0" would read as a session that can never delegate.
+    $delegation.set({ active: [agent()] })
+    render(<AgentsPanel />)
+
+    expect(screen.getByText('1 running')).toBeTruthy()
+  })
+
+  it('orders shallowest first, then oldest first', () => {
+    $delegation.set({
+      active: [
+        agent({ depth: 1, goal: 'child', started_at: 1_700_000_500, subagent_id: 'c' }),
+        agent({ depth: 0, goal: 'later root', started_at: 1_700_000_300, subagent_id: 'b' }),
+        agent({ depth: 0, goal: 'earlier root', started_at: 1_700_000_100, subagent_id: 'a' }),
+      ],
+    })
+    render(<AgentsPanel />)
+
+    const goals = screen.getAllByRole('listitem').map(li => li.textContent ?? '')
+    expect(goals[0]).toContain('earlier root')
+    expect(goals[1]).toContain('later root')
+    expect(goals[2]).toContain('child')
+  })
+
+  it('indents by nesting depth so a child reads under its parent', () => {
+    $delegation.set({ active: [agent({ depth: 2 })] })
+    render(<AgentsPanel />)
+
+    expect(screen.getByRole('listitem').style.paddingLeft).toBe('44px')
+  })
+
+  it('interrupts the agent whose Stop button was pressed', () => {
+    $delegation.set({ active: [agent({ subagent_id: 'a1' }), agent({ subagent_id: 'a2' })] })
+    render(<AgentsPanel />)
+
+    const stops = screen.getAllByRole('button', { name: 'Stop' })
+
+    expect(stops).toHaveLength(2)
+    // The second row's button must target the second agent, not the first —
+    // an index/id mismatch would silently kill the wrong one.
+    stops[1]?.click()
+    expect(actions.interruptSubagent).toHaveBeenCalledWith('a2')
+  })
+
+  it('disables Stop on an agent that is already stopping', () => {
+    // The interrupt already fired; the slot is held until the worker exits, so
+    // a second press would do nothing.
+    $delegation.set({ active: [agent({ status: 'interrupted' })] })
+    render(<AgentsPanel />)
+
+    const stop = screen.getByRole('button', { name: 'Stop' }) as HTMLButtonElement
+    expect(stop.disabled).toBe(true)
+    expect(screen.getByText('interrupted')).toBeTruthy()
+  })
+
+  it('sends the pause state it wants rather than a bare toggle', () => {
+    $delegation.set({ active: [], paused: false })
+    render(<AgentsPanel />)
+
+    screen.getByRole('button', { name: 'Pause spawning' }).click()
+    expect(actions.setDelegationPaused).toHaveBeenCalledWith(true)
+  })
+
+  it('reflects a paused session and offers to resume it', () => {
+    $delegation.set({ active: [], paused: true })
+    render(<AgentsPanel />)
+
+    const button = screen.getByRole('button', { name: 'Spawning paused' })
+    expect(button.getAttribute('aria-pressed')).toBe('true')
+    expect(screen.getByText('No agents running. New ones are paused.')).toBeTruthy()
+
+    button.click()
+    expect(actions.setDelegationPaused).toHaveBeenCalledWith(false)
+  })
+
+  it('fetches on mount when a session is live, and not before one exists', () => {
+    render(<AgentsPanel />)
+    expect(actions.fetchDelegationStatus).toHaveBeenCalledTimes(1)
+
+    cleanup()
+    vi.clearAllMocks()
+    $sessionId.set(null)
+    render(<AgentsPanel />)
+    expect(actions.fetchDelegationStatus).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a placeholder for an agent with no goal or model', () => {
+    $delegation.set({ active: [agent({ goal: '', model: null })] })
+    render(<AgentsPanel />)
+
+    expect(screen.getByText('subagent')).toBeTruthy()
+    expect(screen.getByText(/default model/)).toBeTruthy()
+  })
+
+  it('shows a dash instead of a bogus age when the backend sent no start time', () => {
+    $delegation.set({ active: [agent({ started_at: undefined })] })
+    render(<AgentsPanel />)
+
+    expect(screen.getByText(/· —$/)).toBeTruthy()
+  })
+})

--- a/ui-web/src/agents/AgentsPanel.tsx
+++ b/ui-web/src/agents/AgentsPanel.tsx
@@ -1,0 +1,150 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useMemo, useState } from 'react'
+
+import type { LiveAgent } from '../gateway/protocol.ts'
+import {
+  fetchDelegationStatus,
+  interruptSubagent,
+  setDelegationPaused,
+} from '../state/actions.ts'
+import { $delegation, $sessionId } from '../state/store.ts'
+import css from './AgentsPanel.module.css'
+
+/** How often the live view re-reads the backend snapshot. */
+const POLL_MS = 2_000
+
+/** Agents whose depth is unknown sort as top-level rather than vanishing. */
+const depthOf = (agent: LiveAgent): number => agent.depth ?? 0
+
+/** `started_at` is unix *seconds* from the Python clock, not milliseconds. */
+function elapsed(agent: LiveAgent, now: number): string {
+  const started = agent.started_at
+
+  if (typeof started !== 'number' || started <= 0) return '—'
+
+  const seconds = Math.max(0, Math.round(now / 1000 - started))
+
+  if (seconds < 60) return `${seconds}s`
+
+  const minutes = Math.floor(seconds / 60)
+
+  return minutes < 60 ? `${minutes}m ${seconds % 60}s` : `${Math.floor(minutes / 60)}h ${minutes % 60}m`
+}
+
+/**
+ * Live subagents for this session, with the controls to stop them.
+ *
+ * The rows come from `delegation.status` — the backend supervisor both spawn
+ * paths register with — rather than from accumulated progress events, so a
+ * foreground delegation appears here (it never enters the task registry the
+ * event stream is built from) and the list survives a reconnect.
+ */
+export function AgentsPanel() {
+  const delegation = useStore($delegation)
+  const sessionId = useStore($sessionId)
+  const [now, setNow] = useState(() => Date.now())
+
+  useEffect(() => {
+    if (sessionId === null) return
+
+    void fetchDelegationStatus()
+    const timer = setInterval(() => {
+      setNow(Date.now())
+      void fetchDelegationStatus()
+    }, POLL_MS)
+
+    return () => {
+      clearInterval(timer)
+    }
+  }, [sessionId])
+
+  const agents = useMemo(() => {
+    const active = delegation?.active ?? []
+
+    // Shallowest first, then oldest first, so a parent reads above the children
+    // it spawned instead of the list reordering as agents finish.
+    return [...active].sort(
+      (a, b) => depthOf(a) - depthOf(b) || (a.started_at ?? 0) - (b.started_at ?? 0),
+    )
+  }, [delegation])
+
+  const paused = delegation?.paused === true
+  const cap = delegation?.max_concurrent_children
+
+  if (delegation === null) {
+    return <div className={css.empty}>Loading agents…</div>
+  }
+
+  return (
+    <div className={css.root}>
+      <div className={css.header}>
+        <span className={css.count}>
+          {agents.length} running
+          {/* A missing cap is unknown, not zero — saying "of 0" would read as
+              a session that can never delegate. */}
+          {typeof cap === 'number' ? ` of ${cap}` : ''}
+        </span>
+        <button
+          aria-pressed={paused}
+          className={[css.pauseButton, paused ? css.pauseButtonOn : ''].filter(Boolean).join(' ')}
+          onClick={() => {
+            void setDelegationPaused(!paused)
+          }}
+          title={
+            paused
+              ? 'Allow this session to spawn new agents again'
+              : 'Stop this session spawning new agents; running ones continue'
+          }
+          type="button"
+        >
+          {paused ? 'Spawning paused' : 'Pause spawning'}
+        </button>
+      </div>
+
+      {agents.length === 0 ? (
+        <div className={css.empty}>
+          {paused
+            ? 'No agents running. New ones are paused.'
+            : 'No agents running.'}
+        </div>
+      ) : (
+        <ul className={css.list}>
+          {agents.map(agent => {
+            const id = agent.subagent_id ?? ''
+            const stopping = agent.status === 'interrupted'
+
+            return (
+              <li className={css.row} key={id} style={{ paddingLeft: 12 + depthOf(agent) * 16 }}>
+                <div className={css.main}>
+                  <span className={css.goal} title={agent.goal}>
+                    {agent.goal || 'subagent'}
+                  </span>
+                  <span className={css.meta}>
+                    {agent.model ?? 'default model'} · {agent.tool_count ?? 0} tools ·{' '}
+                    {elapsed(agent, now)}
+                  </span>
+                </div>
+                <span className={[css.status, stopping ? css.statusStopping : ''].filter(Boolean).join(' ')}>
+                  {agent.status ?? 'running'}
+                </span>
+                <button
+                  className={css.stopButton}
+                  // An interrupt already fired; the slot is held until the
+                  // worker actually exits, so a second click would do nothing.
+                  disabled={stopping || id === ''}
+                  onClick={() => {
+                    void interruptSubagent(id)
+                  }}
+                  title={stopping ? 'Already stopping' : 'Interrupt this agent'}
+                  type="button"
+                >
+                  Stop
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/ui-web/src/conversation/ConversationRoot.tsx
+++ b/ui-web/src/conversation/ConversationRoot.tsx
@@ -35,6 +35,7 @@ import {
   $transcript,
   $workspace,
 } from '../state/store.ts'
+import { AgentsPanel } from '../agents/AgentsPanel.tsx'
 import { currentTodos } from '../state/todo-progress.ts'
 import { trajectoryStats } from '../state/trajectory.ts'
 import { RunStatsBar } from '../trajectory/RunStatsBar.tsx'
@@ -64,6 +65,8 @@ const STICK_THRESHOLD = 96
  * before the first message, docked composer after), which are the same
  * components in two positions rather than two screens.
  */
+const TAB_LABELS = { agents: 'Agents', chat: 'Chat', trajectory: 'Trajectory' } as const
+
 export function ConversationRoot() {
   const transcript = useStore($transcript)
   const sessionId = useStore($sessionId)
@@ -357,7 +360,7 @@ export function ConversationRoot() {
       )}
       {!hero && (
         <div className={css.tabs} role="tablist">
-          {(['chat', 'trajectory'] as const).map(id => (
+          {(['chat', 'trajectory', 'agents'] as const).map(id => (
             <button
               aria-selected={tab === id}
               className={[css.tab, tab === id ? css.tabActive : ''].filter(Boolean).join(' ')}
@@ -368,13 +371,17 @@ export function ConversationRoot() {
               role="tab"
               type="button"
             >
-              {id === 'chat' ? 'Chat' : 'Trajectory'}
+              {TAB_LABELS[id]}
             </button>
           ))}
         </div>
       )}
       {banner}
-      {!hero && tab === 'trajectory' ? (
+      {!hero && tab === 'agents' ? (
+        <div className={css.viewBody}>
+          <AgentsPanel />
+        </div>
+      ) : !hero && tab === 'trajectory' ? (
         <>
           <div className={css.viewBody}>
             <TrajectoryView trajectory={trajectory} />

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -415,3 +415,45 @@ export interface DirectoryListing {
 
 /** Approval answers the gateway understands (`approval.respond`). */
 export type ApprovalChoice = 'allow' | 'deny' | 'session' | 'always'
+
+// ── delegation control plane ────────────────────────────────────────────────
+
+/** One live subagent in a `delegation.status` snapshot. */
+export interface LiveAgent {
+  /** Nesting level; 0 is a direct child of the root session. */
+  depth?: number
+  /** The task the agent was spawned for — its `description`, else its prompt. */
+  goal?: string
+  model?: null | string
+  parent_id?: null | string
+  /** Unix seconds, from the backend clock. */
+  started_at?: number
+  status?: string
+  subagent_id?: string
+  tool_count?: number
+}
+
+/**
+ * `delegation.status` — the session's authoritative live-agent state.
+ *
+ * Every field is optional because a backend that predates the supervisor
+ * answers with only `active`; the caps are absent rather than zero there, and a
+ * client must not read a missing cap as "at capacity".
+ */
+export interface DelegationStatusResult {
+  active?: LiveAgent[]
+  max_concurrent_children?: number
+  max_spawn_depth?: number
+  paused?: boolean
+}
+
+/** `delegation.pause` — the resulting admission state, echoed back. */
+export interface DelegationPauseResult {
+  paused?: boolean
+}
+
+/** `subagent.interrupt` — `found` is false when the id was not live. */
+export interface SubagentInterruptResult {
+  found?: boolean
+  subagent_id?: string
+}

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -14,17 +14,20 @@ import type {
   CommandEntry,
   CommandsCatalogResult,
   ContextUsageResult,
+  DelegationPauseResult,
+  DelegationStatusResult,
   DirectoryListing,
-  GatewayEvent,
   EffortOptionsResult,
   FileSearchResult,
+  GatewayEvent,
   GeneralSettingsResult,
   ModelOptionsResult,
+  ProjectsTreeResult,
   ProviderListResult,
   ProviderMutationResult,
-  ProjectsTreeResult,
   SessionResumeResult,
   SlashResult,
+  SubagentInterruptResult,
 } from '../gateway/protocol.ts'
 import {
   $backendNano,
@@ -33,6 +36,7 @@ import {
   $commands,
   $connection,
   $contextUsage,
+  $delegation,
   $effort,
   $generalSettings,
   $detailsNodeId,
@@ -591,6 +595,82 @@ export async function respondQuestion(
   } catch (error) {
     notice(errorText(error), 'error')
   }
+}
+
+// ── delegation control plane ────────────────────────────────────────────────
+
+/**
+ * Refresh the live-agent snapshot.
+ *
+ * Failures leave the last good snapshot in place rather than blanking the
+ * panel: a dropped poll during a reconnect is not evidence that the agents
+ * stopped, and flashing an empty list would say it was.
+ */
+export async function fetchDelegationStatus(): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) return
+
+  try {
+    const result = await gateway().request<DelegationStatusResult>('delegation.status', {
+      session_id: sessionId,
+    })
+
+    $delegation.set(result ?? { active: [] })
+  } catch {
+    // Keep the previous snapshot; the panel shows its own staleness.
+  }
+}
+
+/**
+ * Stop or resume admission of new subagents.
+ *
+ * Sends the value it wants rather than asking the backend to flip, so two
+ * clicks racing from two tabs converge on one state instead of toggling past
+ * each other.
+ */
+export async function setDelegationPaused(paused: boolean): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) return
+
+  try {
+    const result = await gateway().request<DelegationPauseResult>('delegation.pause', {
+      paused,
+      session_id: sessionId,
+    })
+
+    $delegation.set({ ...($delegation.get() ?? {}), paused: result?.paused ?? paused })
+  } catch {
+    notice('Could not change delegation state', 'error')
+  }
+}
+
+/**
+ * Abort one live subagent.
+ *
+ * Reports a miss rather than an interruption when the agent had already
+ * finished — the panel can be a poll behind the truth.
+ */
+export async function interruptSubagent(subagentId: string): Promise<void> {
+  const sessionId = $sessionId.get()
+
+  if (sessionId === null) return
+
+  try {
+    const result = await gateway().request<SubagentInterruptResult>('subagent.interrupt', {
+      session_id: sessionId,
+      subagent_id: subagentId,
+    })
+
+    if (result?.found !== true) {
+      notice('That agent had already finished', 'info')
+    }
+  } catch {
+    notice('Could not interrupt the agent', 'error')
+  }
+
+  await fetchDelegationStatus()
 }
 
 /** The session's plan text, for the plan-review takeover. */

--- a/ui-web/src/state/delegation-actions.test.ts
+++ b/ui-web/src/state/delegation-actions.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GatewayClient } from '../gateway/client.ts'
+import * as actions from './actions.ts'
+import { setGatewayClient } from './actions.ts'
+import { $delegation, $notice, $sessionId } from './store.ts'
+
+// The panel's own tests mock this module wholesale, so the request shapes and
+// the failure behaviour below are only covered here. Injected through the same
+// seam actions.test.ts uses, so the real functions run.
+const request = vi.fn()
+
+beforeEach(() => {
+  request.mockReset()
+  setGatewayClient({ request } as unknown as GatewayClient)
+  $sessionId.set('s1')
+  $delegation.set(null)
+  $notice.set({ text: '', tone: 'info' })
+})
+
+afterEach(() => {
+  setGatewayClient(null)
+  $sessionId.set(null)
+  $delegation.set(null)
+})
+
+describe('fetchDelegationStatus', () => {
+  it('sends the session id and stores the snapshot', async () => {
+    const snapshot = { active: [{ subagent_id: 'a1' }], max_concurrent_children: 32 }
+
+    request.mockResolvedValue(snapshot)
+    await actions.fetchDelegationStatus()
+
+    expect(request).toHaveBeenCalledWith('delegation.status', { session_id: 's1' })
+    expect($delegation.get()).toEqual(snapshot)
+  })
+
+  it('keeps the last good snapshot when a poll fails', async () => {
+    // A dropped poll during a reconnect is not evidence the agents stopped;
+    // blanking the list would say it was.
+    const good = { active: [{ subagent_id: 'a1' }] }
+
+    request.mockResolvedValueOnce(good)
+    await actions.fetchDelegationStatus()
+
+    request.mockRejectedValueOnce(new Error('socket closed'))
+    await actions.fetchDelegationStatus()
+
+    expect($delegation.get()).toEqual(good)
+  })
+
+  it('does nothing without a live session', async () => {
+    $sessionId.set(null)
+    await actions.fetchDelegationStatus()
+
+    expect(request).not.toHaveBeenCalled()
+  })
+})
+
+describe('setDelegationPaused', () => {
+  it('sends the value it wants rather than asking for a flip', async () => {
+    request.mockResolvedValue({ paused: true })
+    await actions.setDelegationPaused(true)
+
+    expect(request).toHaveBeenCalledWith('delegation.pause', {
+      paused: true,
+      session_id: 's1',
+    })
+    expect($delegation.get()?.paused).toBe(true)
+  })
+
+  it('reports a failure to the user instead of showing a state it did not reach', async () => {
+    request.mockRejectedValue(new Error('nope'))
+    await actions.setDelegationPaused(true)
+
+    expect($notice.get().tone).toBe('error')
+  })
+})
+
+describe('interruptSubagent', () => {
+  it('names both the session and the agent', async () => {
+    request.mockResolvedValue({ found: true, subagent_id: 'a1' })
+    await actions.interruptSubagent('a1')
+
+    expect(request).toHaveBeenCalledWith('subagent.interrupt', {
+      session_id: 's1',
+      subagent_id: 'a1',
+    })
+  })
+
+  it('says so when the agent had already finished rather than implying a kill', async () => {
+    request.mockResolvedValue({ found: false, subagent_id: 'a1' })
+    await actions.interruptSubagent('a1')
+
+    expect($notice.get().text).toMatch(/already finished/i)
+  })
+
+  it('refreshes the snapshot afterwards so the row reflects the new state', async () => {
+    request.mockResolvedValue({ active: [], found: true })
+    await actions.interruptSubagent('a1')
+
+    expect(request.mock.calls.map(c => c[0])).toEqual([
+      'subagent.interrupt',
+      'delegation.status',
+    ])
+  })
+})

--- a/ui-web/src/state/store.ts
+++ b/ui-web/src/state/store.ts
@@ -12,6 +12,7 @@ import type { ConnectionState } from '../gateway/client.ts'
 import type {
   CommandEntry,
   ContextUsageResult,
+  DelegationStatusResult,
   EffortOptionsResult,
   GeneralSettingsResult,
   ModelOptionsResult,
@@ -55,7 +56,7 @@ export const $sessionLoading = atom<boolean>(false)
 export const $trajectory = atom<TrajectoryState>(emptyTrajectory())
 
 /** Which view the conversation column is showing. */
-export type ConversationTab = 'chat' | 'trajectory'
+export type ConversationTab = 'agents' | 'chat' | 'trajectory'
 
 export const $conversationTab = atom<ConversationTab>('chat')
 
@@ -83,6 +84,19 @@ export const $providers = atom<ProviderListResult>({})
 export const $generalSettings = atom<GeneralSettingsResult>({})
 export const $commands = atom<CommandEntry[]>([])
 export const $contextUsage = atom<ContextUsageResult | null>(null)
+
+/**
+ * Live subagents plus this session's delegation caps.
+ *
+ * Polled from `delegation.status` rather than accumulated from progress
+ * events: the backend supervisor is the only thing that knows about a
+ * *foreground* delegation, and a client that reconstructs the list from the
+ * event stream cannot recover it after a reconnect.
+ *
+ * `null` means "not fetched yet", which the panel renders differently from a
+ * fetched-and-empty session — one is unknown, the other is idle.
+ */
+export const $delegation = atom<DelegationStatusResult | null>(null)
 
 /**
  * Approval mode chosen before any session existed.


### PR DESCRIPTION
## Why

Clawcodex spawns subagents down two paths that never met: `_run_sync_agent`
(foreground, returns inline) and `_launch_async_agent` (background, lands in
`runtime_tasks`). Only the background path was observable. Comparing against the
OpenAI Codex multi-agent implementation (`codex-rs/core/src/agent/`), three gaps
were verified in the source:

1. **Nothing bounded how many agents could run.** Codex reserves a slot per
   spawn and refuses past a cap (`registry.rs`, `reserve_spawn_slot` →
   `AgentLimitReached`). Clawcodex had no equivalent on the Agent path — the
   workflow engine's cap of 4 is workflow-local and the Agent tool never
   consults it.

2. **Nothing bounded nesting.** Codex has `exceeds_thread_spawn_depth_limit`.
   Clawcodex computes a depth (`subagent_context.py:137`) and never compares it
   to anything.

3. **The TUI's agent controls were dead.** `agentsOverlay.tsx` calls
   `delegation.status`, `delegation.pause` and `subagent.interrupt`.
   `gatewayClient.request()` had no case for any of them, so they hit:

   ```ts
   default:
     // Unhandled RPC (Phase 2): resolve empty so the app degrades gracefully.
     return Promise.resolve({} as T)
   ```

   The status readout stayed empty and the pause and kill keys silently did
   nothing. The response shapes were already declared in `gatewayTypes.ts` —
   including `max_concurrent_children` and `max_spawn_depth` — so the client had
   been specifying this backend for some time. `ui-web` had no agent surface at
   all.

## What

**Backend.** A session-scoped `AgentSupervisor`
(`src/services/swarm/agent_supervisor.py`), shared by reference into every child
context so one object sees the whole tree. Both spawn paths `admit()` before
running and `release()` when the worker actually exits.

- Two independent limits, as in Codex: `max_concurrent_children` (default 32,
  `CLAWCODEX_MAX_CONCURRENT_AGENTS`) and `max_spawn_depth` (default 3,
  `CLAWCODEX_MAX_AGENT_DEPTH`).
- The concurrency default is a **runaway backstop, not a scheduling budget** —
  set well above any legitimate fan-out so that hitting it means something is
  wrong. It deliberately is not derived from the tool orchestrator's own bound:
  a background agent holds its slot until its *worker* exits, potentially many
  turns later, so three background agents plus a ten-wide foreground batch is
  13 live agents from a session nothing over-admitted. Coordinator mode makes
  that routine.
- A refusal returns a tool error the model can act on, not an exception.
- Foreground agents now carry a reachable AbortController, so a synchronous
  delegation can be interrupted — previously impossible, since it never entered
  `runtime_tasks` and no abort handle escaped.
- `interrupt()` holds the slot until the worker exits. A terminal *label* is not
  proof the worker stopped; releasing on the label would let a replacement start
  while the old run was still on the wire. Codex holds its `SpawnReservation`
  for the same window.

**Transport.** Three agent-server control subtypes (`delegation_status`,
`delegation_pause`, `subagent_interrupt`) plus three desktop-gateway forwarders,
so the TUI and the browser read the same authority.

**TUI.** The three orphaned RPCs are wired in `gatewayClient`; the overlay's
existing controls become live with no change to the overlay. Note the scope
honestly: the overlay consumes the caps and `paused` from the snapshot, but its
*rows* still come from the reconstructed `agent_progress` tree — serving those
from `active[]` is follow-up work. `ui-web` renders `active[]` directly.

**Web.** A new `AgentsPanel`, mounted as a third conversation tab: live agents
with model, tool count, age and status, per-agent interrupt, session-wide pause.

## Two bugs caught in review, and their fixes

Both were found by an adversarial review pass before merge, and both now have
regression tests that fail without the fix.

**Parent-ESC propagation was severed for foreground subagents.** `run_agent`
resolves `explicit override → fresh controller for async → the parent's own
controller for sync`. Giving every agent its own handle (needed for
`subagent.interrupt`) took the first branch and quietly unlinked sync
subagents from parent abort. Fixed with `create_child_abort_controller`, whose
one-way semantics are exactly right: parent abort reaches the child, and
interrupting one subagent does not end the turn.

**An interrupted agent reported itself as `completed`.** An aborted `query()`
*returns* rather than raising, so both lifecycles took their success branch:
the background one called `complete_agent_task` (the registry was not yet
terminal) and notified `status="completed"`, and the sync one returned
`status: "completed"` with partial content. The user killed a delegation and
the model was told it succeeded. Background interrupts now route through
`kill_async_agent` — which is what marks the registry, schedules eviction and
enqueues the notification — and the sync path reports `interrupted`, with the
warning in the content the model actually reads.

## Deliberately not in scope

`resume_agent_background` still does not drive a model loop (its `SendMessage`
caller remains honest about that); there is still no `wait_agent` primitive, no
`send_input(interrupt=true)`, and no durable cross-restart agent identity.
`workflow/runner.py` drives `run_agent` directly and is not yet admitted by the
supervisor — its own budget and cap still apply.

## Tests

- `tests/services/test_agent_supervisor.py` (28) — both limits and their
  independence, pause, interrupt-holds-the-slot, snapshot wire shape and
  ordering, env overrides, and a 20-thread race proving admission never exceeds
  the cap.
- `tests/test_agent_tool_admission.py` (22) — refusal returned not raised,
  leaves no registry trace, never reaches the provider; post-admission launch
  failure returns the slot; parent/child identity; and end-to-end runs of BOTH
  spawn paths proving a foreground agent is visible and interruptible while it
  runs, and that each path frees its slot on success, on failure, and only after
  an interrupted worker actually exits.
- `tests/server/test_delegation_control.py` (13) — the three subtypes, including
  absent-supervisor and absent-tool-context degradation, and that an interrupted
  agent still appears in the next snapshot.
- `ui-tui/src/__tests__/gatewayClient.test.ts` (+7) — asserts the
  `control_request` each RPC actually produces, since a wrong subtype reproduces
  the silent no-op exactly.
- `ui-web/src/agents/AgentsPanel.test.tsx` (12) — ordering, depth indentation,
  interrupt targeting, disabled re-interrupt, pause round-trip, unknown-cap
  rendering.
- `ui-web/src/state/delegation-actions.test.ts` (8) — the request shapes, and
  that a failed poll keeps the last good snapshot rather than blanking the
  panel.

`ui-web` typecheck, vitest (440) and production build all pass. Pre-existing
`ui-tui` failures were baselined against `origin/main` before and after: the
branch's failure set is a strict subset, and none are in files this change
touches. `tests/test_agent_loop_compat_model_error.py::test_connection_error_re_raises`
exceeds 75s on pristine `origin/main` too (exit 124) and is deselected from the
local full-suite run for that reason — it is not affected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkutoRWaBMbiRV8xwVVWGC
