### PR TITLE
feat(web): subagents in the header with a child view, model-written titles, and a quieter sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Web: subagents in the header, and a child view per run.** A session that
+  delegates shows **N subagents ▾** beside its title, with a live dot while any
+  still run; the list behind it names each delegation with its type, model,
+  state, tokens and duration, and opens the run in the conversation column —
+  its prompt, everything it did as tool rows, and a read-only seat in place of
+  the composer — with the parent's title as the way back. Fed by two sources
+  that used to be dropped on the floor: the Agent tool's per-message progress
+  now reaches the browser as `subagent.progress` (the gateway translated
+  nothing out of `agent_progress` frames before), and the Agent tool's result
+  envelope (`agent_id`, status, model, duration, tokens, tool count) rides the
+  completion as `result.agent` and is persisted beside the stored result, so a
+  resumed session lists its subagents exactly as the live one did.
+- Foreground subagents now keep the same sidechain transcript background ones
+  do (`~/.clawcodex/transcripts/<agent_id>.jsonl`); a new `subagent.transcript`
+  gateway method reads one in the stored-message shape `session.resume` uses.
+- **Model-written session titles.** After the heuristic first-line name lands,
+  the session's own provider is asked for a short title (`generate_title`
+  control) and its answer replaces the heuristic — on any provider, not the
+  Anthropic-only path `generate_llm_title` was pinned to. An explicit rename
+  in the meantime wins.
 - **Agent control plane — live subagent status, pause and interrupt.** A
   session-scoped supervisor now sees every subagent from both spawn paths
   (foreground delegations previously registered nowhere, so nothing could list
@@ -22,6 +42,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (default 32 — a runaway backstop, not a scheduling budget) and
   `CLAWCODEX_MAX_AGENT_DEPTH` (default 3). A refused spawn returns a tool error
   the model can act on rather than failing the turn.
+
+### Changed
+
+- Web: an `Agent` row reads `Agent · <description>`, with the run's activity
+  (running) or `N tools · duration` (done) at its right edge, and a body of
+  prompt, report and a button into the run — it was a generic IN/OUT card.
+- Web: a `Bash` row's summary is the model's one-line description of the
+  command when it gave one, with the command itself in the terminal card; the
+  raw command line was the summary before.
+- Web: the sidebar lists a blank session only while it is the one on screen,
+  as **New session**; every other never-used runtime session is hidden, and
+  project counts count what is shown.
 
 ### Fixed
 

--- a/src/agent/conversation.py
+++ b/src/agent/conversation.py
@@ -48,18 +48,28 @@ class Conversation:
         *,
         usage: dict[str, Any] | None = None,
         isMeta: bool = False,
+        toolUseResult: Any = None,
     ):
         """``isMeta`` marks injected context (plan-mode / task-reminder
         attachments), not a real prompt. Dropping it here was a real defect:
         the persisted reminder came back ``isMeta=False``, so
         ``_count_prompt_turns`` counted it as a user turn and ``/rewind``
-        treated it as a rewind boundary."""
+        treated it as a rewind boundary.
+
+        ``toolUseResult`` is a tool result's display envelope, kept on the
+        stored user message so it survives a save/resume round trip. Callers
+        pass only what a resumed reader needs — the agent server keeps the
+        Agent tool's (the one link from a stored call to its subagent's
+        transcript) and drops the rest, which are derivable or duplicates."""
         if len(self.messages) >= self.max_history:
             self.messages.pop(0)
 
         normalized_content = _normalize_message_content(content)
         self.messages.append(
-            create_message(role, normalized_content, usage=usage, isMeta=isMeta)
+            create_message(
+                role, normalized_content, usage=usage, isMeta=isMeta,
+                toolUseResult=toolUseResult,
+            )
         )
 
     def add_user_message(self, content: MessageContent):

--- a/src/server/agent_server.py
+++ b/src/server/agent_server.py
@@ -769,6 +769,9 @@ class _AgentSession:
             self._save_session()
             self._reply(request_id, {"ok": True, "name": self._session_name or ""})
             return
+        if subtype == "generate_title":
+            self._start_generate_title(request_id, inner.get("text"))
+            return
         if subtype == "resume":
             self._do_resume(request_id, inner.get("session_id"))
             return
@@ -1318,6 +1321,35 @@ class _AgentSession:
             "name": resolved.name,
             "text": f"@{resolved}",
         })
+
+    def _start_generate_title(self, request_id: object, text: object) -> None:
+        """Name the session after its first prompt with a side query on the
+        session's OWN provider, replying with ``{ok, name}`` once it lands.
+
+        Scheduled rather than awaited: control requests are handled inline on
+        the inbound reader, and a model round-trip held there would stall
+        every control behind it — an interrupt included — for as long as the
+        title takes. The reply is empty (``ok: False``) on any failure; the
+        caller keeps whatever name it already has.
+        """
+        prompt = text if isinstance(text, str) else ""
+        provider = self.provider
+
+        async def _run() -> None:
+            name = None
+            try:
+                from src.services.session_title import generate_title_with_provider
+
+                name = await generate_title_with_provider(provider, prompt)
+            except Exception:  # noqa: BLE001 — a title is never worth a failure frame
+                logger.debug("[agent-server] title generation failed", exc_info=True)
+            self._reply(request_id, {"ok": bool(name), "name": name or ""})
+
+        task = asyncio.get_running_loop().create_task(_run())
+        # asyncio holds tasks weakly; without a strong reference the query can
+        # be collected mid-flight and the reply never sent.
+        _TITLE_TASKS.add(task)
+        task.add_done_callback(_TITLE_TASKS.discard)
 
     def _reply(self, request_id: object, response: dict) -> None:
         if not isinstance(request_id, str):
@@ -5195,7 +5227,10 @@ class _AgentSession:
             # Persist into the session conversation so the next turn pairs
             # tool_use ↔ tool_result, then ship the SDK envelope to the client.
             try:
-                self.session.conversation.add_message(message.role, message.content)
+                self.session.conversation.add_message(
+                    message.role, message.content,
+                    toolUseResult=_persisted_tool_use_result(message),
+                )
             except Exception:  # noqa: BLE001
                 logger.exception("[agent-server] persist failed")
             env = _sdk_envelope(message, self.session_id)
@@ -6219,6 +6254,49 @@ def _non_interactive_ask_user(questions: list[dict]) -> dict[str, str]:
     }
 
 
+# In-flight title queries (see ``_start_generate_title``).
+_TITLE_TASKS: "set[asyncio.Task]" = set()
+
+
+def _persisted_tool_use_result(message: Any) -> dict | None:
+    """The slice of a tool result's display envelope worth keeping on disk.
+
+    Only the Agent tool's. Its envelope is the ONE link from a stored
+    ``Agent`` call to the subagent that ran it — ``agent_id`` names the
+    transcript file — and nothing else in the saved conversation carries it.
+    Every other envelope is derivable from the arguments (an edit's diff) or
+    a copy of the tool_result text (a read), so persisting those would only
+    double the file.
+    """
+    display = _display_tool_result(getattr(message, "toolUseResult", None))
+    if isinstance(display, dict) and display.get("type") == "agent":
+        return display
+    return None
+
+
+def _agent_display_envelope(value: dict) -> dict:
+    """Agent tool output → the facts a client needs to place a subagent.
+
+    Everything the model reads (the report) already travels as the
+    tool_result content; this keeps identity and totals: which run wrote
+    which transcript, how it ended, what it ran on and what it cost.
+    """
+    out: dict[str, Any] = {
+        "type": "agent",
+        "agent_id": str(value["agent_id"]),
+        "status": str(value.get("status") or "completed"),
+    }
+    for key in ("agent_type", "model"):
+        item = value.get(key)
+        if isinstance(item, str) and item:
+            out[key] = item
+    for key in ("total_duration_ms", "total_tokens", "total_tool_use_count"):
+        item = value.get(key)
+        if isinstance(item, int) and not isinstance(item, bool):
+            out[key] = item
+    return out
+
+
 def _display_tool_result(value: Any) -> dict | None:
     """Trim a rich tool output for the wire (display data only).
 
@@ -6266,6 +6344,16 @@ def _display_tool_result(value: Any) -> dict | None:
                 1 for r in value["results"] if r is not None and not isinstance(r, str)
             ),
         }
+    # The Agent tool's output is self-describing by its keys, not a ``type``:
+    # a run id plus how it ended. ``refused`` spawns carry no id and fall
+    # through to None like every other unrecognised shape.
+    if (
+        "type" not in value
+        and isinstance(value.get("agent_id"), str)
+        and value.get("agent_id")
+        and value.get("status") in ("completed", "interrupted", "async_launched")
+    ):
+        return _agent_display_envelope(value)
     from src.tool_system.tools.ask_user_question import RESULT_TYPE
 
     if value.get("type") == RESULT_TYPE:

--- a/src/server/desktop_gateway_methods.py
+++ b/src/server/desktop_gateway_methods.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
+from pathlib import Path
 from typing import Any
 
 from starlette.websockets import WebSocket
@@ -38,6 +39,9 @@ from src.server.desktop_serve import DesktopServeState
 logger = logging.getLogger(__name__)
 
 CONTROL_TIMEOUT_S = 30.0
+# A model-written session title: a small request, but on a reasoning model
+# it thinks first, and the heuristic name is on screen meanwhile.
+TITLE_TIMEOUT_S = 60.0
 
 # GUI↔backend contract version. The ClawCodex ladder restarts at 1 (the
 # reference implementation was at 5); bump when the desktop starts requiring
@@ -155,6 +159,10 @@ class DesktopSession:
         # resumed session (it has the user's own title) and after any explicit
         # rename, so auto-titling only ever fills in a blank.
         self.titled = False
+        # Set by an explicit rename. The model-written title that follows the
+        # heuristic one lands later and asynchronously; a name the user typed
+        # in between outranks it.
+        self.user_titled = False
         self.sockets: set[WebSocket] = set()
         # Scheduled session.info refreshes; held so they aren't GC'd mid-flight.
         self._background: set[asyncio.Task] = set()
@@ -373,12 +381,15 @@ class DesktopSession:
     async def auto_title(self, text: str) -> str | None:
         """Name an untitled session after its first prompt.
 
-        Uses the heuristic, not ``generate_llm_title``: that one is hardcoded
-        to Anthropic and a fixed Haiku model, so on a session running any other
-        provider it would bill an account the user did not choose to use here —
-        and silently return None wherever that provider is not configured.
-        A first line with the throat-clearing stripped is a good title and
-        costs nothing.
+        Two steps. The heuristic name — the first line with the
+        throat-clearing stripped — lands at once, so the header and the
+        sidebar never show a blank. Then the session's own model is asked for
+        a short title (``generate_title``, a side query on the same provider
+        the conversation runs on), and its answer replaces the heuristic when
+        it arrives — unless the user renamed the session in between, in which
+        case theirs stands. Not ``generate_llm_title``: that one is pinned to
+        Anthropic and a fixed Haiku model, so on any other provider it would
+        bill an account the user did not choose here, or silently fail.
         """
         if self.titled:
             return None
@@ -392,6 +403,12 @@ class DesktopSession:
         # Set before the round-trip: a second prompt arriving while this one is
         # in flight must not start a second rename of the same session.
         self.titled = True
+        await self._apply_title(title)
+        await self._upgrade_title(text, title)
+        return title
+
+    async def _apply_title(self, title: str) -> None:
+        """Rename the live session, stamp the saved file, tell every window."""
         await self.control_query("rename", {"name": title})
         try:
             from src.server.desktop_sessions import update_session_meta
@@ -401,7 +418,24 @@ class DesktopSession:
             logger.debug("auto_title: could not stamp the saved session", exc_info=True)
         await self._broadcast("session.title", {"title": title})
         await self._broadcast("sessions.changed", {})
-        return title
+
+    async def _upgrade_title(self, text: str, fallback: str) -> None:
+        """Replace the heuristic name with one the session's model wrote.
+
+        Best-effort: no reply, an empty one, or the same words the heuristic
+        already chose leave the fallback in place. Checked AFTER the round
+        trip, an explicit rename made while the model was writing wins.
+        """
+        reply = await self.control_query(
+            "generate_title", {"text": text}, timeout=TITLE_TIMEOUT_S,
+        )
+        name = reply.get("name") if isinstance(reply, dict) else None
+        if not isinstance(name, str):
+            return
+        name = name.strip()
+        if not name or name == fallback or self.user_titled:
+            return
+        await self._apply_title(name)
 
     async def submit_prompt(self, text: str) -> None:
         if not self.ready:
@@ -930,6 +964,7 @@ class GatewayConnection:
             "delegation.status": self.delegation_status,
             "delegation.pause": self.delegation_pause,
             "subagent.interrupt": self.subagent_interrupt,
+            "subagent.transcript": self.subagent_transcript,
         }
 
     async def on_open(self) -> None:
@@ -1225,6 +1260,7 @@ class GatewayConnection:
         title = str(params.get("title") or params.get("name") or "").strip()
         session = self._session(params)
         session.titled = True
+        session.user_titled = True
         result = await session.control_query("rename", {"name": title})
         name = (result or {}).get("name") if isinstance(result, dict) else None
         # Also stamp the saved-session file so the sidebar row updates without a
@@ -1487,6 +1523,28 @@ class GatewayConnection:
             "path": str(result.get("plan_file_path") or ""),
             "plan": plan if isinstance(plan, str) else "",
         }
+
+    async def subagent_transcript(self, params: dict[str, Any]) -> dict[str, Any]:
+        """A subagent's full record, for the child view a catalog row opens.
+
+        Read from the sidechain transcript the Agent tool wrote
+        (``~/.clawcodex/transcripts/<agent_id>.jsonl``), in the same message
+        shape ``session.resume`` returns, so the client rehydrates a child
+        exactly as it does its parent. ``found`` is false — with no messages,
+        not an error — when there is no file: a subagent that predates
+        transcripts, or one whose record was cleaned up. The id is validated
+        before it names a path; the transcripts directory is the only root.
+        """
+        from src.server.desktop_sessions import load_agent_transcript
+        from src.utils.clawcodex_dirs import get_transcripts_dir
+
+        agent_id = str(params.get("agent_id") or "")
+        result = await asyncio.to_thread(
+            load_agent_transcript, Path(get_transcripts_dir()), agent_id,
+        )
+        if result is None:
+            return {"agent_id": agent_id, "found": False, "messages": [], "message_count": 0}
+        return {"found": True, **result}
 
     # ── delegation control plane ─────────────────────────────────────────────
     #

--- a/src/server/desktop_gateway_translate.py
+++ b/src/server/desktop_gateway_translate.py
@@ -335,7 +335,74 @@ def render_tool_result(name: str, text: str, display: Any) -> dict[str, Any]:
     summary = summarize_tool_result(name, text, display)
     if summary:
         result["context"] = summary
+    agent = agent_result_meta(display)
+    if agent is not None:
+        result["agent"] = agent
     return result
+
+
+def agent_result_meta(display: Any) -> dict[str, Any] | None:
+    """The Agent tool's display envelope → the row's ``agent`` facts.
+
+    ``agent_id`` is what links the row to the subagent that ran it (its
+    transcript file, its live progress); the rest are the totals the run
+    reported — how it ended, what it ran on, how long it took and how much
+    it used — which the report text does not carry. None for every other
+    tool, so an ordinary row's result stays exactly what it was.
+    """
+    if not isinstance(display, dict) or display.get("type") != "agent":
+        return None
+    agent_id = display.get("agent_id")
+    if not isinstance(agent_id, str) or not agent_id:
+        return None
+    meta: dict[str, Any] = {
+        "agent_id": agent_id,
+        "status": str(display.get("status") or "completed"),
+    }
+    for key in ("agent_type", "model"):
+        value = display.get(key)
+        if isinstance(value, str) and value:
+            meta[key] = value
+    for source, key in (
+        ("total_duration_ms", "duration_ms"),
+        ("total_tokens", "tokens"),
+        ("total_tool_use_count", "tool_count"),
+    ):
+        value = display.get(source)
+        if isinstance(value, int) and not isinstance(value, bool):
+            meta[key] = value
+    return meta
+
+
+def translate_agent_progress(frame: dict[str, Any]) -> list[tuple[str, Any]]:
+    """``agent_progress`` frame → one ``subagent.progress`` event.
+
+    The Agent tool emits one of these per subagent message while a
+    delegation runs, and a terminal one when it stops (``status`` other than
+    ``running``). ``tool_use_id`` names the Agent call the run answers, so a
+    client can pin the progress to the row that spawned it; ``agent_id`` is
+    the run's own identity, which the row's result later confirms. A frame
+    without an agent id names nothing and is dropped.
+    """
+    agent_id = str(frame.get("agent_id") or "")
+    if not agent_id:
+        return []
+    payload: dict[str, Any] = {
+        "agent_id": agent_id,
+        "status": str(frame.get("status") or "running"),
+    }
+    for key in ("tool_use_id", "name", "description", "subagent_type", "model", "activity"):
+        value = frame.get(key)
+        if isinstance(value, str) and value:
+            payload[key] = value
+    depth = frame.get("depth")
+    if isinstance(depth, int) and not isinstance(depth, bool):
+        payload["depth"] = depth
+    for source, key in (("tool_use_count", "tool_count"), ("tokens", "tokens")):
+        value = frame.get(source)
+        if isinstance(value, int) and not isinstance(value, bool):
+            payload[key] = value
+    return [("subagent.progress", payload)]
 
 
 # ── frame translators ────────────────────────────────────────────────────────
