### PR TITLE
fix(agent-server): require --token when the bind is not loopback

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -71,8 +71,13 @@ agent-server: connect a TUI with  cc://127.0.0.1:8791
 ```
 
 It uses the same provider/credential resolution as headless mode, so configure
-credentials with `clawcodex login` first. The server binds `127.0.0.1` only; use
-`--token` to require a bearer token on `POST /sessions`.
+credentials with `clawcodex login` first.
+
+It binds `127.0.0.1` by default, where `--token` is optional: reaching the port
+already means being on this machine. `--host` can bind it anywhere else, but
+there `--token` is required and the server refuses to start without one —
+`POST /sessions` authenticates only when a token is set, and a session is a
+shell with this machine's filesystem under it.
 
 ### 2. Frontend — the Ink TUI
 

--- a/src/entrypoints/agent_server_cli.py
+++ b/src/entrypoints/agent_server_cli.py
@@ -189,6 +189,28 @@ def run_agent_server_subcommand(argv: list[str]) -> int:
     )
     args = parser.parse_args(argv)
 
+    # `POST /sessions` authenticates only when a token was configured
+    # (`server/server.py`: `if self.config.auth_token`), and `--token` is
+    # optional — which is fine on the default loopback bind, where reaching the
+    # port already means being on this machine. Off it, that combination serves
+    # session creation to anyone who can route to the port, and a session is a
+    # shell.
+    #
+    # Remote binding stays supported: this server is written for it (see the
+    # multi-tenant note at the permission resolution below), so the refusal is
+    # narrowed to the one combination that has no defence — reachable from the
+    # network AND unauthenticated — rather than to remote binding itself.
+    from src.entrypoints.serve_cli import is_loopback
+
+    if not is_loopback(args.host) and not args.token:
+        print(
+            f"agent-server: refusing to bind {args.host} without --token: "
+            "POST /sessions authenticates only when a token is set, so this "
+            "would accept session creation from anyone who can reach the port.",
+            file=sys.stderr,
+        )
+        return 2
+
     # The agent server is the backend for an interactive TUI/direct-connect
     # client even though its own stdin/stdout are pipes.  Do not let the
     # process-level TTY check classify it like ``--print``: TaskV2 is the

--- a/src/entrypoints/agent_server_cli.py
+++ b/src/entrypoints/agent_server_cli.py
@@ -127,7 +127,8 @@ def run_agent_server_subcommand(argv: list[str]) -> int:
     parser.add_argument("--port", type=int, default=0,
                         help="HTTP port for POST /sessions (default: ephemeral).")
     parser.add_argument("--token", default="",
-                        help="Optional bearer token required on POST /sessions.")
+                        help="Bearer token required on POST /sessions. Optional "
+                             "on a loopback bind, required on any other --host.")
     parser.add_argument("--provider", default=None, help="Provider name override.")
     parser.add_argument("--model", default=None, help="Model override.")
     parser.add_argument(
@@ -200,9 +201,12 @@ def run_agent_server_subcommand(argv: list[str]) -> int:
     # multi-tenant note at the permission resolution below), so the refusal is
     # narrowed to the one combination that has no defence — reachable from the
     # network AND unauthenticated — rather than to remote binding itself.
+    # `--stdio` is exempt because it returns below without ever binding: the
+    # transport is this process's own pipes, so `--host` is inert there and
+    # refusing it would only teach callers to pass a throwaway token.
     from src.entrypoints.serve_cli import is_loopback
 
-    if not is_loopback(args.host) and not args.token:
+    if not args.stdio and not is_loopback(args.host) and not args.token:
         print(
             f"agent-server: refusing to bind {args.host} without --token: "
             "POST /sessions authenticates only when a token is set, so this "

--- a/src/server/server.py
+++ b/src/server/server.py
@@ -293,7 +293,11 @@ class DirectConnectServer:
         if self.config.auth_token:
             authz = request.headers.get('authorization', '')
             expected = f'Bearer {self.config.auth_token}'
-            if authz != expected:
+            # Constant-time: `!=` on str returns at the first differing byte,
+            # which times how much of a guess was right. Compared as bytes
+            # because `compare_digest` rejects non-ASCII str, and this one
+            # comes off the wire.
+            if not secrets.compare_digest(authz.encode(), expected.encode()):
                 writer.write(_build_http_response(
                     status=401, reason='Unauthorized',
                     body=b'{"error":"invalid auth token"}',

--- a/tests/entrypoints/test_agent_server_bind.py
+++ b/tests/entrypoints/test_agent_server_bind.py
@@ -68,3 +68,20 @@ def test_the_default_loopback_bind_is_untouched(monkeypatch) -> None:
 
     with pytest.raises(_Started):
         agent_server_cli.run_agent_server_subcommand([])
+
+
+def test_stdio_is_not_a_bind_and_is_not_refused(monkeypatch) -> None:
+    """`--stdio` serves over this process's pipes and never opens the port.
+
+    `--host` is inert in that mode, so refusing the pair would block a caller
+    that is not exposing anything — and the way around a guard like that is a
+    throwaway token, which is worse than no guard.
+    """
+
+    async def _stop(*_args: object, **_kwargs: object) -> int:
+        raise _Started
+
+    monkeypatch.setattr(agent_server_cli, "_serve_stdio", _stop)
+
+    with pytest.raises(_Started):
+        agent_server_cli.run_agent_server_subcommand(["--stdio", "--host", "0.0.0.0"])

--- a/tests/entrypoints/test_agent_server_bind.py
+++ b/tests/entrypoints/test_agent_server_bind.py
@@ -1,0 +1,70 @@
+"""`clawcodex agent-server` refuses to serve session creation to the network.
+
+`POST /sessions` authenticates only when a token was configured
+(`server/server.py`: ``if self.config.auth_token``), and ``--token`` is
+optional. On the default loopback bind that is fine — reaching the port already
+means being on this machine. Off it, the pair serves session creation to anyone
+who can route there, and a session is a shell.
+
+Remote binding itself stays supported: this server is written for it, so only
+the undefendable combination is refused.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from src.entrypoints import agent_server_cli
+
+
+class _Started(Exception):
+    """Raised from the far side of the gate, to prove where a run reached."""
+
+
+def test_a_remote_bind_without_a_token_is_refused(capsys, monkeypatch) -> None:
+    # `_serve` is stubbed to raise so that a missing guard FAILS here rather
+    # than hanging: without it this call starts a real server and blocks, which
+    # in CI is a timed-out job instead of a red test.
+    async def _stop(*_args: object, **_kwargs: object) -> int:
+        raise _Started
+
+    monkeypatch.setattr(agent_server_cli, "_serve", _stop)
+
+    code = agent_server_cli.run_agent_server_subcommand(["--host", "0.0.0.0"])
+
+    assert code == 2
+    message = capsys.readouterr().err
+    assert "refusing to bind 0.0.0.0" in message
+    # Says which flag closes it, and why it is open.
+    assert "--token" in message
+    assert "POST /sessions" in message
+
+
+def test_a_remote_bind_with_a_token_is_allowed(monkeypatch) -> None:
+    """The token is the opt-out, so it has to actually get through.
+
+    Stopped at `_serve` — the far side of the gate — rather than asserting a
+    return code, which would also pass if the guard silently refused.
+    """
+
+    async def _stop(*_args: object, **_kwargs: object) -> int:
+        raise _Started
+
+    monkeypatch.setattr(agent_server_cli, "_serve", _stop)
+
+    with pytest.raises(_Started):
+        agent_server_cli.run_agent_server_subcommand(
+            ["--host", "0.0.0.0", "--token", "s3cret"]
+        )
+
+
+def test_the_default_loopback_bind_is_untouched(monkeypatch) -> None:
+    """A tokenless local run is the ordinary case and must keep working."""
+
+    async def _stop(*_args: object, **_kwargs: object) -> int:
+        raise _Started
+
+    monkeypatch.setattr(agent_server_cli, "_serve", _stop)
+
+    with pytest.raises(_Started):
+        agent_server_cli.run_agent_server_subcommand([])

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -21,6 +21,8 @@ import pytest
 IS_ROOT = getattr(os, "geteuid", lambda: 1)() == 0
 
 from src.server.desktop_gateway_methods import (
+    CONTROL_TIMEOUT_S,
+    TITLE_TIMEOUT_S,
     DesktopSession,
     _wants_questions,
     question_request_payload,
@@ -528,10 +530,23 @@ def _titling_session(tmp_path, titled: bool = False):
     session.titled = titled
     session._background = set()
     renames: list[dict[str, Any]] = []
+    title_queries: list[dict[str, Any]] = []
     events: list[tuple[str, Any]] = []
 
-    async def _control_query(subtype: str, params: dict[str, Any]) -> Any:
-        renames.append({"subtype": subtype, **params})
+    # Signature mirrors the real `DesktopSession.control_query`, `timeout`
+    # included: a stub that takes fewer arguments than its producer passes only
+    # until the producer starts passing one, and then reports a TypeError the
+    # production path never raises.
+    async def _control_query(subtype: str, params: dict[str, Any],
+                             timeout: float = CONTROL_TIMEOUT_S) -> Any:
+        record = {"subtype": subtype, "timeout": timeout, **params}
+        # Auto-titling makes two different queries: the rename, and the side
+        # query asking the model for a better name. Keeping them in one list
+        # made "how many renames happened" unanswerable.
+        if subtype == "generate_title":
+            title_queries.append(record)
+            return {"ok": True}
+        renames.append(record)
         return {"ok": True, "name": params.get("name")}
 
     async def _broadcast(type_: str, payload: Any = None) -> None:
@@ -544,11 +559,11 @@ def _titling_session(tmp_path, titled: bool = False):
     session.control_query = _control_query  # type: ignore[method-assign]
     session._broadcast = _broadcast  # type: ignore[method-assign]
     session.state = _State()  # type: ignore[assignment]
-    return session, renames, events
+    return session, renames, events, title_queries
 
 
 def test_auto_title_names_an_untitled_session_after_its_first_prompt(tmp_path) -> None:
-    session, renames, events = _titling_session(tmp_path)
+    session, renames, events, _titles = _titling_session(tmp_path)
 
     title = asyncio.run(session.auto_title("please add a retry button to the composer"))
 
@@ -558,10 +573,31 @@ def test_auto_title_names_an_untitled_session_after_its_first_prompt(tmp_path) -
     assert ("session.title", {"title": title}) in events
 
 
+def test_the_model_written_title_gets_its_own_longer_timeout(tmp_path) -> None:
+    """The side query is given longer than an ordinary control round trip.
+
+    A model composing a title takes longer than `set_model` acknowledging one,
+    and on the default the wait would end first — leaving the heuristic name in
+    place with nothing to show it had been cut off. Pinned here because nothing
+    else asked: the stub standing in for `control_query` fell a whole argument
+    behind its producer, and the only symptom was a TypeError in the tests.
+    """
+    session, renames, _events, titles = _titling_session(tmp_path)
+
+    asyncio.run(session.auto_title("please add a retry button to the composer"))
+
+    assert [q["subtype"] for q in titles] == ["generate_title"]
+    assert titles[0]["timeout"] == TITLE_TIMEOUT_S
+    # The rename beside it keeps the ordinary one, so this is a deliberate
+    # difference between two calls rather than a raised global.
+    assert renames[0]["timeout"] == CONTROL_TIMEOUT_S
+    assert TITLE_TIMEOUT_S > CONTROL_TIMEOUT_S
+
+
 def test_auto_title_leaves_a_named_session_alone(tmp_path) -> None:
     # A resumed session carries the user's own title, and an explicit rename
     # is a decision auto-titling must not undo.
-    session, renames, events = _titling_session(tmp_path, titled=True)
+    session, renames, events, _titles = _titling_session(tmp_path, titled=True)
 
     assert asyncio.run(session.auto_title("something else entirely")) is None
     assert renames == []
@@ -571,7 +607,7 @@ def test_auto_title_leaves_a_named_session_alone(tmp_path) -> None:
 def test_auto_title_happens_once_even_if_two_prompts_race(tmp_path) -> None:
     # The flag is set BEFORE the rename round-trip, so a second prompt arriving
     # while the first is in flight cannot start a second rename.
-    session, renames, _ = _titling_session(tmp_path)
+    session, renames, _events, _titles = _titling_session(tmp_path)
 
     asyncio.run(session.auto_title("first prompt"))
     asyncio.run(session.auto_title("second prompt"))
@@ -582,7 +618,7 @@ def test_auto_title_happens_once_even_if_two_prompts_race(tmp_path) -> None:
 def test_auto_title_skips_a_prompt_it_cannot_name(tmp_path) -> None:
     # "Untitled session" is the heuristic's way of saying it has nothing; it
     # would be a worse title than the blank it replaces.
-    session, renames, _ = _titling_session(tmp_path)
+    session, renames, _events, _titles = _titling_session(tmp_path)
 
     assert asyncio.run(session.auto_title("   ")) is None
     assert renames == []
@@ -593,7 +629,7 @@ def test_auto_title_skips_a_prompt_it_cannot_name(tmp_path) -> None:
 def test_auto_title_survives_a_saved_file_it_cannot_stamp(tmp_path) -> None:
     # The runtime rename is the part that matters; a file sync failure must not
     # lose the title the client is about to be told about.
-    session, _renames, events = _titling_session(tmp_path / "does-not-exist")
+    session, _renames, events, _titles = _titling_session(tmp_path / "does-not-exist")
 
     title = asyncio.run(session.auto_title("run the tests"))
 

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -522,7 +522,7 @@ def test_rewind_reports_a_session_that_did_not_answer() -> None:
 
 
 def _titling_session(tmp_path, titled: bool = False,
-                     model_title: Any = None):
+                     model_title: Any = None, during_title_query=None):
     """A DesktopSession wired just enough to auto-title.
 
     `model_title` is what the session's model answers `generate_title`
@@ -554,6 +554,11 @@ def _titling_session(tmp_path, titled: bool = False,
         # made "how many renames happened" unanswerable.
         if subtype == "generate_title":
             title_queries.append(record)
+            # Runs while the model is "writing" — the only way to stage
+            # something that happens DURING the round trip rather than before
+            # it, which is the difference these orderings turn on.
+            if during_title_query is not None:
+                during_title_query()
             return {"ok": True, "name": model_title}
         renames.append(record)
         return {"ok": True, "name": params.get("name")}
@@ -629,18 +634,28 @@ def test_the_model_written_title_replaces_the_heuristic_one(tmp_path) -> None:
 def test_an_explicit_rename_mid_flight_beats_the_model(tmp_path) -> None:
     """A name the user chose is not overwritten by a reply that arrives after.
 
-    `user_titled` is checked after the round trip precisely because the user
-    can rename while the model is still writing.
+    The rename is staged to land *during* the `generate_title` round trip, not
+    before it: reading `user_titled` after the round trip rather than before is
+    the whole point, and a test that sets the flag up front passes either way.
+    With `TITLE_TIMEOUT_S` at 60s the window this guards is a real one.
     """
+    holder: dict[str, Any] = {}
+
+    def _user_renames_it() -> None:
+        holder["session"].user_titled = True
+
     session, renames, _events, _titles = _titling_session(
-        tmp_path, model_title="Retry button for the composer"
+        tmp_path,
+        model_title="Retry button for the composer",
+        during_title_query=_user_renames_it,
     )
-    session.user_titled = True
+    holder["session"] = session
 
     heuristic = asyncio.run(
         session.auto_title("please add a retry button to the composer")
     )
 
+    assert session.user_titled is True
     assert [r["name"] for r in renames] == [heuristic]
 
 

--- a/tests/server/test_gateway_questions.py
+++ b/tests/server/test_gateway_questions.py
@@ -521,13 +521,22 @@ def test_rewind_reports_a_session_that_did_not_answer() -> None:
 # ── auto session title ────────────────────────────────────────────────────────
 
 
-def _titling_session(tmp_path, titled: bool = False):
-    """A DesktopSession wired just enough to auto-title."""
+def _titling_session(tmp_path, titled: bool = False,
+                     model_title: Any = None):
+    """A DesktopSession wired just enough to auto-title.
+
+    `model_title` is what the session's model answers `generate_title`
+    with; the default `None` is the "no usable reply" case that leaves the
+    heuristic name standing.
+    """
     from src.server.desktop_gateway_methods import DesktopSession
 
     session = DesktopSession.__new__(DesktopSession)
     session.session_id = "s1"
     session.titled = titled
+    # Set in the real `__init__` and read by `_upgrade_title`; without it the
+    # model-written-title path raises AttributeError instead of running.
+    session.user_titled = False
     session._background = set()
     renames: list[dict[str, Any]] = []
     title_queries: list[dict[str, Any]] = []
@@ -545,7 +554,7 @@ def _titling_session(tmp_path, titled: bool = False):
         # made "how many renames happened" unanswerable.
         if subtype == "generate_title":
             title_queries.append(record)
-            return {"ok": True}
+            return {"ok": True, "name": model_title}
         renames.append(record)
         return {"ok": True, "name": params.get("name")}
 
@@ -594,13 +603,71 @@ def test_the_model_written_title_gets_its_own_longer_timeout(tmp_path) -> None:
     assert TITLE_TIMEOUT_S > CONTROL_TIMEOUT_S
 
 
+def test_the_model_written_title_replaces_the_heuristic_one(tmp_path) -> None:
+    """The whole point of the side query: a better name lands second.
+
+    The heuristic name goes out first so nothing renders blank, then the
+    model's answer overwrites it — two `session.title` broadcasts, in that
+    order, and the saved file ends up stamped with the second.
+    """
+    session, renames, events, titles = _titling_session(
+        tmp_path, model_title="Retry button for the composer"
+    )
+
+    heuristic = asyncio.run(
+        session.auto_title("please add a retry button to the composer")
+    )
+
+    assert heuristic == "Add a retry button to the composer"
+    assert [q["subtype"] for q in titles] == ["generate_title"]
+    # Renamed twice, and the model's name is what stands at the end.
+    assert [r["name"] for r in renames] == [heuristic, "Retry button for the composer"]
+    assert [payload["title"] for type_, payload in events
+            if type_ == "session.title"] == [heuristic, "Retry button for the composer"]
+
+
+def test_an_explicit_rename_mid_flight_beats_the_model(tmp_path) -> None:
+    """A name the user chose is not overwritten by a reply that arrives after.
+
+    `user_titled` is checked after the round trip precisely because the user
+    can rename while the model is still writing.
+    """
+    session, renames, _events, _titles = _titling_session(
+        tmp_path, model_title="Retry button for the composer"
+    )
+    session.user_titled = True
+
+    heuristic = asyncio.run(
+        session.auto_title("please add a retry button to the composer")
+    )
+
+    assert [r["name"] for r in renames] == [heuristic]
+
+
+def test_a_model_title_identical_to_the_heuristic_does_not_rename_twice(tmp_path) -> None:
+    """Same words, so the second rename would be a broadcast with no news."""
+    session, renames, _events, _titles = _titling_session(
+        tmp_path, model_title="Add a retry button to the composer"
+    )
+
+    heuristic = asyncio.run(
+        session.auto_title("please add a retry button to the composer")
+    )
+
+    assert [r["name"] for r in renames] == [heuristic]
+
+
 def test_auto_title_leaves_a_named_session_alone(tmp_path) -> None:
     # A resumed session carries the user's own title, and an explicit rename
     # is a decision auto-titling must not undo.
-    session, renames, events, _titles = _titling_session(tmp_path, titled=True)
+    session, renames, events, titles = _titling_session(tmp_path, titled=True)
 
     assert asyncio.run(session.auto_title("something else entirely")) is None
     assert renames == []
+    # Both lists, not just the renames: the model is not asked either. Asking
+    # would bill a round trip to answer a question already settled, and the
+    # reply arriving late is a race against the title the user chose.
+    assert titles == []
     assert events == []
 
 
@@ -618,10 +685,12 @@ def test_auto_title_happens_once_even_if_two_prompts_race(tmp_path) -> None:
 def test_auto_title_skips_a_prompt_it_cannot_name(tmp_path) -> None:
     # "Untitled session" is the heuristic's way of saying it has nothing; it
     # would be a worse title than the blank it replaces.
-    session, renames, _events, _titles = _titling_session(tmp_path)
+    session, renames, _events, titles = _titling_session(tmp_path)
 
     assert asyncio.run(session.auto_title("   ")) is None
     assert renames == []
+    # Nothing to improve on, so nothing to ask about either.
+    assert titles == []
     # …and the session stays open to being named by a later prompt.
     assert session.titled is False
 


### PR DESCRIPTION
Three things: the guard the title names, a hardening the guard depends on, and
a red main it would otherwise have been reported against.

## The guard

`clawcodex agent-server --host 0.0.0.0` with no `--token` serves session
creation to anyone who can route to the port. `POST /sessions` authenticates
only when a token was configured — `src/server/server.py`, `if
self.config.auth_token:` — and `--token` defaults to `""`. A session is a
shell with this machine's filesystem under it, so that pair is remote code
execution for the local network.

On the default loopback bind the same tokenless run is fine: reaching the port
already means being on this machine. So the refusal is narrowed to the
combination that has no defence rather than to remote binding as such — this
server is written to be bound remotely, and `--token` is the opt-out the
message names:

```
agent-server: refusing to bind 0.0.0.0 without --token: POST /sessions
authenticates only when a token is set, so this would accept session creation
from anyone who can reach the port.
```

`--stdio` is exempt. It returns before the socket is ever opened — the
transport is this process's own pipes, and `_serve_stdio` is not even passed
`args` — so `--host` is inert there and refusing it would block a run that
exposes nothing. The way around a guard like that is a throwaway token, which
leaves the port open *and* the check satisfied.

`is_loopback` is reused from `serve_cli`, already the shared home for it after
#921. This is the third of the three CLI entry points to get a bind check, and
the only one where the answer was "require auth" rather than "require an
explicit opt-in flag" — unlike `serve`'s `GET /`, remote binding here is a
supported deployment rather than an accident.

## The token the guard now leans on

`POST /sessions` compared the bearer token with `!=`, which returns at the
first differing byte and so times how much of a guess was right. Since this PR
tells operators that `--token` is what makes a remote bind defensible, that
comparison is now `secrets.compare_digest`, on bytes because the header comes
off the wire and `compare_digest` raises on non-ASCII `str`. Behaviour is
unchanged and the existing `test_e2e_unauthorized_session_create_returns_401`
proves it. Length is still leaked, content is not — the documented tradeoff,
and now consistent with the WebSocket path.

`--token`'s help said "optional" unqualified, and `docs/agent-server.md`
claimed the server "binds `127.0.0.1` only" — never true, `--host` has always
existed. Both now state the real rule.

## The red main

`tests/server/test_gateway_questions.py` has been failing three auto-title
tests on main since they landed:

```
TypeError: _control_query() got an unexpected keyword argument 'timeout'
```

Production was never affected — the real `DesktopSession.control_query` does
take `timeout`. The monkeypatched stub had a stale two-argument signature and
`_upgrade_title` started passing the keyword. `ci.yml` runs on pull requests
and not on pushes to main, so nothing caught it at the merge.

The stub now mirrors the real signature, and stops pooling both control
queries into one list — auto-titling makes a `rename` **and** a
`generate_title`, and with both in `renames` the existing `len(renames) == 1`
was really asserting that the second query did not exist yet.

That split had to be paid for: `assert renames == []` used to mean "no control
query of any kind," so both early returns now assert on both lists.

It also turned out the stub never set `user_titled`, which `_upgrade_title`
reads — so the model-written-title path had *no* coverage at all, since any
test reaching it got an `AttributeError`. Four tests now cover it: the longer
timeout it is given, the better name replacing the heuristic, a user's own
rename landing mid-round-trip and winning, and an answer identical to the
heuristic not broadcasting twice.

## Testing

Every test here is mutation-checked, each against a distinct mutation:

| mutation | test that goes red |
| --- | --- |
| guard deleted | `test_a_remote_bind_without_a_token_is_refused` |
| `and not args.token` dropped | `test_a_remote_bind_with_a_token_is_allowed` |
| `not is_loopback(args.host) and` dropped | `test_the_default_loopback_bind_is_untouched` |
| `not args.stdio and` dropped | `test_stdio_is_not_a_bind_and_is_not_refused` |
| token check always accepts | `test_e2e_unauthorized_session_create_returns_401` |
| `timeout=TITLE_TIMEOUT_S` dropped | `test_the_model_written_title_gets_its_own_longer_timeout` |
| `_upgrade_title` call dropped | `test_the_model_written_title_replaces_the_heuristic_one` |
| `user_titled` read *before* the round trip | `test_an_explicit_rename_mid_flight_beats_the_model` |
| `name == fallback` check dropped | `test_a_model_title_identical_to_the_heuristic_does_not_rename_twice` |
| `generate_title` leaked past either early return | the matching early-return test |

The refusal test stubs `_serve` so the first of those *fails* rather than
hanging. Unstubbed it starts a real server and blocks, which in CI is a
timed-out job — a mutation check that cannot tell a caught bug from a hung one
proves nothing. Same fix as in #921.

Two of these came out of review rather than out of my own testing, and both are
the same shape: a test that is load-bearing for one regression and vacuous for
the one it is named after. The mid-flight rename test set the flag before the
call, so it passed with the check moved to the wrong side of the await.

Full local suite: 10,604 passed, 0 failed. CI's four long-standing Windows
failures (nano console encoding, CRLF edit, Windows ignoring directory mode
bits, config-dir default) are unchanged and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAB22BuCSRhjbpR3a8kc5v