### PR TITLE
docs(web): say plainly that the workspace confinement is honesty, in every binding

### DIFF
--- a/src/server/desktop_fs.py
+++ b/src/server/desktop_fs.py
@@ -16,10 +16,15 @@ copying exactly:
   of jump targets rather than a string the client has to re-split.
 
 Scope: read-only, directories only. This adds no reach the agent does not
-already have — it runs in this process, whose tools can read the filesystem —
-and the transport is the same loopback, token-gated socket. What it must not do
-is *hide* a failure: an unreadable directory raises rather than returning an
-empty listing that looks like an empty folder.
+already have: one token gates the whole socket, so anyone who can browse here
+can equally start a session and have the agent's own tools read the filesystem.
+That holds however the server is bound — `clawcodex web --allow-remote` changes
+who can reach the socket, not what reaching it is worth — which is why the
+listing is unconfined by design where `desktop_workspace_files.py`, whose column
+*claims* to be showing one directory tree, is not.
+
+What it must not do is *hide* a failure: an unreadable directory raises rather
+than returning an empty listing that looks like an empty folder.
 """
 
 from __future__ import annotations

--- a/src/server/desktop_workspace_files.py
+++ b/src/server/desktop_workspace_files.py
@@ -8,11 +8,23 @@ time.
 Two rules shape the whole module.
 
 **Everything is confined to the workspace root.** A path is resolved (symlinks
-and all) and must land inside the resolved root; anything else is refused. That
-is not a security boundary — the agent running in this very process can read the
-disk, and the socket is loopback and token-gated — it is honesty: the sidebar
-says it is showing the workspace, so it must not be reachable through `..` or a
-symlink pointing out of the tree.
+and all) and must land inside the resolved root; anything else is refused.
+
+That is honesty, not a security boundary, and it stays honesty under every
+binding. One token gates this whole socket, so anyone who can call these two
+methods can equally call `session.create` and `prompt.submit` and have the agent
+read the disk with its own tools — including through
+`clawcodex web --allow-remote`, which changes *who can reach the socket* and not
+that conclusion. What the check buys is that a column claiming to show the
+workspace cannot be walked out of through `..` or a symlink pointing elsewhere.
+
+Containment is nonetheless decided **before** the path is inspected, where the
+reference service inspects first so a caller learns whether an outside path
+exists and what kind it is before being refused. That is a simplicity choice
+rather than a leak-prevention one — the reference's own justification, that the
+caller can already read the host through the agent, holds here too — and it
+costs exactly one sentence: a missing file outside the root reads "outside the
+workspace" rather than "gone".
 
 A deliberate divergence from the reference service, which refuses a symlink
 outright *wherever it points, including back inside the workspace*: a link into

--- a/ui-web/README.md
+++ b/ui-web/README.md
@@ -110,9 +110,11 @@ resource; here it observes nothing the client can see.
 Both reads are confined to the session's workspace root, symlinks resolved
 (`src/server/desktop_workspace_files.py`). The client names the *session*, never
 the root: the backend derives the boundary, because one the client can move is
-not a boundary. That is honesty rather than a security boundary — the agent in
-that same process can read the disk — but a column that says it is showing the
-workspace must not be reachable through `..`.
+not a boundary. It is honesty rather than a security boundary, under every
+binding: one token gates the whole socket, so anyone who can call these methods
+can also start a session and have the agent read the disk with its own tools.
+What it buys is that a column claiming to show the workspace cannot be walked
+out of through `..`.
 
 ## Trajectory
 


### PR DESCRIPTION
A correction to a claim in the code — and then a correction to my first attempt at correcting it.

## The original claim, and why it needed changing

`desktop_workspace_files.py` opened by calling its confinement *"not a security boundary"*, justified by two things: the agent in this process can read the disk anyway, **and** the socket is loopback and token-gated. The second half is false under `clawcodex web --allow-remote`, which permits a non-loopback bind.

## Why the obvious fix was wrong

My first pass concluded the check therefore *becomes* load-bearing under `--allow-remote`, because the caller might not be someone who could already read the filesystem. That does not survive checking: **one token gates the whole socket**. Anyone who can call `fs.read_file` can equally call `session.create` and `prompt.submit` and have the agent read the disk with its own tools. `--allow-remote` changes *who can reach the socket*, not what reaching it is worth.

So the first half of the justification holds under every binding, and the confinement is honesty throughout — a column claiming to show the workspace cannot be walked out of through `..`. The docstring says that now, without leaning on the transport.

## What follows

The gate order is a **simplicity** choice, not a leak-prevention one. Deciding containment before inspecting the path costs one sentence (a missing file outside the root reads "outside the workspace" rather than "gone"), and the reference service's own justification for inspecting first — that the caller can already read the host through the agent — applies here too. Recorded as the trade it is, not the improvement I first called it.

`desktop_fs.py` (the unconfined picker browse surface) carried the same transport clause and gets the same treatment, plus the contrast that explains why it is unconfined where its sibling is not.

Comments and docs only, no behaviour change. 791 `tests/server` pass; `ui-web` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAB22BuCSRhjbpR3a8kc5v