### PR TITLE
Fix account-specific subscription models and app version display

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -48,7 +48,7 @@ trap 'log_err "Installer crash at line $LINENO: $BASH_COMMAND"' ERR
 # ============================================================================
 #  Config (read-only defaults)
 # ============================================================================
-readonly INSTALLER_VERSION="1.4.0"
+readonly INSTALLER_VERSION="1.6.0"
 # REPO_REF is intentionally NOT readonly — it gets reassigned when the user
 # passes --ref. We have no version tags, so the default is the main branch;
 # --ref is the escape hatch for installing a specific commit/tag/branch.

--- a/src/cli.py
+++ b/src/cli.py
@@ -918,17 +918,19 @@ def _handle_openai_subscription_login(console, Prompt):
         console.print(f"\n[red]ChatGPT subscription login failed:[/red] {exc}")
         return 1
 
+    from src.providers.openai_subscription_models import get_subscription_models
     from src.providers.openai_responses import SUBSCRIPTION_MODELS
 
+    models = get_subscription_models(background=False, force=True)
     info = PROVIDER_INFO["openai"]
     set_api_key(
         "openai", api_key="", base_url=info["default_base_url"],
-        default_model=info["default_model"],
+        default_model=(models or SUBSCRIPTION_MODELS)[0],
     )
     set_default_provider("openai")
     console.print("\n[green]✓ ChatGPT subscription connected.[/green]")
     console.print(
-        "[dim]Subscription models: " + ", ".join(SUBSCRIPTION_MODELS) + "[/dim]"
+        "[dim]Subscription models: " + (", ".join(models) or "none available") + "[/dim]"
     )
     import os as _os
     if (_os.environ.get("OPENAI_API_KEY") or "").strip():

