### PR TITLE
fix(harbor): supply _websearch in the adapter test fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `anthropic` is capped below 1.0. Version 1.0.0 moved the SDK onto `httpx2`,
+  which rejects the `http_client=httpx.Client(...)` hook the provider layer
+  depends on — the same migration `openai` is already capped for. An unpinned
+  resolve installed 1.x in CI while pinned local environments stayed green.
+
 ## [1.6.0] - 2026-08-15
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,14 @@ classifiers = [
 ]
 
 dependencies = [
-    "anthropic>=0.116.0",
+    # Capped below 1.0 for the same reason as the openai cap below:
+    # anthropic 1.0.0 moved the SDK onto httpx2 (``httpx2<3,>=2.0.0``),
+    # so an ``http_client=httpx.Client(...)`` handed to it is rejected
+    # outright — "this SDK uses httpx2". That is what breaks
+    # tests/test_minimax_provider.py under a fresh resolve while a pinned
+    # local env stays green. Lift together with the openai cap once the
+    # transport hooks are migrated to httpx2.
+    "anthropic>=0.116.0,<1",
     # Capped below 3.0 deliberately. openai 3.0.0 (2026-08-12) is the HTTPX2
     # migration: the SDK's default transport became httpx2 (httpx is no
     # longer even a dependency), and requests silently stop flowing through

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,11 @@
 # Runtime dependencies (production install).
 # Dev/test-only tools live in requirements.dev.txt.
-anthropic>=0.116.0
+# Capped below 1.0: anthropic 1.0.0 moved the SDK onto httpx2, exactly as
+# openai 3.0.0 did below — a passed ``http_client=httpx.Client(...)`` is
+# rejected outright ("this SDK uses httpx2"), which is what breaks
+# tests/test_minimax_provider.py in CI while a pinned local env stays
+# green. Lift together with the openai cap once both are on httpx2.
+anthropic>=0.116.0,<1
 # Capped below 3.0: openai 3.0.0 (2026-08-12) moved the SDK onto httpx2, so
 # requests silently bypass the httpx layer we hook — the ``http_client=
 # httpx.Client(verify=False)`` escape hatch stops carrying the transport and

--- a/tests/test_harbor_adapter_advisor.py
+++ b/tests/test_harbor_adapter_advisor.py
@@ -51,6 +51,11 @@ def _agent(
     agent._parsed_model_provider = model_provider
     agent._forward_keys = False
     agent._fusion = None
+    # Set for the same reason as the rest: this helper builds the agent
+    # with __new__, so every attribute _seed_container_settings reads has
+    # to be supplied here. Missing one is an AttributeError, not a
+    # default.
+    agent._websearch = False
     agent._resolved_flags = {"effort": effort} if effort else {}
     agent._extra_env = {}
     agent._get_env = lambda key: f"{key}-VALUE"

--- a/tests/test_harbor_adapter_vision.py
+++ b/tests/test_harbor_adapter_vision.py
@@ -48,6 +48,11 @@ def _agent(
     agent._parsed_model_provider = model_provider
     agent._forward_keys = False
     agent._fusion = None
+    # Set for the same reason as the rest: this helper builds the agent
+    # with __new__, so every attribute _seed_container_settings reads has
+    # to be supplied here. Missing one is an AttributeError, not a
+    # default.
+    agent._websearch = False
     agent._resolved_flags = {"effort": "max"}
     agent._extra_env = {}
     agent._get_env = lambda key: f"{key}-VALUE"


### PR DESCRIPTION
The Harbor adapter job is **red on main** — seven tests fail with
`AttributeError: 'Clawcodex' object has no attribute '_websearch'`.
This is unrelated to any feature work; it reproduces on pristine `origin/main`.

## Cause

`tests/test_harbor_adapter_advisor.py` and `tests/test_harbor_adapter_vision.py`
build their agent with `Clawcodex.__new__(Clawcodex)` and set each attribute by
hand, deliberately bypassing `__init__`. When `_websearch` was added to
`__init__` and read by `_seed_container_settings`
(`eval/harbor/clawcodex_agent.py:868`), those fixtures were not updated — the
attribute exists on a real agent and is simply absent on the test's.

## Fix

Set `_websearch` in both helpers, alongside the attributes already listed there.

That fixture shape keeps inviting this: every attribute the production path
reads has to be repeated by hand, and a missing one raises rather than
defaulting. Whether these should construct through `__init__` instead is worth
revisiting, but it is a larger change than unbreaking CI.

## Verification

The exact command the CI job runs:

```
uv run --isolated --python 3.13 --with harbor --with pytest python -m pytest \
  tests/test_headless_usage_events.py tests/test_harbor_adapter_fusion.py \
  tests/test_harbor_adapter_advisor.py tests/test_harbor_adapter_vision.py \
  tests/test_harbor_adapter_pi.py
```

**82 passed** (previously 7 failed / 75 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CkutoRWaBMbiRV8xwVVWGC