### PR TITLE
docs(agent-server): say what --token does not buy

### DIFF
--- a/docs/agent-server.md
+++ b/docs/agent-server.md
@@ -79,6 +79,16 @@ there `--token` is required and the server refuses to start without one —
 `POST /sessions` authenticates only when a token is set, and a session is a
 shell with this machine's filesystem under it.
 
+What `--token` buys is narrower than it looks, so be clear about it before
+binding wide. Both listeners are plaintext: the bearer token rides an
+`Authorization` header over `http://`, and the per-session token comes back
+inside a `ws://` URL as a query parameter. Anyone positioned to read the
+traffic — not merely to reach the port — can lift either and then create
+sessions as you. So `--token` answers "who may connect", not "who may watch",
+and a remote bind is defensible on a network you trust or behind something
+that terminates TLS in front of it. It is not a configuration to expose to the
+internet on its own.
+
 ### 2. Frontend — the Ink TUI
 
 ```bash


### PR DESCRIPTION
#924 made `--token` mandatory off loopback and explained why it is required. It
never said what the token stops short of, which leaves the paragraph reading as
"bind wide, pass a token, you're fine."

**Both listeners are plaintext.** The bearer token rides an `Authorization`
header over `http://`, and `POST /sessions` replies with a `ws://` URL carrying
the per-session token as a query parameter:

```python
ws_url = f'ws://{host}:{ws_port}/ws/{info.id}?token={token}'
```

There is no TLS anywhere in that server. So `--token` answers *who may
connect*, not *who may watch* — anyone positioned to read the traffic, rather
than merely to reach the port, can lift either token and create sessions
afterwards.

That makes a remote bind defensible on a trusted network or behind a TLS
terminator, and not defensible on its own over the internet. The docs now say
so.

**Deliberately unchanged:** the refusal message and the `--token` help text.
Both were already accurate — they state what is wrong *without* a token and
claim nothing about what having one achieves. Only the prose someone plans a
deployment from needed the caveat.

Raised in review of #924, and verified against the code rather than taken on
report — `grep` for ssl/TLS in `src/server/server.py` returns nothing, and the
`ws_url` line is quoted above. This is the same failure shape as the #920
correction: a true fact (`--token` gates `POST /sessions`) carrying an
inference I had not checked (that it therefore makes the bind safe).

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WAB22BuCSRhjbpR3a8kc5v