--- a/src/providers/catalog.py
+++ b/src/providers/catalog.py
@@ -137,9 +137,9 @@ def provider_catalog(
         key_env = env_vars[0] if env_vars else ""
 
         models = [str(m) for m in (info.get("available_models") or [])]
-        if is_current and current_models:
+        if is_current and current_models is not None:
             models = [str(m) for m in current_models]
-        elif pid == "openai":
+        elif pid == "openai" and authenticated and not api_key:
             # The inactive row must use the same auth-specific catalog as a
             # live OpenAI session. Construction only checks local credentials;
             # it neither creates an SDK client nor refreshes OAuth tokens.

--- a/src/providers/openai_provider.py
+++ b/src/providers/openai_provider.py
@@ -197,6 +197,8 @@ class OpenAIProvider(OpenAICompatibleProvider):
             if credentials is not None:
                 self._subscription_active = True
                 self._subscription_account_id = credentials.account_id
+                if model is None:
+                    self.model = SUBSCRIPTION_MODELS[0]
 
     def _create_client(self) -> Any:
         """Create OpenAI SDK client (API-key path only).
@@ -225,9 +227,9 @@ class OpenAIProvider(OpenAICompatibleProvider):
             List of model names
         """
         if self._subscription_active:
-            # A ChatGPT plan serves a SMALLER set than the API key does, so
-            # this stays its own list — see openai_responses.SUBSCRIPTION_MODELS.
-            return list(SUBSCRIPTION_MODELS)
+            from .openai_subscription_models import get_subscription_models
+
+            return get_subscription_models()
         # Read the registry rather than keep a second copy. This used to
         # duplicate PROVIDER_INFO["openai"]["available_models"] verbatim, and
         # the halves feed different surfaces — the registry drives `login` and
@@ -644,6 +646,7 @@ class OpenAIProvider(OpenAICompatibleProvider):
                     raise RuntimeError(
                         "ChatGPT subscription login expired; run `clawcodex login`"
                     )
+                credentials = refreshed
                 self._subscription_account_id = (
                     refreshed.account_id or self._subscription_account_id
                 )
@@ -659,15 +662,35 @@ class OpenAIProvider(OpenAICompatibleProvider):
             if response.status_code != 200:
                 detail = response.read().decode("utf-8", "replace")
                 _who = "ChatGPT backend" if self._subscription_active else "OpenAI API"
+                hint = ""
+                if (self._subscription_active and response.status_code == 400
+                        and "not supported" in detail and "ChatGPT account" in detail):
+                    from .openai_subscription_models import (
+                        get_subscription_models,
+                        record_subscription_model,
+                    )
+
+                    if credentials is not None:
+                        record_subscription_model(credentials, str(body.get("model", "")), available=False)
+                    get_subscription_models(force=True)
+                    hint = (
+                        " This model is unavailable through your current ChatGPT login. "
+                        "Run /model to choose from your account's catalog."
+                    )
                 raise ResponsesHTTPError(
-                    f"{_who} error ({response.status_code}): {detail[:600]}",
+                    f"{_who} error ({response.status_code}): {detail[:600]}{hint}",
                     status_code=response.status_code,
                     response=response,
                 )
-            return self._consume_subscription_stream(
+            result = self._consume_subscription_stream(
                 response, guard, on_text_chunk, on_thinking_chunk,
                 request_model=str(body.get("model", "")),
             )
+            if credentials is not None and (result.content or result.tool_uses):
+                from .openai_subscription_models import record_subscription_model
+
+                record_subscription_model(credentials, str(body.get("model", "")))
+            return result
         except Exception as exc:
             guard.reraise_if_aborted(exc)
             raise

--- a/src/providers/openai_responses.py
+++ b/src/providers/openai_responses.py
@@ -40,18 +40,11 @@ logger = logging.getLogger(__name__)
 # filter it; Gemini's converter drops unknown block types by construction.
 RESPONSES_ITEM_BLOCK_TYPE = "openai_responses_item"
 
-# Models offered for ChatGPT subscriptions, separate from the API catalog.
-# Current Codex model IDs: https://learn.chatgpt.com/docs/models (2026-09-06).
-# Availability still depends on the user's plan (Spark requires Pro).
+# Conservative fallback while this login's live model catalog is unavailable.
+# New models and plan-specific models must come from account discovery, not
+# the public API catalog or another client's cache.
 SUBSCRIPTION_MODELS = [
-    "gpt-6-astra",
-    "gpt-5.6-sol",
-    "gpt-5.6-terra",
-    "gpt-5.6-luna",
     "gpt-5.5",
-    "gpt-5.4",
-    "gpt-5.4-mini",
-    "gpt-5.3-codex-spark",
 ]
 
 INCLUDE_ENCRYPTED_REASONING = ["reasoning.encrypted_content"]

--- a/src/providers/openai_subscription_models.py
+++ b/src/providers/openai_subscription_models.py
@@ -1,0 +1,211 @@
+"""Account-scoped model discovery for the ChatGPT Codex endpoint.
+
+The public API catalog and another client's model cache do not establish
+what a Clawcodex OAuth login can use. Read this login's catalog instead.
+Picker reads never wait for HTTP; login can explicitly refresh synchronously.
+Successful requests also establish availability: the catalog can lag rollout.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import threading
+import time
+from pathlib import Path
+
+from src.auth.openai_subscription import (
+    ORIGINATOR,
+    SubscriptionCredentials,
+    credentials_path,
+    load_credentials,
+)
+
+from .openai_responses import SUBSCRIPTION_MODELS
+
+MODELS_ENDPOINT = "https://chatgpt.com/backend-api/codex/models"
+# Catalog protocol version verified against the Codex endpoint. This is not
+# Clawcodex's package version (which the endpoint doesn't understand).
+CATALOG_CLIENT_VERSION = "0.149.1"
+TTL_SECONDS = 300
+RETRY_SECONDS = 30
+VERIFICATION_TTL_SECONDS = 86_400
+
+_lock = threading.Lock()
+_in_flight: set[tuple[Path, str]] = set()
+_retry_after: dict[tuple[Path, str], float] = {}
+
+
+def _scope(credentials: SubscriptionCredentials) -> str:
+    # Partition even logins to the same account: entitlements may differ by
+    # token/workspace. Never persist the credentials themselves in this cache.
+    value = credentials.account_id + "\0" + credentials.access_token
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _read_entry(path: Path, scope: str) -> dict:
+    try:
+        entry = json.loads(path.read_text(encoding="utf-8"))
+        if entry.get("scope") == scope and entry.get("version") == 1:
+            return entry
+    except (OSError, ValueError, TypeError, AttributeError):
+        pass
+    return {"version": 1, "scope": scope}
+
+
+def _read_cache(path: Path, scope: str) -> tuple[list[str] | None, float]:
+    entry = _read_entry(path, scope)
+    try:
+        models = entry["models"]
+        if isinstance(models, list) and all(isinstance(m, str) and m for m in models):
+            return models, float(entry["fetched_at"])
+    except (ValueError, TypeError, KeyError):
+        pass
+    return None, 0
+
+
+def _write_entry(path: Path, entry: dict) -> None:
+    tmp = None
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp = tempfile.mkstemp(dir=path.parent, prefix=".openai-models-")
+        with os.fdopen(fd, "w", encoding="utf-8") as stream:
+            json.dump(entry, stream)
+        os.replace(tmp, path)
+    except OSError:
+        pass  # Discovery/cache failures must not break requests or the picker.
+    finally:
+        if tmp is not None:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+
+
+def _recent_models(entry: dict, key: str, ttl_seconds: float) -> dict[str, float]:
+    recorded = entry.get(key)
+    if not isinstance(recorded, dict):
+        return {}
+    now = time.time()
+    return {
+        model: timestamp for model, timestamp in recorded.items()
+        if isinstance(model, str) and model
+        and isinstance(timestamp, (int, float))
+        and 0 <= now - timestamp < ttl_seconds
+    }
+
+
+def record_subscription_model(
+    credentials: SubscriptionCredentials, model: str, *, available: bool = True,
+) -> None:
+    """Remember actual request results for this login, not guessed model IDs."""
+    if not model:
+        return
+    path = credentials_path().with_name("openai-models-cache.json")
+    with _lock:
+        entry = _read_entry(path, _scope(credentials))
+        verified = _recent_models(entry, "verified_models", VERIFICATION_TTL_SECONDS)
+        rejected = _recent_models(entry, "rejected_models", TTL_SECONDS)
+        if available:
+            verified[model] = time.time()
+            rejected.pop(model, None)
+        else:
+            verified.pop(model, None)
+            rejected[model] = time.time()
+        entry["verified_models"] = verified
+        entry["rejected_models"] = rejected
+        _write_entry(path, entry)
+
+
+def _fetch_models(credentials: SubscriptionCredentials) -> list[str] | None:
+    import httpx
+
+    headers = {
+        "Authorization": f"Bearer {credentials.access_token}",
+        "originator": ORIGINATOR,
+        "Accept": "application/json",
+    }
+    if credentials.account_id:
+        headers["chatgpt-account-id"] = credentials.account_id
+    verify = os.environ.get("CLAWCODEX_SSL_VERIFY", "").lower() not in ("0", "false", "no")
+    try:
+        response = httpx.get(
+            MODELS_ENDPOINT,
+            params={"client_version": CATALOG_CLIENT_VERSION},
+            headers=headers,
+            timeout=2.0,
+            verify=verify,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        raw = payload.get("models") if isinstance(payload, dict) else None
+        if not isinstance(raw, list):
+            return None
+        # Preserve backend order, including subscription-only models (their
+        # supported_in_api flag is false). Hidden/internal models stay hidden.
+        return list(dict.fromkeys(
+            model["slug"] for model in raw
+            if isinstance(model, dict)
+            and model.get("visibility") == "list"
+            and isinstance(model.get("slug"), str) and model["slug"]
+        ))
+    except (httpx.HTTPError, ValueError):
+        return None
+
+
+def _refresh(path: Path, scope: str, credentials: SubscriptionCredentials) -> None:
+    key = (path, scope)
+    try:
+        models = _fetch_models(credentials)
+        if models is None:
+            return
+        with _lock:
+            # Re-read after HTTP so an in-flight successful request cannot
+            # lose its verification when discovery finishes later.
+            entry = _read_entry(path, scope)
+            entry.update(models=models, fetched_at=time.time())
+            _write_entry(path, entry)
+    finally:
+        with _lock:
+            _in_flight.discard(key)
+            _retry_after[key] = time.monotonic() + RETRY_SECONDS
+
+
+def get_subscription_models(
+    credentials: SubscriptionCredentials | None = None,
+    *, background: bool = True, force: bool = False,
+) -> list[str]:
+    credentials = credentials or load_credentials()
+    if credentials is None:
+        return []
+    path = credentials_path().with_name("openai-models-cache.json")
+    scope = _scope(credentials)
+    models, fetched_at = _read_cache(path, scope)
+    key = (path, scope)
+    if (force or time.time() - fetched_at >= TTL_SECONDS) and not credentials.needs_refresh:
+        with _lock:
+            refresh = key not in _in_flight and (
+                force or time.monotonic() >= _retry_after.get(key, 0)
+            )
+            if refresh:
+                _in_flight.add(key)
+        if refresh:
+            if background:
+                threading.Thread(
+                    target=_refresh, args=(path, scope, credentials),
+                    daemon=True, name="openai-subscription-models",
+                ).start()
+            else:
+                _refresh(path, scope, credentials)
+                models, _ = _read_cache(path, scope)
+    # Actual successful requests outrank an incomplete discovery catalog.
+    # Verification is scoped to this login and survives catalog refreshes.
+    entry = _read_entry(path, scope)
+    verified = _recent_models(entry, "verified_models", VERIFICATION_TTL_SECONDS)
+    # A stale catalog or fallback must not immediately restore a model that
+    # this login just rejected. Allow another attempt after one cache TTL.
+    rejected = _recent_models(entry, "rejected_models", TTL_SECONDS)
+    listed = list(models) if models is not None else list(SUBSCRIPTION_MODELS)
+    return [model for model in dict.fromkeys([*verified, *listed]) if model not in rejected]

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -15,7 +15,7 @@ Wire protocol
 server → client (``messages_from_agent``)::
 
     {type:'system', subtype:'init', model, tools:[{name,description,input_schema}],
-     permission_mode, protocol_version, session_id, cwd}     # once, on connect
+     permission_mode, protocol_version, version, session_id, cwd}  # once, on connect
     {type:'stream_event', event:{...text_delta...}}           # live token deltas
     {type:'assistant', uuid, session_id, message:{role,content}}
     {type:'user',      uuid, session_id, message:{role,content:[tool_result…]}}
@@ -306,18 +306,26 @@ class _AgentSession:
 
         Re-emitted after a resume-driven coordinator-mode flip (_do_resume) so
         the client's cached tool list tracks the mode."""
-        # Coordinator mode narrows the MAIN loop's advertised tools to the
-        # orchestration set; workers keep the full captured registry. Fresh
-        # per call — see coordinator_main_loop_registry.
+        from src import __version__
         from src.coordinator.mode import coordinator_main_loop_registry
         from src.nano.state import is_nano_mode
 
+        # Coordinator mode narrows the MAIN loop's advertised tools to the
+        # orchestration set; workers keep the full captured registry. Fresh
+        # per call — see coordinator_main_loop_registry.
         tools = _tool_schemas(coordinator_main_loop_registry(self.tool_registry))
         self._emit({
             "type": "system",
             "subtype": "init",
             "session_id": self.session_id,
             "protocol_version": PROTOCOL_VERSION,
+            # The clawcodex APP version (distinct from protocol_version, which
+            # versions this wire format). The Ink client renders it in the
+            # header box as "clawcodex v{version}" and gates session-ready on
+            # it being non-empty. Sourced from src.__version__ so the banner
+            # always agrees with `clawcodex --version` and /release-notes
+            # rather than drifting behind a hand-maintained client constant.
+            "version": __version__,
             "model": getattr(self.provider, "model", self.config.model),
             # The active fusion model's name, "" when not fused. Carried on
             # init (not just the set_model reply) so a session started with

--- a/tests/providers/test_openai_subscription_models.py
+++ b/tests/providers/test_openai_subscription_models.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+from dataclasses import replace
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from src.auth import openai_subscription as auth
+from src.providers import openai_subscription_models as catalog
+
+
+@pytest.fixture
+def credentials(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWCODEX_CONFIG_DIR", str(tmp_path))
+    creds = auth.SubscriptionCredentials("secret-token", "secret-refresh", time.time() + 3600, "acct")
+    monkeypatch.setattr(catalog, "load_credentials", lambda: creds)
+    return creds
+
+
+def test_fetch_uses_this_login_and_only_visible_models(credentials, monkeypatch):
+    get = Mock(return_value=httpx.Response(200, request=httpx.Request("GET", catalog.MODELS_ENDPOINT), json={
+        "models": [
+            {"slug": "internal", "visibility": "hide"},
+            {"slug": "gpt-5.6-terra", "visibility": "list", "supported_in_api": True},
+            {"slug": "gpt-5.3-codex-spark", "visibility": "list", "supported_in_api": False},
+            {"slug": "gpt-5.6-terra", "visibility": "list"},
+            {"visibility": "list"}, None,
+        ],
+    }))
+    monkeypatch.setattr(httpx, "get", get)
+    assert catalog.get_subscription_models(background=False) == ["gpt-5.6-terra", "gpt-5.3-codex-spark"]
+    args, kwargs = get.call_args
+    assert args == (catalog.MODELS_ENDPOINT,)
+    assert kwargs["headers"]["Authorization"] == "Bearer secret-token"
+    assert kwargs["headers"]["chatgpt-account-id"] == "acct"
+    assert kwargs["params"] == {"client_version": catalog.CATALOG_CLIENT_VERSION}
+    # The live list replaces the static one and survives later picker reads.
+    assert catalog.get_subscription_models() == ["gpt-5.6-terra", "gpt-5.3-codex-spark"]
+    assert get.call_count == 1
+    saved = auth.credentials_path().with_name("openai-models-cache.json").read_text()
+    assert "secret-token" not in saved and "secret-refresh" not in saved
+
+
+@pytest.mark.parametrize("changed", [{"account_id": "other"}, {"access_token": "new-token"}])
+def test_cache_cannot_leak_models_between_logins(credentials, monkeypatch, changed):
+    fetch = Mock(side_effect=[["gpt-5.6-sol"], ["gpt-5.6-terra"]])
+    monkeypatch.setattr(catalog, "_fetch_models", fetch)
+    assert catalog.get_subscription_models(credentials, background=False) == ["gpt-5.6-sol"]
+    assert catalog.get_subscription_models(replace(credentials, **changed), background=False) == ["gpt-5.6-terra"]
+    assert fetch.call_count == 2
+
+
+def test_stale_cache_survives_failed_refresh_and_throttles_retries(credentials, monkeypatch):
+    fetch = Mock(return_value=["gpt-5.6-terra"])
+    monkeypatch.setattr(catalog, "_fetch_models", fetch)
+    catalog.get_subscription_models(background=False)
+    path = auth.credentials_path().with_name("openai-models-cache.json")
+    saved = json.loads(path.read_text())
+    saved["fetched_at"] = 0
+    path.write_text(json.dumps(saved))
+    fetch.return_value = None
+    assert catalog.get_subscription_models(background=False, force=True) == ["gpt-5.6-terra"]
+    assert catalog.get_subscription_models(background=False) == ["gpt-5.6-terra"]
+    assert fetch.call_count == 2
+
+
+def test_empty_live_catalog_does_not_restore_static_models(credentials, monkeypatch):
+    monkeypatch.setattr(catalog, "_fetch_models", lambda _: [])
+    assert catalog.get_subscription_models(background=False) == []
+    assert catalog.get_subscription_models() == []
+
+
+def test_cold_failure_has_conservative_fallback(credentials, monkeypatch):
+    monkeypatch.setattr(catalog, "_fetch_models", lambda _: None)
+    assert catalog.get_subscription_models(background=False) == ["gpt-5.5"]
+
+
+def test_corrupt_cache_is_refetched(credentials, monkeypatch):
+    auth.credentials_path().with_name("openai-models-cache.json").write_text("[]")
+    monkeypatch.setattr(catalog, "_fetch_models", lambda _: ["gpt-5.6-terra"])
+    assert catalog.get_subscription_models(background=False) == ["gpt-5.6-terra"]
+
+
+def test_background_discovery_is_nonblocking_and_single_flight(credentials, monkeypatch):
+    started, release, finished = threading.Event(), threading.Event(), threading.Event()
+    calls = []
+    original = catalog._refresh
+
+    def fetch(creds):
+        calls.append(creds)
+        started.set()
+        assert release.wait(3)
+        return ["gpt-5.6-terra"]
+
+    def refresh(*args):
+        try:
+            original(*args)
+        finally:
+            finished.set()
+
+    monkeypatch.setattr(catalog, "_fetch_models", fetch)
+    monkeypatch.setattr(catalog, "_refresh", refresh)
+    try:
+        assert catalog.get_subscription_models() == ["gpt-5.5"]
+        assert started.wait(1)
+        assert catalog.get_subscription_models() == ["gpt-5.5"]
+        assert len(calls) == 1
+    finally:
+        release.set()
+        assert finished.wait(3)
+    assert catalog.get_subscription_models() == ["gpt-5.6-terra"]
+
+
+def test_expired_credentials_do_not_refresh_tokens_on_picker_thread(credentials, monkeypatch):
+    fetch = Mock()
+    monkeypatch.setattr(catalog, "_fetch_models", fetch)
+    assert catalog.get_subscription_models(replace(credentials, expires_at=0), background=False) == ["gpt-5.5"]
+    fetch.assert_not_called()
+
+
+def test_missing_login_does_not_reuse_cache(credentials, monkeypatch):
+    monkeypatch.setattr(catalog, "_fetch_models", lambda _: ["gpt-5.6-terra"])
+    catalog.get_subscription_models(background=False)
+    monkeypatch.setattr(catalog, "load_credentials", lambda: None)
+    assert catalog.get_subscription_models() == []
+
+
+def test_successful_unlisted_model_survives_catalog_refresh(credentials, monkeypatch):
+    monkeypatch.setattr(catalog, "_fetch_models", lambda _: ["gpt-5.6-sol"])
+    assert catalog.get_subscription_models(background=False) == ["gpt-5.6-sol"]
+    catalog.record_subscription_model(credentials, "gpt-6-astra")
+    assert catalog.get_subscription_models(background=False, force=True) == ["gpt-6-astra", "gpt-5.6-sol"]
+    assert catalog.get_subscription_models() == ["gpt-6-astra", "gpt-5.6-sol"]
+
+
+def test_verified_model_is_not_offered_to_another_login(credentials, monkeypatch):
+    monkeypatch.setattr(catalog, "_fetch_models", lambda _: ["gpt-5.6-terra"])
+    catalog.record_subscription_model(credentials, "gpt-6-astra")
+    other = replace(credentials, account_id="free-account", access_token="other-token")
+    assert catalog.get_subscription_models(other, background=False) == ["gpt-5.6-terra"]
+
+
+def test_rejected_model_loses_previous_verification(credentials, monkeypatch):
+    monkeypatch.setattr(catalog, "_fetch_models", lambda _: ["gpt-5.6-sol"])
+    catalog.get_subscription_models(background=False)
+    catalog.record_subscription_model(credentials, "gpt-6-astra")
+    catalog.record_subscription_model(credentials, "gpt-6-astra", available=False)
+    assert catalog.get_subscription_models() == ["gpt-5.6-sol"]
+
+
+@pytest.mark.parametrize("discovered", [["gpt-5.5", "gpt-5.6-sol"], None])
+def test_rejected_model_stays_hidden_after_refresh_or_fallback(credentials, monkeypatch, discovered):
+    monkeypatch.setattr(catalog, "_fetch_models", lambda _: discovered)
+    catalog.get_subscription_models(background=False)
+    catalog.record_subscription_model(credentials, "gpt-5.5", available=False)
+    expected = ["gpt-5.6-sol"] if discovered else []
+    assert catalog.get_subscription_models(background=False, force=True) == expected
+    assert catalog.get_subscription_models() == expected
+
+
+def test_rejection_expires_so_model_can_be_retried(credentials, monkeypatch):
+    monkeypatch.setattr(catalog, "_fetch_models", lambda _: ["gpt-5.6-sol"])
+    catalog.get_subscription_models(background=False)
+    catalog.record_subscription_model(credentials, "gpt-5.6-sol", available=False)
+    assert catalog.get_subscription_models() == []
+    now = time.time()
+    monkeypatch.setattr(catalog.time, "time", lambda: now + catalog.TTL_SECONDS + 1)
+    assert catalog.get_subscription_models(background=False, force=True) == ["gpt-5.6-sol"]
+
+
+def test_success_clears_previous_rejection(credentials, monkeypatch):
+    monkeypatch.setattr(catalog, "_fetch_models", lambda _: [])
+    catalog.get_subscription_models(background=False)
+    catalog.record_subscription_model(credentials, "gpt-6-astra", available=False)
+    catalog.record_subscription_model(credentials, "gpt-6-astra")
+    assert catalog.get_subscription_models() == ["gpt-6-astra"]
+
+
+def test_refresh_preserves_rejection_recorded_during_http(credentials, monkeypatch):
+    def fetch(creds):
+        catalog.record_subscription_model(creds, "gpt-5.6-sol", available=False)
+        return ["gpt-5.6-sol", "gpt-5.6-terra"]
+
+    monkeypatch.setattr(catalog, "_fetch_models", fetch)
+    assert catalog.get_subscription_models(background=False) == ["gpt-5.6-terra"]
+
+
+def test_expired_verification_is_not_offered(credentials, monkeypatch):
+    monkeypatch.setattr(catalog, "_fetch_models", lambda _: ["gpt-5.6-sol"])
+    catalog.get_subscription_models(background=False)
+    catalog.record_subscription_model(credentials, "gpt-6-astra")
+    path = auth.credentials_path().with_name("openai-models-cache.json")
+    saved = json.loads(path.read_text())
+    saved["verified_models"]["gpt-6-astra"] = 0
+    path.write_text(json.dumps(saved))
+    assert catalog.get_subscription_models() == ["gpt-5.6-sol"]
+
+
+def test_refresh_preserves_verification_recorded_during_http(credentials, monkeypatch):
+    def fetch(creds):
+        catalog.record_subscription_model(creds, "gpt-6-astra")
+        return ["gpt-5.6-sol"]
+
+    monkeypatch.setattr(catalog, "_fetch_models", fetch)
+    assert catalog.get_subscription_models(background=False) == ["gpt-6-astra", "gpt-5.6-sol"]
+
+
+def test_subscription_login_saves_discovered_default(credentials, monkeypatch):
+    from src.cli import _handle_openai_subscription_login
+
+    monkeypatch.setattr(auth, "has_codex_cli_credentials", lambda: True)
+    monkeypatch.setattr(auth, "import_codex_cli_credentials", lambda: credentials)
+    monkeypatch.setattr(catalog, "_fetch_models", lambda _: ["gpt-5.6-terra", "gpt-5.6-luna"])
+    save = Mock()
+    monkeypatch.setattr("src.config.set_api_key", save)
+    monkeypatch.setattr("src.config.set_default_provider", Mock())
+    prompt = Mock()
+    prompt.ask.side_effect = ["yes", "import-codex-cli"]
+    assert _handle_openai_subscription_login(Mock(), prompt) == 0
+    assert save.call_args.kwargs["default_model"] == "gpt-5.6-terra"

--- a/tests/server/test_init_app_version.py
+++ b/tests/server/test_init_app_version.py
@@ -1,0 +1,124 @@
+"""The ``system/init`` frame carries the clawcodex APP version.
+
+The Ink client renders the header box title as ``clawcodex v{version}``
+(ui-tui/src/components/branding.tsx) and gates session-ready on the field being
+non-empty (ui-tui/src/app/useSessionLifecycle.ts). Before this, the client
+supplied that string from a hand-maintained constant of its own, which drifted
+two releases behind (banner read v1.4.0 on a v1.6.0 build). The backend is the
+only party that knows what is actually running, so it reports it.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _reset_all() -> None:
+    from src.bootstrap.state import reset_state_for_tests
+    from src.eco.state import reset_eco
+    from src.nano.state import reset_nano_mode
+    from src.services.startup_gates import reset_session_trust_for_testing
+
+    reset_state_for_tests()
+    reset_eco()
+    reset_nano_mode()
+    reset_session_trust_for_testing()
+
+
+class TestInitCarriesAppVersion(unittest.TestCase):
+    """Real ``_AgentSession`` against the keyless ``ollama`` provider, with
+    global config redirected to a temp dir (the tests/nano/test_nano_tui.py
+    harness shape)."""
+
+    def setUp(self) -> None:
+        _reset_all()
+        self._tmp = tempfile.TemporaryDirectory()
+        root = Path(self._tmp.name)
+        self.ws = root / "ws"
+        self.ws.mkdir()
+        config_dir = root / "config-home"
+        config_dir.mkdir()
+        global_path = config_dir / "config.json"
+        global_path.write_text(json.dumps({}), encoding="utf-8")
+        self._patches = [
+            patch("src.config.get_global_config_path", return_value=global_path),
+            patch("src.config.GLOBAL_CONFIG_DIR", str(config_dir)),
+        ]
+        for p in self._patches:
+            p.start()
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+
+    def tearDown(self) -> None:
+        for p in self._patches:
+            p.stop()
+        from src.settings.settings import invalidate_settings_cache
+
+        invalidate_settings_cache()
+        _reset_all()
+        self._tmp.cleanup()
+
+    def _init_frame(self) -> dict:
+        from src.server.agent_server import (
+            AgentServerConfig,
+            _AgentSession,
+            _build_runtime,
+        )
+
+        sess = _AgentSession(
+            session_id="s-version",
+            cwd=str(self.ws),
+            config=AgentServerConfig(provider_name="ollama", single_session=True),
+            loop=MagicMock(),
+            out_queue=MagicMock(),
+        )
+        _build_runtime(sess, None)
+        self.assertIsNone(sess.init_error, f"runtime build failed: {sess.init_error}")
+        sess.emit_init()
+        frames = [
+            call.args[1]
+            for call in sess.loop.call_soon_threadsafe.call_args_list
+            if len(call.args) == 2 and isinstance(call.args[1], dict)
+        ]
+        init = [
+            f for f in frames
+            if f.get("type") == "system" and f.get("subtype") == "init"
+        ]
+        self.assertTrue(init, "emit_init produced no system/init frame")
+        return init[-1]
+
+    def test_init_reports_the_running_app_version(self) -> None:
+        from src import __version__
+
+        init = self._init_frame()
+        self.assertEqual(init["version"], __version__)
+
+    def test_version_is_non_empty_so_the_client_reaches_ready(self) -> None:
+        # useSessionLifecycle gates `status: 'ready'` on this being truthy —
+        # an empty string would strand the session at "starting agent…".
+        init = self._init_frame()
+        self.assertIsInstance(init["version"], str)
+        self.assertTrue(init["version"].strip())
+
+    def test_app_version_is_distinct_from_protocol_version(self) -> None:
+        # Two different things that both live on this frame: `version` is the
+        # release the user installed, `protocol_version` versions the wire
+        # format. Conflating them would put the wrong number in the banner.
+        from src.server.agent_server import PROTOCOL_VERSION
+
+        init = self._init_frame()
+        self.assertEqual(init["protocol_version"], PROTOCOL_VERSION)
+        self.assertIn("version", init)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/server/test_model_provider_picker.py
+++ b/tests/server/test_model_provider_picker.py
@@ -200,7 +200,11 @@ class TestProviderCatalog:
     def test_inactive_openai_catalog_matches_its_auth_route(
         self, monkeypatch, api_key, base_url, subscription,
     ):
-        from src.providers.openai_responses import SUBSCRIPTION_MODELS
+        discovered = ["gpt-6-astra", "gpt-5.6-terra"]
+        monkeypatch.setattr(
+            "src.providers.openai_subscription_models.get_subscription_models",
+            lambda: list(discovered),
+        )
 
         monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
         monkeypatch.setattr("src.providers.resolve_api_key", lambda pid: api_key if pid == "openai" else "")
@@ -216,9 +220,10 @@ class TestProviderCatalog:
         if base_url:
             config_mod.save_config({"providers": {"openai": {"base_url": base_url}}})
         row = next(r for r in provider_catalog(current="deepseek") if r["slug"] == "openai")
-        expected = SUBSCRIPTION_MODELS if subscription else PROVIDER_INFO["openai"]["available_models"]
+        expected = discovered if subscription else PROVIDER_INFO["openai"]["available_models"]
         assert row["models"] == expected
-        assert {"gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} <= set(row["models"])
+        if not subscription:
+            assert {"gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} <= set(row["models"])
         assert ("gpt-4o" in row["models"]) is not subscription
 
     def test_live_gateway_models_are_not_filtered_by_vendor_name(self):
@@ -234,6 +239,24 @@ class TestProviderCatalog:
         rows = provider_catalog(current="anthropic")
 
         assert len(rows) == len(PROVIDER_INFO)
+
+    def test_inactive_openai_subscription_uses_account_catalog(self, monkeypatch):
+        from src.auth import openai_subscription as auth
+
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+        auth.save_credentials(auth.SubscriptionCredentials("token", "refresh", time.time() + 3600, "acct"))
+        monkeypatch.setattr(
+            "src.providers.openai_subscription_models.get_subscription_models",
+            lambda: ["gpt-5.6-terra", "gpt-5.6-luna"],
+        )
+        row = next(r for r in provider_catalog(current="anthropic") if r["slug"] == "openai")
+        assert row["models"] == ["gpt-5.6-terra", "gpt-5.6-luna"]
+        assert row["total_models"] == 2
+
+    def test_empty_current_catalog_does_not_offer_api_models(self):
+        row = next(r for r in provider_catalog(current="openai", current_models=[]) if r["slug"] == "openai")
+        assert row["models"] == []
 
     def test_active_provider_is_authenticated_even_under_an_alias_spelling(
         self, sandbox_config

--- a/tests/test_openai_subscription.py
+++ b/tests/test_openai_subscription.py
@@ -24,6 +24,11 @@ from src.providers.openai_responses import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_subscription_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("CLAWCODEX_CONFIG_DIR", str(tmp_path))
+
+
 def _credentials(expires_at: float | None = None) -> auth.SubscriptionCredentials:
     return auth.SubscriptionCredentials(
         "access", "refresh", expires_at or time.time() + 3600, "acct-123", "idtok"
@@ -400,10 +405,13 @@ def test_provider_streams_responses_and_builds_chat_response(monkeypatch) -> Non
 
     text_chunks: list[str] = []
     thinking_chunks: list[str] = []
+    credentials = _credentials()
     with patch(
         "src.auth.openai_subscription.get_valid_credentials",
-        return_value=_credentials(),
-    ), patch("httpx.Client", _FakeClient):
+        return_value=credentials,
+    ), patch("httpx.Client", _FakeClient), patch(
+        "src.providers.openai_subscription_models.record_subscription_model",
+    ) as record:
         result = provider.chat_stream_response(
             [
                 {"role": "system", "content": "SYS"},
@@ -421,6 +429,7 @@ def test_provider_streams_responses_and_builds_chat_response(monkeypatch) -> Non
     assert captured["headers"]["chatgpt-account-id"] == "acct-123"
     assert captured["headers"]["originator"] == auth.ORIGINATOR
     body = captured["body"]
+    record.assert_called_once_with(credentials, body["model"])
     assert body["store"] is False and body["stream"] is True
     assert body["include"] == ["reasoning.encrypted_content"]
     assert body["instructions"] == "EXTRA\n\nSYS"
@@ -514,13 +523,16 @@ def test_provider_refreshes_once_on_401(monkeypatch) -> None:
         return_value=_credentials(),
     ), patch(
         "src.auth.openai_subscription.force_refresh", return_value=refreshed,
-    ) as force, patch("httpx.Client", _FakeClient):
+    ) as force, patch("httpx.Client", _FakeClient), patch(
+        "src.providers.openai_subscription_models.record_subscription_model",
+    ) as record:
         result = provider.chat_stream_response([{"role": "user", "content": "hi"}])
 
     assert force.call_count == 1
     assert sent_headers[0]["Authorization"] == "Bearer access"
     assert sent_headers[1]["Authorization"] == "Bearer fresh-access"
     assert result.content == "ok"
+    record.assert_called_once_with(refreshed, provider.model)
 
 
 def test_provider_surfaces_backend_failure_events(monkeypatch) -> None:
@@ -547,12 +559,15 @@ def test_provider_surfaces_backend_failure_events(monkeypatch) -> None:
     with patch(
         "src.auth.openai_subscription.get_valid_credentials",
         return_value=_credentials(),
-    ), patch("httpx.Client", _FakeClient):
+    ), patch("httpx.Client", _FakeClient), patch(
+        "src.providers.openai_subscription_models.record_subscription_model",
+    ) as record:
         try:
             provider.chat_stream_response([{"role": "user", "content": "hi"}])
             raise AssertionError("expected RuntimeError")
         except RuntimeError as exc:
             assert "usage limit reached" in str(exc)
+    record.assert_not_called()
 
 
 def test_abort_mid_stream_raises_and_closes_response(monkeypatch) -> None:
@@ -635,12 +650,37 @@ def test_effort_setting_reaches_reasoning_body(monkeypatch) -> None:
 
 def test_provider_lists_subscription_models(monkeypatch) -> None:
     provider = _subscription_provider(monkeypatch)
+    monkeypatch.setattr(
+        "src.providers.openai_subscription_models.get_subscription_models",
+        lambda: ["gpt-5.6-terra", "gpt-5.6-luna"],
+    )
     models = provider.get_available_models()
-    assert models[:4] == [
-        "gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
-    ]
-    assert "gpt-5.5" in models and "gpt-5.3-codex-spark" in models
-    assert "gpt-4o" not in models and "gpt-5.4-pro" not in models
+    assert models == ["gpt-5.6-terra", "gpt-5.6-luna"]
+
+
+def test_unsupported_subscription_model_refreshes_picker_without_switching(monkeypatch) -> None:
+    import httpx
+    from src.providers.openai_provider import ResponsesHTTPError
+
+    provider = _subscription_provider(monkeypatch)
+    provider.model = "gpt-5.6-sol"
+    response = httpx.Response(400, json={
+        "detail": "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+    })
+    with patch.object(auth, "get_valid_credentials", return_value=_credentials()), patch(
+        "src.providers.openai_subscription_models.get_subscription_models", return_value=["gpt-5.6-terra"],
+    ) as models, patch("httpx.Client") as client, patch(
+        "src.providers.openai_subscription_models.record_subscription_model",
+    ) as record:
+        client.return_value.send.return_value = response
+        with pytest.raises(ResponsesHTTPError, match="Run /model") as exc:
+            provider.chat_stream_response([{"role": "user", "content": "hi"}])
+    assert exc.value.status_code == 400
+    assert provider.model == "gpt-5.6-sol"
+    models.assert_called_once_with(force=True)
+    assert record.call_args.args[1] == "gpt-5.6-sol"
+    assert record.call_args.kwargs == {"available": False}
+    assert client.return_value.send.call_count == 1
 
 
 def test_api_key_wins_over_subscription(monkeypatch) -> None:

--- a/tests/test_tui_header_version_e2e.py
+++ b/tests/test_tui_header_version_e2e.py
@@ -1,0 +1,187 @@
+"""The header box shows the version the BACKEND reports.
+
+End-to-end proof for the drift bug: the banner read ``clawcodex v1.4.0`` on a
+v1.6.0 build because the Ink client filled ``SessionInfo.version`` from a
+constant of its own instead of from the ``system/init`` frame. Same PTY + pyte
+shape as tests/test_tui_recap_ghost_e2e.py — the real TUI bundle against a
+scripted agent-server, screen read through a terminal emulator.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import select
+import shutil
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+ENTRY = REPO / "ui-tui" / "dist" / "entry.js"
+
+pyte = pytest.importorskip("pyte", reason="pyte not installed (dev-only e2e)")
+# importorskip, NOT a top-level import: `pty` does not exist on Windows and a
+# module-level ImportError is a pytest COLLECTION ERROR there, so the win32
+# skipif below would never get to apply.
+pty = pytest.importorskip("pty", reason="POSIX pty required")
+
+pytestmark = [
+    pytest.mark.skipif(sys.platform == "win32", reason="POSIX pty required"),
+    pytest.mark.skipif(shutil.which("node") is None, reason="node not on PATH"),
+    pytest.mark.skipif(not ENTRY.exists(), reason="ui-tui/dist not built"),
+]
+
+# A distinctive version no constant in the client could coincidentally hold —
+# if the header shows this, it can only have come off the wire.
+BACKEND_VERSION = "9.9.9"
+
+# Minimal agent-server: one init frame, then an empty reply to every control
+# request so the startup RPCs resolve and the composer paints. `%(version)s` is
+# spliced in as a JSON fragment: a quoted string for the normal case, or the
+# bare word `null`-free omission handled by the caller.
+FAKE_SERVER = textwrap.dedent(
+    """
+    import json, sys
+
+    def emit(obj):
+        sys.stdout.write(json.dumps(obj) + "\\n")
+        sys.stdout.flush()
+
+    init = {
+        "type": "system", "subtype": "init", "session_id": "s1",
+        "model": "fake-model", "tools": [], "permission_mode": "default",
+        "protocol_version": "0.1.0", "cwd": ".",
+    }
+    version = %(version)r
+    if version is not None:
+        init["version"] = version
+    emit(init)
+
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if msg.get("type") == "control_request":
+            req = msg.get("request") or {}
+            emit({"type": "control_response", "response": {
+                "subtype": req.get("subtype", ""),
+                "request_id": msg.get("request_id"),
+                "response": {}}})
+    """
+)
+
+
+class _TuiSession:
+    """The real TUI in a PTY, screen mirrored into a pyte emulator."""
+
+    COLS, ROWS = 140, 40
+
+    def __init__(self, tmp_path: Path, version: str | None):
+        server_path = tmp_path / "fake_agent_server.py"
+        server_path.write_text(FAKE_SERVER % {"version": version}, encoding="utf-8")
+        env = {
+            **os.environ,
+            "TERM": "xterm-256color",
+            "CLAWCODEX_WORKSPACE": str(tmp_path),
+            "CLAWCODEX_CONFIG_DIR": str(tmp_path / "cfg"),
+            "CLAWCODEX_AGENT_SERVER_CMD": json.dumps(
+                [sys.executable, str(server_path)]
+            ),
+        }
+        self.master, slave = pty.openpty()
+        # Emulator and PTY must agree on geometry or wraps differ.
+        import fcntl
+        import struct
+        import termios
+
+        fcntl.ioctl(
+            slave, termios.TIOCSWINSZ,
+            struct.pack("HHHH", self.ROWS, self.COLS, 0, 0),
+        )
+        self.proc = subprocess.Popen(
+            ["node", str(ENTRY)],
+            stdin=slave, stdout=slave, stderr=slave,
+            cwd=str(tmp_path), env=env, close_fds=True,
+        )
+        os.close(slave)
+        self.screen = pyte.Screen(self.COLS, self.ROWS)
+        self.stream = pyte.ByteStream(self.screen)
+
+    def pump(self, seconds: float) -> None:
+        end = time.time() + seconds
+        while time.time() < end:
+            ready, _, _ = select.select([self.master], [], [], 0.05)
+            if not ready:
+                continue
+            try:
+                data = os.read(self.master, 65536)
+            except OSError:
+                return
+            if not data:
+                return
+            self.stream.feed(data)
+
+    def wait_for(self, needle: str, timeout: float) -> bool:
+        end = time.time() + timeout
+        while time.time() < end:
+            self.pump(0.2)
+            if any(needle in row for row in self.screen.display):
+                return True
+        return False
+
+    def row_with(self, needle: str) -> str | None:
+        for row in self.screen.display:
+            if needle in row:
+                return row
+        return None
+
+    def dump(self) -> str:
+        return "\n".join(
+            row.rstrip() for row in self.screen.display if row.strip()
+        )
+
+    def close(self) -> None:
+        self.proc.terminate()
+        try:
+            self.proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+            self.proc.wait()  # reap — no zombie for the rest of the run
+        os.close(self.master)
+
+
+def test_header_shows_the_version_the_backend_reports(tmp_path):
+    tui = _TuiSession(tmp_path, BACKEND_VERSION)
+    try:
+        assert tui.wait_for(
+            f"clawcodex v{BACKEND_VERSION}", 30
+        ), f"header did not show the backend's version:\n{tui.dump()}"
+    finally:
+        tui.close()
+
+
+def test_header_falls_back_and_still_reaches_ready_without_a_version(tmp_path):
+    # A backend predating the field. The banner must still name a version and
+    # the session must still go interactive — ready is gated on this string
+    # being non-empty, so a blank would hang the app at "starting agent…".
+    tui = _TuiSession(tmp_path, None)
+    try:
+        assert tui.wait_for("clawcodex v", 30), f"header missing:\n{tui.dump()}"
+        row = tui.row_with("clawcodex v")
+        assert row is not None
+        trailing = row.split("clawcodex v", 1)[1].strip()
+        assert trailing and trailing[0].isdigit(), (
+            f"expected a fallback version after 'clawcodex v', got {row!r}"
+        )
+        assert tui.wait_for("❯", 30), f"composer never appeared:\n{tui.dump()}"
+    finally:
+        tui.close()

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -99,6 +99,46 @@ describe('GatewayClient NDJSON adapter', () => {
     await expect(gw.request('session.create', {})).resolves.toMatchObject({ session_id: 's1' })
   })
 
+  // ─── banner version ──────────────────────────────────────────────────
+  // The header box renders "clawcodex v{version}" from SessionInfo.version
+  // (branding.tsx borderTitleParts) and useSessionLifecycle gates ready on it
+  // being truthy. It used to be a constant in this file, which drifted two
+  // releases behind the app (banner said v1.4.0 on a v1.6.0 build), so the
+  // backend now reports the running version on init.
+  const infoAfterInit = async (over: Record<string, unknown>) => {
+    proc.line({ ...INIT, ...over })
+    await vi.waitFor(() => expect(last('session.info')).toBeTruthy())
+
+    return last('session.info').payload
+  }
+
+  it('takes the banner version from the backend init frame', async () => {
+    expect(await infoAfterInit({ version: '9.9.9' })).toMatchObject({ version: '9.9.9' })
+  })
+
+  it('falls back to the bundled version when an older backend omits it', async () => {
+    // Pre-#838 backends send no `version` at all. The banner must still show
+    // something and the session must still reach ready.
+    const info = await infoAfterInit({})
+    expect(info.version).toBeTruthy()
+    expect(info.version).toMatch(/^\d+\.\d+\.\d+$/)
+  })
+
+  it('falls back rather than rendering an empty or non-string version', async () => {
+    // An empty string would render a bare "clawcodex v" AND strand the app at
+    // "starting agent…" forever, since ready is gated on truthiness.
+    expect((await infoAfterInit({ version: '' })).version).toBeTruthy()
+  })
+
+  it('ignores a non-string version from a malformed frame', async () => {
+    expect(typeof (await infoAfterInit({ version: 160 })).version).toBe('string')
+  })
+
+  it('keeps the app version separate from the wire protocol_version', async () => {
+    const info = await infoAfterInit({ protocol_version: '0.1.0', version: '1.6.0' })
+    expect(info.version).toBe('1.6.0')
+  })
+
   it('passes the session totals rider through on result (cost + session_turns)', async () => {
     proc.line({
       cost: { total_cost_usd: 0.0048 },

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -50,9 +50,16 @@ const WORKTREE_RPC_TIMEOUT_MS = 600_000
  *  downsamples through Pillow. A timeout here would drop an image the user
  *  watched themselves paste. */
 const IMAGE_RPC_TIMEOUT_MS = 30_000
-// clawcodex app version shown in the banner ("clawcodex v{version}"). Keep in
-// sync with the installer (install.sh INSTALLER_VERSION).
-const CLAWCODEX_VERSION = '1.4.0'
+/** Fallback app version for the banner ("clawcodex v{version}").
+ *
+ *  The version normally comes from the backend's `system/init` frame, which
+ *  sources it from `src.__version__` — the same value `clawcodex --version`
+ *  prints. This constant is used ONLY when talking to a backend old enough not
+ *  to send the field, so it is a floor, not the source of truth: it names the
+ *  last release before init carried a version. Do not wire it into the release
+ *  checklist — a hand-maintained copy here is exactly what drifted two
+ *  releases behind (the banner showed v1.4.0 on a v1.6.0 build). */
+const CLAWCODEX_FALLBACK_VERSION = '1.6.0'
 
 /** Command that launches the clawcodex agent-server (set by the Python launcher). */
 function resolveAgentCmd(): string[] {
@@ -2868,10 +2875,15 @@ export class GatewayClient extends EventEmitter {
       reasoning_effort: typeof init.reasoning_effort === 'string' ? init.reasoning_effort : undefined,
       skills: {},
       tools: { '': toolNames },
-      // The app gates "ready" on info.version (useSessionLifecycle:227) and the
+      // The app gates "ready" on info.version (useSessionLifecycle:242) and the
       // banner shows it as "clawcodex v{version}", so this is the app version,
-      // not the wire protocol_version.
-      version: CLAWCODEX_VERSION
+      // not the wire protocol_version. Prefer what the backend reports; the
+      // constant only covers backends predating that field. The empty-string
+      // guard matters twice over: an empty version would render "clawcodex v"
+      // AND stall the session at "starting agent…" forever.
+      version: typeof init.version === 'string' && init.version
+        ? init.version
+        : CLAWCODEX_FALLBACK_VERSION
     } as SessionInfo
   }
 }


### PR DESCRIPTION
ChatGPT subscription logins currently show a hardcoded model list, which can omit newly available models and offer models that the signed-in account cannot use. Discover visible models from the current login, cache them by account and token, and use the discovered default during login. Picker reads refresh in the background; successful requests retain models missing from the catalog. Unsupported-model responses refresh discovery and hide the rejected model for five minutes, including across stale catalog responses and fallback reads.

The terminal banner also reports an outdated app version. Send the running Python package version in the init frame and render it in the TUI, with a fallback for older backends. Update the installer banner to 1.6.0. Preserve the Fusion-provider grouping already on main.

Validation:
- 164 focused Python tests passed (subscription discovery, routing, provider picker, Fusion controls, and init version).
- 376 provider/compatibility tests and 18 subtests passed (overlaps the focused discovery tests).
- 128 gateway/model-picker/model-switch TUI tests passed; TUI typecheck and production build passed.
- Both real PTY terminal-header tests passed, including startup with an older backend.
- Installer shell syntax and git diff checks passed.
- Read-only live catalog request succeeded for the current login and returned five visible models. This verifies catalog discovery, not inference availability for each model.

Full TUI suite: 1,886 passed, 4 skipped, 10 failed. Eight failures reproduce on unchanged main at 096ba558 (diff rendering, status bar, indicator defaults, height estimation, and cursor-test timeout). The two additional timing failures in modelPicker and execFileNoThrow pass when run separately. No unrelated test behavior was changed.

CI completed on 36ec91f3 ([run 34325473562](https://github.com/agentforce314/clawcodex/actions/runs/34325473562)):
- Linux Python: 10,535 passed, 19 skipped.
- Linux and Windows desktop, web, and Harbor: passed.
- Windows Python: 10,510 passed, 38 skipped, 5 failed. Four failures match [the existing main baseline](https://github.com/agentforce314/clawcodex/actions/runs/34115995249): nano UTF-8 tail decoding, CRLF editing, unreadable-directory permissions, and default config-home detection.
- The fifth Windows failure is `test_shutdown_bounded_when_session_done_task_is_slow`: its fixed 50 x 10ms startup wait expires before the fake session handle exists. The bridge implementation and tests are unchanged by this PR. The test passes locally without a delay, and the exact IndexError reproduces on unchanged origin/main (096ba558) when worktree startup is delayed by 0.8s. No bridge changes are included.
- Subscription discovery and backend-version tests passed in both CI platforms. The PTY header tests ran locally against the built TUI; CI skips them because it does not build that bundle.

The hosted installer copy is synchronized by [website PR #30](https://github.com/Singula-Inc/clawcodex-website/pull/30), whose build/unit/integration and browser CI checks passed.
