### PR TITLE
docs(web): record the stats strip as a divergence, not as an adaptation

### DIFF
--- a/ui-web/README.md
+++ b/ui-web/README.md
@@ -279,9 +279,17 @@ Adapted here: the design-token architecture (raw palette → semantic aliases �
 surface-specific roles, with only the aliases moving between themes), the
 three-column concession solver, the single-scrollport conversation column with
 its sticky composer seat and shared width axis, the tool-card family
-(terminal / diff / read / generic), the tabbed right column with its lazy
-workspace tree and paged text reader, and the one-line session stats strip
-under the composer.
+(terminal / diff / read / generic), and the tabbed right column with its lazy
+workspace tree and paged text reader.
+
+Diverged deliberately: the session stats strip under the composer. The
+reference ran an in-page A/B between a one-line strip and a two-pill variant
+with click-open dialogs, kept the pills, and deleted the line. This app has
+the line. It is not what upstream settled on and is not a port of the current
+design — it reads the same figures from the same ledger and drops a group with
+nothing measured, but exact token counts are not reachable from it the way the
+dialogs made them. Anyone re-syncing this column against the reference should
+know the difference is a decision here rather than drift.
 
 Not adapted: the DeepSeek branding, the cordis plugin runtime, the client module
 system, and the right column's docking engine — splits, floating panes, drag and


### PR DESCRIPTION
`ui-web/README.md` listed "the one-line session stats strip under the composer"
among the pieces adapted from the DeepSeek Harness client. It is not one.

The reference ran an in-page A/B between exactly that one-line strip and a
two-pill variant with click-open dialogs. The pills won on scannability and on
giving each figure family a home; the line was deleted. Its note on the change
(`.agents/notes/implemented/feature/2026-09-07-composer-session-stats-pills.md`)
names the single-line variant as the A/B loser, and the reference tree today
contains `StatsPills.tsx` and no `StatsLine`.

**This does not change the component.** Keeping the line is a decision, made
with the tradeoff visible: it reads the same figures from the same ledger and
drops a group with nothing measured, but exact token counts are not reachable
from it the way the dialogs made them.

What had to change is the README implying the line came from upstream. That
section exists to tell the next person re-syncing this column which parts are a
port and which are ours — and a deliberate divergence filed under "adapted" is
the one error it cannot absorb, because it reads as drift to be reconciled
rather than as a choice to be re-made. It now has its own "Diverged
deliberately" entry saying what upstream settled on and what this app has
instead.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAB22BuCSRhjbpR3a8kc5v