@@ -523,6 +590,8 @@ def translate_frame(
         return translate_sdk_envelope(frame, tool_names)
     if kind == "result":
         return translate_result(frame)
+    if kind == "agent_progress":
+        return translate_agent_progress(frame)
     if kind == "text":
         # Final rendered text also arrives via `result`; interim standalone
         # text frames seal an interim bubble so the final complete doesn't
@@ -533,6 +602,7 @@ def translate_frame(
 
 
 __all__ = [
+    "agent_result_meta",
     "approval_request_payload",
     "as_text",
     "clean_tool_error",
@@ -543,6 +613,7 @@ __all__ = [
     "step_complete_payload",
     "summarize_tool_result",
     "tool_context",
+    "translate_agent_progress",
     "translate_frame",
     "translate_result",
     "translate_sdk_envelope",

--- a/src/server/desktop_sessions.py
+++ b/src/server/desktop_sessions.py
@@ -122,20 +122,14 @@ def load_session_meta(sessions_dir: Path, session_id: str) -> dict[str, Any]:
     }
 
 
-def load_session_messages(sessions_dir: Path, session_id: str) -> dict[str, Any] | None:
-    """Transcript for one saved session: ``{messages, message_count, title}``.
+def shape_stored_messages(raw: Any) -> list[dict[str, Any]]:
+    """Stored message dicts → the shape the web client rehydrates from.
 
     Messages pass through in their stored shape (string or content-block list)
-    — the renderer already narrows both, live and rehydrated.
+    — the renderer already narrows both, live and rehydrated. Shared by the
+    saved-session loader and the subagent-transcript loader, so a child's
+    record renders exactly like its parent's.
     """
-    safe = _safe_id(session_id)
-    if safe is None:
-        return None
-    data = _read_session_file(sessions_dir / f"{safe}.json")
-    if data is None:
-        return None
-    conversation = data.get("conversation") or {}
-    raw = conversation.get("messages") if isinstance(conversation, dict) else conversation
     messages: list[dict[str, Any]] = []
     for entry in raw or []:
         if not isinstance(entry, dict):
@@ -155,7 +149,65 @@ def load_session_messages(sessions_dir: Path, session_id: str) -> dict[str, Any]
         stop_reason = entry.get("stop_reason")
         if isinstance(stop_reason, str) and stop_reason:
             message["stop_reason"] = stop_reason
+        # The Agent tool's display envelope — the one the agent server chose
+        # to persist — under the same snake_case key the live SDK envelope
+        # uses, so the client reads a resumed Agent row and a live one alike.
+        envelope = entry.get("toolUseResult")
+        if isinstance(envelope, dict) and envelope.get("type") == "agent":
+            message["tool_use_result"] = envelope
         messages.append(message)
+    return messages
+
+
+def _safe_agent_id(agent_id: str) -> str | None:
+    """An agent id that can name a transcript file, or None.
+
+    Ids are ``generate_task_id`` output (``a`` + base36); anything else —
+    a separator, a dot, an empty string — is refused before it touches a
+    path, the same defence the transcript writer applies.
+    """
+    if not isinstance(agent_id, str) or not agent_id or len(agent_id) > 64:
+        return None
+    if not all(c.isalnum() or c in "_-" for c in agent_id):
+        return None
+    return agent_id
+
+
+def load_agent_transcript(transcripts_dir: Path, agent_id: str) -> dict[str, Any] | None:
+    """A subagent's sidechain transcript: ``{agent_id, messages, message_count}``.
+
+    Read from ``<transcripts>/<agent_id>.jsonl``, the file the Agent tool
+    appends every message the subagent produced to. None when the id is
+    unusable or the file is not there — a subagent that ran before
+    transcripts were written, or one whose file was cleaned up.
+    """
+    safe = _safe_agent_id(agent_id)
+    if safe is None:
+        return None
+    path = transcripts_dir / f"{safe}.jsonl"
+    if not path.is_file():
+        return None
+    from src.agent.transcript import TranscriptReader
+
+    raw = [entry for entry in TranscriptReader(path).read_all() if isinstance(entry, dict)]
+    messages = shape_stored_messages(raw)
+    return {"agent_id": safe, "messages": messages, "message_count": len(messages)}
+
+
+def load_session_messages(sessions_dir: Path, session_id: str) -> dict[str, Any] | None:
+    """Transcript for one saved session: ``{messages, message_count, title}``.
+
+    See :func:`shape_stored_messages` for the message shape.
+    """
+    safe = _safe_id(session_id)
+    if safe is None:
+        return None
+    data = _read_session_file(sessions_dir / f"{safe}.json")
+    if data is None:
+        return None
+    conversation = data.get("conversation") or {}
+    raw = conversation.get("messages") if isinstance(conversation, dict) else conversation
+    messages = shape_stored_messages(raw)
     # The stored name, so a resumed session keeps the title it was given —
     # the sidebar reads it from this same file, and a header that disagreed
     # with the row the user just clicked is its own small confusion.

--- a/src/services/session_title.py
+++ b/src/services/session_title.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 from typing import Any
@@ -9,6 +10,26 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 MAX_TITLE_LENGTH = 80
+
+# The side query that names a session, sent to the session's OWN provider so
+# it never bills an account the user did not choose for this conversation.
+_TITLE_PROMPT = (
+    "Write a title for a chat that begins with the request below. "
+    "Reply with the title only: three to six words, in the language of the "
+    "request, no quotes, no trailing punctuation.\n\nRequest:\n{text}"
+)
+
+# How much of the first prompt the title query sees. A pasted log or a long
+# spec is summarised from its head; the title is about what was asked.
+_TITLE_INPUT_CHARS = 2000
+
+# Room for the reply. A reasoning model thinks inside this budget before it
+# answers — DeepSeek's thinking mode spent a 48-token cap entirely on thought
+# and returned nothing — so the cap leaves room for a paragraph of reasoning
+# ahead of the six words that come out.
+_TITLE_MAX_TOKENS = 512
+
+_TITLE_LABEL_RE = re.compile(r"^(?:title|标题)\s*[:：]\s*", re.IGNORECASE)
 
 
 def auto_title_from_message(text: str) -> str:
@@ -39,6 +60,56 @@ def auto_title_from_message(text: str) -> str:
         first_line = first_line[:MAX_TITLE_LENGTH - 3].rstrip() + "..."
 
     return first_line or "Untitled session"
+
+
+def clean_generated_title(raw: Any) -> str | None:
+    """The first usable line of a model's title reply, or None.
+
+    Models decorate: quotes, a ``Title:`` label, a trailing period, a
+    preamble line. The title is whatever survives — and nothing, when the
+    reply was empty or only decoration, so the caller keeps its fallback
+    rather than naming a session "".
+    """
+    if not isinstance(raw, str):
+        return None
+    line = next((part.strip() for part in raw.strip().splitlines() if part.strip()), "")
+    line = _TITLE_LABEL_RE.sub("", line)
+    line = line.strip("\"'`“”‘’ ").rstrip(".!。！").strip()
+    line = _TITLE_LABEL_RE.sub("", line).strip("\"'“” ")
+    if not line:
+        return None
+    if len(line) > MAX_TITLE_LENGTH:
+        line = line[:MAX_TITLE_LENGTH - 3].rstrip() + "..."
+    return line
+
+
+async def generate_title_with_provider(
+    provider: Any,
+    text: str,
+    *,
+    timeout_s: float = 30.0,
+) -> str | None:
+    """A short title for a session, written by the session's own model.
+
+    One small non-streaming request through ``provider.chat_async`` — the
+    same provider (and account) the conversation runs on, unlike
+    :func:`generate_llm_title`, which is pinned to Anthropic. Best-effort by
+    contract: no provider, an empty prompt, a timeout, a provider error or an
+    unusable reply all answer None, and the caller keeps the heuristic name
+    it already has.
+    """
+    if provider is None or not isinstance(text, str) or not text.strip():
+        return None
+    body = text.strip()[:_TITLE_INPUT_CHARS]
+    messages = [{"role": "user", "content": _TITLE_PROMPT.format(text=body)}]
+    try:
+        response = await asyncio.wait_for(
+            provider.chat_async(messages, max_tokens=_TITLE_MAX_TOKENS), timeout_s,
+        )
+    except Exception as exc:  # noqa: BLE001 — a title is never worth an error
+        logger.debug("provider title generation failed: %s", exc)
+        return None
+    return clean_generated_title(getattr(response, "content", None))
 
 
 async def generate_llm_title(

--- a/src/tool_system/tools/agent.py
+++ b/src/tool_system/tools/agent.py
@@ -69,6 +69,7 @@ def _emit_terminal_agent_progress(
     subagent_type: Any,
     status: str,
     model: Any = None,
+    tool_use_id: Any = None,
 ) -> None:
     """R5 round-5 (ch13) — emit a TERMINAL ``agent_progress`` so the TUI
     subagent HUD marks the subagent done instead of lingering "running"
@@ -95,6 +96,10 @@ def _emit_terminal_agent_progress(
                 "model": model,
                 "activity": None,
                 "status": status,
+                # The Agent tool_use this run answers, so a client can pin the
+                # progress to the row that spawned it (the web client's
+                # subagent catalog) instead of guessing by description.
+                "tool_use_id": tool_use_id,
             })
     except Exception:  # noqa: BLE001
         logger.debug("terminal subagent progress emit failed", exc_info=True)
@@ -210,6 +215,11 @@ def make_agent_tool(
 
         description = tool_input.get("description", prompt[:50])
         subagent_type = tool_input.get("subagent_type")
+        # Read FIRST, before anything awaits or spawns: the executor stamps
+        # the shared ToolContext with each call's tool_use_id right before
+        # calling, so a later concurrent call can overwrite it. Captured here
+        # it names THIS delegation's row for every progress emit below.
+        tool_use_id = getattr(context, "tool_use_id", None)
         # Coordinator mode ignores the model param — the coordinator prompt
         # says "Do not set the model parameter. Workers need the default
         # model"; this enforces it. Mirrors AgentTool.tsx:252. "Default
@@ -467,6 +477,7 @@ def make_agent_tool(
                         "tool_use_count": _tracker.tool_use_count,
                         "tokens": total_tokens_from_tracker(_tracker),
                         "status": "running",
+                        "tool_use_id": tool_use_id,
                     })
                 except Exception:
                     logger.debug("subagent progress emit failed", exc_info=True)
@@ -542,6 +553,7 @@ def make_agent_tool(
                     agent_type=agent_def.agent_type,
                     agent_name=agent_name,
                     resolved_model=resolved_model,
+                    tool_use_id=tool_use_id,
                 )
             return _run_sync_agent(
                 run_params=run_params,
@@ -552,6 +564,7 @@ def make_agent_tool(
                 description=description,
                 agent_name=agent_name,
                 resolved_model=resolved_model,
+                tool_use_id=tool_use_id,
             )
         except BaseException:
             context.agent_supervisor.release(agent_id)
@@ -567,6 +580,7 @@ def make_agent_tool(
         description: Any = None,
         agent_name: Any = None,
         resolved_model: str | None = None,
+        tool_use_id: Any = None,
     ) -> ToolResult:
         """Run an agent synchronously and return the result."""
         from ..protocol import ToolResult as TR
@@ -580,6 +594,41 @@ def make_agent_tool(
             getattr(run_params.agent_definition, "agent_type", "")
         _hud_desc = description if description is not None else \
             (run_params.prompt or "")[:80]
+
+        # The same sidechain record a background run keeps
+        # (``_launch_async_agent``): the web client's child view reads it to
+        # show what the agent did, not only what it concluded. Appended from
+        # run_agent's per-message hook, ahead of the progress emit already
+        # chained there. Opening it can fail (a read-only home); the run goes
+        # on without a record, and so does an append that fails.
+        from src.agent.transcript import TranscriptWriter, get_agent_transcript_path
+
+        transcript: TranscriptWriter | None = None
+        try:
+            transcript = TranscriptWriter(get_agent_transcript_path(agent_id))
+        except OSError:
+            logger.exception(
+                "transcript open failed for %s; continuing without disk persistence",
+                agent_id,
+            )
+        if transcript is not None:
+            _forward = run_params.on_message
+
+            def _record_then_forward(message: Any) -> None:
+                nonlocal transcript
+                if transcript is not None:
+                    try:
+                        transcript.append(message)
+                    except OSError:
+                        logger.exception(
+                            "transcript append failed for %s; further appends will be skipped",
+                            agent_id,
+                        )
+                        transcript = None
+                if _forward is not None:
+                    _forward(message)
+
+            run_params.on_message = _record_then_forward
 
         try:
             try:
@@ -614,10 +663,12 @@ def make_agent_tool(
             _emit_terminal_agent_progress(
                 run_params.parent_context, agent_id=agent_id, name=_hud_name,
                 description=_hud_desc, subagent_type=agent_type,
-                status="failed", model=resolved_model,
+                status="failed", model=resolved_model, tool_use_id=tool_use_id,
             )
             raise
         finally:
+            if transcript is not None:
+                transcript.close()
             # The worker has genuinely exited by here (the messages are
             # collected and finalize_agent_tool has returned), so this is the
             # earliest honest point to free the slot. Releasing on a status
@@ -636,7 +687,7 @@ def make_agent_tool(
             run_params.parent_context, agent_id=agent_id, name=_hud_name,
             description=_hud_desc, subagent_type=agent_type,
             status="interrupted" if interrupted else "completed",
-            model=resolved_model,
+            model=resolved_model, tool_use_id=tool_use_id,
         )
 
         # An aborted query() RETURNS rather than raising, so finalize_agent_tool
@@ -691,6 +742,7 @@ def make_agent_tool(
         agent_type: str,
         agent_name: str | None = None,
         resolved_model: str | None = None,
+        tool_use_id: Any = None,
     ) -> ToolResult:
         """Launch an agent in the background and return immediately.
 
@@ -872,6 +924,7 @@ def make_agent_tool(
                         context, agent_id=agent_id, name=agent_name,
                         description=description, subagent_type=agent_type,
                         status=_final_status, model=resolved_model,
+                        tool_use_id=tool_use_id,
                     )
                     # Chunk D / WI-3.1 + WI-3.2 — enqueue a single
                     # ``<task-notification>`` envelope. Atomic check-and-
@@ -917,6 +970,7 @@ def make_agent_tool(
                         context, agent_id=agent_id, name=agent_name,
                         description=description, subagent_type=agent_type,
                         status="failed", model=resolved_model,
+                        tool_use_id=tool_use_id,
                     )
                     logger.exception(
                         "Async agent %s (%s) failed",

--- a/src/types/messages.py
+++ b/src/types/messages.py
@@ -298,10 +298,16 @@ def create_message(
     timestamp: str | None = None,
     isMeta: bool = False,
     usage: dict[str, Any] | None = None,
+    toolUseResult: Any = None,
 ) -> Message:
     ts = timestamp or datetime.now().isoformat()
     if role == "user":
-        return create_user_message(content, isMeta=isMeta, timestamp=ts)
+        # ``toolUseResult`` is the display envelope beside a tool_result
+        # block; only user messages carry one, and only when the caller
+        # chose to persist it (see ``Conversation.add_message``).
+        return create_user_message(
+            content, isMeta=isMeta, timestamp=ts, toolUseResult=toolUseResult,
+        )
     if role == "assistant":
         # ``usage`` is the turn's token accounting (input/output/cache);
         # only assistant messages carry it.

--- a/tests/server/test_desktop_gateway.py
+++ b/tests/server/test_desktop_gateway.py
@@ -898,3 +898,29 @@ def test_real_agent_permission_roundtrip_runs_tool(tmp_path: Path) -> None:
             types = [e["type"] for e in events]
             assert "tool.start" in types
             assert "tool.complete" in types
+
+
+def test_subagent_transcript_reads_the_run_record(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("CLAWCODEX_CONFIG_DIR", str(tmp_path))
+    transcripts = tmp_path / "transcripts"
+    transcripts.mkdir()
+    (transcripts / "a7.jsonl").write_text(
+        json.dumps({"role": "assistant", "content": [{"type": "text", "text": "Done."}]}) + "\n",
+        encoding="utf-8",
+    )
+    state, _ = _fake_state(tmp_path)
+    with TestClient(build_app(state)) as client, _connect(client) as ws:
+        ws.receive_json()  # gateway.ready
+        events: list[dict] = []
+        _rpc(ws, 1, "subagent.transcript", {"agent_id": "a7"})
+        reply = _drain_for_response(ws, 1, events)["result"]
+        assert reply["found"] is True
+        assert reply["agent_id"] == "a7"
+        assert reply["message_count"] == 1
+        assert reply["messages"][0]["role"] == "assistant"
+
+        # A miss and a path-shaped id both answer "not found", never an error.
+        for rid, agent_id in ((2, "nope"), (3, "../a7")):
+            _rpc(ws, rid, "subagent.transcript", {"agent_id": agent_id})
+            reply = _drain_for_response(ws, rid, events)["result"]
+            assert reply == {"agent_id": agent_id, "found": False, "messages": [], "message_count": 0}

--- a/tests/server/test_desktop_sessions.py
+++ b/tests/server/test_desktop_sessions.py
@@ -386,3 +386,69 @@ def test_desktop_port_guard_detects_running_instance(
 
     # Listener closed — the guard clears.
     assert mod.dev_port_busy(port) is False
+
+
+# ─── subagent records ────────────────────────────────────────────────────────
+
+
+def test_stored_agent_envelope_reaches_the_client(tmp_path: Path) -> None:
+    from src.server.desktop_sessions import load_session_messages
+
+    envelope = {"type": "agent", "agent_id": "a1", "status": "completed", "total_tool_use_count": 2}
+    messages = [
+        {"role": "assistant", "content": [{"type": "tool_use", "id": "c1", "name": "Agent", "input": {}}]},
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "c1", "content": "report"}],
+            "toolUseResult": envelope,
+        },
+        # A read's envelope (a plain string) is not forwarded: only the Agent's is.
+        {
+            "role": "user",
+            "content": [{"type": "tool_result", "tool_use_id": "c2", "content": "1\tx"}],
+            "toolUseResult": "1\tx",
+        },
+    ]
+    _write_session(tmp_path, "s1", preview="p", count=3, messages=messages)
+    loaded = load_session_messages(tmp_path, "s1")
+    assert loaded is not None
+    assert loaded["messages"][1]["tool_use_result"] == envelope
+    assert "tool_use_result" not in loaded["messages"][2]
+
+
+def test_agent_transcript_loads_in_the_stored_message_shape(tmp_path: Path) -> None:
+    from src.server.desktop_sessions import load_agent_transcript
+
+    transcripts = tmp_path / "transcripts"
+    transcripts.mkdir()
+    lines = [
+        json.dumps({"role": "assistant", "content": [{"type": "text", "text": "Looking."}],
+                    "timestamp": "2026-09-09T19:00:00", "stop_reason": "end_turn"}),
+        json.dumps({"role": "system", "content": "Running tool: Bash", "type": "system"}),
+        "{not json",
+        json.dumps({"role": "user", "content": [{"type": "tool_result", "tool_use_id": "c", "content": "ok"}]}),
+    ]
+    (transcripts / "a1b2.jsonl").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    loaded = load_agent_transcript(transcripts, "a1b2")
+    assert loaded is not None
+    assert loaded["agent_id"] == "a1b2"
+    assert loaded["message_count"] == 3
+    assert loaded["messages"][0] == {
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Looking."}],
+        "timestamp": "2026-09-09T19:00:00",
+        "stop_reason": "end_turn",
+    }
+    assert loaded["messages"][1]["role"] == "system"
+    assert loaded["messages"][2]["role"] == "user"
+
+
+def test_agent_transcript_refuses_bad_ids_and_misses(tmp_path: Path) -> None:
+    from src.server.desktop_sessions import load_agent_transcript
+
+    (tmp_path / "secret.jsonl").write_text("{}\n", encoding="utf-8")
+    assert load_agent_transcript(tmp_path, "../secret") is None
+    assert load_agent_transcript(tmp_path, "") is None
+    assert load_agent_transcript(tmp_path, "a" * 65) is None
+    assert load_agent_transcript(tmp_path, "missing") is None

--- a/tests/server/test_desktop_translate.py
+++ b/tests/server/test_desktop_translate.py
@@ -342,3 +342,95 @@ def test_step_complete_payload_carries_whichever_facts_exist() -> None:
     assert step_complete_payload({"model": "m"}) == {"model": "m"}
     assert step_complete_payload({}) is None
     assert step_complete_payload({"usage": None, "model": "", "stop_reason": ""}) is None
+
+
+# ─── subagents ───────────────────────────────────────────────────────────────
+
+
+def test_agent_progress_becomes_subagent_progress():
+    from src.server.desktop_gateway_translate import translate_agent_progress
+
+    frame = {
+        "type": "agent_progress",
+        "agent_id": "a1b2c3",
+        "tool_use_id": "call_7",
+        "depth": 0,
+        "name": "dive-core",
+        "description": "Deep dive: core",
+        "subagent_type": "Explore",
+        "model": "deepseek-v4-flash",
+        "activity": "Reading README.md",
+        "tool_use_count": 4,
+        "tokens": 12345,
+        "status": "running",
+    }
+    events = translate_frame(frame)
+    assert events == translate_agent_progress(frame)
+    (type_, payload), = events
+    assert type_ == "subagent.progress"
+    assert payload == {
+        "agent_id": "a1b2c3",
+        "status": "running",
+        "tool_use_id": "call_7",
+        "name": "dive-core",
+        "description": "Deep dive: core",
+        "subagent_type": "Explore",
+        "model": "deepseek-v4-flash",
+        "activity": "Reading README.md",
+        "depth": 0,
+        "tool_count": 4,
+        "tokens": 12345,
+    }
+
+
+def test_terminal_agent_progress_keeps_only_what_it_carries():
+    from src.server.desktop_gateway_translate import translate_agent_progress
+
+    # The terminal emit names no activity and no counts; a None must not
+    # become a field, and a boolean must not pass as a count.
+    (_, payload), = translate_agent_progress({
+        "agent_id": "a1", "status": "completed", "activity": None,
+        "tool_use_count": True, "model": None, "tool_use_id": "call_1",
+    })
+    assert payload == {"agent_id": "a1", "status": "completed", "tool_use_id": "call_1"}
+
+
+def test_agent_progress_without_an_id_is_dropped():
+    assert translate_frame({"type": "agent_progress", "status": "running"}) == []
+
+
+def test_agent_result_envelope_rides_the_completion():
+    from src.server.desktop_gateway_translate import agent_result_meta
+
+    display = {
+        "type": "agent",
+        "agent_id": "a9",
+        "status": "completed",
+        "agent_type": "Explore",
+        "model": "deepseek-v4-flash",
+        "total_duration_ms": 4200,
+        "total_tokens": 9001,
+        "total_tool_use_count": 6,
+    }
+    assert agent_result_meta(display) == {
+        "agent_id": "a9",
+        "status": "completed",
+        "agent_type": "Explore",
+        "model": "deepseek-v4-flash",
+        "duration_ms": 4200,
+        "tokens": 9001,
+        "tool_count": 6,
+    }
+    payload = _complete("Agent", "# Report\n\nfindings", display)
+    assert payload["name"] == "Agent"
+    assert payload["result"]["agent"]["agent_id"] == "a9"
+    assert payload["result"]["output"] == "# Report\n\nfindings"
+
+
+def test_other_display_envelopes_carry_no_agent():
+    from src.server.desktop_gateway_translate import agent_result_meta
+
+    assert agent_result_meta(None) is None
+    assert agent_result_meta({"type": "image", "originalSize": 3}) is None
+    assert agent_result_meta({"type": "agent", "agent_id": ""}) is None
+    assert "agent" not in _complete("Read", "1\tline", {"type": "image", "originalSize": 3})["result"]

--- a/tests/test_session_title.py
+++ b/tests/test_session_title.py
@@ -41,3 +41,68 @@ class TestAutoTitle:
     def test_already_capitalized(self):
         title = auto_title_from_message("Update the README")
         assert title == "Update the README"
+
+
+class TestGeneratedTitle:
+    def test_cleans_quotes_labels_and_trailing_stops(self):
+        from src.services.session_title import clean_generated_title
+
+        assert clean_generated_title('"Deep dive into repository."') == "Deep dive into repository"
+        assert clean_generated_title("Title: Repo Deep Dive\nSecond line") == "Repo Deep Dive"
+        assert clean_generated_title("  \n  Fix login bug!  ") == "Fix login bug"
+
+    def test_nothing_usable_is_none(self):
+        from src.services.session_title import clean_generated_title
+
+        assert clean_generated_title("") is None
+        assert clean_generated_title('""') is None
+        assert clean_generated_title(None) is None
+        assert clean_generated_title(42) is None
+
+    def test_caps_the_length(self):
+        from src.services.session_title import clean_generated_title
+
+        title = clean_generated_title("x" * 200)
+        assert title is not None
+        assert len(title) <= MAX_TITLE_LENGTH
+        assert title.endswith("...")
+
+    @pytest.mark.asyncio
+    async def test_asks_the_session_provider_once(self):
+        from src.services.session_title import generate_title_with_provider
+
+        class Provider:
+            calls: list = []
+
+            async def chat_async(self, messages, tools=None, **kwargs):
+                Provider.calls.append((messages, kwargs))
+                from types import SimpleNamespace
+
+                return SimpleNamespace(content="Repository deep dive\n")
+
+        title = await generate_title_with_provider(Provider(), "make a plan and do a deep dive of this repo")
+        assert title == "Repository deep dive"
+        assert len(Provider.calls) == 1
+        messages, kwargs = Provider.calls[0]
+        assert "make a plan and do a deep dive" in messages[0]["content"]
+        # Enough for a reasoning model to think before the six words come out.
+        assert kwargs["max_tokens"] >= 256
+
+    @pytest.mark.asyncio
+    async def test_failures_and_blanks_answer_none(self):
+        from src.services.session_title import generate_title_with_provider
+
+        class Broken:
+            async def chat_async(self, *a, **k):
+                raise RuntimeError("no network")
+
+        class Slow:
+            async def chat_async(self, *a, **k):
+                import asyncio
+
+                await asyncio.sleep(1)
+
+        assert await generate_title_with_provider(Broken(), "hello") is None
+        assert await generate_title_with_provider(Slow(), "hello", timeout_s=0.01) is None
+        assert await generate_title_with_provider(None, "hello") is None
+        assert await generate_title_with_provider(Broken(), "   ") is None

--- a/ui-web/README.md
+++ b/ui-web/README.md
@@ -116,6 +116,57 @@ can also start a session and have the agent read the disk with its own tools.
 What it buys is that a column claiming to show the workspace cannot be walked
 out of through `..`.
 
+## Subagents
+
+A session that delegates shows it in the header: **N subagents ▾** beside the
+title, with a live dot while any are still running. The list behind it is one
+row per delegation — what it was asked (the `Agent` call's description), the
+agent type and model it ran on, its state, and what it cost in tokens and
+time. Clicking a row opens the subagent in the conversation column, in the
+session's place: its prompt, then everything it did, rendered with the same
+tool rows the session uses, and a read-only seat where the composer would be.
+The parent's title is the way back, and the child's own name switches among
+its siblings.
+
+Two sources feed that list, and the catalog (`src/state/subagents.ts`) is a
+pure fold over both:
+
+- **The `Agent` tool rows** in the transcript carry the prompt and, once the
+  call settles, the report and the run's own totals. The backend persists the
+  Agent tool's display envelope (`agent_id`, status, model, duration, tokens,
+  tool count) beside the stored result, so a resumed session lists its
+  subagents exactly as the live one did.
+- **`subagent.progress` events** — the Agent tool's per-message progress,
+  translated by the gateway — carry what a run is doing while it runs: its
+  last activity, its tool count so far, and finally how it stopped. A frame
+  names the call it answers (`tool_use_id`), which is how a running row and its
+  progress find each other before the row's result names the run.
+
+A subagent's full record is the sidechain transcript the Agent tool writes as
+the run goes (`~/.clawcodex/transcripts/<agent_id>.jsonl`, for foreground and
+background runs alike), read through `subagent.transcript` and rehydrated with
+the same fold as a resumed session. A run that predates transcripts, or whose
+file was cleaned up, shows its prompt and report alone.
+
+The Agent row itself reads `Agent · <description>` with, at its right edge,
+the run's activity while it runs and `N tools · duration` once it is done; its
+body holds the prompt, the report as prose, and a button into the run.
+
+## Session titles
+
+A session is named the moment its first prompt is sent — the prompt's first
+line, throat-clearing stripped — so neither the header nor the sidebar ever
+shows a blank. Then the session's own model is asked for a short title, and
+its answer replaces the heuristic when it arrives, a few seconds later. The
+side query runs on the same provider the conversation does, never a
+hard-coded one, and a rename typed in the meantime stands. Nothing about the
+title ever reaches the model's context.
+
+The sidebar lists a blank session — one nothing has been typed into — only
+while it is the one on screen, labelled **New session**; the backend keeps
+every runtime session it spawned, and a row per abandoned press of the button
+was a column of nothing.
+
 ## Trajectory
 
 The **Trajectory** tab is the forensic view of the same session: every model

--- a/ui-web/src/conversation/ChatView.tsx
+++ b/ui-web/src/conversation/ChatView.tsx
@@ -1,12 +1,17 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
-import type { TranscriptNode } from '../state/transcript.ts'
+import { subagentCatalog, type SubagentEntry } from '../state/subagents.ts'
+import type { SubagentLive, TranscriptNode } from '../state/transcript.ts'
 import { AssistantMessage, NoticeMessage, UserMessage } from './MessageItem.tsx'
 import { ReasoningRow } from './ReasoningRow.tsx'
 import { ToolRow } from './ToolRow.tsx'
 import css from './ChatView.module.css'
 
+const NO_AGENTS: Record<string, SubagentLive> = {}
+
 export interface ChatViewProps {
+  /** Live subagent state, so an Agent row can say what its run is doing. */
+  agents?: Record<string, SubagentLive>
   nodes: TranscriptNode[]
   onEditPrompt?: (text: string) => void
   onRetry?: () => void
@@ -52,6 +57,7 @@ function formatClock(seconds: number): string {
  * still moves the conversation.
  */
 export function ChatView({
+  agents = NO_AGENTS,
   nodes,
   onEditPrompt,
   onRetry,
@@ -60,6 +66,17 @@ export function ChatView({
   workspace,
 }: ChatViewProps) {
   const elapsed = useElapsed(running ? turnStartedAt : undefined)
+
+  // One fold for every Agent row on screen, keyed by the call it came from.
+  const agentEntries = useMemo(() => {
+    const byTool = new Map<string, SubagentEntry>()
+
+    for (const entry of subagentCatalog(nodes, agents)) {
+      if (entry.toolId !== undefined) byTool.set(entry.toolId, entry)
+    }
+
+    return byTool
+  }, [agents, nodes])
 
   // The status line is the only thing marking a turn that has produced nothing
   // yet; once prose or a tool row is streaming, those carry the activity.
@@ -81,7 +98,9 @@ export function ChatView({
               />
             )}
             {node.kind === 'reasoning' && <ReasoningRow node={node} />}
-            {node.kind === 'tool' && <ToolRow node={node} workspace={workspace} />}
+            {node.kind === 'tool' && (
+              <ToolRow agent={agentEntries.get(node.toolId)} node={node} workspace={workspace} />
+            )}
             {node.kind === 'notice' && <NoticeMessage node={node} />}
           </div>
         ))}

--- a/ui-web/src/conversation/ConversationRoot.module.css
+++ b/ui-web/src/conversation/ConversationRoot.module.css
@@ -72,6 +72,29 @@
   font-size: 14px;
 }
 
+/* The parent session's title while a subagent is on show: a crumb that goes
+   back. Tertiary ink, so the child's own name (primary) reads as the title. */
+.crumbParent {
+  min-width: 0;
+  max-width: 220px;
+  overflow: hidden;
+  padding: 4px 8px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--cc-alias-label-tertiary);
+  font-size: 14px;
+  line-height: 20px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.crumbParent:hover {
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-secondary);
+}
+
 .crumb {
   min-width: 0;
   overflow: hidden;

--- a/ui-web/src/conversation/ConversationRoot.tsx
+++ b/ui-web/src/conversation/ConversationRoot.tsx
@@ -3,9 +3,11 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 
 import {
   clearSession,
+  closeSubagent,
   createSession,
   dequeue,
   interrupt,
+  openSubagent,
   renameSession,
   respondApproval,
   fetchPlan,
@@ -31,17 +33,19 @@ import {
   $sessionId,
   $sessionLoading,
   $sessionTitle,
+  $subagentView,
   $trajectory,
   $transcript,
   $workspace,
 } from '../state/store.ts'
 import { AgentsPanel } from '../agents/AgentsPanel.tsx'
+import { subagentCatalog } from '../state/subagents.ts'
 import { currentTodos } from '../state/todo-progress.ts'
 import { trajectoryStats } from '../state/trajectory.ts'
 import { WorkspaceChip } from '../workspace/WorkspaceChip.tsx'
 import { TrajectoryView } from '../trajectory/TrajectoryView.tsx'
 import { $detailsWidth, openDetails } from '../state/layout.ts'
-import { ArrowDownIcon, LayersIcon, MessageIcon, PlusIcon } from '../ui/icons.tsx'
+import { AgentIcon, ArrowDownIcon, LayersIcon, MessageIcon, PlusIcon } from '../ui/icons.tsx'
 import { ApprovalPanel } from './ApprovalPanel.tsx'
 import { ChatView } from './ChatView.tsx'
 import { HeroShell } from './HeroShell.tsx'
@@ -51,6 +55,8 @@ import { QuestionComposer } from './QuestionComposer.tsx'
 import { closeSidebar } from '../sidebar-right/store.ts'
 import { QueueDock } from './QueueDock.tsx'
 import { StatsPills } from './StatsPills.tsx'
+import { SubagentChip } from './SubagentChip.tsx'
+import { SubagentView } from './SubagentView.tsx'
 import { TodoPanel } from './TodoPanel.tsx'
 import css from './ConversationRoot.module.css'
 
@@ -86,8 +92,16 @@ export function ConversationRoot() {
   const tab = useStore($conversationTab)
   const trajectory = useStore($trajectory)
   const backendNano = useStore($backendNano)
+  const subagentView = useStore($subagentView)
   const stats = useMemo(() => trajectoryStats(trajectory), [trajectory])
   const todos = useMemo(() => currentTodos(transcript.nodes), [transcript.nodes])
+  const subagents = useMemo(
+    () => subagentCatalog(transcript.nodes, transcript.agents),
+    [transcript.agents, transcript.nodes],
+  )
+  // The child on show, if the key still names one — a cleared conversation
+  // takes its delegations with it, and the view falls back to the session.
+  const child = subagentView === null ? undefined : subagents.find(entry => entry.key === subagentView)
 
   // The session's own truth once session.info reported it, else the backend's
   // process-wide fact (/api/status) — same shape as the approval mode and
@@ -298,28 +312,61 @@ export function ConversationRoot() {
       {!hero && (
         <div className={css.header}>
           <div className={css.titleCluster}>
-            <MessageIcon size={16} />
-            <input
-              aria-label="Session title"
-              className={css.title}
-              onBlur={event => {
-                const value = event.target.value.trim()
-
-                if (value !== '' && value !== sessionTitle) void renameSession(value)
-              }}
-              onChange={event => {
-                $sessionTitle.set(event.target.value)
-              }}
-              onKeyDown={event => {
-                if (event.key === 'Enter') event.currentTarget.blur()
-              }}
-              placeholder="Untitled session"
-              value={sessionTitle}
-            />
-            {workspace !== '' && (
+            {child === undefined ? (
               <>
+                <MessageIcon size={16} />
+                <input
+                  aria-label="Session title"
+                  className={css.title}
+                  onBlur={event => {
+                    const value = event.target.value.trim()
+
+                    if (value !== '' && value !== sessionTitle) void renameSession(value)
+                  }}
+                  onChange={event => {
+                    $sessionTitle.set(event.target.value)
+                  }}
+                  onKeyDown={event => {
+                    if (event.key === 'Enter') event.currentTarget.blur()
+                  }}
+                  placeholder="Untitled session"
+                  value={sessionTitle}
+                />
+                {/* "N subagents ▾": the delegations this session made, and
+                    the way into each. Absent until there is one. */}
+                {subagents.length > 0 && (
+                  <>
+                    <span className={css.crumbSep}>/</span>
+                    <SubagentChip entries={subagents} onOpen={openSubagent} variant="count" />
+                  </>
+                )}
+                {workspace !== '' && (
+                  <>
+                    <span className={css.crumbSep}>/</span>
+                    <WorkspaceChip variant="crumb" />
+                  </>
+                )}
+              </>
+            ) : (
+              <>
+                <AgentIcon size={16} />
+                {/* The parent's title is the way back; the child's name is
+                    a switcher among its siblings, as the reference does it. */}
+                <button
+                  className={css.crumbParent}
+                  onClick={closeSubagent}
+                  title="Back to the session"
+                  type="button"
+                >
+                  {sessionTitle === '' ? 'Untitled session' : sessionTitle}
+                </button>
                 <span className={css.crumbSep}>/</span>
-                <WorkspaceChip variant="crumb" />
+                <SubagentChip
+                  currentKey={child.key}
+                  entries={subagents}
+                  onOpen={openSubagent}
+                  variant="switcher"
+                />
               </>
             )}
           </div>
@@ -359,7 +406,7 @@ export function ConversationRoot() {
           </div>
         </div>
       )}
-      {!hero && (
+      {!hero && child === undefined && (
         <div className={css.tabs} role="tablist">
           {(['chat', 'trajectory', 'agents'] as const).map(id => (
             <button
@@ -378,7 +425,11 @@ export function ConversationRoot() {
         </div>
       )}
       {banner}
-      {!hero && tab === 'agents' ? (
+      {!hero && child !== undefined ? (
+        <div className={css.viewBody}>
+          <SubagentView entry={child} workspace={workspace} />
+        </div>
+      ) : !hero && tab === 'agents' ? (
         <div className={css.viewBody}>
           <AgentsPanel />
         </div>
@@ -416,6 +467,7 @@ export function ConversationRoot() {
                 <div className={css.settling}>Loading session…</div>
               ) : (
                 <ChatView
+                  agents={transcript.agents}
                   nodes={transcript.nodes}
                   onEditPrompt={setDraft}
                   onRetry={() => {

--- a/ui-web/src/conversation/SubagentChip.module.css
+++ b/ui-web/src/conversation/SubagentChip.module.css
@@ -1,0 +1,159 @@
+/* The header's subagent control: a quiet count (or the child's own name) with
+   the catalog behind it. Anchored like the Menu primitive — the list is a
+   sibling of the trigger, absolutely placed below it — rather than portaled,
+   because the header is never inside a transformed ancestor. */
+
+.root {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.trigger,
+.switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 28px;
+  padding: 3px 4px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--cc-alias-label-tertiary);
+  font-size: 12px;
+  line-height: 18px;
+  cursor: pointer;
+}
+
+.trigger:hover,
+.trigger:focus-visible {
+  color: var(--cc-alias-label-secondary);
+}
+
+/* The child's name reads as the title it replaces: primary ink, medium weight. */
+.switcher {
+  min-width: 0;
+  max-width: 244px;
+  color: var(--cc-alias-label-primary);
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 500;
+}
+
+.switcherTitle {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.trigger svg,
+.switcher svg {
+  flex: none;
+  transition: transform 120ms ease;
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+.activity {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  width: 10px;
+  height: 10px;
+}
+
+.menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  z-index: 100;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  width: 336px;
+  max-width: min(400px, calc(100vw - 32px));
+  max-height: min(560px, calc(100vh - 140px));
+  padding: 4px;
+  overflow-y: auto;
+  border: 1px solid var(--cc-alias-border-inverted);
+  border-radius: 16px;
+  background: var(--cc-specific-menu);
+  box-shadow: var(--cc-shadow-lv3);
+  --cc-scrollbar-thumb: var(--cc-alias-scrollbar-bg-l2);
+  --cc-scrollbar-thumb-hover: var(--cc-alias-scrollbar-hover-l2);
+}
+
+.row {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 50px;
+  padding: 7px 8px 7px 11px;
+  border: none;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--cc-alias-label-primary);
+  font-size: 13px;
+  line-height: 18px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.row:hover,
+.row:focus-visible {
+  background: var(--cc-alias-interactive-bg-hover);
+  outline: none;
+}
+
+.rowDot {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  height: 18px;
+}
+
+.rowBody {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.rowLabel,
+.rowSecondary {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.rowCurrent .rowLabel {
+  font-weight: 600;
+}
+
+.rowSecondary,
+.rowMetrics {
+  color: var(--cc-alias-label-tertiary);
+  font-size: 11px;
+  line-height: 16px;
+}
+
+/* Two figures stacked on the right, tabular so a list of them lines up. */
+.rowMetrics {
+  display: flex;
+  flex: none;
+  flex-direction: column;
+  align-items: flex-end;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.rowMetrics > :first-child {
+  line-height: 18px;
+}

--- a/ui-web/src/conversation/SubagentChip.tsx
+++ b/ui-web/src/conversation/SubagentChip.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react'
+
+import { formatTokens } from '../state/trajectory.ts'
+import {
+  describeStatus,
+  formatRunDuration,
+  subagentCounts,
+  type SubagentEntry,
+} from '../state/subagents.ts'
+import { ChevronDownIcon, SwitchIcon } from '../ui/icons.tsx'
+import { StateDot, type RunState } from '../ui/primitives/StateDot.tsx'
+import css from './SubagentChip.module.css'
+
+export interface SubagentChipProps {
+  /** The entry the column is showing, for the switcher's highlight. */
+  currentKey?: string | null
+  entries: readonly SubagentEntry[]
+  onOpen: (key: string) => void
+  /**
+   * `count` is the parent's "N subagents ▾"; `switcher` is the child's own
+   * name with a way to its siblings.
+   */
+  variant: 'count' | 'switcher'
+}
+
+function dotState(entry: SubagentEntry): RunState {
+  switch (entry.status) {
+    case 'running':
+      return 'running'
+    case 'failed':
+      return 'error'
+    case 'interrupted':
+    case 'killed':
+      return 'warning'
+    default:
+      return 'done'
+  }
+}
+
+/** `Explore · deepseek-v4-flash · running` — the line under a row's label. */
+function secondaryLine(entry: SubagentEntry): string {
+  return [entry.subagentType, entry.model, entry.activity ?? describeStatus(entry.status)]
+    .filter((part): part is string => part !== undefined && part !== '')
+    .join(' · ')
+}
+
+function countLabel(total: number, running: number): string {
+  const noun = total === 1 ? 'subagent' : 'subagents'
+
+  return running > 0 ? `${total} ${noun}, ${running} running` : `${total} ${noun}`
+}
+
+/**
+ * The header's subagent control: how many there are, with the list behind it.
+ *
+ * Reads the catalog the conversation state folds (`subagentCatalog`); it
+ * neither polls nor holds agents of its own. Rendered on the session title as
+ * a count, and on a child's title as a switcher between siblings — the same
+ * list, the two ways the reference client offers it.
+ */
+export function SubagentChip({ currentKey, entries, onOpen, variant }: SubagentChipProps) {
+  const [open, setOpen] = useState(false)
+  const root = useRef<HTMLSpanElement | null>(null)
+  const { running, total } = subagentCounts(entries)
+  const current = currentKey === undefined || currentKey === null
+    ? undefined
+    : entries.find(entry => entry.key === currentKey)
+
+  useEffect(() => {
+    if (!open) return
+
+    const onPointerDown = (event: PointerEvent) => {
+      if (root.current?.contains(event.target as Node) === true) return
+
+      setOpen(false)
+    }
+
+    document.addEventListener('pointerdown', onPointerDown)
+
+    return () => {
+      document.removeEventListener('pointerdown', onPointerDown)
+    }
+  }, [open])
+
+  // A session with no delegations has nothing to count; the switcher, once
+  // there is a child to show, always has at least that child.
+  if (total === 0 && variant === 'count') return null
+
+  const onKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
+    if (event.key === 'Escape' && open) {
+      event.stopPropagation()
+      setOpen(false)
+    }
+  }
+
+  return (
+    <span className={css.root} onKeyDown={onKeyDown} ref={root}>
+      <button
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label={
+          variant === 'switcher'
+            ? `Subagent: ${current?.label ?? 'subagent'}`
+            : countLabel(total, running)
+        }
+        className={variant === 'switcher' ? css.switcher : css.trigger}
+        onClick={() => {
+          setOpen(value => !value)
+        }}
+        type="button"
+      >
+        {variant === 'switcher' ? (
+          <>
+            <span className={css.switcherTitle}>{current?.label ?? 'subagent'}</span>
+            <SwitchIcon size={14} />
+          </>
+        ) : (
+          <>
+            {running > 0 && (
+              <span className={css.activity}>
+                <StateDot state="running" />
+              </span>
+            )}
+            <span>{`${total} ${total === 1 ? 'subagent' : 'subagents'}`}</span>
+            <ChevronDownIcon className={open ? css.chevronOpen : undefined} size={14} />
+          </>
+        )}
+      </button>
+      {open && (
+        <div aria-label="Subagents" className={css.menu} role="listbox">
+          {entries.map(entry => {
+            const selected = entry.key === currentKey
+            const secondary = secondaryLine(entry)
+            const tokens = entry.tokens === undefined ? undefined : `${formatTokens(entry.tokens)} tok`
+            const duration =
+              entry.durationMs === undefined ? undefined : formatRunDuration(entry.durationMs)
+
+            return (
+              <button
+                aria-selected={selected}
+                className={[css.row, selected ? css.rowCurrent : ''].filter(Boolean).join(' ')}
+                key={entry.key}
+                onClick={() => {
+                  setOpen(false)
+                  onOpen(entry.key)
+                }}
+                role="option"
+                type="button"
+              >
+                <span className={css.rowDot}>
+                  <StateDot label={describeStatus(entry.status)} state={dotState(entry)} />
+                </span>
+                <span className={css.rowBody}>
+                  <span className={css.rowLabel}>{entry.label}</span>
+                  {secondary !== '' && <span className={css.rowSecondary}>{secondary}</span>}
+                </span>
+                {(tokens !== undefined || duration !== undefined) && (
+                  <span className={css.rowMetrics}>
+                    {tokens !== undefined && <span>{tokens}</span>}
+                    {duration !== undefined && <span>{duration}</span>}
+                  </span>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </span>
+  )
+}

--- a/ui-web/src/conversation/SubagentView.module.css
+++ b/ui-web/src/conversation/SubagentView.module.css
@@ -1,0 +1,104 @@
+/* A subagent's run in the conversation column. The same content width as the
+   session's transcript (the one width axis on the conversation root), with a
+   read-only note where the composer would sit. */
+
+.root {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+}
+
+.column {
+  flex: 1 0 auto;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: calc(var(--cc-chat-content-width) + 2 * (var(--cc-composer-side-clearance) + 16px));
+  margin: 0 auto;
+  padding: 24px calc(var(--cc-composer-side-clearance) + 16px) 16px;
+}
+
+.promptRow {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 16px;
+}
+
+.prompt {
+  max-width: min(525px, 82%);
+  max-height: 336px;
+  padding: 10px 16px;
+  overflow-y: auto;
+  border-radius: 22px;
+  background: var(--cc-specific-bubble);
+  color: var(--cc-alias-label-primary);
+  font-size: 15px;
+  line-height: 24px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.status {
+  padding: 8px 0;
+  color: var(--cc-alias-label-caption);
+  font-size: 13px;
+  line-height: 20px;
+}
+
+.report {
+  min-width: 0;
+  margin-top: 8px;
+}
+
+.facts {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--cc-alias-border-l1);
+  color: var(--cc-alias-label-caption);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.foot {
+  position: sticky;
+  bottom: 0;
+  flex: none;
+  padding: 0 var(--cc-composer-side-clearance) 16px;
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--cc-alias-bg-base) 0%, transparent) 0px,
+    var(--cc-alias-bg-base) 24px
+  );
+}
+
+/* The seat the composer would take, holding the reason there is none. */
+.readOnly {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  box-sizing: border-box;
+  width: 100%;
+  max-width: var(--cc-composer-card-max-width);
+  margin: 0 auto;
+  padding: 12px 16px;
+  border: 1px solid var(--cc-alias-border-l2);
+  border-radius: 16px;
+  background: var(--cc-alias-bg-module-platform);
+}
+
+.readOnlyTitle {
+  color: var(--cc-alias-label-primary);
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 500;
+}
+
+.readOnlyBody {
+  color: var(--cc-alias-label-tertiary);
+  font-size: 12px;
+  line-height: 18px;
+}

--- a/ui-web/src/conversation/SubagentView.tsx
+++ b/ui-web/src/conversation/SubagentView.tsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from 'react'
+
+import { fetchSubagentTranscript } from '../state/actions.ts'
+import { describeStatus, formatRunDuration, type SubagentEntry } from '../state/subagents.ts'
+import { formatTokens } from '../state/trajectory.ts'
+import { hydrateStoredMessages, type TranscriptNode } from '../state/transcript.ts'
+import { Markdown } from '../ui/markdown/Markdown.tsx'
+import { ChatView } from './ChatView.tsx'
+import css from './SubagentView.module.css'
+
+/** How often a running subagent's record is re-read; it appends as it goes. */
+const POLL_MS = 3_000
+
+interface RecordState {
+  nodes: TranscriptNode[]
+  /** `missing` is a genuine miss: no file for this run, or no id to ask with. */
+  state: 'idle' | 'loading' | 'missing' | 'ready'
+}
+
+export interface SubagentViewProps {
+  entry: SubagentEntry
+  workspace?: string
+}
+
+/**
+ * One subagent's run, shown in the conversation column in place of the
+ * session it belongs to: the prompt it was given, then everything it did —
+ * from its own record when there is one, else the report it handed back.
+ *
+ * The record is the sidechain transcript the Agent tool writes as the run
+ * goes, read through `subagent.transcript` and rehydrated with the same fold
+ * as a resumed session, so a child's tool rows are the parent's tool rows. A
+ * run that is still going is re-read on a slow tick; once it settles the
+ * final read is the whole story.
+ *
+ * Read-only by construction. A one-shot delegation takes no follow-ups — the
+ * way to steer it is the parent's composer, one click back.
+ */
+export function SubagentView({ entry, workspace }: SubagentViewProps) {
+  const [record, setRecord] = useState<RecordState>({ nodes: [], state: 'idle' })
+  const agentId = entry.agentId ?? ''
+  const running = entry.status === 'running'
+
+  useEffect(() => {
+    if (agentId === '') {
+      setRecord({ nodes: [], state: 'missing' })
+
+      return
+    }
+
+    let live = true
+    let first = true
+
+    const load = () => {
+      if (first) {
+        first = false
+        setRecord(current => ({ ...current, state: current.state === 'ready' ? 'ready' : 'loading' }))
+      }
+
+      void fetchSubagentTranscript(agentId).then(result => {
+        if (!live) return
+
+        const messages = result.messages ?? []
+
+        if (!result.found || messages.length === 0) {
+          // Keep rows already shown: a poll that misses mid-run is a hiccup,
+          // not evidence the record vanished.
+          setRecord(current => (current.state === 'ready' ? current : { nodes: [], state: 'missing' }))
+
+          return
+        }
+
+        setRecord({ nodes: hydrateStoredMessages(messages), state: 'ready' })
+      })
+    }
+
+    load()
+
+    const timer = running ? setInterval(load, POLL_MS) : undefined
+
+    return () => {
+      live = false
+
+      if (timer !== undefined) clearInterval(timer)
+    }
+    // Re-read when the run settles: the file is complete only then.
+  }, [agentId, running])
+
+  const facts = [
+    describeStatus(entry.status),
+    entry.toolCount === undefined
+      ? undefined
+      : `${entry.toolCount} ${entry.toolCount === 1 ? 'tool call' : 'tool calls'}`,
+    entry.tokens === undefined ? undefined : `${formatTokens(entry.tokens)} tok`,
+    entry.durationMs === undefined ? undefined : formatRunDuration(entry.durationMs),
+    entry.model,
+  ].filter((part): part is string => part !== undefined && part !== '')
+
+  const showReport = record.state !== 'ready' && !running && entry.report !== undefined
+
+  return (
+    <div className={css.root}>
+      <div className={css.column}>
+        {entry.prompt !== undefined && (
+          <div className={css.promptRow}>
+            {/* The prompt the parent wrote for this run, in the user's seat:
+                to the subagent, that IS the user. */}
+            <div className={css.prompt}>{entry.prompt}</div>
+          </div>
+        )}
+        {record.state === 'ready' && (
+          <ChatView nodes={record.nodes} running={running} workspace={workspace} />
+        )}
+        {record.state === 'loading' && record.nodes.length === 0 && (
+          <div className={css.status}>Loading the run…</div>
+        )}
+        {running && record.state !== 'ready' && record.state !== 'loading' && (
+          <div className={css.status}>
+            Working
+            {entry.activity !== undefined && ` · ${entry.activity}`}
+          </div>
+        )}
+        {showReport && (
+          <div className={css.report}>
+            <Markdown text={entry.report ?? ''} />
+          </div>
+        )}
+        {record.state === 'missing' && !running && entry.report === undefined && (
+          <div className={css.status}>No record of this run was kept.</div>
+        )}
+        {facts.length > 0 && <div className={css.facts}>{facts.join(' · ')}</div>}
+      </div>
+      <div className={css.foot}>
+        <div className={css.readOnly}>
+          <span className={css.readOnlyTitle}>This subagent is read-only.</span>
+          <span className={css.readOnlyBody}>
+            A delegated run takes no follow-ups; to steer it, write to the session it belongs to.
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/ui-web/src/conversation/ToolRow.module.css
+++ b/ui-web/src/conversation/ToolRow.module.css
@@ -99,3 +99,53 @@
   color: var(--cc-alias-label-tertiary);
   text-decoration: line-through;
 }
+
+/* A delegation's body: the prompt folded above, the report as prose, and the
+   way into the run at the end. Indented under the row like every other card. */
+.agentBody {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 4px 0 4px 22px;
+}
+
+.agentPrompt {
+  max-height: 200px;
+}
+
+.agentReport {
+  min-width: 0;
+  padding: 4px 0;
+  color: var(--cc-alias-label-secondary);
+  font-size: 14px;
+  line-height: 24px;
+}
+
+.agentOpen {
+  align-self: flex-start;
+  padding: 3px 10px;
+  border: 1px solid var(--cc-alias-border-l2);
+  border-radius: 12px;
+  background: transparent;
+  color: var(--cc-alias-label-secondary);
+  font-size: 12px;
+  line-height: 18px;
+  cursor: pointer;
+}
+
+.agentOpen:hover {
+  background: var(--cc-alias-interactive-bg-hover);
+  color: var(--cc-alias-label-primary);
+}
+
+/* What a delegation is doing (or what it cost), at the row's right edge. */
+.trailing {
+  flex: none;
+  max-width: 40%;
+  overflow: hidden;
+  color: var(--cc-alias-label-caption);
+  font-size: 12px;
+  line-height: 18px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/ui-web/src/conversation/ToolRow.tsx
+++ b/ui-web/src/conversation/ToolRow.tsx
@@ -1,6 +1,7 @@
 import { memo, useState, type ReactNode } from 'react'
 
 import {
+  AgentIcon,
   FilePenIcon,
   FileTextIcon,
   GlobeIcon,
@@ -11,6 +12,7 @@ import {
   TerminalIcon,
   WrenchIcon,
 } from '../ui/icons.tsx'
+import { Markdown } from '../ui/markdown/Markdown.tsx'
 import { DiffBlock } from '../ui/primitives/DiffBlock.tsx'
 import { DisclosureRow } from '../ui/primitives/DisclosureRow.tsx'
 import { IoCard } from '../ui/primitives/IoCard.tsx'
@@ -19,6 +21,8 @@ import { ReadBlock } from '../ui/primitives/ReadBlock.tsx'
 import { TerminalBlock } from '../ui/primitives/TerminalBlock.tsx'
 import { WebBlock } from '../ui/primitives/WebBlock.tsx'
 import { openFile } from '../sidebar-right/store.ts'
+import { openSubagent } from '../state/actions.ts'
+import { formatRunDuration, type SubagentEntry } from '../state/subagents.ts'
 import type { ToolNode } from '../state/transcript.ts'
 import {
   describeTool,
@@ -36,6 +40,7 @@ import {
 import css from './ToolRow.module.css'
 
 const ICON_COMPONENTS: Record<ToolIconName, (props: { size?: number }) => ReactNode> = {
+  agent: AgentIcon,
   edit: FilePenIcon,
   file: FileTextIcon,
   globe: GlobeIcon,
@@ -45,6 +50,63 @@ const ICON_COMPONENTS: Record<ToolIconName, (props: { size?: number }) => ReactN
   search: SearchIcon,
   terminal: TerminalIcon,
   tool: WrenchIcon,
+}
+
+/**
+ * A delegation's body: what the agent was told, then what it said back.
+ *
+ * The report is markdown — it is the agent's answer, written for a reader
+ * the same way the assistant's prose is — and the prompt sits above it,
+ * folded into a plain block, because it is the only record of the task. The
+ * way into the run itself (its own tool rows) is the button at the end.
+ */
+function AgentBody({ entry, node }: { entry?: SubagentEntry; node: ToolNode }) {
+  const prompt = typeof node.args.prompt === 'string' ? node.args.prompt : ''
+  const report = entry?.report ?? genericBodyText(node)
+
+  return (
+    <div className={css.agentBody}>
+      {prompt !== '' && <OutputBlock className={css.agentPrompt} label="prompt" text={prompt} />}
+      {node.error !== undefined ? (
+        <OutputBlock className={css.agentPrompt} label="error" text={node.error} tone="error" />
+      ) : (
+        report !== '' && (
+          <div className={css.agentReport}>
+            <Markdown text={report} />
+          </div>
+        )
+      )}
+      {entry !== undefined && (
+        <button
+          className={css.agentOpen}
+          onClick={() => {
+            openSubagent(entry.key)
+          }}
+          type="button"
+        >
+          Open this subagent
+        </button>
+      )}
+    </div>
+  )
+}
+
+/** `3 tools · 42s` once settled; what the agent is doing while it runs. */
+function agentTrailing(entry: SubagentEntry | undefined): string {
+  if (entry === undefined) return ''
+
+  if (entry.status === 'running') {
+    const parts = [entry.activity, entry.toolCount === undefined ? undefined : `${entry.toolCount} tools`]
+
+    return parts.filter((part): part is string => part !== undefined && part !== '').join(' · ')
+  }
+
+  const parts = [
+    entry.toolCount === undefined ? undefined : `${entry.toolCount} ${entry.toolCount === 1 ? 'tool' : 'tools'}`,
+    entry.durationMs === undefined ? undefined : formatRunDuration(entry.durationMs),
+  ]
+
+  return parts.filter((part): part is string => part !== undefined).join(' · ')
 }
 
 function TodoBody({ todos }: { todos: TodoEntry[] }) {
@@ -71,6 +133,8 @@ function TodoBody({ todos }: { todos: TodoEntry[] }) {
 }
 
 export interface ToolRowProps {
+  /** For an Agent row: the catalog entry its call became, live figures included. */
+  agent?: SubagentEntry
   node: ToolNode
   workspace?: string
 }
@@ -84,12 +148,13 @@ export interface ToolRowProps {
  * to disclose yet, and reserving space for a card that has not arrived makes
  * the flow jump twice instead of once.
  */
-function ToolRowImpl({ node, workspace }: ToolRowProps) {
+function ToolRowImpl({ agent, node, workspace }: ToolRowProps) {
   const [expanded, setExpanded] = useState(false)
   const view = describeTool(node, workspace)
   const Icon = ICON_COMPONENTS[view.icon]
   const running = node.state === 'running'
   const failed = node.state === 'error'
+  const trailing = view.body === 'agent' ? agentTrailing(agent) : ''
 
   // The checklist card serves two families: TodoWrite carries its list in the
   // ARGUMENTS, the task registry's TaskList in its result JSON.
@@ -106,6 +171,10 @@ function ToolRowImpl({ node, workspace }: ToolRowProps) {
 
   if (running) {
     body = undefined
+  } else if (view.body === 'agent') {
+    // Settled either way: a failed delegation keeps its shape, with the
+    // failure where the report would be.
+    body = <AgentBody entry={agent} node={node} />
   } else if (failed) {
     // A failed terminal keeps its terminal shape — the error text is what the
     // command printed. Everything else shows the exchange, arguments first:
@@ -216,6 +285,7 @@ function ToolRowImpl({ node, workspace }: ToolRowProps) {
         summary={summary}
         summaryTone={failed ? 'error' : 'default'}
         title={view.title}
+        trailing={trailing === '' ? undefined : <span className={css.trailing}>{trailing}</span>}
       />
     </div>
   )

--- a/ui-web/src/conversation/tool-view.test.ts
+++ b/ui-web/src/conversation/tool-view.test.ts
@@ -105,10 +105,46 @@ describe('describeTool', () => {
   })
 
   it('falls back to an IN/OUT row for an unknown tool', () => {
-    const view = describeTool(tool({ context: 'Explore the repo', name: 'Task', state: 'running' }))
+    const view = describeTool(tool({ context: 'Explore the repo', name: 'Widget', state: 'running' }))
 
-    expect(view).toMatchObject({ body: 'io', icon: 'tool', title: 'Task' })
+    expect(view).toMatchObject({ body: 'io', icon: 'tool', title: 'Widget' })
     expect(view.summary).toBe('Explore the repo')
+  })
+
+  it('gives a delegation its own shape, named by its description', () => {
+    const view = describeTool(
+      tool({
+        args: { description: 'Deep dive: server core', prompt: 'Read everything under server/' },
+        name: 'Agent',
+        state: 'running',
+      }),
+    )
+
+    expect(view).toMatchObject({ body: 'agent', icon: 'agent', title: 'Agent' })
+    expect(view.summary).toBe('Deep dive: server core')
+  })
+
+  it('names a delegation by its prompt when it has no description', () => {
+    const view = describeTool(tool({ args: { prompt: 'Find the tests\nthen run them' }, name: 'Task' }))
+
+    expect(view.summary).toBe('Find the tests')
+  })
+
+  it('keeps the delegation shape when the run failed', () => {
+    const view = describeTool(
+      tool({ args: { description: 'Audit' }, error: 'Error: spawn refused', name: 'Agent', state: 'error' }),
+    )
+
+    expect(view).toMatchObject({ body: 'agent', summary: 'Audit', title: 'Agent' })
+  })
+
+  it('prefers the command description over the command itself', () => {
+    const view = describeTool(
+      tool({ args: { command: 'find . -name "*.ts" | wc -l', description: 'Count TypeScript files' } }),
+    )
+
+    expect(view.summary).toBe('Count TypeScript files')
+    expect(view.body).toBe('terminal')
   })
 
   it('summarises todos as progress plus the live item', () => {

--- a/ui-web/src/conversation/tool-view.ts
+++ b/ui-web/src/conversation/tool-view.ts
@@ -13,11 +13,22 @@
  */
 
 import type { ToolResult } from '../gateway/protocol.ts'
+import { isAgentTool } from '../state/subagents.ts'
 import type { ToolNode } from '../state/transcript.ts'
 
-export type ToolBodyKind = 'diff' | 'io' | 'none' | 'output' | 'read' | 'terminal' | 'todo' | 'web'
+export type ToolBodyKind =
+  | 'agent'
+  | 'diff'
+  | 'io'
+  | 'none'
+  | 'output'
+  | 'read'
+  | 'terminal'
+  | 'todo'
+  | 'web'
 
 export type ToolIconName =
+  | 'agent'
   | 'edit'
   | 'file'
   | 'globe'
@@ -371,10 +382,22 @@ function mcpTitle(name: string): string | undefined {
   return parts.join(' · ')
 }
 
+/** `Agent · Deep dive: server core` — what the delegation was for, never its prompt. */
+export function agentSummary(node: ToolNode): string {
+  return str(node.args.description) || str(node.args.name) || firstLine(str(node.args.prompt))
+}
+
 export function describeTool(node: ToolNode, workspace?: string): ToolView {
   const name = node.name
   const args = node.args
   const title = TITLES[name] ?? mcpTitle(name) ?? name
+
+  // A delegation keeps its own shape even when it failed: the row is still
+  // the way into what was asked, and the failure is read in the body.
+  if (isAgentTool(name)) {
+    return { body: 'agent', icon: 'agent', summary: agentSummary(node), title: 'Agent' }
+  }
+
   const icon = ICONS[name] ?? 'tool'
 
   if (node.error !== undefined) {
@@ -385,10 +408,15 @@ export function describeTool(node: ToolNode, workspace?: string): ToolView {
     case 'terminal': {
       const command = str(args.command)
 
+      // The model's own one-line account of the command outranks the command:
+      // "Count API endpoints" reads at a glance where `find . -name '*.ts' |
+      // xargs grep -l router | wc -l` does not, and the command itself is one
+      // click away in the terminal card. The reference client reads the same
+      // way.
       return {
         body: 'terminal',
         icon,
-        summary: command === '' ? str(node.context) : command,
+        summary: str(args.description) || (command === '' ? str(node.context) : command),
         title,
       }
     }

--- a/ui-web/src/gateway/protocol.ts
+++ b/ui-web/src/gateway/protocol.ts
@@ -121,6 +121,12 @@ export interface ToolCompletePayload {
 }
 
 export interface ToolResult {
+  /**
+   * An Agent row's link to the subagent that answered it. Present on a live
+   * completion (the server's display envelope) and on a resumed one (the
+   * envelope the agent server persisted), so both render alike.
+   */
+  agent?: AgentResultMeta
   content?: string
   context?: string
   duration_s?: number
@@ -131,6 +137,47 @@ export interface ToolResult {
   output?: string
   path?: string
   result_count?: number
+}
+
+/**
+ * What an Agent call reported about its run, beyond the report text.
+ *
+ * `agent_id` names the run — its live progress and its transcript file — and
+ * the totals are the ones the run counted itself, which the report does not
+ * carry. Mirrors `agent_result_meta` in `desktop_gateway_translate.py`.
+ */
+export interface AgentResultMeta {
+  agent_id: string
+  agent_type?: string
+  duration_ms?: number
+  model?: string
+  /** `completed`, `interrupted`, or `async_launched` for a background spawn. */
+  status: string
+  tokens?: number
+  tool_count?: number
+}
+
+/**
+ * `subagent.progress` — one subagent's latest state, while it runs and once
+ * more when it stops.
+ *
+ * `agent_id` is the run's identity; `tool_use_id`, when present, is the Agent
+ * call the run answers, which is how a row and its progress find each other
+ * before the row's result names the id. A terminal frame carries a `status`
+ * other than `running` and no activity.
+ */
+export interface SubagentProgressPayload {
+  activity?: string
+  agent_id: string
+  depth?: number
+  description?: string
+  model?: string
+  name?: string
+  status?: string
+  subagent_type?: string
+  tokens?: number
+  tool_count?: number
+  tool_use_id?: string
 }
 
 export interface ApprovalRequestPayload {
@@ -177,6 +224,7 @@ export type GatewayEventType =
   | 'session.info'
   | 'session.title'
   | 'sessions.changed'
+  | 'subagent.progress'
   | 'thinking.delta'
   | 'tool.complete'
   | 'step.complete'
@@ -200,6 +248,11 @@ export interface SessionCreateResult {
 export interface StoredMessage {
   content?: unknown
   role?: string
+  /**
+   * The Agent tool's persisted display envelope, beside its `tool_result`
+   * block — the same one a live `tool.complete` carries.
+   */
+  tool_use_result?: unknown
   [key: string]: unknown
 }
 
@@ -210,6 +263,21 @@ export interface SessionResumeResult extends SessionCreateResult {
   resumed?: string
   /** The stored name, so the header keeps the title the sidebar row showed. */
   title?: string
+}
+
+/**
+ * `subagent.transcript` — a subagent's own record, in the stored-message
+ * shape `session.resume` uses, so a child rehydrates like its parent.
+ *
+ * `found` is false, with no messages, when there is no file: a run that
+ * predates transcripts, or one whose record was cleaned up. Not an error —
+ * the row still has the prompt and the report to show.
+ */
+export interface SubagentTranscriptResult {
+  agent_id: string
+  found: boolean
+  message_count?: number
+  messages?: StoredMessage[]
 }
 
 export interface ModelOption {

--- a/ui-web/src/gateway/tool-vocabulary.ts
+++ b/ui-web/src/gateway/tool-vocabulary.ts
@@ -16,7 +16,7 @@
  * Keep in step with the Python table; the two are one contract.
  */
 
-import type { ToolResult } from './protocol.ts'
+import type { AgentResultMeta, ToolResult } from './protocol.ts'
 
 const RENDER_TOOL_NAMES: Record<string, string> = {
   askuserquestion: 'clarify',
@@ -87,4 +87,45 @@ export function renderToolResult(name: string, text: string): ToolResult {
   // No dedicated card: the generic path prefers `context`, and `output` feeds
   // the copy affordance.
   return { context: text, output: text }
+}
+
+function positiveInt(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0 ? value : undefined
+}
+
+/**
+ * A stored Agent display envelope → the `agent` facts a live row carries.
+ *
+ * The agent server persists `{type: "agent", agent_id, status, …}` beside an
+ * Agent call's result; the live gateway turns the same envelope into
+ * `result.agent` (`agent_result_meta`, the Python twin of this). Doing it
+ * here for the stored copy is what makes a resumed Agent row indistinguishable
+ * from the one that streamed. Anything that is not that envelope is ignored.
+ */
+export function agentResultMeta(display: unknown): AgentResultMeta | undefined {
+  if (display === null || typeof display !== 'object') return undefined
+
+  const record = display as Record<string, unknown>
+
+  if (record.type !== 'agent' || typeof record.agent_id !== 'string' || record.agent_id === '') {
+    return undefined
+  }
+
+  const meta: AgentResultMeta = {
+    agent_id: record.agent_id,
+    status: typeof record.status === 'string' && record.status !== '' ? record.status : 'completed',
+  }
+
+  if (typeof record.agent_type === 'string' && record.agent_type !== '') meta.agent_type = record.agent_type
+  if (typeof record.model === 'string' && record.model !== '') meta.model = record.model
+
+  const duration = positiveInt(record.total_duration_ms)
+  const tokens = positiveInt(record.total_tokens)
+  const tools = positiveInt(record.total_tool_use_count)
+
+  if (duration !== undefined) meta.duration_ms = duration
+  if (tokens !== undefined) meta.tokens = tokens
+  if (tools !== undefined) meta.tool_count = tools
+
+  return meta
 }

--- a/ui-web/src/sidebar/Sidebar.tsx
+++ b/ui-web/src/sidebar/Sidebar.tsx
@@ -27,7 +27,7 @@ import {
   SunIcon,
   XIcon,
 } from '../ui/icons.tsx'
-import { filterProjects } from './filter.ts'
+import { filterProjects, isBlankSession, visibleSessions } from './filter.ts'
 import { absoluteTime, relativeTime } from './recency.ts'
 import css from './Sidebar.module.css'
 
@@ -42,22 +42,48 @@ function sessionLabel(row: SessionRow): string {
 
   const preview = row.preview ?? ''
 
-  return preview.trim() === '' ? 'Untitled session' : preview.slice(0, 80)
+  // A blank row is the one on screen (every other blank one is hidden), and
+  // what is on screen is a new session — say so, not "untitled", which reads
+  // as a conversation that lost its name.
+  return preview.trim() === '' ? 'New session' : preview.slice(0, 80)
 }
 
 function laneCount(project: ProjectNode): number {
   return project.repos.reduce((total, repo) => total + repo.groups.length, 0)
 }
 
+/** The rows a lane shows: its sessions minus the hidden twin and idle blanks. */
+function laneRows(
+  sessions: readonly SessionRow[],
+  hiddenId: string | null,
+  keep: ReadonlySet<string>,
+): SessionRow[] {
+  return visibleSessions(
+    sessions.filter(row => row.id !== hiddenId),
+    keep,
+  )
+}
+
+/** How many rows the project will actually show, for its header count. */
+function visibleCount(project: ProjectNode, hiddenId: string | null, keep: ReadonlySet<string>): number {
+  return project.repos.reduce(
+    (total, repo) =>
+      total + repo.groups.reduce((sum, lane) => sum + laneRows(lane.sessions, hiddenId, keep).length, 0),
+    0,
+  )
+}
+
 interface SessionListProps {
   activeId: string | null
   /** Runtime session id to suppress: a replay's fresh session duplicating a row. */
   hiddenId: string | null
+  /** Blank sessions still worth a row: the one on screen. */
+  keep: ReadonlySet<string>
   liveId: string | null
   project: ProjectNode
 }
 
-function SessionList({ activeId, hiddenId, liveId, project }: SessionListProps) {
+function SessionList({ activeId, hiddenId, keep, liveId, project }: SessionListProps) {
   // Lane headers only earn their line when a repo actually has more than one
   // checkout — a single-worktree project would otherwise show a header that
   // repeats its own name.
@@ -74,7 +100,7 @@ function SessionList({ activeId, hiddenId, liveId, project }: SessionListProps) 
                 {lane.label}
               </div>
             )}
-            {lane.sessions.filter(row => row.id !== hiddenId).map(row => (
+            {laneRows(lane.sessions, hiddenId, keep).map(row => (
               <button
                 className={[css.sessionRow, row.id === activeId ? css.sessionActive : '']
                   .filter(Boolean)
@@ -88,9 +114,12 @@ function SessionList({ activeId, hiddenId, liveId, project }: SessionListProps) 
               >
                 {row.id === liveId && <span className={css.liveDot} />}
                 <span className={css.sessionTitle}>{sessionLabel(row)}</span>
-                <span className={css.sessionMeta} title={absoluteTime(row.last_active)}>
-                  {relativeTime(row.last_active)}
-                </span>
+                {/* A blank row has no last activity worth a stamp. */}
+                {!isBlankSession(row) && (
+                  <span className={css.sessionMeta} title={absoluteTime(row.last_active)}>
+                    {relativeTime(row.last_active)}
+                  </span>
+                )}
               </button>
             ))}
           </div>
@@ -132,6 +161,18 @@ export function Sidebar({ collapsed }: SidebarProps) {
   // for the runtime. They are one conversation — show the row that has the
   // history, and suppress its runtime twin.
   const duplicateLiveId = liveId !== null && liveId !== activeId ? liveId : null
+
+  // Blank sessions are listed only while they are the one on screen; the
+  // backend keeps every runtime session it ever spawned, and a row per
+  // abandoned "New session" press is a column of nothing.
+  const keep = useMemo(() => {
+    const ids = new Set<string>()
+
+    if (liveId !== null) ids.add(liveId)
+    if (activeId !== null) ids.add(activeId)
+
+    return ids
+  }, [activeId, liveId])
 
   const ThemeIcon =
     themePreference === 'light' ? SunIcon : themePreference === 'dark' ? MoonIcon : MonitorIcon
@@ -225,6 +266,11 @@ export function Sidebar({ collapsed }: SidebarProps) {
               // that kept a match is exactly the one the user is looking in,
               // and leaving it collapsed hides the result they searched for.
               const isCollapsed = !searching && collapsedProjects[project.id] === true
+              const count = visibleCount(project, duplicateLiveId, keep)
+
+              // A project whose every session is an idle blank has nothing
+              // to open; the header would announce a count over no rows.
+              if (count === 0) return null
 
               return (
                 <div className={css.project} key={project.id}>
@@ -241,12 +287,13 @@ export function Sidebar({ collapsed }: SidebarProps) {
                   >
                     {isCollapsed ? <ChevronRightIcon size={12} /> : <ChevronDownIcon size={12} />}
                     <span className={css.projectLabel}>{project.label}</span>
-                    <span className={css.projectCount}>{project.sessionCount ?? 0}</span>
+                    <span className={css.projectCount}>{count}</span>
                   </button>
                   {!isCollapsed && (
                     <SessionList
                       activeId={activeId}
                       hiddenId={duplicateLiveId}
+                      keep={keep}
                       liveId={liveId}
                       project={project}
                     />

--- a/ui-web/src/sidebar/filter.test.ts
+++ b/ui-web/src/sidebar/filter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import type { ProjectNode, SessionRow } from '../gateway/protocol.ts'
-import { filterProjects, matches, termsOf } from './filter.ts'
+import { filterProjects, isBlankSession, matches, termsOf, visibleSessions } from './filter.ts'
 
 function row(id: string, title: string, preview = ''): SessionRow {
   return { id, preview, title }
@@ -126,5 +126,30 @@ describe('filterProjects', () => {
 
     expect(projects[0]?.repos[0]?.groups[0]?.sessions).toHaveLength(3)
     expect(projects[0]?.sessionCount).toBe(3)
+  })
+})
+
+describe('isBlankSession', () => {
+  it('is a row with no messages, no name and no prompt', () => {
+    expect(isBlankSession({ id: 'x' })).toBe(true)
+    expect(isBlankSession({ id: 'x', message_count: 0, preview: '  ', title: '' })).toBe(true)
+  })
+
+  it('is not a row with anything in it', () => {
+    expect(isBlankSession({ id: 'x', message_count: 1 })).toBe(false)
+    expect(isBlankSession({ id: 'x', message_count: 0, preview: 'hello' })).toBe(false)
+    expect(isBlankSession({ id: 'x', message_count: 0, title: 'Named' })).toBe(false)
+  })
+})
+
+describe('visibleSessions', () => {
+  it('drops idle blanks and keeps the ones on screen', () => {
+    const rows = [
+      { id: 'full', message_count: 3, preview: 'prompt', title: 'Title' },
+      { id: 'idle', message_count: 0, preview: '', title: '' },
+      { id: 'mine', message_count: 0, preview: '', title: '' },
+    ]
+
+    expect(visibleSessions(rows, new Set(['mine'])).map(item => item.id)).toEqual(['full', 'mine'])
   })
 })

--- a/ui-web/src/sidebar/filter.ts
+++ b/ui-web/src/sidebar/filter.ts
@@ -26,6 +26,31 @@ export function termsOf(query: string): string[] {
 }
 
 /**
+ * A session nothing has happened in: no messages, no name, no prompt.
+ *
+ * The backend lists every live runtime session, and "New session" spawns one
+ * before anything is typed — so each press that was never followed by a
+ * prompt used to leave an "Untitled session" row behind for the life of the
+ * server.
+ */
+export function isBlankSession(row: SessionRow): boolean {
+  return (
+    (row.message_count ?? 0) === 0 &&
+    (row.title ?? '').trim() === '' &&
+    (row.preview ?? '').trim() === ''
+  )
+}
+
+/**
+ * The rows worth a line: every session with something in it, plus the blank
+ * ones in `keep` — the session on screen, which the reader is looking at even
+ * while it is still empty.
+ */
+export function visibleSessions(rows: readonly SessionRow[], keep: ReadonlySet<string>): SessionRow[] {
+  return rows.filter(row => !isBlankSession(row) || keep.has(row.id))
+}
+
+/**
  * The tree with every non-matching session removed, and every project, repo
  * and lane that ends up empty removed with it.
  *

--- a/ui-web/src/state/actions.ts
+++ b/ui-web/src/state/actions.ts
@@ -29,6 +29,7 @@ import type {
   SessionResumeResult,
   SlashResult,
   SubagentInterruptResult,
+  SubagentTranscriptResult,
   WorkspaceFileFailure,
   WorkspaceFileResult,
   WorkspaceLevel,
@@ -56,6 +57,7 @@ import {
   $sessionLoading,
   $sessionTitle,
   $storedSessionId,
+  $subagentView,
   $trajectory,
   $transcript,
   $workspace,
@@ -239,6 +241,7 @@ export async function createSession(options: SessionSpawnOptions = {}): Promise<
   $transcript.set(emptyTranscript())
   $trajectory.set(emptyTrajectory())
   $detailsNodeId.set(null)
+  $subagentView.set(null)
   $sessionTitle.set('')
   $sessionId.set(null)
   $storedSessionId.set(null)
@@ -285,6 +288,7 @@ export async function resumeSession(storedId: string, cwd?: string): Promise<voi
   // below, timestamps included.
   $trajectory.set(emptyTrajectory())
   $detailsNodeId.set(null)
+  $subagentView.set(null)
   $sessionLoading.set(true)
 
   const params: Record<string, unknown> = { capabilities: CAPABILITIES, session_id: storedId }
@@ -416,6 +420,7 @@ export async function clearSession(): Promise<void> {
 
     $transcript.set({ ...emptyTranscript(), info: $transcript.get().info })
     $trajectory.set(emptyTrajectory())
+    $subagentView.set(null)
     notice('Conversation cleared.')
   } catch (error) {
     if (isStillCurrent()) notice(errorText(error), 'error')
@@ -675,6 +680,40 @@ export async function interruptSubagent(subagentId: string): Promise<void> {
   }
 
   await fetchDelegationStatus()
+}
+
+/** Show one subagent (a catalog entry's key) in the conversation column. */
+export function openSubagent(key: string): void {
+  $subagentView.set(key)
+}
+
+/** Back to the session the subagent belongs to. */
+export function closeSubagent(): void {
+  $subagentView.set(null)
+}
+
+/**
+ * A subagent's own record, for the child view.
+ *
+ * `found: false` on any failure as well as on a genuine miss: the view has
+ * the prompt and the report either way, and a banner over them would say
+ * less than the rows it hides.
+ */
+export async function fetchSubagentTranscript(agentId: string): Promise<SubagentTranscriptResult> {
+  const missing: SubagentTranscriptResult = { agent_id: agentId, found: false, messages: [] }
+
+  if (agentId === '') return missing
+
+  try {
+    const result = await gateway().request<SubagentTranscriptResult>('subagent.transcript', {
+      agent_id: agentId,
+      session_id: $sessionId.get(),
+    })
+
+    return result.found === true ? result : missing
+  } catch {
+    return missing
+  }
 }
 
 /** The session's plan text, for the plan-review takeover. */

--- a/ui-web/src/state/store.ts
+++ b/ui-web/src/state/store.ts
@@ -60,6 +60,16 @@ export type ConversationTab = 'agents' | 'chat' | 'trajectory'
 
 export const $conversationTab = atom<ConversationTab>('chat')
 
+/**
+ * The subagent the conversation column is showing instead of the session —
+ * a catalog entry's key — or null for the session itself.
+ *
+ * A child is a view over the parent's own state (its rows, its progress
+ * frames, its transcript files), not a session of its own: leaving it is a
+ * matter of clearing this, and nothing about the parent moves meanwhile.
+ */
+export const $subagentView = atom<string | null>(null)
+
 export const $projects = atom<ProjectNode[]>([])
 export const $projectsLoading = atom<boolean>(false)
 export const $workspace = atom<string>('')

--- a/ui-web/src/state/subagents.test.ts
+++ b/ui-web/src/state/subagents.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  describeStatus,
+  formatRunDuration,
+  isAgentTool,
+  subagentCatalog,
+  subagentCounts,
+} from './subagents.ts'
+import type { SubagentLive, ToolNode, TranscriptNode } from './transcript.ts'
+
+let counter = 0
+
+function agentCall(overrides: Partial<ToolNode> = {}): ToolNode {
+  counter += 1
+
+  return {
+    args: { description: `Task ${counter}`, prompt: `Do task ${counter}\nin detail`, subagent_type: 'Explore' },
+    id: `n${counter}`,
+    kind: 'tool',
+    name: 'Agent',
+    startedAt: 1_000,
+    state: 'running',
+    toolId: `call_${counter}`,
+    ...overrides,
+  }
+}
+
+function live(overrides: Partial<SubagentLive> & { agentId: string }): SubagentLive {
+  return { startedAt: 1_000, status: 'running', ...overrides }
+}
+
+describe('isAgentTool', () => {
+  it('names both spellings of the delegation tool', () => {
+    expect(isAgentTool('Agent')).toBe(true)
+    expect(isAgentTool('Task')).toBe(true)
+    expect(isAgentTool('terminal')).toBe(false)
+  })
+})
+
+describe('subagentCatalog', () => {
+  it('lists nothing for a transcript without delegations', () => {
+    const nodes: TranscriptNode[] = [
+      { at: 0, id: 'u', kind: 'user', text: 'hi' },
+      { ...agentCall(), name: 'terminal' },
+    ]
+
+    expect(subagentCatalog(nodes, {}, 5_000)).toEqual([])
+  })
+
+  it('describes a settled call from its own result', () => {
+    const node = agentCall({
+      endedAt: 4_000,
+      result: {
+        agent: { agent_id: 'a1', duration_ms: 2_500, model: 'flash', status: 'completed', tokens: 1_200, tool_count: 3 },
+        output: '# Report\n\nAll good.',
+      },
+      state: 'done',
+    })
+
+    const [entry] = subagentCatalog([node], {}, 9_000)
+
+    expect(entry).toMatchObject({
+      agentId: 'a1',
+      durationMs: 2_500,
+      key: `tool:${node.toolId}`,
+      label: node.args.description,
+      model: 'flash',
+      report: '# Report\n\nAll good.',
+      status: 'completed',
+      subagentType: 'Explore',
+      tokens: 1_200,
+      toolCount: 3,
+      toolId: node.toolId,
+    })
+    expect(entry?.prompt).toBe(node.args.prompt)
+  })
+
+  it('joins a running call to its progress by the call id', () => {
+    const node = agentCall()
+    const agents = {
+      a9: live({ activity: 'Reading README.md', agentId: 'a9', toolCount: 2, toolUseId: node.toolId }),
+    }
+
+    const [entry] = subagentCatalog([node], agents, 3_000)
+
+    expect(entry).toMatchObject({
+      activity: 'Reading README.md',
+      agentId: 'a9',
+      durationMs: 2_000,
+      status: 'running',
+      toolCount: 2,
+    })
+  })
+
+  it('falls back to the description when the progress names no call', () => {
+    const first = agentCall({ args: { description: 'Audit auth', prompt: 'x' } })
+    const second = agentCall({ args: { description: 'Audit data', prompt: 'y' } })
+    const agents = {
+      p1: live({ agentId: 'p1', description: 'Audit data' }),
+      p2: live({ agentId: 'p2', description: 'Audit auth' }),
+    }
+
+    const entries = subagentCatalog([first, second], agents, 2_000)
+
+    expect(entries.map(entry => entry.agentId)).toEqual(['p2', 'p1'])
+  })
+
+  it('never claims one run for two calls', () => {
+    const first = agentCall({ args: { description: 'Same', prompt: 'x' } })
+    const second = agentCall({ args: { description: 'Same', prompt: 'y' } })
+    const agents = { only: live({ agentId: 'only', description: 'Same' }) }
+
+    const entries = subagentCatalog([first, second], agents, 2_000)
+
+    expect(entries[0]?.agentId).toBe('only')
+    expect(entries[1]?.agentId).toBeUndefined()
+  })
+
+  it('reads a terminal frame as the run ending, even before the row settles', () => {
+    const node = agentCall()
+    const agents = {
+      a1: live({ agentId: 'a1', endedAt: 4_000, status: 'failed', toolUseId: node.toolId }),
+    }
+
+    expect(subagentCatalog([node], agents, 9_000)[0]).toMatchObject({ durationMs: 3_000, status: 'failed' })
+  })
+
+  it('reports a failed call as failed, with the error as its report', () => {
+    const node = agentCall({ endedAt: 2_000, error: 'Error: spawn refused', state: 'error' })
+
+    expect(subagentCatalog([node], {}, 9_000)[0]).toMatchObject({
+      report: 'Error: spawn refused',
+      status: 'failed',
+    })
+  })
+
+  it('marks a background launch whose outcome never arrived', () => {
+    const node = agentCall({
+      endedAt: 1_100,
+      result: { agent: { agent_id: 'bg', status: 'async_launched' }, output: 'Async agent launched' },
+      state: 'done',
+    })
+
+    expect(subagentCatalog([node], {}, 9_000)[0]).toMatchObject({ agentId: 'bg', status: 'background' })
+  })
+
+  it('lets a later frame settle a background launch', () => {
+    const node = agentCall({
+      endedAt: 1_100,
+      result: { agent: { agent_id: 'bg', status: 'async_launched' } },
+      state: 'done',
+    })
+    const agents = { bg: live({ agentId: 'bg', endedAt: 8_000, status: 'completed', toolCount: 7 }) }
+
+    expect(subagentCatalog([node], agents, 9_000)[0]).toMatchObject({ status: 'completed', toolCount: 7 })
+  })
+
+  it('keeps a run that has frames but no row', () => {
+    const agents = { lone: live({ agentId: 'lone', description: 'Orphan work', name: 'orphan' }) }
+
+    expect(subagentCatalog([], agents, 5_000)).toEqual([
+      expect.objectContaining({ agentId: 'lone', key: 'agent:lone', label: 'Orphan work', status: 'running' }),
+    ])
+  })
+
+  it('counts the running ones', () => {
+    const entries = subagentCatalog(
+      [agentCall(), agentCall({ endedAt: 2_000, result: { agent: { agent_id: 'd', status: 'completed' } }, state: 'done' })],
+      {},
+      3_000,
+    )
+
+    expect(subagentCounts(entries)).toEqual({ running: 1, total: 2 })
+  })
+})
+
+describe('formatRunDuration', () => {
+  it('reads seconds, minutes and hours at their own precision', () => {
+    expect(formatRunDuration(42_000)).toBe('42s')
+    expect(formatRunDuration(198_000)).toBe('3m 18s')
+    expect(formatRunDuration(3_720_000)).toBe('1h 02m')
+  })
+})
+
+describe('describeStatus', () => {
+  it('has a word for every state', () => {
+    expect(describeStatus('running')).toBe('running')
+    expect(describeStatus('completed')).toBe('done')
+    expect(describeStatus('background')).toBe('in background')
+  })
+})

--- a/ui-web/src/state/subagents.ts
+++ b/ui-web/src/state/subagents.ts
@@ -1,0 +1,271 @@
+/**
+ * The session's subagents, as one list: every Agent call the transcript holds,
+ * joined with whatever its run has reported so far.
+ *
+ * Two sources describe one delegation. The Agent tool row carries what was
+ * asked (the prompt, the description) and, once settled, the report and the
+ * totals the run counted; the `subagent.progress` frames carry what the run
+ * is doing while it is still going. Neither is complete alone — a running row
+ * has no result yet, and a resumed session has no frames — so the catalog is
+ * folded from both, here, as a pure function of the transcript state. The
+ * header's count, the dropdown and the child view all read this one list.
+ *
+ * Joining is by evidence, strongest first: the row's own result names the run
+ * (`agent_id`); a frame names its row (`tool_use_id`); failing both, a running
+ * frame that describes what the row described is taken to be it.
+ */
+
+import type { SubagentLive, SubagentStatus, ToolNode, TranscriptNode } from './transcript.ts'
+
+/** Tool names that spawn a subagent — ClawCodex's `Agent`, Claude Code's `Task`. */
+const AGENT_TOOLS = new Set(['Agent', 'Task'])
+
+export function isAgentTool(name: string): boolean {
+  return AGENT_TOOLS.has(name)
+}
+
+export interface SubagentEntry {
+  /** What the run was last seen doing, while it runs. */
+  activity?: string
+  agentId?: string
+  description?: string
+  /** Milliseconds: the run's own total once settled, the elapsed time while live. */
+  durationMs?: number
+  /** Stable identity for rendering and for the child view: the row, else the run. */
+  key: string
+  /** The line the catalog shows: the description, the name, or the prompt's opening. */
+  label: string
+  model?: string
+  name?: string
+  prompt?: string
+  /** The final report, once the row has one; the error text when it failed. */
+  report?: string
+  status: SubagentStatus
+  subagentType?: string
+  tokens?: number
+  toolCount?: number
+  toolId?: string
+}
+
+export interface SubagentCounts {
+  running: number
+  total: number
+}
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function firstLine(text: string): string {
+  const line = text.split('\n').find(candidate => candidate.trim() !== '')
+
+  return line === undefined ? '' : line.trim()
+}
+
+function labelOf(description: string, name: string, prompt: string): string {
+  return description || name || firstLine(prompt) || 'subagent'
+}
+
+/** How a settled row's reported status reads in the catalog's vocabulary. */
+function statusFromResult(status: string, live: SubagentLive | undefined): SubagentStatus {
+  switch (status) {
+    case 'completed':
+    case 'interrupted':
+      return status
+
+    case 'async_launched':
+      // The call returned at launch; only a progress frame can say how the
+      // run went, and a resumed session has none.
+      return live?.status ?? 'background'
+
+    default:
+      return live?.status ?? 'completed'
+  }
+}
+
+/**
+ * The frame for a running row that names no run yet: one that points at the
+ * row, else the first unclaimed running one describing the same task.
+ */
+function liveFor(
+  node: ToolNode,
+  agents: readonly SubagentLive[],
+  claimed: Set<string>,
+): SubagentLive | undefined {
+  const byToolId = agents.find(agent => agent.toolUseId === node.toolId && !claimed.has(agent.agentId))
+
+  if (byToolId !== undefined) return byToolId
+
+  const description = str(node.args.description)
+  const name = str(node.args.name)
+
+  return agents.find(
+    agent =>
+      !claimed.has(agent.agentId) &&
+      agent.status === 'running' &&
+      agent.toolUseId === undefined &&
+      ((description !== '' && agent.description === description) ||
+        (name !== '' && agent.name === name)),
+  )
+}
+
+function entryFromNode(
+  node: ToolNode,
+  agents: Record<string, SubagentLive>,
+  claimed: Set<string>,
+  now: number,
+): SubagentEntry {
+  const meta = node.result?.agent
+  const live =
+    meta !== undefined
+      ? agents[meta.agent_id]
+      : node.state === 'running'
+        ? liveFor(node, Object.values(agents), claimed)
+        : undefined
+
+  if (live !== undefined) claimed.add(live.agentId)
+
+  const description = str(node.args.description)
+  const name = str(node.args.name)
+  const prompt = str(node.args.prompt)
+  const agentId = meta?.agent_id ?? live?.agentId
+
+  let status: SubagentStatus
+
+  if (node.state === 'error') status = 'failed'
+  else if (node.state === 'running') status = live?.status ?? 'running'
+  else status = statusFromResult(meta?.status ?? '', live)
+
+  let durationMs: number | undefined
+
+  if (meta?.duration_ms !== undefined) durationMs = meta.duration_ms
+  else if (live !== undefined) durationMs = Math.max(0, (live.endedAt ?? now) - live.startedAt)
+  else if (node.startedAt > 0) {
+    durationMs = Math.max(0, (node.endedAt ?? (node.state === 'running' ? now : node.startedAt)) - node.startedAt)
+  }
+
+  const report =
+    node.state === 'error'
+      ? node.error
+      : node.state === 'done'
+        ? str(node.result?.output) || str(node.result?.context) || undefined
+        : undefined
+
+  const entry: SubagentEntry = {
+    key: `tool:${node.toolId}`,
+    label: labelOf(description || (live?.description ?? ''), name || (live?.name ?? ''), prompt),
+    status,
+    toolId: node.toolId,
+  }
+
+  if (agentId !== undefined) entry.agentId = agentId
+  if (description !== '') entry.description = description
+  if (name !== '') entry.name = name
+  if (prompt !== '') entry.prompt = prompt
+  if (report !== undefined && report !== '') entry.report = report
+
+  const subagentType = str(node.args.subagent_type) || live?.subagentType || meta?.agent_type
+  const model = meta?.model ?? live?.model ?? str(node.args.model)
+  const toolCount = meta?.tool_count ?? live?.toolCount
+  const tokens = meta?.tokens ?? live?.tokens
+
+  if (subagentType !== undefined && subagentType !== '') entry.subagentType = subagentType
+  if (model !== undefined && model !== '') entry.model = model
+  if (toolCount !== undefined) entry.toolCount = toolCount
+  if (tokens !== undefined) entry.tokens = tokens
+  if (durationMs !== undefined) entry.durationMs = durationMs
+  if (live?.activity !== undefined && status === 'running') entry.activity = live.activity
+
+  return entry
+}
+
+/** A run the transcript has frames for but no row — kept, so nothing live goes unlisted. */
+function entryFromLive(live: SubagentLive, now: number): SubagentEntry {
+  const entry: SubagentEntry = {
+    agentId: live.agentId,
+    durationMs: Math.max(0, (live.endedAt ?? now) - live.startedAt),
+    key: `agent:${live.agentId}`,
+    label: labelOf(live.description ?? '', live.name ?? '', ''),
+    status: live.status,
+  }
+
+  if (live.description !== undefined) entry.description = live.description
+  if (live.name !== undefined) entry.name = live.name
+  if (live.subagentType !== undefined) entry.subagentType = live.subagentType
+  if (live.model !== undefined) entry.model = live.model
+  if (live.toolCount !== undefined) entry.toolCount = live.toolCount
+  if (live.tokens !== undefined) entry.tokens = live.tokens
+  if (live.activity !== undefined && live.status === 'running') entry.activity = live.activity
+
+  return entry
+}
+
+/**
+ * Every subagent this session spawned, in the order it spawned them.
+ *
+ * `now` is taken as a parameter so a running entry's elapsed time is a pure
+ * function of its inputs — and so a test can hold the clock still.
+ */
+export function subagentCatalog(
+  nodes: readonly TranscriptNode[],
+  agents: Record<string, SubagentLive>,
+  now: number = Date.now(),
+): SubagentEntry[] {
+  const claimed = new Set<string>()
+  const entries: SubagentEntry[] = []
+
+  for (const node of nodes) {
+    if (node.kind !== 'tool' || !isAgentTool(node.name)) continue
+
+    entries.push(entryFromNode(node, agents, claimed, now))
+  }
+
+  for (const live of Object.values(agents)) {
+    if (claimed.has(live.agentId)) continue
+
+    entries.push(entryFromLive(live, now))
+  }
+
+  return entries
+}
+
+export function subagentCounts(entries: readonly SubagentEntry[]): SubagentCounts {
+  let running = 0
+
+  for (const entry of entries) {
+    if (entry.status === 'running') running += 1
+  }
+
+  return { running, total: entries.length }
+}
+
+/** `3m 18s`, `42s`, `1h 02m` — a run's length at the width a row affords. */
+export function formatRunDuration(ms: number): string {
+  const seconds = Math.floor(Math.max(0, ms) / 1000)
+
+  if (seconds < 60) return `${seconds}s`
+
+  const minutes = Math.floor(seconds / 60)
+
+  if (minutes < 60) return `${minutes}m ${String(seconds % 60).padStart(2, '0')}s`
+
+  return `${Math.floor(minutes / 60)}h ${String(minutes % 60).padStart(2, '0')}m`
+}
+
+/** The status word a row shows beside its dot. */
+export function describeStatus(status: SubagentStatus): string {
+  switch (status) {
+    case 'running':
+      return 'running'
+    case 'completed':
+      return 'done'
+    case 'failed':
+      return 'failed'
+    case 'interrupted':
+      return 'interrupted'
+    case 'killed':
+      return 'stopped'
+    case 'background':
+      return 'in background'
+  }
+}

--- a/ui-web/src/state/transcript.test.ts
+++ b/ui-web/src/state/transcript.test.ts
@@ -456,3 +456,110 @@ describe('rewindLastTurn', () => {
     expect(rewindLastTurn(fold([event('error', { message: 'boom' })]))).toBeNull()
   })
 })
+
+describe('subagent progress', () => {
+  it('folds frames into one live record per run', () => {
+    const state = fold([
+      event('subagent.progress', {
+        activity: 'Reading README.md',
+        agent_id: 'a1',
+        description: 'Deep dive: core',
+        model: 'flash',
+        status: 'running',
+        tool_count: 1,
+        tool_use_id: 'call_1',
+      }),
+      event('subagent.progress', { activity: 'Listing src', agent_id: 'a1', status: 'running', tool_count: 2 }),
+    ])
+
+    expect(state.agents.a1).toMatchObject({
+      activity: 'Listing src',
+      agentId: 'a1',
+      description: 'Deep dive: core',
+      model: 'flash',
+      status: 'running',
+      toolCount: 2,
+      toolUseId: 'call_1',
+    })
+    expect(state.agents.a1?.endedAt).toBeUndefined()
+  })
+
+  it('keeps the last activity and counts when the terminal frame carries none', () => {
+    const state = fold([
+      event('subagent.progress', { activity: 'Grep', agent_id: 'a1', status: 'running', tokens: 500, tool_count: 3 }),
+      event('subagent.progress', { agent_id: 'a1', status: 'completed' }),
+    ])
+
+    expect(state.agents.a1).toMatchObject({ activity: 'Grep', status: 'completed', tokens: 500, toolCount: 3 })
+    expect(state.agents.a1?.endedAt).toBeTypeOf('number')
+  })
+
+  it('reads an unknown status as still running, and ignores a frame with no id', () => {
+    const state = fold([
+      event('subagent.progress', { agent_id: 'a1', status: 'mystery' }),
+      event('subagent.progress', { status: 'running' }),
+    ])
+
+    expect(Object.keys(state.agents)).toEqual(['a1'])
+    expect(state.agents.a1?.status).toBe('running')
+  })
+
+  it('does not disturb the flow', () => {
+    const state = fold([
+      event('message.start'),
+      event('message.delta', { text: 'Spawning' }),
+      event('subagent.progress', { agent_id: 'a1', status: 'running' }),
+    ])
+
+    expect(state.nodes).toHaveLength(1)
+    expect(state.running).toBe(true)
+  })
+})
+
+describe('rehydrating delegations', () => {
+  it('attaches the persisted Agent envelope to its row', () => {
+    const nodes = hydrateStoredMessages([
+      { content: 'go', role: 'user' },
+      {
+        content: [{ id: 'c1', input: { description: 'Dive', prompt: 'p' }, name: 'Agent', type: 'tool_use' }],
+        role: 'assistant',
+      },
+      {
+        content: [{ content: '# Report', tool_use_id: 'c1', type: 'tool_result' }],
+        role: 'user',
+        tool_use_result: {
+          agent_id: 'a9',
+          status: 'completed',
+          total_duration_ms: 1200,
+          total_tokens: 33,
+          total_tool_use_count: 4,
+          type: 'agent',
+        },
+      },
+    ])
+
+    const [row] = nodes.filter((node): node is ToolNode => node.kind === 'tool')
+
+    expect(row?.name).toBe('Agent')
+    expect(row?.state).toBe('done')
+    expect(row?.result?.agent).toEqual({
+      agent_id: 'a9',
+      duration_ms: 1200,
+      status: 'completed',
+      tokens: 33,
+      tool_count: 4,
+    })
+    expect(row?.result?.output).toBe('# Report')
+  })
+
+  it('leaves rows without an envelope exactly as before', () => {
+    const nodes = hydrateStoredMessages([
+      { content: [{ id: 'c1', input: { command: 'ls' }, name: 'Bash', type: 'tool_use' }], role: 'assistant' },
+      { content: [{ content: 'a\nb', tool_use_id: 'c1', type: 'tool_result' }], role: 'user', tool_use_result: 'a\nb' },
+    ])
+
+    const [row] = nodes.filter((node): node is ToolNode => node.kind === 'tool')
+
+    expect(row?.result).toEqual({ output: 'a\nb' })
+  })
+})

--- a/ui-web/src/state/transcript.ts
+++ b/ui-web/src/state/transcript.ts
@@ -22,12 +22,13 @@ import type {
   MessageDeltaPayload,
   QuestionRequestPayload,
   SessionInfoPayload,
+  SubagentProgressPayload,
   ToolCompletePayload,
   ToolResult,
   ToolStartPayload,
   UsagePayload,
 } from '../gateway/protocol.ts'
-import { renderToolName, renderToolResult } from '../gateway/tool-vocabulary.ts'
+import { agentResultMeta, renderToolName, renderToolResult } from '../gateway/tool-vocabulary.ts'
 
 export type ToolState = 'running' | 'done' | 'error'
 
@@ -76,7 +77,45 @@ export interface NoticeNode {
 
 export type TranscriptNode = AssistantNode | NoticeNode | ReasoningNode | ToolNode | UserNode
 
+/**
+ * How a subagent run stands. `running` until its terminal frame; the rest are
+ * the backend's own words for how it stopped. `background` is a run launched
+ * to finish on its own, whose outcome this transcript never hears.
+ */
+export type SubagentStatus =
+  | 'background'
+  | 'completed'
+  | 'failed'
+  | 'interrupted'
+  | 'killed'
+  | 'running'
+
+/**
+ * One subagent as its progress frames describe it — the live half of the
+ * catalog the header counts. The Agent row that spawned it holds the other
+ * half (the prompt, the report); `toolUseId` is how the two are joined
+ * before the row's result names the run.
+ */
+export interface SubagentLive {
+  /** What the agent was last seen doing — a tool name or its description. */
+  activity?: string
+  agentId: string
+  depth?: number
+  description?: string
+  endedAt?: number
+  model?: string
+  name?: string
+  startedAt: number
+  status: SubagentStatus
+  subagentType?: string
+  tokens?: number
+  toolCount?: number
+  toolUseId?: string
+}
+
 export interface TranscriptState {
+  /** Live subagents by agent id, folded from `subagent.progress`. */
+  agents: Record<string, SubagentLive>
   approval?: ApprovalRequestPayload
   info: SessionInfoPayload
   nodes: TranscriptNode[]
@@ -90,7 +129,56 @@ export interface TranscriptState {
 }
 
 export function emptyTranscript(): TranscriptState {
-  return { info: {}, nodes: [], running: false, turnStreamedText: false }
+  return { agents: {}, info: {}, nodes: [], running: false, turnStreamedText: false }
+}
+
+const TERMINAL_STATUSES = new Set<SubagentStatus>(['completed', 'failed', 'interrupted', 'killed'])
+
+/** The backend's status word as one of ours; anything unexpected is still running. */
+function asSubagentStatus(value: unknown): SubagentStatus {
+  return typeof value === 'string' && TERMINAL_STATUSES.has(value as SubagentStatus)
+    ? (value as SubagentStatus)
+    : 'running'
+}
+
+/** Fold one progress frame into the live-agent map. */
+function applySubagentProgress(
+  agents: Record<string, SubagentLive>,
+  payload: SubagentProgressPayload,
+  at: number,
+): Record<string, SubagentLive> {
+  const id = payload.agent_id
+  const previous = agents[id]
+  const status = asSubagentStatus(payload.status)
+  const next: SubagentLive = {
+    ...previous,
+    agentId: id,
+    startedAt: previous?.startedAt ?? at,
+    status,
+  }
+
+  // A frame names only what changed; the terminal one, for instance, carries
+  // no activity or counts, and must not blank the ones the last frame set.
+  if (typeof payload.tool_use_id === 'string' && payload.tool_use_id !== '') {
+    next.toolUseId = payload.tool_use_id
+  }
+  if (typeof payload.description === 'string' && payload.description !== '') {
+    next.description = payload.description
+  }
+  if (typeof payload.name === 'string' && payload.name !== '') next.name = payload.name
+  if (typeof payload.subagent_type === 'string' && payload.subagent_type !== '') {
+    next.subagentType = payload.subagent_type
+  }
+  if (typeof payload.model === 'string' && payload.model !== '') next.model = payload.model
+  if (typeof payload.activity === 'string' && payload.activity !== '') {
+    next.activity = payload.activity
+  }
+  if (typeof payload.depth === 'number') next.depth = payload.depth
+  if (typeof payload.tool_count === 'number') next.toolCount = payload.tool_count
+  if (typeof payload.tokens === 'number') next.tokens = payload.tokens
+  if (status !== 'running') next.endedAt = previous?.endedAt ?? at
+
+  return { ...agents, [id]: next }
 }
 
 let idCounter = 0
@@ -440,6 +528,16 @@ export function applyEvent(state: TranscriptState, event: GatewayEvent): Transcr
       }
     }
 
+    case 'subagent.progress': {
+      const payload = event.payload as SubagentProgressPayload | undefined
+
+      if (payload === undefined || typeof payload.agent_id !== 'string' || payload.agent_id === '') {
+        return state
+      }
+
+      return { ...state, agents: applySubagentProgress(state.agents, payload, Date.now()) }
+    }
+
     case 'approval.request':
       return { ...state, approval: (event.payload ?? {}) as ApprovalRequestPayload }
 
@@ -567,7 +665,12 @@ function blockText(content: unknown): string {
  * resolved on the second, exactly as the live stream does it.
  */
 export function hydrateStoredMessages(
-  messages: readonly { content?: unknown; display_kind?: string; role?: string }[],
+  messages: readonly {
+    content?: unknown
+    display_kind?: string
+    role?: string
+    tool_use_result?: unknown
+  }[],
 ): TranscriptNode[] {
   let nodes: TranscriptNode[] = []
   const toolNames = new Map<string, string>()
@@ -583,6 +686,10 @@ export function hydrateStoredMessages(
       const results = blocks.filter(block => block?.type === 'tool_result')
 
       if (results.length > 0) {
+        // The persisted envelope rides the message, not the block; a stored
+        // tool-result message holds one block, so it names the same call.
+        const agent = agentResultMeta(message.tool_use_result)
+
         for (const block of results) {
           const toolId = String(block.tool_use_id ?? '')
           const text = blockText(block.content)
@@ -591,7 +698,10 @@ export function hydrateStoredMessages(
           nodes = completeTool(nodes, {
             error: block.is_error === true ? text : undefined,
             name: rawName === '' ? undefined : renderToolName(rawName),
-            result: block.is_error === true ? {} : renderToolResult(rawName, text),
+            result:
+              block.is_error === true
+                ? {}
+                : { ...renderToolResult(rawName, text), ...(agent !== undefined && { agent }) },
             tool_id: toolId,
           })
         }

--- a/ui-web/src/ui/icons.tsx
+++ b/ui-web/src/ui/icons.tsx
@@ -48,6 +48,23 @@ export const PlusIcon = (p: IconProps) => (
   </Svg>
 )
 
+/** A delegation: one node handing work down to two. */
+export const AgentIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <circle cx="12" cy="5" r="2.5" />
+    <circle cx="6" cy="19" r="2.5" />
+    <circle cx="18" cy="19" r="2.5" />
+    <path d="M12 7.5v4M12 11.5 7 16.5M12 11.5l5 5" />
+  </Svg>
+)
+
+/** Switch between siblings: two chevrons, up and down. */
+export const SwitchIcon = (p: IconProps) => (
+  <Svg {...p}>
+    <path d="m7 9 5-5 5 5M7 15l5 5 5-5" />
+  </Svg>
+)
+
 export const FolderIcon = (p: IconProps) => (
   <Svg {...p}>
     <path d="M4 20a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2Z" />


### PR DESCRIPTION
## Summary

Brings the browser client up to the DeepSeek Harness reference on the three gaps that showed in a side-by-side: subagents were invisible, session titles were the raw first prompt, and the sidebar filled with untitled rows.

- **Subagents.** `N subagents ▾` beside the session title, a live dot while any run, and a dropdown naming each delegation with its type, model, state, tokens and duration. A row opens the run in the conversation column: its prompt, everything it did as tool rows, and a read-only seat where the composer would be, with the parent title as the way back and a sibling switcher on the child's name.
- **Data behind it.** The gateway now translates `agent_progress` frames into `subagent.progress` events (they were dropped before) carrying the `tool_use_id` of the Agent call; the Agent tool's result envelope rides `tool.complete` as `result.agent` and is persisted beside the stored result, so a resumed session lists its subagents exactly as the live one did. Foreground subagents keep the same sidechain transcript background ones do, and a new `subagent.transcript` method serves it.
- **Titles.** After the instant heuristic name, a `generate_title` control asks the session's own provider for a short title and swaps it in; a rename typed in between wins. Not the Anthropic-only `generate_llm_title` path.
- **Rows and sidebar.** Agent rows read `Agent · description` with live activity or `N tools · duration`; Bash rows summarise with the model's description of the command; blank sessions are listed only while on screen, as "New session".

## Test plan

- `ui-web`: `npm run typecheck` clean, `vitest` 588 passing, including new suites for the subagent catalog fold, progress folding, envelope hydration, Agent/Bash row descriptions and blank-session filtering.
- Python: `tests/server/test_desktop_translate.py`, `test_desktop_sessions.py`, `test_desktop_gateway.py`, `tests/test_session_title.py`, the Agent tool admission and terminal-progress suites, and the message-construction suites all pass, with new tests for `subagent.progress`, `result.agent`, transcript loading, the RPC and title generation.
- Live, against DeepSeek: a session spawning two Explore subagents with a three-item checklist showed `2 subagents, 1 running`, the to-dos panel moving to `3 completed`, both child views with their transcripts, and a model-written title replacing the heuristic within thirty seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
